### PR TITLE
Fix Maud ID shorthand for Rust 2024

### DIFF
--- a/crates/strategic-web/src/routes/characters.rs
+++ b/crates/strategic-web/src/routes/characters.rs
@@ -160,7 +160,7 @@ async fn show_inventory(State(state): State<AppState>, Path(id): Path<String>) -
 
     // Return a simple inventory fragment
     let html = maud::html! {
-        div #"inventory" {
+        div # "inventory" {
             h3 { "Inventory" }
             @if inventory.is_empty() {
                 p { "No items" }

--- a/crates/strategic-web/src/templates/character.rs
+++ b/crates/strategic-web/src/templates/character.rs
@@ -26,7 +26,7 @@ pub fn characters_list_page(
                         "No characters yet"
                     }
                 } @else {
-                    div #"character-list" {
+                    div # "character-list" {
                         @for character in characters {
                             @let is_current = current_character_id == Some(character.id);
                             div class=(if is_current { "list-item-wrapper current" } else { "list-item-wrapper" }) {
@@ -119,7 +119,7 @@ pub fn character_new_page(logged_in_as: Option<&str>, theme: &str) -> Markup {
         main class="center-content" {
             h2 class="page-title" { "Create Character" }
             (panel("Character Details", html! {
-                form #"character-form" action="/characters" method="post" {
+                form # "character-form" action="/characters" method="post" {
                     (input_field("name", "Character Name", "text", true, None))
                     div class="form-actions" {
                         button type="submit" class="btn btn-primary" { "Create Character" }
@@ -258,7 +258,7 @@ pub fn character_detail_page(
 /// Character list fragment for Datastar updates
 pub fn characters_list_fragment(characters: &[Character]) -> Markup {
     html! {
-        div #"character-list" {
+        div # "character-list" {
             @for character in characters {
                 (list_item(
                     &format!("/characters/{}", character.id),

--- a/crates/strategic-web/src/templates/home.rs
+++ b/crates/strategic-web/src/templates/home.rs
@@ -198,7 +198,7 @@ pub fn home_fragment(
     active_quest: Option<&Quest>,
 ) -> Markup {
     html! {
-        div #"main-content" {
+        div # "main-content" {
             @if let Some(character) = current_character {
                 @if let Some(settlement) = current_settlement {
                     h2 class="page-title" { (settlement.name) }

--- a/crates/strategic-web/src/templates/mission.rs
+++ b/crates/strategic-web/src/templates/mission.rs
@@ -38,7 +38,7 @@ pub fn mission_status_page(
         main class="center-content" {
             h2 class="page-title" { "Mission Status" }
 
-            div #"mission-status" {
+            div # "mission-status" {
                 @match status.as_str() {
                     "Ready" => { (ready_state(server)) }
                     "Failed" => { (failed_state()) }
@@ -186,7 +186,7 @@ pub fn mission_status_fragment(server: &TacticalServer) -> Markup {
     let status = effective_status(&server.status);
 
     html! {
-        div #"mission-status" {
+        div # "mission-status" {
             @match status.as_str() {
                 "Ready" => { (ready_state(server)) }
                 "Failed" => { (failed_state()) }

--- a/crates/strategic-web/src/templates/party.rs
+++ b/crates/strategic-web/src/templates/party.rs
@@ -22,7 +22,7 @@ pub fn parties_list_page(
                         "No parties found"
                     }
                 } @else {
-                    div #"party-list" {
+                    div # "party-list" {
                         @for party in parties {
                             (list_item(
                                 &format!("/parties/{}", party.id),
@@ -103,7 +103,7 @@ pub fn party_new_page(logged_in_as: Option<&str>, theme: &str) -> Markup {
         main class="center-content" {
             h2 class="page-title" { "Create Party" }
             (panel("Party Details", html! {
-                form #"party-form" action="/parties" method="post" {
+                form # "party-form" action="/parties" method="post" {
                     (input_field("name", "Party Name", "text", true, None))
                     div class="form-actions" {
                         button type="submit" class="btn btn-primary" { "Create Party" }
@@ -247,7 +247,7 @@ pub fn party_detail_page(
 /// Party list fragment for Datastar updates
 pub fn parties_list_fragment(parties: &[Party]) -> Markup {
     html! {
-        div #"party-list" {
+        div # "party-list" {
             @for party in parties {
                 (list_item(
                     &format!("/parties/{}", party.id),

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -16,7 +16,7 @@ pub fn quests_list_page(quests: &[Quest], logged_in_as: Option<&str>, theme: &st
                 @if quests.is_empty() {
                     (empty_state("No quests available.", None, None))
                 } @else {
-                    div #"quest-list" {
+                    div # "quest-list" {
                         @for quest in quests {
                             (list_item(
                                 &format!("/quests/{}", quest.id),
@@ -189,7 +189,7 @@ pub fn quest_detail_page(
 /// Quest list fragment for Datastar updates
 pub fn quests_list_fragment(quests: &[Quest]) -> Markup {
     html! {
-        div #"quest-list" {
+        div # "quest-list" {
             @for quest in quests {
                 (list_item(
                     &format!("/quests/{}", quest.id),


### PR DESCRIPTION
## Summary

Adds whitespace between Maud's `#` ID shorthand and quoted IDs throughout `strategic-web`.

## Root cause

The workspace moved to Rust 2024. In that edition, `#"id"` is reserved guarded-string syntax, so Maud receives an invalid literal. `# "id"` preserves the existing quoted-ID shorthand while keeping the tokens separate.

## Impact

`strategic-web` compiles again under the workspace's Rust 2024 edition.

## Validation

- `cargo check -p strategic-web`

The check passes with only pre-existing warnings.