### PR TITLE
Add settlement travel overview

### DIFF
--- a/crates/adventuresim-stdb-client/src/mod.rs
+++ b/crates/adventuresim-stdb-client/src/mod.rs
@@ -75,6 +75,7 @@ pub mod quest_type;
 pub mod refresh_world_clock_reducer;
 pub mod request_tactical_server_for_scene_reducer;
 pub mod request_tactical_server_reducer;
+pub mod rest_at_settlement_reducer;
 pub mod seed_damaged_character_reducer;
 pub mod seed_party_companions_reducer;
 pub mod seed_world_reducer;
@@ -236,6 +237,9 @@ pub use request_tactical_server_for_scene_reducer::{
 };
 pub use request_tactical_server_reducer::{
     request_tactical_server, set_flags_for_request_tactical_server, RequestTacticalServerCallbackId,
+};
+pub use rest_at_settlement_reducer::{
+    rest_at_settlement, set_flags_for_rest_at_settlement, RestAtSettlementCallbackId,
 };
 pub use seed_damaged_character_reducer::{
     seed_damaged_character, set_flags_for_seed_damaged_character, SeedDamagedCharacterCallbackId,
@@ -445,6 +449,11 @@ pub enum Reducer {
     RequestTacticalServerForScene {
         scene_key: String,
     },
+    RestAtSettlement {
+        character_id: u64,
+        requested_days: u16,
+        at_inn: bool,
+    },
     SeedDamagedCharacter,
     SeedPartyCompanions {
         leader_id: u64,
@@ -528,6 +537,7 @@ impl __sdk::Reducer for Reducer {
             Reducer::RefreshWorldClock { .. } => "refresh_world_clock",
             Reducer::RequestTacticalServer { .. } => "request_tactical_server",
             Reducer::RequestTacticalServerForScene { .. } => "request_tactical_server_for_scene",
+            Reducer::RestAtSettlement { .. } => "rest_at_settlement",
             Reducer::SeedDamagedCharacter => "seed_damaged_character",
             Reducer::SeedPartyCompanions { .. } => "seed_party_companions",
             Reducer::SeedWorld => "seed_world",
@@ -723,6 +733,10 @@ impl TryFrom<__ws::ReducerCallInfo<__ws::BsatnFormat>> for Reducer {
                 >("request_tactical_server_for_scene", &value.args)?
                 .into())
             }
+            "rest_at_settlement" => Ok(__sdk::parse_reducer_args::<
+                rest_at_settlement_reducer::RestAtSettlementArgs,
+            >("rest_at_settlement", &value.args)?
+            .into()),
             "seed_damaged_character" => Ok(__sdk::parse_reducer_args::<
                 seed_damaged_character_reducer::SeedDamagedCharacterArgs,
             >("seed_damaged_character", &value.args)?

--- a/crates/adventuresim-stdb-client/src/settlement_import_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_import_type.rs
@@ -13,6 +13,7 @@ pub struct SettlementImport {
     pub longitude: f64,
     pub latitude: f64,
     pub population_level: i32,
+    pub population_estimate: u32,
     pub scene_key: String,
 }
 

--- a/crates/adventuresim-stdb-client/src/settlement_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_type.rs
@@ -12,6 +12,7 @@ pub struct Settlement {
     pub coord_x: f64,
     pub coord_y: f64,
     pub population_level: i32,
+    pub population_estimate: u32,
     pub scene_key: String,
     pub source_node_id: Option<u64>,
 }

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -4,11 +4,15 @@ use crate::{
     character::{character, character_equip},
     item::{InventoryItem, inventory_item, item},
     tactical::tactical_server_request,
+    time::advance_character_time,
 };
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 const MERCHANT_MARGIN: f32 = 1.25;
 const SALES_TAX: f32 = 0.10;
+const WALKING_SPEED_KM_PER_HOUR: u64 = 5;
+const METERS_PER_KILOMETER: u64 = 1_000;
+const MINUTES_PER_HOUR: u64 = 60;
 
 #[derive(SpacetimeType, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum QuestStatus {
@@ -26,6 +30,8 @@ pub struct Settlement {
     pub coord_x: f64,
     pub coord_y: f64,
     pub population_level: i32,
+    /// Approximate population in inhabitants; zero means the world data has no estimate.
+    pub population_estimate: u32,
     pub scene_key: String,
     /// Viabundus node that supplies this settlement, if it was imported from
     /// the historical world dataset. Demo settlements deliberately leave this
@@ -109,6 +115,8 @@ pub struct SettlementImport {
     pub longitude: f64,
     pub latitude: f64,
     pub population_level: i32,
+    /// Viabundus records this approximation in thousands of inhabitants; zero means absent.
+    pub population_estimate: u32,
     pub scene_key: String,
 }
 
@@ -231,6 +239,7 @@ pub fn import_settlements(
             coord_x: settlement.longitude,
             coord_y: settlement.latitude,
             population_level: settlement.population_level,
+            population_estimate: settlement.population_estimate,
             scene_key: settlement.scene_key,
             source_node_id: Some(settlement.source_node_id),
         };
@@ -825,32 +834,70 @@ pub fn abandon_quest(
     Ok(())
 }
 
-fn route_exists(ctx: &ReducerContext, start: u64, destination: u64) -> bool {
-    if start == destination {
-        return true;
-    }
+fn travel_neighbors(ctx: &ReducerContext, node: u64) -> Vec<(u64, u32)> {
+    let mut neighbors: Vec<_> = ctx
+        .db
+        .travel_edge()
+        .from_node_id()
+        .filter(&node)
+        .filter_map(|edge| {
+            matches!(edge.kind.as_str(), "land" | "ferry")
+                .then_some((edge.to_node_id, edge.length_m))
+        })
+        .collect();
+    neighbors.extend(
+        ctx.db
+            .travel_edge()
+            .to_node_id()
+            .filter(&node)
+            .filter_map(|edge| {
+                matches!(edge.kind.as_str(), "land" | "ferry")
+                    .then_some((edge.from_node_id, edge.length_m))
+            }),
+    );
+    neighbors
+}
 
-    let mut visited = HashSet::from([start]);
-    let mut pending = VecDeque::from([start]);
-    while let Some(node) = pending.pop_front() {
-        for edge in ctx.db.travel_edge().from_node_id().filter(&node) {
-            if matches!(edge.kind.as_str(), "land" | "ferry") && visited.insert(edge.to_node_id) {
-                if edge.to_node_id == destination {
-                    return true;
-                }
-                pending.push_back(edge.to_node_id);
-            }
+/// Returns the next settlements reached from a source. Paths end at the first
+/// settlement encountered, so journeys cannot skip intermediate settlements.
+fn connected_settlement_distances(ctx: &ReducerContext, source_node_id: u64) -> HashMap<u64, u64> {
+    let settlement_nodes: HashSet<u64> = ctx
+        .db
+        .settlement()
+        .iter()
+        .filter_map(|settlement| settlement.source_node_id)
+        .collect();
+    let mut distances = HashMap::from([(source_node_id, 0_u64)]);
+    let mut pending = BinaryHeap::from([std::cmp::Reverse((0_u64, source_node_id))]);
+    let mut destinations = HashMap::new();
+
+    while let Some(std::cmp::Reverse((distance, node))) = pending.pop() {
+        if distances.get(&node).is_some_and(|known| *known != distance) {
+            continue;
         }
-        for edge in ctx.db.travel_edge().to_node_id().filter(&node) {
-            if matches!(edge.kind.as_str(), "land" | "ferry") && visited.insert(edge.from_node_id) {
-                if edge.from_node_id == destination {
-                    return true;
-                }
-                pending.push_back(edge.from_node_id);
+        if node != source_node_id && settlement_nodes.contains(&node) {
+            destinations.insert(node, distance);
+            continue;
+        }
+        for (neighbor, length_m) in travel_neighbors(ctx, node) {
+            let next_distance = distance.saturating_add(u64::from(length_m));
+            if distances
+                .get(&neighbor)
+                .is_none_or(|known| next_distance < *known)
+            {
+                distances.insert(neighbor, next_distance);
+                pending.push(std::cmp::Reverse((next_distance, neighbor)));
             }
         }
     }
-    false
+    destinations
+}
+
+fn journey_minutes(distance_m: u64) -> u64 {
+    distance_m
+        .saturating_mul(MINUTES_PER_HOUR)
+        .div_ceil(WALKING_SPEED_KM_PER_HOUR * METERS_PER_KILOMETER)
+        .max(1)
 }
 
 #[reducer]
@@ -872,14 +919,27 @@ pub fn travel_to_settlement(
             return Err("Character's current settlement does not exist".into());
         };
         // Demo settlements remain usable before a Viabundus world is loaded.
-        // Once both endpoints are sourced from the imported graph, teleporting
-        // between disconnected settlements is no longer permitted.
+        // Imported journeys must lead to the next settlement on the road graph.
         if let (Some(origin_node), Some(destination_node)) =
             (origin.source_node_id, destination.source_node_id)
         {
-            if !route_exists(ctx, origin_node, destination_node) {
-                return Err("No land or ferry route connects those settlements".into());
-            }
+            let Some(distance_m) = connected_settlement_distances(ctx, origin_node)
+                .get(&destination_node)
+                .copied()
+            else {
+                return Err("That settlement is not directly connected by land or ferry".into());
+            };
+            advance_character_time(ctx, character_id, journey_minutes(distance_m))?;
+        } else {
+            let distance_km = ((origin.coord_x - destination.coord_x).powi(2)
+                + (origin.coord_y - destination.coord_y).powi(2))
+            .sqrt()
+            .ceil() as u64;
+            advance_character_time(
+                ctx,
+                character_id,
+                journey_minutes(distance_km.saturating_mul(METERS_PER_KILOMETER)),
+            )?;
         }
     }
 
@@ -963,6 +1023,7 @@ pub fn seed_world(ctx: &ReducerContext) -> Result<(), String> {
                 coord_x: x,
                 coord_y: y,
                 population_level: pop,
+                population_estimate: 0,
                 scene_key: scene.into(),
                 source_node_id: None,
             });

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -143,6 +143,28 @@ pub fn initialize_character_time(ctx: &ReducerContext, character_id: u64) -> Res
     ensure_character_time(ctx, character_id)
 }
 
+/// Record time spent travelling without applying settlement-only recovery or
+/// training. Travel time belongs to the character's personal strategic clock.
+pub fn advance_character_time(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minutes: u64,
+) -> Result<(), String> {
+    ensure_character_time(ctx, character_id)?;
+    let mut character_time = ctx
+        .db
+        .character_time()
+        .character_id()
+        .find(character_id)
+        .ok_or_else(|| "Character time record not found".to_string())?;
+    character_time.minutes = character_time.minutes.saturating_add(minutes);
+    ctx.db
+        .character_time()
+        .character_id()
+        .update(character_time);
+    Ok(())
+}
+
 fn default_schedule(character_id: u64) -> CharacterTrainingSchedule {
     CharacterTrainingSchedule {
         character_id,

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -8,18 +8,19 @@ use axum::{
 };
 use serde::Deserialize;
 use serde_json::json;
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use super::AppState;
 use crate::session::Session;
 use crate::spacetimedb::{
     Character, CharacterAttributes, CharacterEquip, CharacterLimbs, CharacterSkills,
     CharacterTrainingSchedule, InventoryItem, ItemDefinition, Party, PartyMember, Quest,
-    Settlement,
+    Settlement, TravelEdge,
 };
 use crate::templates::settlement::{
     MerchantShop, RestSummary, inn_page, live_merchant_shop_page, merchants_page, noticeboard_page,
     party_inventory_page, party_personal_page, party_stats_page, religion_page, rest_result_page,
-    settlements_list_page, smith_page,
+    settlement_overview_page, settlements_list_page, smith_page,
 };
 
 pub fn routes() -> Router<AppState> {
@@ -81,8 +82,147 @@ async fn list_settlements(State(state): State<AppState>, session: Session) -> Ht
     )
 }
 
-async fn show_settlement(Path(id): Path<String>) -> Redirect {
-    Redirect::to(&format!("/settlements/{id}/noticeboard"))
+async fn show_settlement(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    session: Session,
+) -> Html<String> {
+    let settlements: Vec<Settlement> = state
+        .db
+        .query("SELECT * FROM settlement")
+        .await
+        .unwrap_or_default();
+    let Some(settlement) = settlements.iter().find(|settlement| settlement.id == id) else {
+        return Html("<h1>Settlement not found</h1>".to_string());
+    };
+    let edges: Vec<TravelEdge> = state
+        .db
+        .query("SELECT * FROM travel_edge")
+        .await
+        .unwrap_or_default();
+    let destinations = connected_destinations(settlement, &settlements, &edges);
+    let active_character = get_active_character(&state, session.character_id_u64()).await;
+    let party_members = get_active_party_members(
+        &state,
+        active_character.as_ref().map(|(character, _)| character),
+    )
+    .await;
+    let logged_in_as = active_character
+        .as_ref()
+        .map(|(character, _)| character.name.clone());
+    let can_travel = active_character.as_ref().is_some_and(|(character, _)| {
+        character.current_settlement_id.as_deref() == Some(&settlement.id)
+    });
+    Html(
+        settlement_overview_page(
+            settlement,
+            &destinations,
+            active_character.as_ref().map(|(character, _)| character),
+            &party_members,
+            can_travel,
+            logged_in_as.as_deref(),
+            session.theme(),
+        )
+        .into_string(),
+    )
+}
+
+const WALKING_SPEED_KM_PER_HOUR: u64 = 5;
+
+#[derive(Clone)]
+pub struct TravelDestination {
+    pub settlement: Settlement,
+    pub distance_m: u64,
+    pub journey_minutes: u64,
+}
+
+fn connected_destinations(
+    origin: &Settlement,
+    settlements: &[Settlement],
+    edges: &[TravelEdge],
+) -> Vec<TravelDestination> {
+    let Some(origin_node) = origin.source_node_id else {
+        return settlements
+            .iter()
+            .filter(|settlement| settlement.id != origin.id)
+            .cloned()
+            .map(|settlement| {
+                let distance_km = ((origin.coord_x - settlement.coord_x).powi(2)
+                    + (origin.coord_y - settlement.coord_y).powi(2))
+                .sqrt()
+                .ceil() as u64;
+                let distance_m = distance_km.saturating_mul(1_000);
+                TravelDestination {
+                    settlement,
+                    distance_m,
+                    journey_minutes: journey_minutes(distance_m),
+                }
+            })
+            .collect();
+    };
+
+    let settlement_nodes: HashSet<u64> = settlements
+        .iter()
+        .filter_map(|settlement| settlement.source_node_id)
+        .collect();
+    let settlements_by_node: HashMap<u64, &Settlement> = settlements
+        .iter()
+        .filter_map(|settlement| settlement.source_node_id.map(|node| (node, settlement)))
+        .collect();
+    let mut adjacency: HashMap<u64, Vec<(u64, u32)>> = HashMap::new();
+    for edge in edges
+        .iter()
+        .filter(|edge| matches!(edge.kind.as_str(), "land" | "ferry"))
+    {
+        adjacency
+            .entry(edge.from_node_id)
+            .or_default()
+            .push((edge.to_node_id, edge.length_m));
+        adjacency
+            .entry(edge.to_node_id)
+            .or_default()
+            .push((edge.from_node_id, edge.length_m));
+    }
+    let mut distances = HashMap::from([(origin_node, 0_u64)]);
+    let mut pending = BinaryHeap::from([std::cmp::Reverse((0_u64, origin_node))]);
+    let mut destinations = Vec::new();
+    while let Some(std::cmp::Reverse((distance_m, node))) = pending.pop() {
+        if distances
+            .get(&node)
+            .is_some_and(|known| *known != distance_m)
+        {
+            continue;
+        }
+        if node != origin_node && settlement_nodes.contains(&node) {
+            if let Some(settlement) = settlements_by_node.get(&node) {
+                destinations.push(TravelDestination {
+                    settlement: (*settlement).clone(),
+                    distance_m,
+                    journey_minutes: journey_minutes(distance_m),
+                });
+            }
+            continue;
+        }
+        for (neighbor, edge_length_m) in adjacency.get(&node).into_iter().flatten() {
+            let next_distance = distance_m.saturating_add(u64::from(*edge_length_m));
+            if distances
+                .get(neighbor)
+                .is_none_or(|known| next_distance < *known)
+            {
+                distances.insert(*neighbor, next_distance);
+                pending.push(std::cmp::Reverse((next_distance, *neighbor)));
+            }
+        }
+    }
+    destinations.sort_by_key(|destination| destination.distance_m);
+    destinations
+}
+
+fn journey_minutes(distance_m: u64) -> u64 {
+    distance_m
+        .saturating_mul(60)
+        .div_ceil(WALKING_SPEED_KM_PER_HOUR * 1_000)
+        .max(1)
 }
 
 async fn redirect_to_inn(Path(id): Path<String>) -> Redirect {

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -55,8 +55,21 @@ pub struct Settlement {
     pub coord_x: f64,
     pub coord_y: f64,
     pub population_level: i32,
+    pub population_estimate: u32,
     pub scene_key: String,
     pub source_node_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TravelEdge {
+    pub id: u64,
+    pub from_node_id: u64,
+    pub to_node_id: u64,
+    pub kind: String,
+    pub length_m: u32,
+    pub slope_multiplier: f32,
+    pub certainty: u8,
+    pub section: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -10,6 +10,7 @@ use super::{
     difficulty_stars, empty_state, gold_display, list_item, population_description,
     settlement_layout_with_session, sidebar_section, status_badge,
 };
+use crate::routes::settlements::TravelDestination;
 use crate::spacetimedb::{
     Character, CharacterAttributes, CharacterEquip, CharacterLimbs, CharacterSkills,
     CharacterTrainingSchedule, InventoryItem, Party, Quest, Settlement,
@@ -106,6 +107,111 @@ pub fn settlements_list_page(
     };
 
     super::base_layout_with_session("Settlements", content, logged_in_as, theme)
+}
+
+/// Settlement information and the next destinations on the imported road and
+/// ferry network.
+pub fn settlement_overview_page(
+    settlement: &Settlement,
+    destinations: &[TravelDestination],
+    active_character: Option<&Character>,
+    party_members: &[Character],
+    can_travel: bool,
+    logged_in_as: Option<&str>,
+    theme: &str,
+) -> Markup {
+    let content = html! {
+        aside class="left-sidebar" {
+            (sidebar_section("Settlement", html! {
+                div class="settlement-summary" {
+                    strong { (&settlement.name) }
+                    span class="text-muted small-copy" { "Population: " (format_population(settlement)) }
+                }
+            }))
+        }
+        main class="center-content settlement-main settlement-overview" {
+            (party_portrait_overlay(party_members, active_character, &settlement.id, None))
+            (visual_stage("map", &settlement.name, "TODO: settlement image"))
+            (settlement_chat_area(&settlement.name, active_character))
+        }
+        aside class="right-sidebar" {
+            (sidebar_section("Connected destinations", html! {
+                @if destinations.is_empty() {
+                    (empty_state("No land or ferry destination is currently connected to this settlement.", None, None))
+                } @else {
+                    @for destination in destinations {
+                        article class="travel-destination" {
+                            div {
+                                strong { (&destination.settlement.name) }
+                                p class="text-muted small-copy" {
+                                    (format_population(&destination.settlement))
+                                    " · " (format_distance(destination.distance_m))
+                                    " · " (format_journey_time(destination.journey_minutes))
+                                }
+                            }
+                            @if can_travel {
+                                form method="post" action={ "/settlements/" (&destination.settlement.id) "/travel" } {
+                                    button type="submit" class="btn btn-primary btn-small" { "Travel" }
+                                }
+                            } @else {
+                                span class="text-muted small-copy" { "Travel from your current settlement" }
+                            }
+                        }
+                    }
+                }
+            }))
+            (sidebar_section("Travel", html! {
+                p class="small-copy" { "Journeys use an average walking pace of 5 km/h." }
+                p class="text-muted small-copy" { "Travel time advances your strategic clock." }
+            }))
+        }
+    };
+    settlement_layout_with_session(
+        &settlement.name,
+        &settlement.name,
+        &settlement.id,
+        "overview",
+        content,
+        logged_in_as,
+        theme,
+    )
+}
+
+fn format_distance(distance_m: u64) -> String {
+    format!("{:.1} km", distance_m as f64 / 1_000.0)
+}
+
+fn format_population(settlement: &Settlement) -> String {
+    match settlement.population_estimate {
+        0 => population_description(settlement.population_level).to_string(),
+        population => format!("approximately {}", format_number(population)),
+    }
+}
+
+fn format_number(value: u32) -> String {
+    let digits = value.to_string();
+    let first_group = match digits.len() % 3 {
+        0 => 3,
+        remainder => remainder,
+    };
+    let mut formatted = digits[..first_group].to_string();
+    for group in digits[first_group..].as_bytes().chunks(3) {
+        formatted.push(',');
+        formatted.push_str(std::str::from_utf8(group).expect("population digits are valid UTF-8"));
+    }
+    formatted
+}
+
+fn format_journey_time(minutes: u64) -> String {
+    let hours = minutes / 60;
+    let minutes = minutes % 60;
+    if hours == 0 {
+        format!("{minutes} min")
+    } else if minutes == 0 {
+        format!("{hours} h")
+    } else {
+        format!("{hours} h {minutes} min")
+    }
 }
 
 /// Notice board page.

--- a/crates/strategic-web/static/css/components.css
+++ b/crates/strategic-web/static/css/components.css
@@ -933,6 +933,31 @@
   cursor: not-allowed;
 }
 
+/* ============================================
+   SETTLEMENT TRAVEL
+   ============================================ */
+.travel-destinations {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.travel-destinations > h3 {
+  font-family: var(--font-display), serif;
+  font-size: var(--font-size-lg);
+}
+
+.travel-destination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem;
+  border: 1px solid var(--border-light);
+  background: var(--panel-bg);
+}
+
+.travel-destination p { margin: 0.2rem 0 0; }
+
 .trade-transfer:not(:disabled) { cursor: pointer; }
 
 .party-trade-changed { background: color-mix(in srgb, var(--accent) 12%, var(--panel-bg)); }

--- a/docs/VIABUNDUS.md
+++ b/docs/VIABUNDUS.md
@@ -10,7 +10,8 @@ version 2 (released 25 April 2025), edited by Bart Holterman et al.
 The upstream CSVs are downloaded locally into the Git-ignored `viabundus/`
 directory with `just init-viabundus`. The generated strategic graph contains
 only the source attributes required to route between settlements in 1544:
-nodes, active land/ferry edges, and settlement metadata. It is an adapted
+nodes, active land/ferry edges, and settlement metadata, including each
+settlement's approximate population estimate. It is an adapted
 dataset and must retain this attribution and CC BY-SA 4.0 licensing when
 distributed.
 

--- a/scripts/import_viabundus.py
+++ b/scripts/import_viabundus.py
@@ -119,6 +119,7 @@ def normalise(raw_dir: Path, year: int) -> dict[str, Any]:
                 "longitude": float(row["longitude"]),
                 "latitude": float(row["latitude"]),
                 "population_level": population_level(estimate[1] if estimate else None),
+                "population_estimate": estimate[1] * 1_000 if estimate else 0,
                 # Terrain-scene selection remains a tactical content decision.
                 "scene_key": "hills",
             }

--- a/wiki/strategic/Travel.md
+++ b/wiki/strategic/Travel.md
@@ -38,9 +38,13 @@ The historical world importer represents the Viabundus road system as graph
 nodes and edges in the strategic database. The initial 1544 import admits land
 roads and ferries; intermediate junctions, bridges, and ferry endpoints remain
 in the graph so that a route is not incorrectly collapsed into a direct line
-between settlements. Travel currently requires a connected land/ferry route
-between imported settlements. Route cost, party speed, terrain, rest stops,
-and encounters are subsequent layers on this graph.
+between settlements. Selecting a settlement name opens its overview, which
+lists the next connected settlements on the road/ferry graph. Selecting a
+destination shows its route distance and an MVP journey-time estimate at an
+average walking pace of 5 km/h. Confirming advances the character's strategic
+time by that duration and moves them to the destination. Route cost, party
+speed, terrain, rest stops, and encounters are subsequent layers on this
+graph.
 ### Rest Stops
 - A point may be made into a rest stop, at which you will rest for the day once you arrive.
 - Placing a rest stop at an inn allows you to fully rest faster (no watch schedule or tent pitching) increasing the amount of time available each day for traveling. The inn also has a cost, but this is trivially cheap unless you are an impoverished mendicant.


### PR DESCRIPTION
## Summary

- add a settlement overview reached from the settlement name, with connected destinations and direct travel actions
- calculate connected destinations from the imported road and ferry graph, advance strategic time at 5 km/h, and redirect after travel
- retain and display imported approximate population estimates as inhabitants instead of only UI population bands

## Verification

- `cargo check -p adventuresim-stdb-module -p strategic-web`
- regenerated SpacetimeDB client bindings
- reloaded the local Viabundus world data and confirmed a stored population estimate (`Göttingen: 7000`)
- local Strategic Web health endpoint returned HTTP 200
