### PR TITLE
Rework strategic chat window

### DIFF
--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -131,7 +131,7 @@ fn page_shell(
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=quest-status-2";
                 link rel="stylesheet" href="/static/css/components.css?v=map-quest-status-1";
-                link rel="stylesheet" href="/static/css/strategic.css?v=unified-chat-1";
+                link rel="stylesheet" href="/static/css/strategic.css?v=unified-chat-2";
                 link rel="stylesheet" href="/static/css/utilities.css?v=typed-frontend-1";
 
                 // Datastar
@@ -145,9 +145,9 @@ fn page_shell(
                     script src="/static/party-trade.js?v=live-control-init-1" {}
                     script src="/static/party-notifications.js?v=party-requests-2" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-2" defer {}
-                    script src="/static/service-quests.js?v=settlement-faith-1" defer {}
-                    script src="/static/chat-resize.js?v=floating-chat-1" defer {}
-                    script src="/static/local-chat.js?v=unified-chat-1" defer {}
+                    script src="/static/service-quests.js?v=unified-chat-2" defer {}
+                    script src="/static/chat-resize.js?v=floating-chat-2" defer {}
+                    script src="/static/local-chat.js?v=unified-chat-2" defer {}
                     script src="/static/strategic-condition.js?v=strategic-condition-2" defer {}
                 }
             }

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -131,7 +131,7 @@ fn page_shell(
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=quest-status-2";
                 link rel="stylesheet" href="/static/css/components.css?v=map-quest-status-1";
-                link rel="stylesheet" href="/static/css/strategic.css?v=dual-context-schedule-1";
+                link rel="stylesheet" href="/static/css/strategic.css?v=unified-chat-1";
                 link rel="stylesheet" href="/static/css/utilities.css?v=typed-frontend-1";
 
                 // Datastar
@@ -146,8 +146,8 @@ fn page_shell(
                     script src="/static/party-notifications.js?v=party-requests-2" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-2" defer {}
                     script src="/static/service-quests.js?v=settlement-faith-1" defer {}
-                    script src="/static/chat-resize.js?v=chat-resize-1" defer {}
-                    script src="/static/local-chat.js?v=quest-links-live-2" defer {}
+                    script src="/static/chat-resize.js?v=floating-chat-1" defer {}
+                    script src="/static/local-chat.js?v=unified-chat-1" defer {}
                     script src="/static/strategic-condition.js?v=strategic-condition-2" defer {}
                 }
             }

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1780,6 +1780,7 @@ fn chat_area(
             div class="settlement-chat-messages" aria-live="polite" {
                 @if local_context.is_none() { div class="chat-system-message" data-chat-channel="info" {
                     span class="chat-timestamp" { "[--:--]" }
+                    span class="chat-channel-badge" { " [Info] " }
                     " Select a local character or settlement service to begin talking."
                 } }
             }
@@ -2025,5 +2026,65 @@ mod tests {
             );
         }
         assert!(markup.contains("data-chat-channel=\"info\""));
+        assert!(markup.contains("class=\"chat-channel-badge\"> [Info] "));
+    }
+
+    #[test]
+    fn chat_palette_meets_text_contrast_on_the_lightest_composite() {
+        fn linear_channel(channel: u8) -> f64 {
+            let channel = f64::from(channel) / 255.0;
+            if channel <= 0.04045 {
+                channel / 12.92
+            } else {
+                ((channel + 0.055) / 1.055).powf(2.4)
+            }
+        }
+
+        fn luminance([red, green, blue]: [u8; 3]) -> f64 {
+            0.2126 * linear_channel(red)
+                + 0.7152 * linear_channel(green)
+                + 0.0722 * linear_channel(blue)
+        }
+
+        fn contrast(first: [u8; 3], second: [u8; 3]) -> f64 {
+            let (lighter, darker) = if luminance(first) > luminance(second) {
+                (luminance(first), luminance(second))
+            } else {
+                (luminance(second), luminance(first))
+            };
+            (lighter + 0.05) / (darker + 0.05)
+        }
+
+        // The 88% #0c0f18 surface over white is the lightest possible panel
+        // composite and therefore the lowest-contrast case for this palette.
+        let lightest_chat_surface = [41, 43, 52];
+        for (channel, color) in [
+            ("Local", [0xff, 0xff, 0xff]),
+            ("Party", [0x6f, 0xb5, 0xff]),
+            ("Settlement", [0xf2, 0xd2, 0x6b]),
+            ("DM", [0xc9, 0x95, 0xff]),
+            ("Guild", [0x73, 0xd5, 0x8a]),
+            ("Info", [0x9c, 0xa3, 0xad]),
+        ] {
+            assert!(
+                contrast(color, lightest_chat_surface) >= 4.5,
+                "{channel} does not meet WCAG AA text contrast"
+            );
+        }
+    }
+
+    #[test]
+    fn chat_css_keeps_fallbacks_and_mobile_message_space() {
+        let css = include_str!("../../static/css/strategic.css");
+        let fallback = css
+            .find("background: rgb(12 15 24 / 88%);")
+            .expect("chat needs a background fallback");
+        let enhanced = css
+            .find("background: color-mix(in srgb, #0c0f18 88%, transparent);")
+            .expect("chat should enhance its fallback with color-mix");
+
+        assert!(fallback < enhanced);
+        assert!(css.contains(".settlement-chat-filters {\n    flex-wrap: nowrap;"));
+        assert!(css.contains("min-height: 10rem;"));
     }
 }

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1718,8 +1718,9 @@ fn incapacitation_wheel(character_id: u64) -> Markup {
     }
 }
 
-/// Layout-only chat panel matching the UX prototype. Channels, message history,
-/// and sending are deliberately disabled until the strategic chat backend exists.
+/// Shared chat panel. Local conversations are live; the remaining channel
+/// filters are present so their messages can join the same stream as their
+/// backends become available.
 pub(crate) fn settlement_chat_area(location: &str, active_character: Option<&Character>) -> Markup {
     chat_area(location, active_character, None, None)
 }
@@ -1761,27 +1762,31 @@ fn chat_area(
                 aria-valuenow="184" tabindex="0" title="Drag to resize chat" {
                 span aria-hidden="true" {}
             }
-            div class="settlement-chat-tabs" role="tablist" aria-label="Chat channels" {
-                button type="button" class="settlement-chat-tab active" {
-                    "Local"
-                }
-                button type="button" class="settlement-chat-tab" disabled
-                    title="TODO: settlement chat requires real-time message delivery" {
-                    "Settlement"
-                }
-                button type="button" class="settlement-chat-tab" disabled
-                    title="TODO: guild chat requires guild membership and real-time message delivery" {
-                    "Guild"
+            div class="settlement-chat-filters" role="group" aria-label="Visible chat channels" {
+                @for (channel, label) in [
+                    ("local", "Local"),
+                    ("party", "Party"),
+                    ("settlement", "Settlement"),
+                    ("dm", "DMs"),
+                    ("guild", "Guild"),
+                    ("info", "Info"),
+                ] {
+                    label class=(format!("chat-channel-filter chat-channel-filter-{channel}")) {
+                        input type="checkbox" checked data-chat-filter=(channel);
+                        span { (label) }
+                    }
                 }
             }
             div class="settlement-chat-messages" aria-live="polite" {
-                @if local_context.is_none() { div class="chat-system-message" {
+                @if local_context.is_none() { div class="chat-system-message" data-chat-channel="info" {
                     span class="chat-timestamp" { "[--:--]" }
                     " Select a local character or settlement service to begin talking."
                 } }
             }
             div class="settlement-chat-composer" {
-                input type="text" name="body" disabled[local_context.is_none()] placeholder=(format!("Message {location}"));
+                input type="text" name="body" disabled[local_context.is_none()]
+                    aria-label="Local message"
+                    placeholder=(format!("Message {location} (Local)"));
                 button type="button" class="btn btn-primary btn-icon" disabled[local_context.is_none()]
                     aria-label="Send message" {
                     "➤"
@@ -2006,5 +2011,19 @@ mod tests {
         assert!(markup.contains("value=\"underprovisioned\""));
         assert!(!markup.contains("Provision and travel"));
         assert!(!markup.contains("Provision forecast"));
+    }
+
+    #[test]
+    fn chat_uses_one_stream_with_all_channel_filters() {
+        let markup = chat_area("Lubeck", None, None, None).into_string();
+
+        assert!(!markup.contains("role=\"tablist\""));
+        for channel in ["local", "party", "settlement", "dm", "guild", "info"] {
+            assert!(
+                markup.contains(&format!("data-chat-filter=\"{channel}\"")),
+                "missing {channel} filter"
+            );
+        }
+        assert!(markup.contains("data-chat-channel=\"info\""));
     }
 }

--- a/crates/strategic-web/static/chat-resize.js
+++ b/crates/strategic-web/static/chat-resize.js
@@ -1,6 +1,7 @@
 (() => {
   const STORAGE_KEY = "adventuresim.chat-height";
-  const MIN_HEIGHT = 128;
+  const DESKTOP_MIN_HEIGHT = 128;
+  const MOBILE_MIN_HEIGHT = 160;
   const MIN_STAGE_HEIGHT = 128;
   const CHAT_BOTTOM_GAP = 5;
   const KEYBOARD_STEP = 24;
@@ -10,12 +11,14 @@
   const container = chat?.closest(".settlement-main");
   if (!chat || !handle || !container) return;
 
-  const maximumHeight = () => Math.max(MIN_HEIGHT, container.clientHeight - MIN_STAGE_HEIGHT - CHAT_BOTTOM_GAP);
-  const clampHeight = (height) => Math.min(maximumHeight(), Math.max(MIN_HEIGHT, height));
+  const minimumHeight = () => window.matchMedia("(max-width: 768px)").matches ? MOBILE_MIN_HEIGHT : DESKTOP_MIN_HEIGHT;
+  const maximumHeight = () => Math.max(minimumHeight(), container.clientHeight - MIN_STAGE_HEIGHT - CHAT_BOTTOM_GAP);
+  const clampHeight = (height) => Math.min(maximumHeight(), Math.max(minimumHeight(), height));
 
   const setHeight = (height, persist = true) => {
     const next = Math.round(clampHeight(height));
     chat.style.setProperty("--chat-height", `${next}px`);
+    handle.setAttribute("aria-valuemin", String(minimumHeight()));
     handle.setAttribute("aria-valuenow", String(next));
     handle.setAttribute("aria-valuemax", String(Math.round(maximumHeight())));
     if (persist) localStorage.setItem(STORAGE_KEY, String(next));

--- a/crates/strategic-web/static/chat-resize.js
+++ b/crates/strategic-web/static/chat-resize.js
@@ -2,6 +2,7 @@
   const STORAGE_KEY = "adventuresim.chat-height";
   const MIN_HEIGHT = 128;
   const MIN_STAGE_HEIGHT = 128;
+  const CHAT_BOTTOM_GAP = 5;
   const KEYBOARD_STEP = 24;
 
   const chat = document.querySelector(".settlement-chat");
@@ -9,7 +10,7 @@
   const container = chat?.closest(".settlement-main");
   if (!chat || !handle || !container) return;
 
-  const maximumHeight = () => Math.max(MIN_HEIGHT, container.clientHeight - MIN_STAGE_HEIGHT);
+  const maximumHeight = () => Math.max(MIN_HEIGHT, container.clientHeight - MIN_STAGE_HEIGHT - CHAT_BOTTOM_GAP);
   const clampHeight = (height) => Math.min(maximumHeight(), Math.max(MIN_HEIGHT, height));
 
   const setHeight = (height, persist = true) => {

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -3,6 +3,8 @@
    SETTLEMENT INTERFACE
    ============================================ */
 .settlement-main {
+  --chat-bottom-gap: 0.3rem;
+  --chat-inline-gap: 1rem;
   display: flex;
   flex-direction: column;
   max-width: none;
@@ -1840,13 +1842,14 @@ button.party-portrait-action {
   display: flex;
   flex: 0 0 var(--chat-height);
   flex-direction: column;
-  margin: 0 1rem 0.3rem;
+  margin: 0 var(--chat-inline-gap) var(--chat-bottom-gap);
   min-height: 8rem;
-  max-height: calc(100% - 8rem - 0.3rem);
+  max-height: calc(100% - 8rem - var(--chat-bottom-gap));
   overflow: hidden;
   border: 1px solid var(--border-accent);
   border-radius: var(--radius);
-  background: color-mix(in srgb, var(--panel-bg) 78%, transparent);
+  background: rgb(12 15 24 / 88%);
+  background: color-mix(in srgb, #0c0f18 88%, transparent);
   box-shadow: 0 0.35rem 1rem #0005;
   backdrop-filter: blur(5px);
 }
@@ -1856,7 +1859,8 @@ button.party-portrait-action {
   flex: 0 0 0.65rem;
   place-items: center;
   border-bottom: 1px solid var(--border-light);
-  background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
+  background: rgb(17 21 33 / 90%);
+  background: color-mix(in srgb, #111521 90%, transparent);
   cursor: ns-resize;
   touch-action: none;
   user-select: none;
@@ -1895,7 +1899,8 @@ body.chat-resizing {
   flex: 0 0 auto;
   padding: 0.42rem 0.65rem;
   border-bottom: 1px solid var(--border-light);
-  background: color-mix(in srgb, var(--bg-secondary) 68%, transparent);
+  background: rgb(17 21 33 / 86%);
+  background: color-mix(in srgb, #111521 86%, transparent);
 }
 
 .chat-channel-filter {
@@ -1903,7 +1908,7 @@ body.chat-resizing {
   display: inline-flex;
   gap: 0.32rem;
   align-items: center;
-  color: var(--text-secondary);
+  color: #d7dbe4;
   font-family: var(--font-display), serif;
   font-size: var(--font-size-xs);
   letter-spacing: 0.05em;
@@ -1919,7 +1924,8 @@ body.chat-resizing {
   margin: 0;
   appearance: none;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--channel-color) 72%, #111);
+  border: 1px solid #353b48;
+  border-color: color-mix(in srgb, var(--channel-color) 72%, #111);
   border-radius: 0.2rem;
   background: var(--channel-color);
   box-shadow: inset 0 0 0 1px #0004;
@@ -1939,8 +1945,9 @@ body.chat-resizing {
 }
 
 .chat-channel-filter input:checked::after { opacity: 1; transform: scale(1); }
-.chat-channel-filter input:focus-visible { outline: 2px solid var(--text-primary); outline-offset: 2px; }
-.chat-channel-filter:has(input:not(:checked)) { opacity: 0.52; }
+.chat-channel-filter input:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+.chat-channel-filter input:not(:checked),
+.chat-channel-filter input:not(:checked) + span { opacity: 0.52; }
 
 .chat-channel-filter-local { --channel-color: #fff; }
 .chat-channel-filter-party { --channel-color: #4a9eff; }
@@ -1975,6 +1982,17 @@ body.chat-resizing {
   font-style: italic;
 }
 
+.chat-channel-badge {
+  display: inline-block;
+  min-width: 4.4em;
+  font-family: var(--font-display), serif;
+  font-size: 0.68rem;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
 .chat-quest-link {
   color: inherit;
   font-weight: 700;
@@ -1983,7 +2001,7 @@ body.chat-resizing {
 }
 
 .chat-timestamp {
-  color: var(--text-muted);
+  color: #a0a7b2;
   font-size: var(--font-size-xs);
 }
 
@@ -1993,7 +2011,8 @@ body.chat-resizing {
   flex: 0 0 auto;
   padding: 0.5rem;
   border-top: 1px solid var(--border-light);
-  background: color-mix(in srgb, var(--bg-secondary) 68%, transparent);
+  background: rgb(17 21 33 / 86%);
+  background: color-mix(in srgb, #111521 86%, transparent);
 }
 
 .settlement-chat-composer input {
@@ -2002,12 +2021,14 @@ body.chat-resizing {
   padding: 0.4rem 0.55rem;
   border: 1px solid var(--border-light);
   border-radius: var(--radius);
-  background: var(--bg-tertiary);
-  color: var(--text-muted);
+  background: rgb(255 255 255 / 10%);
+  color: #e2e5eb;
   font: inherit;
   font-size: var(--font-size-sm);
-  cursor: not-allowed;
+  cursor: text;
 }
+
+.settlement-chat-composer input:disabled { cursor: not-allowed; }
 
 .settlement-chat-composer .btn:disabled {
   opacity: 0.55;
@@ -2017,8 +2038,8 @@ body.chat-resizing {
 .local-chat-incoming {
   position: absolute;
   z-index: 6;
-  right: 0.75rem;
-  bottom: calc(var(--chat-height, 11.5rem) + 1.05rem);
+  right: calc(var(--chat-inline-gap) + 0.75rem);
+  bottom: calc(var(--chat-height, 11.5rem) + var(--chat-bottom-gap) + 0.75rem);
   display: flex;
   flex-direction: row-reverse;
   gap: 0.35rem;
@@ -2036,6 +2057,21 @@ body.chat-resizing {
   color: var(--text-primary);
   font-weight: 700;
   text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  .settlement-chat {
+    min-height: 10rem;
+    max-height: calc(100% - 8rem - var(--chat-bottom-gap));
+  }
+
+  .settlement-chat-filters {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: thin;
+  }
+
+  .chat-channel-filter { flex: 0 0 auto; }
 }
 
 .small-copy {

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -1834,19 +1834,21 @@ button.party-portrait-action {
   filter: drop-shadow(0 0 0.2rem #c84747);
 }
 
-/* Persistent, currently read-only chat area from the settlement UX prototype. */
+/* Unified floating chat stream. */
 .settlement-chat {
   --chat-height: 11.5rem;
   display: flex;
   flex: 0 0 var(--chat-height);
   flex-direction: column;
+  margin: 0 1rem 0.3rem;
   min-height: 8rem;
-  max-height: calc(100% - 8rem);
+  max-height: calc(100% - 8rem - 0.3rem);
   overflow: hidden;
   border: 1px solid var(--border-accent);
   border-radius: var(--radius);
-  background: var(--panel-bg);
-  box-shadow: var(--shadow-sm);
+  background: color-mix(in srgb, var(--panel-bg) 78%, transparent);
+  box-shadow: 0 0.35rem 1rem #0005;
+  backdrop-filter: blur(5px);
 }
 
 .settlement-chat-resize {
@@ -1854,7 +1856,7 @@ button.party-portrait-action {
   flex: 0 0 0.65rem;
   place-items: center;
   border-bottom: 1px solid var(--border-light);
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--bg-secondary) 72%, transparent);
   cursor: ns-resize;
   touch-action: none;
   user-select: none;
@@ -1885,37 +1887,67 @@ body.chat-resizing {
   user-select: none;
 }
 
-.settlement-chat-tabs {
+.settlement-chat-filters {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.8rem;
+  align-items: center;
   flex: 0 0 auto;
+  padding: 0.42rem 0.65rem;
   border-bottom: 1px solid var(--border-light);
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--bg-secondary) 68%, transparent);
 }
 
-.settlement-chat-tab {
-  flex: 1;
-  min-width: 0;
-  padding: 0.45rem 0.6rem;
-  border: 0;
-  border-right: 1px solid var(--border-light);
-  background: transparent;
-  color: var(--text-muted);
+.chat-channel-filter {
+  --channel-color: #fff;
+  display: inline-flex;
+  gap: 0.32rem;
+  align-items: center;
+  color: var(--text-secondary);
   font-family: var(--font-display), serif;
   font-size: var(--font-size-xs);
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  cursor: not-allowed;
+  cursor: pointer;
+  user-select: none;
 }
 
-.settlement-chat-tab:last-child {
-  border-right: 0;
+.chat-channel-filter input {
+  display: grid;
+  width: 0.9rem;
+  height: 0.9rem;
+  margin: 0;
+  appearance: none;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--channel-color) 72%, #111);
+  border-radius: 0.2rem;
+  background: var(--channel-color);
+  box-shadow: inset 0 0 0 1px #0004;
+  cursor: pointer;
 }
 
-.settlement-chat-tab.active {
-  background: var(--panel-bg);
-  color: var(--accent-dark);
-  box-shadow: inset 0 -2px 0 var(--accent);
+.chat-channel-filter input::after {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 0 0 1px #0008;
+  content: "";
+  opacity: 0;
+  transform: scale(0.45);
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
 }
+
+.chat-channel-filter input:checked::after { opacity: 1; transform: scale(1); }
+.chat-channel-filter input:focus-visible { outline: 2px solid var(--text-primary); outline-offset: 2px; }
+.chat-channel-filter:has(input:not(:checked)) { opacity: 0.52; }
+
+.chat-channel-filter-local { --channel-color: #fff; }
+.chat-channel-filter-party { --channel-color: #4a9eff; }
+.chat-channel-filter-settlement { --channel-color: #e6bd3f; }
+.chat-channel-filter-dm { --channel-color: #a968e8; }
+.chat-channel-filter-guild { --channel-color: #43ad62; }
+.chat-channel-filter-info { --channel-color: #858b94; }
 
 .settlement-chat-messages {
   flex: 1;
@@ -1932,21 +1964,19 @@ body.chat-resizing {
   margin-bottom: 0.35rem;
 }
 
+.settlement-chat-messages [data-chat-channel="local"] { color: #fff; }
+.settlement-chat-messages [data-chat-channel="party"] { color: #6fb5ff; }
+.settlement-chat-messages [data-chat-channel="settlement"] { color: #f2d26b; }
+.settlement-chat-messages [data-chat-channel="dm"] { color: #c995ff; }
+.settlement-chat-messages [data-chat-channel="guild"] { color: #73d58a; }
+.settlement-chat-messages [data-chat-channel="info"] { color: #9ca3ad; }
+
 .chat-system-message {
-  color: var(--text-muted);
   font-style: italic;
 }
 
-.chat-npc-message {
-  color: var(--text-primary);
-}
-
-.chat-player-message {
-  color: var(--accent-dark);
-}
-
 .chat-quest-link {
-  color: var(--accent);
+  color: inherit;
   font-weight: 700;
   text-decoration: underline;
   text-underline-offset: 0.14em;
@@ -1963,7 +1993,7 @@ body.chat-resizing {
   flex: 0 0 auto;
   padding: 0.5rem;
   border-top: 1px solid var(--border-light);
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--bg-secondary) 68%, transparent);
 }
 
 .settlement-chat-composer input {
@@ -1988,7 +2018,7 @@ body.chat-resizing {
   position: absolute;
   z-index: 6;
   right: 0.75rem;
-  bottom: calc(var(--chat-height, 11.5rem) + 0.75rem);
+  bottom: calc(var(--chat-height, 11.5rem) + 1.05rem);
   display: flex;
   flex-direction: row-reverse;
   gap: 0.35rem;

--- a/crates/strategic-web/static/local-chat.js
+++ b/crates/strategic-web/static/local-chat.js
@@ -1,4 +1,22 @@
 (() => {
+  document.querySelectorAll(".settlement-chat").forEach((panel) => {
+    const messages = panel.querySelector(".settlement-chat-messages");
+    const filters = [...panel.querySelectorAll("[data-chat-filter]")];
+    if (!messages || !filters.length) return;
+
+    const applyFilters = () => {
+      const visibleChannels = new Set(filters
+        .filter((filter) => filter.checked)
+        .map((filter) => filter.dataset.chatFilter));
+      messages.querySelectorAll("[data-chat-channel]").forEach((message) => {
+        message.hidden = !visibleChannels.has(message.dataset.chatChannel);
+      });
+    };
+    filters.forEach((filter) => filter.addEventListener("change", applyFilters));
+    new MutationObserver(applyFilters).observe(messages, { childList: true, subtree: true });
+    applyFilters();
+  });
+
   const incomingHost = document.createElement("div");
   incomingHost.className = "local-chat-incoming";
   document.querySelector("main.center-content")?.append(incomingHost);
@@ -80,6 +98,7 @@
       }
       const row = document.createElement("div");
       row.className = message.sender_id === 0 ? "chat-npc-message" : "chat-player-message";
+      row.dataset.chatChannel = "local";
       const time = document.createElement("span");
       time.className = "chat-timestamp";
       time.textContent = `[${new Date(message.created_micros / 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}] `;

--- a/crates/strategic-web/static/local-chat.js
+++ b/crates/strategic-web/static/local-chat.js
@@ -1,4 +1,68 @@
 (() => {
+  const CHANNEL_LABELS = Object.freeze({
+    local: "Local",
+    party: "Party",
+    settlement: "Settlement",
+    dm: "DM",
+    guild: "Guild",
+    info: "Info",
+  });
+
+  const chatTimestamp = (row) => {
+    const value = Number(row.dataset.chatCreatedMicros);
+    return Number.isFinite(value) && value > 0 ? value : Number.POSITIVE_INFINITY;
+  };
+
+  const mergeChannelRows = (existingRows, channel, replacementRows, pendingRows = []) => {
+    const rows = [
+      ...existingRows.filter((row) => row.dataset.chatChannel !== channel),
+      ...replacementRows,
+      ...pendingRows,
+    ];
+    return rows
+      .map((row, index) => ({
+        row,
+        index,
+        messageId: row.dataset.chatMessageId || "",
+        timestamp: chatTimestamp(row),
+      }))
+      .sort((left, right) => left.timestamp - right.timestamp
+        || left.messageId.localeCompare(right.messageId, undefined, { numeric: true })
+        || left.index - right.index)
+      .map(({ row }) => row);
+  };
+
+  const applyChannelVisibility = (rows, visibleChannels) => {
+    rows.forEach((message) => {
+      message.hidden = !visibleChannels.has(message.dataset.chatChannel);
+    });
+  };
+
+  const channelBadge = (channel, ownerDocument) => {
+    const badge = ownerDocument.createElement("span");
+    badge.className = "chat-channel-badge";
+    badge.textContent = `[${CHANNEL_LABELS[channel] || channel}] `;
+    return badge;
+  };
+
+  const decorateMessage = (message, ownerDocument) => {
+    if (message.querySelector(".chat-channel-badge")) return;
+    const badge = channelBadge(message.dataset.chatChannel, ownerDocument);
+    const timestamp = message.querySelector(".chat-timestamp");
+    if (timestamp) timestamp.after(badge);
+    else message.prepend(badge);
+  };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+      applyChannelVisibility,
+      chatTimestamp,
+      decorateMessage,
+      mergeChannelRows,
+    };
+  }
+  if (typeof document === "undefined") return;
+
   document.querySelectorAll(".settlement-chat").forEach((panel) => {
     const messages = panel.querySelector(".settlement-chat-messages");
     const filters = [...panel.querySelectorAll("[data-chat-filter]")];
@@ -8,9 +72,9 @@
       const visibleChannels = new Set(filters
         .filter((filter) => filter.checked)
         .map((filter) => filter.dataset.chatFilter));
-      messages.querySelectorAll("[data-chat-channel]").forEach((message) => {
-        message.hidden = !visibleChannels.has(message.dataset.chatChannel);
-      });
+      const rows = [...messages.querySelectorAll("[data-chat-channel]")];
+      rows.forEach((message) => decorateMessage(message, document));
+      applyChannelVisibility(rows, visibleChannels);
     };
     filters.forEach((filter) => filter.addEventListener("change", applyFilters));
     new MutationObserver(applyFilters).observe(messages, { childList: true, subtree: true });
@@ -63,10 +127,11 @@
     // the persisted copy of that line arrives over SSE, retain the matching DOM
     // row so reconciliation does not replace the anchor and its click handler
     // with plain text. Unmatched rows are pending writes and stay at the end.
+    const existingRows = [...messages.children];
     const interactiveRows = [...new Set(
       [...messages.querySelectorAll(".chat-quest-link")]
         .map((anchor) => anchor.closest(".chat-npc-message, .chat-player-message"))
-        .filter((row) => row?.dataset.localChatBody),
+        .filter((row) => row?.dataset.chatChannel === "local" && row.dataset.localChatBody),
     )];
     const interactiveByMessage = new Map();
     const pendingInteractiveRows = [];
@@ -84,30 +149,35 @@
       if (match >= 0) interactiveByMessage.set(match, row);
       else pendingInteractiveRows.push(row);
     }
-    messages.replaceChildren();
-    data.messages.forEach((message, index) => {
+    const localRows = data.messages.map((message, index) => {
       const interactiveRow = interactiveByMessage.get(index);
       if (interactiveRow) {
         const row = interactiveRow;
+        row.dataset.chatChannel = "local";
+        row.dataset.chatMessageId = String(message.id);
+        row.dataset.chatCreatedMicros = String(message.created_micros);
         const time = row.querySelector(".chat-timestamp");
         if (time) {
           time.textContent = `[${new Date(message.created_micros / 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}] `;
         }
-        messages.append(row);
-        return;
+        decorateMessage(row, document);
+        return row;
       }
       const row = document.createElement("div");
       row.className = message.sender_id === 0 ? "chat-npc-message" : "chat-player-message";
       row.dataset.chatChannel = "local";
+      row.dataset.chatMessageId = String(message.id);
+      row.dataset.chatCreatedMicros = String(message.created_micros);
       const time = document.createElement("span");
       time.className = "chat-timestamp";
       time.textContent = `[${new Date(message.created_micros / 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}] `;
+      const badge = channelBadge("local", document);
       const name = document.createElement("strong");
       name.textContent = `${message.sender_name}: `;
-      row.append(time, name, document.createTextNode(message.body));
-      messages.append(row);
+      row.append(time, badge, name, document.createTextNode(message.body));
+      return row;
     });
-    messages.append(...pendingInteractiveRows);
+    messages.replaceChildren(...mergeChannelRows(existingRows, "local", localRows, pendingInteractiveRows));
     messages.scrollTop = messages.scrollHeight;
   };
   const submit = async () => {

--- a/crates/strategic-web/static/service-quests.js
+++ b/crates/strategic-web/static/service-quests.js
@@ -14,6 +14,7 @@
     const row = document.createElement("div");
     const body = typeof content === "string" ? content : content.textContent;
     row.className = kind === "player" ? "chat-player-message" : "chat-npc-message";
+    row.dataset.chatChannel = "local";
     row.dataset.localChatBody = body || "";
     row.dataset.localChatSpeaker = speaker || "";
     const timestamp = document.createElement("span");

--- a/crates/strategic-web/static/service-quests.js
+++ b/crates/strategic-web/static/service-quests.js
@@ -20,7 +20,10 @@
     const timestamp = document.createElement("span");
     timestamp.className = "chat-timestamp";
     timestamp.textContent = "[--:--] ";
-    row.append(timestamp);
+    const badge = document.createElement("span");
+    badge.className = "chat-channel-badge";
+    badge.textContent = "[Local] ";
+    row.append(timestamp, badge);
     if (speaker) {
       const name = document.createElement("strong");
       name.textContent = `${speaker}: `;

--- a/crates/strategic-web/tests/local-chat.test.cjs
+++ b/crates/strategic-web/tests/local-chat.test.cjs
@@ -1,0 +1,79 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  applyChannelVisibility,
+  chatTimestamp,
+  decorateMessage,
+  mergeChannelRows,
+} = require("../static/local-chat.js");
+
+const row = (channel, id, createdMicros) => ({
+  dataset: {
+    chatChannel: channel,
+    chatMessageId: id,
+    ...(createdMicros === undefined ? {} : { chatCreatedMicros: String(createdMicros) }),
+  },
+  hidden: false,
+});
+
+test("channel visibility applies to existing and dynamically inserted messages", () => {
+  const local = row("local", "local-1", 100);
+  const party = row("party", "party-1", 200);
+  const info = row("info", "info-1", 300);
+
+  applyChannelVisibility([local, party], new Set(["local"]));
+  assert.equal(local.hidden, false);
+  assert.equal(party.hidden, true);
+
+  applyChannelVisibility([local, party, info], new Set(["local", "info"]));
+  assert.equal(info.hidden, false);
+  assert.equal(party.hidden, true);
+});
+
+test("Local reconciliation preserves other channels and chronological order", () => {
+  const staleLocal = row("local", "local-old", 50);
+  const party = row("party", "party-1", 300);
+  const info = row("info", "info-1", 200);
+  const replacementLocal = row("local", "local-1", 100);
+  const pendingLocal = row("local", "local-pending");
+
+  const merged = mergeChannelRows(
+    [staleLocal, party, info],
+    "local",
+    [replacementLocal],
+    [pendingLocal],
+  );
+
+  assert.deepEqual(merged, [replacementLocal, info, party, pendingLocal]);
+  assert.equal(merged.includes(staleLocal), false);
+});
+
+test("message IDs provide deterministic ordering when timestamps match", () => {
+  const laterId = row("party", "10", 100);
+  const earlierId = row("local", "2", 100);
+
+  const merged = mergeChannelRows([laterId], "local", [earlierId]);
+
+  assert.deepEqual(merged, [earlierId, laterId]);
+  assert.equal(chatTimestamp(row("info", "pending")), Number.POSITIVE_INFINITY);
+});
+
+test("message decoration adds a visible channel label beside the timestamp", () => {
+  const inserted = [];
+  const timestamp = { after: (element) => inserted.push(element) };
+  const message = {
+    dataset: { chatChannel: "guild" },
+    prepend: (element) => inserted.unshift(element),
+    querySelector: (selector) => selector === ".chat-timestamp" ? timestamp : null,
+  };
+  const ownerDocument = {
+    createElement: () => ({ className: "", textContent: "" }),
+  };
+
+  decorateMessage(message, ownerDocument);
+
+  assert.equal(inserted.length, 1);
+  assert.equal(inserted[0].className, "chat-channel-badge");
+  assert.equal(inserted[0].textContent, "[Guild] ");
+});

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -54,6 +54,7 @@ Now when you click a location in the browser, a tactical server will automatical
   `curl -sSf https://install.spacetimedb.com | bash`, then
   `spacetime version install 2.6.1` and `spacetime version use 2.6.1`
 - Python 3
+- Node.js 20 or newer (strategic browser behavior tests)
 - wasm-bindgen (`cargo install wasm-bindgen-cli`) - for WASM builds
 - Caddy (for the HTTPS HTTP/2 development entry point)
 
@@ -79,6 +80,8 @@ just spawner          # Run tactical server spawner
 just build-wasm       # Build WASM client
 
 # Testing
+just test             # Run the Rust workspace and strategic browser behavior tests
+just test-chat        # Run only the strategic chat behavior tests
 just tactical         # Run a single tactical server (for testing)
 just status           # Check service status
 just stop             # Stop all services

--- a/justfile
+++ b/justfile
@@ -382,7 +382,10 @@ win-dev:
 check:
     @cargo check --workspace
 
-test:
+test-chat:
+    @node --test crates/strategic-web/tests/local-chat.test.cjs
+
+test: test-chat
     @cargo test --workspace
 
 fmt:

--- a/wiki/strategic/Settlement.md
+++ b/wiki/strategic/Settlement.md
@@ -8,7 +8,7 @@ Services show up at the top, above the list of items in their own list. Each ser
 
 In the center of the screen, clients may render a 3D window of the NPC representing the service. They can have dialogue that plays, like a greeting when you open their menu, a goodbye when you leave it, and comments as you interact with their menu. But this should never interfere with the gameplay. You don't have to click through dialogue in order to buy something, it just plays in the background as you use their service. This is not important for the MVP, and later down the line this would also be a great opportunity to add voice acting and mocap to give the world some personality.
 
-The shared chat panel can be resized vertically from its top edge. Its height is shared across settlement and quest-location pages and remembered by the client.
+The shared chat panel floats just above the bottom of the center view with a translucent background and can be resized vertically from its top edge. Its height is shared across settlement and quest-location pages and remembered by the client. Local, Party, Settlement, direct-message, Guild, and Info messages share one chronological stream rather than separate tabs. A row of colored dot toggles filters each channel: Local is white, Party blue, Settlement yellow, direct messages purple, Guild green, and Info grey. Info is reserved for game notices such as inventory and currency changes.
 > Halbe: The inspiration for this is the Maiden in Black from Demon's Souls, who recites an incantation while you are in the level-up menu.
 
 # Social


### PR DESCRIPTION
## Summary

- replace separate chat-channel tabs with one combined, chronologically ordered stream
- add colored dot filters for Local, Party, Settlement, DMs, Guild, and Info
- give every message a visible channel label and preserve non-Local rows during Local refreshes
- float the panel above the center view with a dark translucent, contrast-tested surface
- keep filters usable on narrow layouts and align incoming-player portraits with the inset panel
- add browser behavior tests plus contrast and responsive layout contract tests

## Why

The chat design now treats channels as filters over one conversation window instead of separate destinations. This keeps cross-channel activity visible together while retaining clear visual identity and user-controlled filtering.

The follow-up hardening addresses review findings around light-theme contrast, mixed-channel reconciliation, accessibility, narrow-screen sizing, CSS compatibility fallbacks, portrait alignment, and test coverage.

## Impact

Players get one floating chat surface with consistent channel colors across themes. Local remains the currently backed channel, while the markup and reconciliation behavior safely support Party, Settlement, DM, Guild, and Info messages as those sources are added.

Developers can run the focused browser behavior suite with `just test-chat`; `just test` now includes it.

## Validation

- `cargo test -p strategic-web` — 18 passed
- `node --test crates/strategic-web/tests/local-chat.test.cjs` — 4 passed
- JavaScript syntax checks for the changed chat scripts
- `python scripts/update_project_map.py --check`
- `git diff --check`
