### PR TITLE
Integrate environmental world data sources

### DIFF
--- a/crates/adventuresim-stdb-client/src/settlement_import_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_import_type.rs
@@ -36,6 +36,7 @@ pub struct SettlementImport {
     pub drought: DroughtProfile,
     pub hydrology: SettlementHydrology,
     pub scene_key: String,
+    pub sources: String,
 }
 
 impl __sdk::InModule for SettlementImport {

--- a/crates/adventuresim-stdb-client/src/settlement_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_type.rs
@@ -37,6 +37,7 @@ pub struct Settlement {
     pub scene_key: String,
     pub religion_id: String,
     pub source_node_id: Option<u64>,
+    pub sources: String,
 }
 
 impl __sdk::InModule for Settlement {

--- a/crates/adventuresim-stdb-client/src/travel_edge_import_type.rs
+++ b/crates/adventuresim-stdb-client/src/travel_edge_import_type.rs
@@ -19,6 +19,7 @@ pub struct TravelEdgeImport {
     pub slope_multiplier: f32,
     pub certainty: u8,
     pub section: String,
+    pub sources: String,
 }
 
 impl __sdk::InModule for TravelEdgeImport {

--- a/crates/adventuresim-stdb-client/src/travel_edge_type.rs
+++ b/crates/adventuresim-stdb-client/src/travel_edge_type.rs
@@ -19,6 +19,7 @@ pub struct TravelEdge {
     pub slope_multiplier: f32,
     pub certainty: u8,
     pub section: String,
+    pub sources: String,
 }
 
 impl __sdk::InModule for TravelEdge {

--- a/crates/adventuresim-stdb-client/src/world_data_import_type.rs
+++ b/crates/adventuresim-stdb-client/src/world_data_import_type.rs
@@ -11,6 +11,7 @@ pub struct WorldDataImport {
     pub owner: __sdk::Identity,
     pub schema_version: u32,
     pub artifact_id: String,
+    pub sources: String,
     pub completed: bool,
 }
 

--- a/crates/adventuresim-stdb-client/src/world_node_import_type.rs
+++ b/crates/adventuresim-stdb-client/src/world_node_import_type.rs
@@ -15,6 +15,7 @@ pub struct WorldNodeImport {
     pub is_town: bool,
     pub is_ferry: bool,
     pub is_harbour: bool,
+    pub sources: String,
 }
 
 impl __sdk::InModule for WorldNodeImport {

--- a/crates/adventuresim-stdb-client/src/world_node_type.rs
+++ b/crates/adventuresim-stdb-client/src/world_node_type.rs
@@ -15,6 +15,7 @@ pub struct WorldNode {
     pub is_town: bool,
     pub is_ferry: bool,
     pub is_harbour: bool,
+    pub sources: String,
 }
 
 impl __sdk::InModule for WorldNode {

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -11,7 +11,7 @@ use adventuresim_world_schema::{
     SoilDepth, SoilMappingUnit, SoilProfile, SoilProperties, SoilSubstrate, SoilWaterRegime,
     StoneContentPercent, SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport,
     TravelRoute, TreeSpeciesId, TreeSpeciesProfile, UnconsolidatedDeposit, WORLD_SCHEMA_VERSION,
-    Woodland, WorldNodeImport,
+    Woodland, WorldNodeImport, valid_sources_markdown,
 };
 use spacetimedb::{Identity, ReducerContext, SpacetimeType, Table, reducer, table};
 
@@ -114,6 +114,9 @@ pub struct Settlement {
     /// the historical world dataset. Demo settlements deliberately leave this
     /// empty.
     pub source_node_id: Option<u64>,
+    /// Unstructured Markdown explaining source evidence and deterministic
+    /// inferences. Reserved for a future debug view.
+    pub sources: String,
 }
 
 /// A navigational point in the imported Viabundus network. This contains the
@@ -130,6 +133,8 @@ pub struct WorldNode {
     pub is_town: bool,
     pub is_ferry: bool,
     pub is_harbour: bool,
+    /// Unstructured Markdown source notes for future debugging.
+    pub sources: String,
 }
 
 /// An active 1544 land-network segment. Geometry remains an offline map asset;
@@ -149,6 +154,8 @@ pub struct TravelEdge {
     pub slope_multiplier: f32,
     pub certainty: u8,
     pub section: String,
+    /// Unstructured Markdown source and inference notes for future debugging.
+    pub sources: String,
 }
 
 /// The identity that started the one-time local world-data import. All later
@@ -161,6 +168,9 @@ pub struct WorldDataImport {
     pub owner: Identity,
     pub schema_version: u32,
     pub artifact_id: String,
+    /// Unstructured Markdown describing the source distributions in this
+    /// compiled artifact. Per-record inference details live on imported rows.
+    pub sources: String,
     pub completed: bool,
 }
 
@@ -172,6 +182,7 @@ pub fn begin_world_data_import(
     ctx: &ReducerContext,
     schema_version: u32,
     artifact_id: String,
+    sources: String,
 ) -> Result<(), String> {
     if schema_version != WORLD_SCHEMA_VERSION {
         return Err(format!(
@@ -181,12 +192,17 @@ pub fn begin_world_data_import(
     if artifact_id.trim().is_empty() {
         return Err("World artifact ID must not be empty".into());
     }
+    if !valid_sources_markdown(&sources) {
+        return Err("World source notes are empty, too large, or contain a NUL byte".into());
+    }
     match ctx.db.world_data_import().id().find(0) {
         Some(import) if import.owner != ctx.sender() => {
             Err("World data import is owned by another identity".into())
         }
         Some(import)
-            if import.schema_version == schema_version && import.artifact_id == artifact_id =>
+            if import.schema_version == schema_version
+                && import.artifact_id == artifact_id
+                && import.sources == sources =>
         {
             if import.completed {
                 Err("This world artifact has already been imported".into())
@@ -204,6 +220,7 @@ pub fn begin_world_data_import(
                 owner: ctx.sender(),
                 schema_version,
                 artifact_id,
+                sources,
                 completed: false,
             });
             Ok(())
@@ -244,6 +261,9 @@ pub fn import_world_nodes(ctx: &ReducerContext, nodes: Vec<WorldNodeImport>) -> 
         return Err("World-node batch is empty".into());
     }
     for node in nodes {
+        if !valid_sources_markdown(&node.sources) {
+            return Err(format!("World node {} has invalid source notes", node.id));
+        }
         let row = WorldNode {
             id: node.id,
             parent_node_id: node.parent_node_id,
@@ -253,6 +273,7 @@ pub fn import_world_nodes(ctx: &ReducerContext, nodes: Vec<WorldNodeImport>) -> 
             is_town: node.is_town,
             is_ferry: node.is_ferry,
             is_harbour: node.is_harbour,
+            sources: node.sources,
         };
         if ctx.db.world_node().id().find(row.id).is_some() {
             ctx.db.world_node().id().update(row);
@@ -282,6 +303,9 @@ pub fn import_travel_edges(
             ));
         }
         validate_travel_route(edge.id, &edge.route)?;
+        if !valid_sources_markdown(&edge.sources) {
+            return Err(format!("Travel edge {} has invalid source notes", edge.id));
+        }
         let row = TravelEdge {
             id: edge.id,
             from_node_id: edge.from_node_id,
@@ -292,6 +316,7 @@ pub fn import_travel_edges(
             slope_multiplier: edge.slope_multiplier,
             certainty: edge.certainty,
             section: edge.section,
+            sources: edge.sources,
         };
         if ctx.db.travel_edge().id().find(row.id).is_some() {
             ctx.db.travel_edge().id().update(row);
@@ -419,6 +444,12 @@ pub fn import_settlements(
         let geology = reconstruct_geology_profile(&settlement.id, settlement.geology)?;
         let drought = reconstruct_drought_profile(&settlement.id, settlement.drought)?;
         validate_settlement_hydrology(&settlement.id, settlement.hydrology)?;
+        if !valid_sources_markdown(&settlement.sources) {
+            return Err(format!(
+                "Settlement {} has invalid source notes",
+                settlement.id
+            ));
+        }
         if ctx
             .db
             .world_node()
@@ -451,6 +482,7 @@ pub fn import_settlements(
             drought,
             hydrology: settlement.hydrology,
             source_node_id: Some(settlement.source_node_id),
+            sources: settlement.sources,
         };
         let settlement_id = row.id.clone();
         if ctx.db.settlement().id().find(&row.id).is_some() {
@@ -4101,6 +4133,7 @@ pub fn seed_world(ctx: &ReducerContext) -> Result<(), String> {
                 scene_key: scene.into(),
                 religion_id: religious_status.church().faith_id().into(),
                 source_node_id: None,
+                sources: "- **Adventure Simulator demo data:** Hand-authored settlement and deterministic placeholder environment; no external world-data source was imported.".into(),
             });
         }
     }

--- a/crates/adventuresim-world-import/src/draft.rs
+++ b/crates/adventuresim-world-import/src/draft.rs
@@ -38,6 +38,7 @@ pub(crate) struct TravelEdgeDraft {
     pub(crate) slope_multiplier: f32,
     pub(crate) certainty: u8,
     pub(crate) section: String,
+    pub(crate) sources: String,
 }
 
 #[derive(Debug)]
@@ -50,6 +51,45 @@ pub(crate) struct SettlementDraft {
     pub(crate) population_level: i32,
     pub(crate) population_estimate: u32,
     pub(crate) scene_key: String,
+    pub(crate) sources: String,
+}
+
+pub(crate) trait SettlementDraftAccess {
+    fn base_settlement(&self) -> &SettlementDraft;
+    fn base_settlement_mut(&mut self) -> &mut SettlementDraft;
+}
+
+impl SettlementDraftAccess for SettlementDraft {
+    fn base_settlement(&self) -> &SettlementDraft {
+        self
+    }
+
+    fn base_settlement_mut(&mut self) -> &mut SettlementDraft {
+        self
+    }
+}
+
+macro_rules! delegate_settlement_access {
+    ($type:ty, $field:ident) => {
+        impl SettlementDraftAccess for $type {
+            fn base_settlement(&self) -> &SettlementDraft {
+                self.$field.base_settlement()
+            }
+
+            fn base_settlement_mut(&mut self) -> &mut SettlementDraft {
+                self.$field.base_settlement_mut()
+            }
+        }
+    };
+}
+
+pub(crate) fn push_source_note(target: &mut impl SettlementDraftAccess, note: &str) {
+    let sources = &mut target.base_settlement_mut().sources;
+    if !sources.is_empty() {
+        sources.push('\n');
+    }
+    sources.push_str("- ");
+    sources.push_str(note);
 }
 
 #[derive(Debug)]
@@ -57,51 +97,87 @@ pub(crate) struct ElevatedSettlementDraft {
     pub(crate) settlement: SettlementDraft,
     pub(crate) elevation: ElevationMeters,
 }
+delegate_settlement_access!(ElevatedSettlementDraft, settlement);
 
 #[derive(Debug)]
 pub(crate) struct LandUseSettlementDraft {
     pub(crate) elevated: ElevatedSettlementDraft,
     pub(crate) land_use: LandUseProfile,
 }
+delegate_settlement_access!(LandUseSettlementDraft, elevated);
 
 #[derive(Debug)]
 pub(crate) struct ForestSettlementDraft {
     pub(crate) land: LandUseSettlementDraft,
     pub(crate) forest_cover: ForestCover,
 }
+delegate_settlement_access!(ForestSettlementDraft, land);
 
 #[derive(Debug)]
 pub(crate) struct PotentialVegetationSettlementDraft {
     pub(crate) forest: ForestSettlementDraft,
     pub(crate) potential_vegetation: PotentialVegetation,
 }
+delegate_settlement_access!(PotentialVegetationSettlementDraft, forest);
 
 #[derive(Debug)]
 pub(crate) struct TreeSpeciesSettlementDraft {
     pub(crate) vegetated: PotentialVegetationSettlementDraft,
     pub(crate) tree_species: TreeSpeciesProfile,
 }
+delegate_settlement_access!(TreeSpeciesSettlementDraft, vegetated);
 
 #[derive(Debug)]
 pub(crate) struct SoilSettlementDraft {
     pub(crate) trees: TreeSpeciesSettlementDraft,
     pub(crate) soil: SoilProfile,
 }
+delegate_settlement_access!(SoilSettlementDraft, trees);
 
 #[derive(Debug)]
 pub(crate) struct GeologySettlementDraft {
     pub(crate) soil: SoilSettlementDraft,
     pub(crate) geology: adventuresim_world_schema::SurfaceGeology,
 }
+delegate_settlement_access!(GeologySettlementDraft, soil);
 
 #[derive(Debug)]
 pub(crate) struct ReligionSettlementDraft {
     pub(crate) geologic: GeologySettlementDraft,
     pub(crate) religious_status: adventuresim_world_schema::SettlementReligiousStatus,
 }
+delegate_settlement_access!(ReligionSettlementDraft, geologic);
 
 #[derive(Debug)]
 pub(crate) struct DroughtSettlementDraft {
     pub(crate) religious: ReligionSettlementDraft,
     pub(crate) drought: DroughtProfile,
+}
+delegate_settlement_access!(DroughtSettlementDraft, religious);
+
+#[cfg(test)]
+mod tests {
+    use super::{SettlementDraft, push_source_note};
+
+    #[test]
+    fn source_notes_append_as_deterministic_markdown_bullets() {
+        let mut settlement = SettlementDraft {
+            id: "test".into(),
+            source_node_id: 1,
+            name: "Test".into(),
+            longitude: 0.0,
+            latitude: 0.0,
+            population_level: 1,
+            population_estimate: 0,
+            scene_key: "test".into(),
+            sources: "- First source.".into(),
+        };
+
+        push_source_note(&mut settlement, "**Fallback:** Deterministic guess.");
+
+        assert_eq!(
+            settlement.sources,
+            "- First source.\n- **Fallback:** Deterministic guess."
+        );
+    }
 }

--- a/crates/adventuresim-world-import/src/main.rs
+++ b/crates/adventuresim-world-import/src/main.rs
@@ -111,10 +111,26 @@ fn run(args: Args) -> Result<()> {
 }
 
 fn load_world(world: &CompiledWorld, artifact_id: &str, args: &Args) -> Result<()> {
+    let sources = world
+        .metadata
+        .sources
+        .iter()
+        .map(|source| {
+            format!(
+                "- **[{}]({}):** {}",
+                source.name, source.url, source.license
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
     call_reducer(
         args,
         "begin_world_data_import",
-        &[json!(world.metadata.schema_version), json!(artifact_id)],
+        &[
+            json!(world.metadata.schema_version),
+            json!(artifact_id),
+            json!(sources),
+        ],
     )?;
 
     for (label, reducer, batches) in [
@@ -190,6 +206,7 @@ fn encode_world_node(node: &WorldNodeImport) -> Result<Value> {
         "is_town": node.is_town,
         "is_ferry": node.is_ferry,
         "is_harbour": node.is_harbour,
+        "sources": node.sources,
     }))
 }
 
@@ -217,6 +234,7 @@ fn encode_travel_edge(edge: &TravelEdgeImport) -> Result<Value> {
         "slope_multiplier": edge.slope_multiplier,
         "certainty": edge.certainty,
         "section": edge.section,
+        "sources": edge.sources,
     }))
 }
 
@@ -280,6 +298,7 @@ fn encode_settlement(settlement: &SettlementImport) -> Result<Value> {
         "drought": encode_drought(settlement.drought),
         "hydrology": encode_hydrology(settlement.hydrology),
         "scene_key": settlement.scene_key,
+        "sources": settlement.sources,
     }))
 }
 
@@ -814,6 +833,7 @@ mod tests {
             slope_multiplier: 1.0,
             certainty: 1,
             section: String::new(),
+            sources: "- Test source.".into(),
         };
         let batches = serialize_batches(&[edge], 100, encode_travel_edge).unwrap();
         assert_eq!(
@@ -824,11 +844,16 @@ mod tests {
             batches[0][0]["toll"],
             serde_json::json!({ "some": { "From": [] } })
         );
+        assert_eq!(batches[0][0]["sources"], "- Test source.");
     }
 
     #[test]
     fn encodes_all_forest_variants_for_spacetimedb_sats_json() {
         let mut settlement = settlement(ForestCover::Open);
+        assert_eq!(
+            encode_settlement(&settlement).unwrap()["sources"],
+            "- Test source."
+        );
         assert_eq!(
             encode_settlement(&settlement).unwrap()["forest_cover"],
             serde_json::json!({ "Open": [] })
@@ -1062,6 +1087,7 @@ mod tests {
             ),
             hydrology: adventuresim_world_schema::SettlementHydrology::default(),
             scene_key: "village".into(),
+            sources: "- Test source.".into(),
         }
     }
 

--- a/crates/adventuresim-world-import/src/sources/drought.rs
+++ b/crates/adventuresim-world-import/src/sources/drought.rs
@@ -9,7 +9,7 @@ use netcdf_reader::{NcFile, NcFormat, NcSliceInfo, NcSliceInfoElem, NcType};
 
 use crate::{
     Error, Result,
-    draft::{DroughtSettlementDraft, ReligionSettlementDraft, WorldDraft},
+    draft::{DroughtSettlementDraft, ReligionSettlementDraft, WorldDraft, push_source_note},
 };
 
 const SOURCE_NAME: &str = "NOAA Old World Drought Atlas v1.0";
@@ -24,7 +24,7 @@ const FIRST_LATITUDE: f64 = 27.25;
 const MAX_NEIGHBOR_DISTANCE_DEGREES: f64 = 1.5;
 
 pub(crate) fn enrich(
-    draft: WorldDraft<ReligionSettlementDraft>,
+    mut draft: WorldDraft<ReligionSettlementDraft>,
     netcdf_path: &Path,
 ) -> Result<WorldDraft<DroughtSettlementDraft>> {
     let grid = OwdaGrid::open(netcdf_path, draft.year)?;
@@ -35,7 +35,7 @@ pub(crate) fn enrich(
     let mut fallbacks = 0;
     let profiles = draft
         .settlements
-        .iter()
+        .iter_mut()
         .map(|religious| {
             let settlement = &religious
                 .geologic
@@ -49,10 +49,22 @@ pub(crate) fn enrich(
             match grid.sample(settlement.latitude, settlement.longitude) {
                 Some(sample) => {
                     neighbor_samples += usize::from(sample.used_neighbor);
+                    push_source_note(
+                        religious,
+                        if sample.used_neighbor {
+                            "**[NOAA Old World Drought Atlas](https://doi.org/10.25921/rjm6-mq74):** The containing cell lacked a complete reconstruction, so the 1525–1544 profile uses the nearest complete OWDA grid point within 1.5 degrees."
+                        } else {
+                            "**[NOAA Old World Drought Atlas](https://doi.org/10.25921/rjm6-mq74):** The 1544 summer PDSI and 1525–1544 summary are reconstructed directly from the containing OWDA grid point."
+                        },
+                    );
                     DroughtProfile::Reconstructed(sample.history)
                 }
                 None => {
                     fallbacks += 1;
+                    push_source_note(
+                        religious,
+                        "**OWDA drought fallback:** No complete reconstruction was available within 1.5 degrees, so the canonical twenty-year profile is the documented neutral deterministic fallback.",
+                    );
                     DroughtProfile::Inferred(neutral_history())
                 }
             }

--- a/crates/adventuresim-world-import/src/sources/elevation.rs
+++ b/crates/adventuresim-world-import/src/sources/elevation.rs
@@ -15,7 +15,7 @@ use tiff::{
 
 use crate::{
     Error, Result,
-    draft::{ElevatedSettlementDraft, SettlementDraft, WorldDraft},
+    draft::{ElevatedSettlementDraft, SettlementDraft, WorldDraft, push_source_note},
 };
 
 const SOURCE_NAME: &str = "Copernicus DEM GLO-30";
@@ -65,6 +65,14 @@ pub(crate) fn enrich(
             let (column, row) = raster.pixel(settlement.latitude, settlement.longitude)?;
             let (elevation, used_fallback) = raster.elevation_near(column, row);
             fallback_samples += usize::from(used_fallback);
+            push_source_note(
+                &mut draft.settlements[index],
+                if used_fallback {
+                    "**[Copernicus DEM GLO-30](https://doi.org/10.5270/ESA-c5d3d65):** The nominal raster pixel was void, so elevation uses the deterministic nearest-valid-pixel search (or sea-level terminal fallback if the local search window was entirely void)."
+                } else {
+                    "**[Copernicus DEM GLO-30](https://doi.org/10.5270/ESA-c5d3d65):** Elevation is sampled directly from the settlement's GLO-30 raster pixel."
+                },
+            );
             samples[index] = Some(elevation);
         }
     }

--- a/crates/adventuresim-world-import/src/sources/forest_cover.rs
+++ b/crates/adventuresim-world-import/src/sources/forest_cover.rs
@@ -18,7 +18,7 @@ use tiff::{
 
 use crate::{
     Error, Result,
-    draft::{ForestSettlementDraft, LandUseSettlementDraft, WorldDraft},
+    draft::{ForestSettlementDraft, LandUseSettlementDraft, WorldDraft, push_source_note},
 };
 
 const SOURCE_NAME: &str = "Copernicus Land Monitoring Service Forest 2018";
@@ -83,15 +83,27 @@ pub(crate) fn enrich(
                 settlement.elevated.elevation.get(),
             );
             fallbacks += usize::from(fallback);
-            covers[index] = Some(cover);
+            covers[index] = Some((cover, fallback));
         }
     }
     let settlements = std::mem::take(&mut draft.settlements)
         .into_iter()
         .zip(covers)
-        .map(|(land, cover)| ForestSettlementDraft {
-            land,
-            forest_cover: cover.expect("every settlement was grouped into a forest tile"),
+        .map(|(mut land, cover)| {
+            let (forest_cover, fallback) =
+                cover.expect("every settlement was grouped into a forest tile");
+            push_source_note(
+                &mut land,
+                if fallback {
+                    "**[Copernicus HRL Forests](https://land.copernicus.eu/en/products/high-resolution-layer-forests-and-tree-cover):** At least one TCD/DLT source value was missing or reserved; forest density/type uses the documented deterministic HYDE/elevation fallback."
+                } else {
+                    "**[Copernicus HRL Forests](https://land.copernicus.eu/en/products/high-resolution-layer-forests-and-tree-cover):** Forest density and dominant leaf type are sampled from the prepared 2018 TCD/DLT rasters."
+                },
+            );
+            ForestSettlementDraft {
+                land,
+                forest_cover,
+            }
         })
         .collect::<Vec<_>>();
     draft.sources.push(SourceProvenance {

--- a/crates/adventuresim-world-import/src/sources/geology.rs
+++ b/crates/adventuresim-world-import/src/sources/geology.rs
@@ -15,7 +15,7 @@ use rusqlite::{Connection, OpenFlags, params};
 
 use crate::{
     Error, Result,
-    draft::{GeologySettlementDraft, SoilSettlementDraft, WorldDraft},
+    draft::{GeologySettlementDraft, SoilSettlementDraft, WorldDraft, push_source_note},
 };
 
 const SOURCE_NAME: &str = "EGDI 1:1 Million pan-European Surface Geology";
@@ -63,7 +63,16 @@ fn finish(
     let settlements = std::mem::take(&mut draft.settlements)
         .into_iter()
         .zip(profiles)
-        .map(|(soil, geology)| GeologySettlementDraft { soil, geology })
+        .map(|(mut soil, geology)| {
+            push_source_note(
+                &mut soil,
+                match &geology {
+                    SurfaceGeology::Mapped(_) => "**[EGDI pan-European Surface Geology](https://doi.org/10.22008/y9hj-va55):** Surface lithology and age come from containment in the indexed aggregate geologic-unit layer; missing source attributes may use the mapped record's explicit deterministic evidence classifications.",
+                    SurfaceGeology::Inferred(_) => "**EGDI geology fallback:** No usable geologic unit covered the settlement, so a plausible geologic setting is deterministically inferred from the soil profile.",
+                },
+            );
+            GeologySettlementDraft { soil, geology }
+        })
         .collect();
     draft.sources.push(SourceProvenance {
         name: SOURCE_NAME.into(),

--- a/crates/adventuresim-world-import/src/sources/hydrology.rs
+++ b/crates/adventuresim-world-import/src/sources/hydrology.rs
@@ -25,7 +25,10 @@ use rusqlite::{Connection, OpenFlags, params};
 
 use crate::{
     Error, Result,
-    draft::{DroughtSettlementDraft, TravelEdgeDraft, TravelRouteDraft, WorldDraft},
+    draft::{
+        DroughtSettlementDraft, SettlementDraftAccess, TravelEdgeDraft, TravelRouteDraft,
+        WorldDraft, push_source_note,
+    },
 };
 
 const SOURCE_NAME: &str = "Copernicus EU-Hydro River Network Database v1.3";
@@ -69,12 +72,21 @@ pub(crate) fn enrich(
     let mut inferred_ferries = 0;
     let edges = std::mem::take(&mut draft.edges)
         .into_iter()
-        .map(|edge| {
+        .map(|mut edge| {
             let from = projected_nodes[&edge.from_node_id];
             let to = projected_nodes[&edge.to_node_id];
             let (route, edge_crossings, inferred) = database.enrich_route(edge.route, from, to)?;
             crossings += edge_crossings;
             inferred_ferries += usize::from(inferred);
+            let note = match &route {
+                TravelRoute::Land(route) if route.water_crossings.is_empty() => "**[EU-Hydro v1.3](https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c):** No mapped linear watercourse intersects the straight endpoint-to-endpoint road geometry after endpoint-touch filtering.",
+                TravelRoute::Land(_) => "**[EU-Hydro v1.3](https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c):** Water crossings come from mapped road/linear-water intersections. Bridge versus ford is inferred deterministically from watercourse attributes unless Viabundus supplies endpoint bridge evidence; unmatched Viabundus bridge evidence receives the documented small-river fallback.",
+                TravelRoute::Ferry(_) if inferred => "**EU-Hydro ferry fallback:** No mapped water feature explained this Viabundus ferry, so the route uses the documented plausible small perennial river waterway.",
+                TravelRoute::Ferry(_) => "**[EU-Hydro v1.3](https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c):** The ferry waterway is classified from a mapped river, inland-water, tidal-water, or coastal feature near the route.",
+            };
+            edge.sources.push('\n');
+            edge.sources.push_str("- ");
+            edge.sources.push_str(note);
             Ok(finish_edge(edge, route))
         })
         .collect::<Result<Vec<_>>>()?;
@@ -82,7 +94,17 @@ pub(crate) fn enrich(
     let settlements = std::mem::take(&mut draft.settlements)
         .into_iter()
         .zip(hydrology)
-        .map(|(drought, hydrology)| finish_settlement(drought, hydrology))
+        .map(|(mut drought, hydrology)| {
+            push_source_note(
+                &mut drought,
+                if hydrology == SettlementHydrology::default() {
+                    "**[EU-Hydro v1.3](https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c):** No mapped flowing, inland, tidal, or coastal feature lies within the two-kilometer settlement-adjacency threshold; absence is treated as landlocked rather than unknown."
+                } else {
+                    "**[EU-Hydro v1.3](https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c):** Flowing, inland, and marine access is derived by exact geometry distance within two kilometers. Missing/sentinel source attributes are resolved by documented parser-boundary defaults rather than stored as unknown."
+                },
+            );
+            finish_settlement(drought, hydrology)
+        })
         .collect::<Vec<_>>();
 
     draft.sources.push(SourceProvenance {
@@ -126,6 +148,7 @@ fn finish_edge(edge: TravelEdgeDraft, route: TravelRoute) -> TravelEdgeImport {
         slope_multiplier: edge.slope_multiplier,
         certainty: edge.certainty,
         section: edge.section,
+        sources: edge.sources,
     }
 }
 
@@ -161,20 +184,12 @@ fn finish_settlement(
         drought: drought.drought,
         hydrology,
         scene_key: settlement.scene_key,
+        sources: settlement.sources,
     }
 }
 
 fn base_settlement(draft: &DroughtSettlementDraft) -> &crate::draft::SettlementDraft {
-    &draft
-        .religious
-        .geologic
-        .soil
-        .trees
-        .vegetated
-        .forest
-        .land
-        .elevated
-        .settlement
+    draft.base_settlement()
 }
 
 struct HydrologyProjection {

--- a/crates/adventuresim-world-import/src/sources/land_use.rs
+++ b/crates/adventuresim-world-import/src/sources/land_use.rs
@@ -11,7 +11,7 @@ use adventuresim_world_schema::{LandUseFraction, LandUseProfile, SourceProvenanc
 
 use crate::{
     Error, Result,
-    draft::{ElevatedSettlementDraft, LandUseSettlementDraft, WorldDraft},
+    draft::{ElevatedSettlementDraft, LandUseSettlementDraft, WorldDraft, push_source_note},
 };
 
 const SOURCE_NAME: &str = "History Database of the Global Environment 3.2.1";
@@ -106,17 +106,28 @@ pub(crate) fn enrich(
     let settlements = elevated_settlements
         .into_iter()
         .zip(values)
-        .map(|(elevated, values)| {
-            let land_use = match values.profile(interpolation)? {
+        .map(|(mut elevated, values)| {
+            let (land_use, note) = match values.profile(interpolation)? {
                 Some((profile, normalized)) => {
                     normalized_samples += usize::from(normalized);
-                    profile
+                    (
+                        profile,
+                        if normalized {
+                            "**[HYDE 3.2.1](https://doi.org/10.17026/DANS-25G-GEZ3):** Land-use fractions are linearly interpolated to the world year from source cells; overlapping human-use fractions were deterministically normalized to an exhaustive profile."
+                        } else {
+                            "**[HYDE 3.2.1](https://doi.org/10.17026/DANS-25G-GEZ3):** Land-use fractions are linearly interpolated to the world year from the source grid cells."
+                        },
+                    )
                 }
                 None => {
                     fallback_samples += 1;
-                    fallback_profile(&elevated)
+                    (
+                        fallback_profile(&elevated),
+                        "**HYDE land-use fallback:** The source cells had no usable profile, so cropland and grazing are deterministically seeded by the Viabundus node, built-up land by settlement population level, and the remainder is natural land.",
+                    )
                 }
             };
+            push_source_note(&mut elevated, note);
             Ok(LandUseSettlementDraft { elevated, land_use })
         })
         .collect::<Result<Vec<_>>>()?;

--- a/crates/adventuresim-world-import/src/sources/potential_vegetation.rs
+++ b/crates/adventuresim-world-import/src/sources/potential_vegetation.rs
@@ -16,7 +16,9 @@ use proj4rs::{proj::Proj, transform::transform};
 
 use crate::{
     Error, Result,
-    draft::{ForestSettlementDraft, PotentialVegetationSettlementDraft, WorldDraft},
+    draft::{
+        ForestSettlementDraft, PotentialVegetationSettlementDraft, WorldDraft, push_source_note,
+    },
 };
 
 const SOURCE_NAME: &str = "EuroVegMap 2.1 Map of the Natural Vegetation of Europe";
@@ -68,9 +70,18 @@ fn finish(
         .into_iter()
         .zip(samples)
         .map(
-            |(forest, potential_vegetation)| PotentialVegetationSettlementDraft {
-                forest,
-                potential_vegetation,
+            |(mut forest, potential_vegetation)| {
+                push_source_note(
+                    &mut forest,
+                    match &potential_vegetation {
+                        PotentialVegetation::Mapped(_) => "**[EuroVegMap 2.1](https://www.synbiosys.alterra.nl/eurovegmap/):** Potential-natural-vegetation unit and formation come from polygon containment in the source map.",
+                        PotentialVegetation::Inferred(_) => "**EuroVegMap fallback:** No source polygon contained this settlement, so formation is deterministically inferred from forest cover, dominant leaf type, elevation, and HYDE land use.",
+                    },
+                );
+                PotentialVegetationSettlementDraft {
+                    forest,
+                    potential_vegetation,
+                }
             },
         )
         .collect::<Vec<_>>();

--- a/crates/adventuresim-world-import/src/sources/religion.rs
+++ b/crates/adventuresim-world-import/src/sources/religion.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::{
     Error, Result,
-    draft::{GeologySettlementDraft, ReligionSettlementDraft, WorldDraft},
+    draft::{GeologySettlementDraft, ReligionSettlementDraft, WorldDraft, push_source_note},
 };
 
 const SOURCE_NAME: &str = "IEG Maps of Confessional Europe (1500 and 1555)";
@@ -272,7 +272,7 @@ pub(crate) fn enrich(
     let mut fallbacks = 0;
     let settlements: Vec<ReligionSettlementDraft> = std::mem::take(&mut draft.settlements)
         .into_iter()
-        .map(|geologic| {
+        .map(|mut geologic| {
             let settlement = &geologic
                 .soil
                 .trees
@@ -281,14 +281,21 @@ pub(crate) fn enrich(
                 .land
                 .elevated
                 .settlement;
-            let religious_status = regions
+            let matched = regions
                 .iter()
-                .find(|region| region.contains(settlement.latitude, settlement.longitude))
-                .map(|region| region.status)
-                .unwrap_or_else(|| {
+                .find(|region| region.contains(settlement.latitude, settlement.longitude));
+            let religious_status = matched.map(|region| region.status).unwrap_or_else(|| {
                     fallbacks += 1;
                     infer_fallback(settlement.latitude, settlement.longitude)
                 });
+            push_source_note(
+                &mut geologic,
+                if matched.is_some() {
+                    "**[IEG AtlasEuropa religion maps](https://www.atlas-europa.de/t02/rel-anerkannt/t02-anerkannte-religionen.htm):** Official 1544 legal status comes from the prioritized, coarse project-curated intermediate between the 1500 and 1555 maps; it is a gameplay approximation rather than an exact historical border claim."
+                } else {
+                    "**IEG religion fallback:** No curated region covered the settlement, so official religion is deterministically assigned from the documented broad geographic fallback; personal belief is not inferred."
+                },
+            );
             ReligionSettlementDraft {
                 geologic,
                 religious_status,

--- a/crates/adventuresim-world-import/src/sources/soil.rs
+++ b/crates/adventuresim-world-import/src/sources/soil.rs
@@ -19,7 +19,7 @@ use proj4rs::{proj::Proj, transform::transform};
 
 use crate::{
     Error, Result,
-    draft::{SoilSettlementDraft, TreeSpeciesSettlementDraft, WorldDraft},
+    draft::{SoilSettlementDraft, TreeSpeciesSettlementDraft, WorldDraft, push_source_note},
 };
 
 const SOURCE_NAME: &str = "European Soil Database v2.0 (SGDBE/PTRDB)";
@@ -79,7 +79,16 @@ fn finish(
     let settlements = std::mem::take(&mut draft.settlements)
         .into_iter()
         .zip(profiles)
-        .map(|(trees, soil)| SoilSettlementDraft { trees, soil })
+        .map(|(mut trees, soil)| {
+            push_source_note(
+                &mut trees,
+                match &soil {
+                    SoilProfile::Mapped(_) => "**[European Soil Database v2](https://esdac.jrc.ec.europa.eu/content/european-soil-database-v20-vector-and-attribute-data):** Soil properties come from source polygon containment and joined SGDBE/PTRDB attributes.",
+                    SoilProfile::Inferred(_) => "**ESDB soil fallback:** No usable mapping unit covered the settlement, so soil properties are deterministically inferred from potential vegetation, elevation, and related environmental inputs.",
+                },
+            );
+            SoilSettlementDraft { trees, soil }
+        })
         .collect::<Vec<_>>();
     draft.sources.push(SourceProvenance {
         name: SOURCE_NAME.into(),

--- a/crates/adventuresim-world-import/src/sources/tree_species.rs
+++ b/crates/adventuresim-world-import/src/sources/tree_species.rs
@@ -22,7 +22,10 @@ use zip::ZipArchive;
 
 use crate::{
     Error, Result,
-    draft::{PotentialVegetationSettlementDraft, TreeSpeciesSettlementDraft, WorldDraft},
+    draft::{
+        PotentialVegetationSettlementDraft, TreeSpeciesSettlementDraft, WorldDraft,
+        push_source_note,
+    },
 };
 
 const SOURCE_NAME: &str = "EU-Trees4F v2 current-climate ensemble";
@@ -239,9 +242,18 @@ fn finish(
     let settlements = std::mem::take(&mut draft.settlements)
         .into_iter()
         .zip(profiles)
-        .map(|(vegetated, tree_species)| TreeSpeciesSettlementDraft {
-            vegetated,
-            tree_species,
+        .map(|(mut vegetated, tree_species)| {
+            push_source_note(
+                &mut vegetated,
+                match &tree_species {
+                    TreeSpeciesProfile::Modeled(_) => "**[EU-Trees4F v2](https://doi.org/10.6084/m9.figshare.17032328.v2):** Ranked tree candidates come from current-climate probability, potential-range, and native-range rasters; suitability is modeled habitat suitability, not observed abundance.",
+                    TreeSpeciesProfile::Inferred(_) => "**EU-Trees4F fallback:** No modeled candidate survived the source masks, so a deterministic non-empty species profile is inferred from potential-vegetation formation.",
+                },
+            );
+            TreeSpeciesSettlementDraft {
+                vegetated,
+                tree_species,
+            }
         })
         .collect::<Vec<_>>();
     draft.sources.push(SourceProvenance {

--- a/crates/adventuresim-world-import/src/sources/viabundus.rs
+++ b/crates/adventuresim-world-import/src/sources/viabundus.rs
@@ -179,8 +179,10 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
                 ),
             },
         };
+        let edge_id = required_number(&edges_path, "id", &raw.id)?;
+        let slope_was_inferred = raw.slopemultiplier.trim().is_empty();
         edges.push(TravelEdgeDraft {
-            id: required_number(&edges_path, "id", &raw.id)?,
+            id: edge_id,
             from_node_id,
             to_node_id,
             route,
@@ -193,6 +195,14 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
             },
             certainty: required_number(&edges_path, "certainty", &raw.certainty)?,
             section: raw.section,
+            sources: format!(
+                "- **[Viabundus 2]({SOURCE_DOI}):** Direct edge record `{edge_id}` supplies endpoints, route type, length, certainty, section, and active bridge/toll endpoint evidence.{}",
+                if slope_was_inferred {
+                    " The source slope multiplier was empty, so the importer used the documented neutral multiplier `1.0`."
+                } else {
+                    " The slope multiplier is source-provided."
+                }
+            ),
         });
     }
 
@@ -203,7 +213,8 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
             continue;
         }
         settlement_node_ids.insert(node.id);
-        let estimate = population_by_node.get(&node.id).map(|(_, value)| *value);
+        let population = population_by_node.get(&node.id).copied();
+        let estimate = population.map(|(_, value)| value);
         settlements.push(SettlementDraft {
             id: format!("viabundus-{}", node.id),
             source_node_id: node.id,
@@ -213,6 +224,16 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
             population_level: population_level(estimate),
             population_estimate: population_estimate(&population_path, estimate)?,
             scene_key: "hills".into(),
+            sources: format!(
+                "- **[Viabundus 2]({SOURCE_DOI}):** Direct settlement node `{}` supplies name, coordinates, settlement/town status, and transport flags. {}",
+                node.id,
+                population.map_or_else(
+                    || "No eligible population observation was available; the canonical estimate is `0` and the population band uses the documented fallback.".to_owned(),
+                    |(population_year, value)| format!(
+                        "Population `{value}` comes from the latest source observation not after the world year (`{population_year}`)."
+                    ),
+                )
+            ),
         });
     }
     settlements.sort_by(|left, right| left.id.cmp(&right.id));
@@ -243,6 +264,10 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
             is_town: node.is_town,
             is_ferry: node.is_ferry,
             is_harbour: node.is_harbour,
+            sources: format!(
+                "- **[Viabundus 2]({SOURCE_DOI}):** Direct node record `{}` supplies coordinates, parent relationship, and settlement/town/ferry/harbour flags.",
+                node.id
+            ),
         })
         .collect();
     let connected_settlements: HashSet<_> = edges

--- a/crates/adventuresim-world-import/src/validation.rs
+++ b/crates/adventuresim-world-import/src/validation.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use adventuresim_world_schema::{
     CompiledWorld, DroughtProfile, SettlementHydrology, SoilProfile, SurfaceGeology, TravelRoute,
-    TreeSpeciesProfile, WORLD_SCHEMA_VERSION,
+    TreeSpeciesProfile, WORLD_SCHEMA_VERSION, valid_sources_markdown,
 };
 
 use crate::{Error, Result};
@@ -20,6 +20,12 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
         return Err(Error::Validation("world node IDs are not unique".into()));
     }
     for node in &world.nodes {
+        if !valid_sources_markdown(&node.sources) {
+            return Err(Error::Validation(format!(
+                "world node {} has invalid source notes",
+                node.id
+            )));
+        }
         if !node.latitude.is_finite()
             || !(-90.0..=90.0).contains(&node.latitude)
             || !node.longitude.is_finite()
@@ -46,6 +52,12 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
         return Err(Error::Validation("travel edge IDs are not unique".into()));
     }
     for edge in &world.edges {
+        if !valid_sources_markdown(&edge.sources) {
+            return Err(Error::Validation(format!(
+                "travel edge {} has invalid source notes",
+                edge.id
+            )));
+        }
         if !node_ids.contains(&edge.from_node_id) || !node_ids.contains(&edge.to_node_id) {
             return Err(Error::Validation(format!(
                 "travel edge {} references an unknown node",
@@ -92,6 +104,12 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
         return Err(Error::Validation("settlement IDs are not unique".into()));
     }
     for settlement in &world.settlements {
+        if !valid_sources_markdown(&settlement.sources) {
+            return Err(Error::Validation(format!(
+                "settlement {} has invalid source notes",
+                settlement.id
+            )));
+        }
         if !node_ids.contains(&settlement.source_node_id) {
             return Err(Error::Validation(format!(
                 "settlement {} references an unknown source node",

--- a/crates/adventuresim-world-schema/src/lib.rs
+++ b/crates/adventuresim-world-schema/src/lib.rs
@@ -5,7 +5,17 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const WORLD_SCHEMA_VERSION: u32 = 12;
+pub const WORLD_SCHEMA_VERSION: u32 = 13;
+pub const MAX_SOURCES_MARKDOWN_CHARS: usize = 32_768;
+
+/// Source and inference notes are deliberately unstructured Markdown for a
+/// future debug view. Keep the payload bounded even though the contents are
+/// not parsed into canonical provenance types.
+pub fn valid_sources_markdown(value: &str) -> bool {
+    !value.trim().is_empty()
+        && value.chars().count() <= MAX_SOURCES_MARKDOWN_CHARS
+        && !value.contains('\0')
+}
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
@@ -1752,6 +1762,7 @@ pub struct WorldNodeImport {
     pub is_town: bool,
     pub is_ferry: bool,
     pub is_harbour: bool,
+    pub sources: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -1766,6 +1777,7 @@ pub struct TravelEdgeImport {
     pub slope_multiplier: f32,
     pub certainty: u8,
     pub section: String,
+    pub sources: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -1789,6 +1801,7 @@ pub struct SettlementImport {
     pub drought: DroughtProfile,
     pub hydrology: SettlementHydrology,
     pub scene_key: String,
+    pub sources: String,
 }
 
 #[cfg(test)]
@@ -1802,6 +1815,16 @@ mod tests {
         SettlementReligiousStatus, SoilMappingUnit, StoneContentPercent, SummerHydroclimate,
         TreeSpeciesId,
     };
+
+    #[test]
+    fn source_markdown_is_nonempty_nul_free_and_bounded() {
+        assert!(super::valid_sources_markdown("- **Source:** Direct value."));
+        assert!(!super::valid_sources_markdown("   \n"));
+        assert!(!super::valid_sources_markdown("- Source\0hidden"));
+        assert!(!super::valid_sources_markdown(
+            &"x".repeat(super::MAX_SOURCES_MARKDOWN_CHARS + 1)
+        ));
+    }
 
     #[test]
     fn religious_status_derives_the_single_church_faith() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,6 +42,15 @@ stage consumes only settlements that have all of its required predecessor data.
 This keeps source-specific placeholders out of canonical records and prevents
 later stages from being called before their dependencies exist.
 
+The compiled world and persisted strategic tables retain source explanations as
+bounded, unstructured Markdown in a `sources` field. The world-import session
+stores the distribution-level list, while each imported node, travel edge, and
+settlement stores record-specific notes describing direct samples,
+interpolation, deterministic inference, and fallbacks. This is deliberately a
+display/debug payload rather than a structured provenance API. No debug view
+renders it yet; any future renderer must treat it as untrusted Markdown and
+sanitize generated HTML.
+
 Each compiled artifact is identified by a content hash. An interrupted load may
 resume only with the same artifact; a different artifact requires a database
 reset. Successful loads explicitly complete their import session so later

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -153,7 +153,9 @@ local download. The command records the source URLs and SHA-256 checksums in
 needed to connect those segments, and active settlements. The Rust world
 compiler writes a deterministic, schema-versioned artifact to
 `target/world-1544.json`, validates its references and invariants, and emits a
-build report. `just load-world` sends that same compiled
+build report. Canonical nodes, edges, and settlements include a bounded,
+unstructured Markdown `sources` field for future debugging; it is persisted but
+not currently displayed. `just load-world` sends that same compiled
 data in bounded batches to a published local module. Run it after
 `just publish-reset`, without `_seed-world`, when using the historical world.
 Interrupted loads can be resumed with the identical compiled artifact. The


### PR DESCRIPTION
## Summary

- expose the existing linear environmental world-data integration chain as a reviewable PR
- add typed Copernicus elevation, HYDE land use, forest cover, potential vegetation, EU-Trees4F, soil, geology, religion, OWDA drought, and EU-Hydro enrichment stages
- persist bounded per-record Markdown provenance and validate deterministic canonical world output
- keep all raw geospatial parsing in the offline Rust compiler and out of SpacetimeDB

## Why

These source integrations were already pushed as a linear sequence of checkpoint branches, but `codex/data-markdown-sources` had no PR and therefore gave PR #70 no merge path. This draft closes that stack gap without rewriting the existing source commits.

Part of #62. This targets PR #60's `codex/rust-world-import` branch and does not close the umbrella issue.

## Stack

`codex/rust-world-import` → `codex/data-markdown-sources` → PR #70 → PR #73 → PR #61 (strategic autoresolver) → PR #76 and subsequent #62 data PRs

Combat autoresolve is now intentionally embedded in the same linear ancestry after PR #73.

## Validation

This publication step changes no files. The source commits include per-source parser fixtures, canonical validation, and affected-package checks. The follow-up orchestration reruns the combined world-import checks before additional grid, PNV, or SoilGrids branches are stacked.

## Review notes

Several official full-world distributions require authentication or remain unavailable locally. Their ignored full-source audits and redistribution constraints are documented per source; synthetic source-boundary tests remain the default CI coverage.
