### PR TITLE
Define canonical world spatial grid

### DIFF
--- a/crates/adventuresim-world-import/src/builder.rs
+++ b/crates/adventuresim-world-import/src/builder.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
 use adventuresim_world_schema::{
-    CompiledWorld, SettlementAliasImport, SettlementDescriptionImport, WorldBuildReport,
+    CompiledWorld, SettlementAliasImport, SettlementDescriptionImport, SpatialGridSpec,
+    WorldBuildReport,
 };
 
 use crate::{
@@ -16,6 +17,7 @@ use crate::{
 #[derive(Clone, Copy, Debug)]
 pub struct WorldBuilder {
     year: i32,
+    spatial_grid: SpatialGridSpec,
 }
 
 /// Viabundus-only enrichment output used to inspect source-boundary behavior
@@ -28,12 +30,20 @@ pub struct ViabundusEnrichment {
 }
 
 impl WorldBuilder {
-    pub const fn new(year: i32) -> Self {
-        Self { year }
+    pub fn new(year: i32) -> Self {
+        Self {
+            year,
+            spatial_grid: SpatialGridSpec::default(),
+        }
+    }
+
+    pub const fn with_spatial_grid(mut self, spatial_grid: SpatialGridSpec) -> Self {
+        self.spatial_grid = spatial_grid;
+        self
     }
 
     pub fn build_from_viabundus(self, directory: &Path) -> Result<ViabundusEnrichment> {
-        let draft = viabundus::compile(directory, self.year)?;
+        let draft = viabundus::compile(directory, self.year, self.spatial_grid)?;
         Ok(ViabundusEnrichment {
             settlement_aliases: draft.settlement_aliases,
             settlement_descriptions: draft.settlement_descriptions,
@@ -55,7 +65,7 @@ impl WorldBuilder {
         drought_netcdf: &Path,
         hydrology_directory: &Path,
     ) -> Result<CompiledWorld> {
-        let draft = viabundus::compile(viabundus_directory, self.year)?;
+        let draft = viabundus::compile(viabundus_directory, self.year, self.spatial_grid)?;
         let draft = elevation::enrich(draft, elevation_directory)?;
         let draft = land_use::enrich(draft, land_use_directory)?;
         let draft = forest_cover::enrich(draft, forest_cover_directory)?;

--- a/crates/adventuresim-world-import/src/draft.rs
+++ b/crates/adventuresim-world-import/src/draft.rs
@@ -1,12 +1,14 @@
 use adventuresim_world_schema::{
     DroughtProfile, EdgeEndpoint, ElevationMeters, ForestCover, LandUseProfile,
     PotentialVegetation, SettlementAliasImport, SettlementDescriptionImport, SoilProfile,
-    SourceProvenance, TravelEdgeKind, TreeSpeciesProfile, WorldBuildReport, WorldNodeImport,
+    SourceProvenance, SpatialGridSpec, TravelEdgeKind, TreeSpeciesProfile, WorldBuildReport,
+    WorldNodeImport,
 };
 
 #[derive(Debug)]
 pub(crate) struct WorldDraft<S> {
     pub(crate) year: i32,
+    pub(crate) spatial_grid: SpatialGridSpec,
     pub(crate) sources: Vec<SourceProvenance>,
     pub(crate) road_types: Vec<TravelEdgeKind>,
     pub(crate) nodes: Vec<WorldNodeImport>,

--- a/crates/adventuresim-world-import/src/lib.rs
+++ b/crates/adventuresim-world-import/src/lib.rs
@@ -7,6 +7,7 @@ pub mod builder;
 mod draft;
 pub mod error;
 mod sources;
+pub mod spatial;
 mod validation;
 
 pub use builder::WorldBuilder;

--- a/crates/adventuresim-world-import/src/main.rs
+++ b/crates/adventuresim-world-import/src/main.rs
@@ -8,14 +8,14 @@ use adventuresim_world_schema::{
     AgriculturalLimitation, AvailableWaterCapacity, CompiledWorld, CrossingTraversal,
     CrossingWatercourse, DominantLeafType, DroughtHistory, DroughtProfile, EdgeEndpoint,
     FerryWaterway, FlowPersistence, FlowingWaterAccess, ForestCover, GeologicAgeEvidence,
-    GeologicEra, GeologicLithologyEvidence, IgneousRock, InlandWaterSize, MarineWaterAccess,
-    MetamorphicRock, MineralSoilTexture, MixedLithology, NativeRangeEvidence, PotentialVegetation,
-    PotentialVegetationFormation, SedimentaryRock, SettlementAliasImport,
+    GeologicEra, GeologicLithologyEvidence, GridCellSizeMeters, IgneousRock, InlandWaterSize,
+    MarineWaterAccess, MetamorphicRock, MineralSoilTexture, MixedLithology, NativeRangeEvidence,
+    PotentialVegetation, PotentialVegetationFormation, SedimentaryRock, SettlementAliasImport,
     SettlementDescriptionImport, SettlementDescriptionKind, SettlementImport,
     SettlementReligiousStatus, SoilDepth, SoilProfile, SoilSubstrate, SoilWaterRegime,
-    SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport, TravelRoute,
-    TreeSpeciesProfile, UnconsolidatedDeposit, WesternChristianArrangement, WorldNodeImport,
-    WrbReferenceGroup,
+    SpatialGridSpec, SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport,
+    TravelRoute, TreeSpeciesProfile, UnconsolidatedDeposit, WesternChristianArrangement,
+    WorldNodeImport, WrbReferenceGroup,
 };
 use clap::Parser;
 use serde_json::{Value, json};
@@ -52,6 +52,8 @@ struct Args {
     hydrology_dir: PathBuf,
     #[arg(long, default_value_t = WORLD_YEAR)]
     year: i32,
+    #[arg(long, default_value_t = GridCellSizeMeters::default())]
+    grid_cell_size_meters: GridCellSizeMeters,
     #[arg(long)]
     output: Option<PathBuf>,
     #[arg(long)]
@@ -80,19 +82,21 @@ fn run(args: Args) -> Result<()> {
     if args.batch_size == 0 {
         return Err(Error::Validation("batch size must be positive".into()));
     }
-    let world = WorldBuilder::new(args.year).build_from_sources(
-        &args.viabundus_dir,
-        &args.elevation_dir,
-        &args.land_use_dir,
-        &args.forest_cover_dir,
-        &args.potential_vegetation_dir,
-        &args.tree_species_archive,
-        &args.soil_dir,
-        &args.geology_geopackage,
-        &args.religion_regions,
-        &args.drought_netcdf,
-        &args.hydrology_dir,
-    )?;
+    let world = WorldBuilder::new(args.year)
+        .with_spatial_grid(SpatialGridSpec::new(args.grid_cell_size_meters))
+        .build_from_sources(
+            &args.viabundus_dir,
+            &args.elevation_dir,
+            &args.land_use_dir,
+            &args.forest_cover_dir,
+            &args.potential_vegetation_dir,
+            &args.tree_species_archive,
+            &args.soil_dir,
+            &args.geology_geopackage,
+            &args.religion_regions,
+            &args.drought_netcdf,
+            &args.hydrology_dir,
+        )?;
     let output = args
         .output
         .clone()
@@ -858,25 +862,64 @@ fn default_output(year: i32) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use adventuresim_world_schema::{
-        AgriculturalLimitation, AvailableWaterCapacity, CanopyDensity, DominantLeafType,
-        DroughtHistory, DroughtProfile, EdgeEndpoint, ElevationMeters, EuroVegMapUnitCode,
-        ForestCover, GeologicAgeEvidence, GeologicEra, GeologicLithologyEvidence, GeologicSetting,
-        GeologicUnitId, HabitatSuitability, IgneousRock, InferredGeologicSetting,
+        AgriculturalLimitation, AvailableWaterCapacity, CURRENT_INFERENCE_RULES_VERSION,
+        CanopyDensity, CompiledWorld, DominantLeafType, DroughtHistory, DroughtProfile,
+        EdgeEndpoint, ElevationMeters, EuroVegMapUnitCode, ForestCover, GeologicAgeEvidence,
+        GeologicEra, GeologicLithologyEvidence, GeologicSetting, GeologicUnitId,
+        GridCellSizeMeters, HabitatSuitability, IgneousRock, InferredGeologicSetting,
         InferredTreeSpeciesProfile, LandRoute, LandUseFraction, LandUseProfile, LanguageCode,
         MappedPotentialVegetation, MappedSoilProfile, MappedSurfaceGeology, MineralSoil,
         MineralSoilTexture, ModeledTreeSpecies, ModeledTreeSpeciesProfile, NativeRangeEvidence,
         OfficialReligion, PalmerDroughtSeverityIndex, ParentMaterialCode, PotentialVegetation,
         PotentialVegetationFormation, SettlementDescriptionImport, SettlementDescriptionKind,
         SettlementImport, SettlementReligiousStatus, SoilDepth, SoilMappingUnit, SoilProfile,
-        SoilProperties, SoilSubstrate, SoilWaterRegime, StoneContentPercent, SurfaceGeology,
-        SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport, TravelRoute, TreeSpeciesId,
-        TreeSpeciesProfile, UnconsolidatedDeposit, Woodland, WrbReferenceGroup,
+        SoilProperties, SoilSubstrate, SoilWaterRegime, SpatialGridSpec, StoneContentPercent,
+        SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport, TravelRoute,
+        TreeSpeciesId, TreeSpeciesProfile, UnconsolidatedDeposit, WORLD_SCHEMA_VERSION, Woodland,
+        WorldBuildReport, WorldMetadata, WrbReferenceGroup,
     };
+    use clap::Parser;
 
     use super::{
-        MAX_REDUCER_ARGUMENT_CHARS, default_output, encode_settlement,
+        Args, MAX_REDUCER_ARGUMENT_CHARS, default_output, encode_settlement,
         encode_settlement_description, encode_travel_edge, serialize_batches,
     };
+
+    #[test]
+    fn cli_validates_grid_cell_size_at_the_trust_boundary() {
+        let args =
+            Args::try_parse_from(["world-import", "--grid-cell-size-meters", "250"]).unwrap();
+        assert_eq!(args.grid_cell_size_meters.get(), 250);
+        for value in ["0", "251", "100001", "not-a-number"] {
+            assert!(
+                Args::try_parse_from(["world-import", "--grid-cell-size-meters", value]).is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn grid_spec_is_part_of_serialized_world_artifact_identity() {
+        let world = |cell_size| CompiledWorld {
+            metadata: WorldMetadata {
+                schema_version: WORLD_SCHEMA_VERSION,
+                inference_rules_version: CURRENT_INFERENCE_RULES_VERSION,
+                spatial_grid: SpatialGridSpec::new(GridCellSizeMeters::new(cell_size).unwrap()),
+                world_year: 1544,
+                sources: Vec::new(),
+                road_types: Vec::new(),
+            },
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            settlements: Vec::new(),
+            settlement_aliases: Vec::new(),
+            settlement_descriptions: Vec::new(),
+            report: WorldBuildReport::default(),
+        };
+        let default_bytes = serde_json::to_vec(&world(1_000)).unwrap();
+        let fine_bytes = serde_json::to_vec(&world(250)).unwrap();
+        assert_ne!(default_bytes, fine_bytes);
+        assert_ne!(blake3::hash(&default_bytes), blake3::hash(&fine_bytes));
+    }
 
     #[test]
     fn encodes_shared_enum_for_spacetimedb_sats_json() {

--- a/crates/adventuresim-world-import/src/sources/drought.rs
+++ b/crates/adventuresim-world-import/src/sources/drought.rs
@@ -152,6 +152,7 @@ fn finish(
     draft.report.drought_fallback_samples = fallbacks;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,
@@ -666,6 +667,7 @@ mod tests {
     fn empty_world_still_requires_the_source() {
         let draft = WorldDraft {
             year: 1544,
+            spatial_grid: adventuresim_world_schema::SpatialGridSpec::default(),
             sources: Vec::new(),
             road_types: Vec::new(),
             nodes: Vec::new(),
@@ -697,7 +699,12 @@ mod tests {
         let owda = std::env::var_os("OWDA_NETCDF").expect("set OWDA_NETCDF");
         let viabundus = std::env::var_os("VIABUNDUS_DIR").expect("set VIABUNDUS_DIR");
         let grid = OwdaGrid::open(Path::new(&owda), 1544).unwrap();
-        let draft = crate::sources::viabundus::compile(Path::new(&viabundus), 1544).unwrap();
+        let draft = crate::sources::viabundus::compile(
+            Path::new(&viabundus),
+            1544,
+            adventuresim_world_schema::SpatialGridSpec::default(),
+        )
+        .unwrap();
         let mut direct = 0;
         let mut neighbors = 0;
         let mut fallbacks = 0;

--- a/crates/adventuresim-world-import/src/sources/elevation.rs
+++ b/crates/adventuresim-world-import/src/sources/elevation.rs
@@ -100,6 +100,7 @@ pub(crate) fn enrich(
     draft.report.elevation_fallback_samples = fallback_samples;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,

--- a/crates/adventuresim-world-import/src/sources/forest_cover.rs
+++ b/crates/adventuresim-world-import/src/sources/forest_cover.rs
@@ -116,6 +116,7 @@ pub(crate) fn enrich(
     draft.report.forest_fallback_samples = fallbacks;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,

--- a/crates/adventuresim-world-import/src/sources/geology.rs
+++ b/crates/adventuresim-world-import/src/sources/geology.rs
@@ -84,6 +84,7 @@ fn finish(
     draft.report.geology_fallback_samples = fallbacks;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,

--- a/crates/adventuresim-world-import/src/sources/hydrology.rs
+++ b/crates/adventuresim-world-import/src/sources/hydrology.rs
@@ -11,16 +11,15 @@ use std::{
 };
 
 use adventuresim_world_schema::{
-    CanalWatercourse, CompiledWorld, CrossingTraversal, CrossingWatercourse, EdgeEndpoint,
-    EdgeProgressPermille, FerryRoute, FerryWaterway, FlowPersistence, FlowingWaterAccess,
-    InlandWaterAccess, InlandWaterSize, LandRoute, LandWaterCrossing, MarineWaterAccess,
-    RiverAccess, RiverAndCanalAccess, RiverWatercourse, SettlementHydrology, SettlementImport,
-    SourceProvenance, StrahlerOrder, TravelEdgeImport, TravelRoute, WORLD_SCHEMA_VERSION,
-    WaterDistanceMeters, WorldMetadata,
+    CURRENT_INFERENCE_RULES_VERSION, CanalWatercourse, CompiledWorld, CrossingTraversal,
+    CrossingWatercourse, EdgeEndpoint, EdgeProgressPermille, FerryRoute, FerryWaterway,
+    FlowPersistence, FlowingWaterAccess, InlandWaterAccess, InlandWaterSize, LandRoute,
+    LandWaterCrossing, MarineWaterAccess, RiverAccess, RiverAndCanalAccess, RiverWatercourse,
+    SettlementHydrology, SettlementImport, SourceProvenance, StrahlerOrder, TravelEdgeImport,
+    TravelRoute, WORLD_SCHEMA_VERSION, WaterDistanceMeters, WorldMetadata,
 };
 use geo::{BoundingRect, Contains, Coord, Geometry, Line, LineString, Point};
 use geozero::{ToGeo, wkb::GpkgWkb};
-use proj4rs::{proj::Proj, transform::transform};
 use rusqlite::{Connection, OpenFlags, params};
 
 use crate::{
@@ -29,6 +28,7 @@ use crate::{
         DroughtSettlementDraft, SettlementDraftAccess, TravelEdgeDraft, TravelRouteDraft,
         WorldDraft, push_source_note,
     },
+    spatial::SpatialProjection,
 };
 
 const SOURCE_NAME: &str = "Copernicus EU-Hydro River Network Database v1.3";
@@ -46,11 +46,17 @@ pub(crate) fn enrich(
     mut draft: WorldDraft<DroughtSettlementDraft>,
     source_directory: &Path,
 ) -> Result<CompiledWorld> {
-    let projection = HydrologyProjection::new()?;
+    let projection = SpatialProjection::new()?;
     let projected_nodes = draft
         .nodes
         .iter()
-        .map(|node| Ok((node.id, projection.project(node.latitude, node.longitude)?)))
+        .map(|node| {
+            let coordinate = projection.project(node.latitude, node.longitude)?;
+            Ok((
+                node.id,
+                Point::new(coordinate.easting_meters(), coordinate.northing_meters()),
+            ))
+        })
         .collect::<Result<HashMap<_, _>>>()?;
     let bounds = world_bounds(projected_nodes.values().copied());
     let database = HydrologyDatabase::open(source_directory, bounds)?;
@@ -126,6 +132,8 @@ pub(crate) fn enrich(
     Ok(CompiledWorld {
         metadata: WorldMetadata {
             schema_version: WORLD_SCHEMA_VERSION,
+            inference_rules_version: CURRENT_INFERENCE_RULES_VERSION,
+            spatial_grid: draft.spatial_grid,
             world_year: draft.year,
             sources: draft.sources,
             road_types: draft.road_types,
@@ -192,39 +200,6 @@ fn finish_settlement(
 
 fn base_settlement(draft: &DroughtSettlementDraft) -> &crate::draft::SettlementDraft {
     draft.base_settlement()
-}
-
-struct HydrologyProjection {
-    geographic: Proj,
-    projected: Proj,
-}
-
-impl HydrologyProjection {
-    fn new() -> Result<Self> {
-        Ok(Self {
-            geographic: Proj::from_proj_string(
-                "+proj=longlat +datum=WGS84 +ellps=WGS84 +no_defs +type=crs",
-            )?,
-            projected: Proj::from_proj_string(
-                "+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +units=m +no_defs +type=crs",
-            )?,
-        })
-    }
-
-    fn project(&self, latitude: f64, longitude: f64) -> Result<Point<f64>> {
-        if !latitude.is_finite()
-            || !longitude.is_finite()
-            || !(-90.0..=90.0).contains(&latitude)
-            || !(-180.0..=180.0).contains(&longitude)
-        {
-            return Err(Error::Validation(format!(
-                "invalid coordinate ({latitude}, {longitude}) for EU-Hydro"
-            )));
-        }
-        let mut coordinate = (longitude.to_radians(), latitude.to_radians(), 0.0);
-        transform(&self.geographic, &self.projected, &mut coordinate)?;
-        Ok(Point::new(coordinate.0, coordinate.1))
-    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/adventuresim-world-import/src/sources/land_use.rs
+++ b/crates/adventuresim-world-import/src/sources/land_use.rs
@@ -72,6 +72,7 @@ pub(crate) fn enrich(
         draft.sources.push(source_provenance());
         return Ok(WorldDraft {
             year: draft.year,
+            spatial_grid: draft.spatial_grid,
             sources: draft.sources,
             road_types: draft.road_types,
             nodes: draft.nodes,
@@ -140,6 +141,7 @@ pub(crate) fn enrich(
     draft.report.land_use_normalized_samples = normalized_samples;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,

--- a/crates/adventuresim-world-import/src/sources/potential_vegetation.rs
+++ b/crates/adventuresim-world-import/src/sources/potential_vegetation.rs
@@ -95,6 +95,7 @@ fn finish(
     draft.report.potential_vegetation_fallback_samples = fallbacks;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,
@@ -584,9 +585,13 @@ mod tests {
         }
 
         let viabundus = std::env::var_os("VIABUNDUS_DIR").expect("set VIABUNDUS_DIR");
-        let settlements = crate::sources::viabundus::compile(Path::new(&viabundus), 1544)
-            .unwrap()
-            .settlements;
+        let settlements = crate::sources::viabundus::compile(
+            Path::new(&viabundus),
+            1544,
+            adventuresim_world_schema::SpatialGridSpec::default(),
+        )
+        .unwrap()
+        .settlements;
         let mapped = settlements
             .iter()
             .filter(|settlement| {

--- a/crates/adventuresim-world-import/src/sources/religion.rs
+++ b/crates/adventuresim-world-import/src/sources/religion.rs
@@ -312,6 +312,7 @@ pub(crate) fn enrich(
     draft.report.religion_fallback_samples = fallbacks;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,

--- a/crates/adventuresim-world-import/src/sources/soil.rs
+++ b/crates/adventuresim-world-import/src/sources/soil.rs
@@ -101,6 +101,7 @@ fn finish(
     draft.report.soil_fallback_samples = fallbacks;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,

--- a/crates/adventuresim-world-import/src/sources/tree_species.rs
+++ b/crates/adventuresim-world-import/src/sources/tree_species.rs
@@ -267,6 +267,7 @@ fn finish(
     draft.report.tree_species_candidates = candidate_count;
     Ok(WorldDraft {
         year: draft.year,
+        spatial_grid: draft.spatial_grid,
         sources: draft.sources,
         road_types: draft.road_types,
         nodes: draft.nodes,
@@ -974,7 +975,12 @@ mod tests {
     fn full_stage_enriches_all_viabundus_settlements() {
         let viabundus = std::env::var_os("VIABUNDUS_DIR").expect("set VIABUNDUS_DIR");
         let archive = std::env::var_os("EU_TREES4F_ARCHIVE").expect("set EU_TREES4F_ARCHIVE");
-        let mut raw = crate::sources::viabundus::compile(Path::new(&viabundus), 1544).unwrap();
+        let mut raw = crate::sources::viabundus::compile(
+            Path::new(&viabundus),
+            1544,
+            adventuresim_world_schema::SpatialGridSpec::default(),
+        )
+        .unwrap();
         let settlements = std::mem::take(&mut raw.settlements)
             .into_iter()
             .map(|settlement| PotentialVegetationSettlementDraft {
@@ -1001,6 +1007,7 @@ mod tests {
             .collect();
         let draft = WorldDraft {
             year: raw.year,
+            spatial_grid: raw.spatial_grid,
             sources: raw.sources,
             road_types: raw.road_types,
             nodes: raw.nodes,

--- a/crates/adventuresim-world-import/src/sources/viabundus/mod.rs
+++ b/crates/adventuresim-world-import/src/sources/viabundus/mod.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use adventuresim_world_schema::{
-    EdgeEndpoint, SourceProvenance, TravelEdgeKind, WorldBuildReport, WorldNodeImport,
+    EdgeEndpoint, SourceProvenance, SpatialGridSpec, TravelEdgeKind, WorldBuildReport,
+    WorldNodeImport,
 };
 use serde::{Deserialize, Deserializer, de};
 
@@ -81,7 +82,11 @@ struct RawPopulation {
     inhabitants: String,
 }
 
-pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<SettlementDraft>> {
+pub(crate) fn compile(
+    directory: &Path,
+    year: i32,
+    spatial_grid: SpatialGridSpec,
+) -> Result<WorldDraft<SettlementDraft>> {
     let nodes_path = require(directory, "nodes.csv")?;
     let edges_path = require(directory, "edges.csv")?;
     let population_path = require(directory, "population.csv")?;
@@ -310,6 +315,7 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
 
     Ok(WorldDraft {
         year,
+        spatial_grid,
         sources: vec![SourceProvenance {
             name: SOURCE_NAME.into(),
             url: SOURCE_DOI.into(),

--- a/crates/adventuresim-world-import/src/spatial.rs
+++ b/crates/adventuresim-world-import/src/spatial.rs
@@ -1,0 +1,190 @@
+//! Canonical spatial-grid projection and cell assignment for importer stages.
+//!
+//! This module deliberately contains no raster/vector readers. A source stage
+//! must resolve nodata explicitly: distinguish outside source coverage from a
+//! covered cell whose observations are nodata, record the chosen fallback in
+//! provenance, and never silently treat either state as a numeric zero.
+
+use adventuresim_world_schema::SpatialGridSpec;
+use proj4rs::{proj::Proj, transform::transform};
+
+use crate::{Error, Result};
+
+const MILLIMETERS_PER_METER: i64 = 1_000;
+const I64_LOWER_INCLUSIVE: f64 = -9_223_372_036_854_775_808.0;
+const I64_UPPER_EXCLUSIVE: f64 = 9_223_372_036_854_775_808.0;
+
+/// Finite EPSG:3035 coordinate quantized to the nearest millimetre.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ProjectedCoordinate {
+    easting_mm: i64,
+    northing_mm: i64,
+}
+
+impl ProjectedCoordinate {
+    pub fn from_meters(easting_m: f64, northing_m: f64) -> Result<Self> {
+        let quantize = |meters: f64| {
+            let millimeters = (meters * MILLIMETERS_PER_METER as f64).round();
+            (millimeters.is_finite()
+                && (I64_LOWER_INCLUSIVE..I64_UPPER_EXCLUSIVE).contains(&millimeters))
+            .then_some(millimeters as i64)
+        };
+        let Some(easting_mm) = quantize(easting_m) else {
+            return Err(invalid_projected_coordinate(easting_m, northing_m));
+        };
+        let Some(northing_mm) = quantize(northing_m) else {
+            return Err(invalid_projected_coordinate(easting_m, northing_m));
+        };
+        Ok(Self {
+            easting_mm,
+            northing_mm,
+        })
+    }
+
+    pub const fn easting_millimeters(self) -> i64 {
+        self.easting_mm
+    }
+    pub const fn northing_millimeters(self) -> i64 {
+        self.northing_mm
+    }
+    pub fn easting_meters(self) -> f64 {
+        self.easting_mm as f64 / MILLIMETERS_PER_METER as f64
+    }
+    pub fn northing_meters(self) -> f64 {
+        self.northing_mm as f64 / MILLIMETERS_PER_METER as f64
+    }
+
+    pub fn cell(self, grid: SpatialGridSpec) -> SpatialCellId {
+        let cell_mm = i64::from(grid.cell_size_meters().get()) * MILLIMETERS_PER_METER;
+        SpatialCellId {
+            column: self.easting_mm.div_euclid(cell_mm),
+            row: self.northing_mm.div_euclid(cell_mm),
+        }
+    }
+}
+
+fn invalid_projected_coordinate(easting_m: f64, northing_m: f64) -> Error {
+    Error::Validation(format!(
+        "invalid EPSG:3035 coordinate ({easting_m}, {northing_m})"
+    ))
+}
+
+/// Stable column/row address in a [`SpatialGridSpec`].
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SpatialCellId {
+    column: i64,
+    row: i64,
+}
+
+impl SpatialCellId {
+    pub const fn column(self) -> i64 {
+        self.column
+    }
+    pub const fn row(self) -> i64 {
+        self.row
+    }
+}
+
+/// Deterministic WGS84 longitude/latitude to EPSG:3035 projector.
+pub struct SpatialProjection {
+    geographic: Proj,
+    projected: Proj,
+}
+
+impl SpatialProjection {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            geographic: Proj::from_proj_string(
+                "+proj=longlat +datum=WGS84 +ellps=WGS84 +no_defs +type=crs",
+            )?,
+            projected: Proj::from_proj_string(
+                "+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +units=m +no_defs +type=crs",
+            )?,
+        })
+    }
+
+    pub fn project(&self, latitude: f64, longitude: f64) -> Result<ProjectedCoordinate> {
+        if !latitude.is_finite()
+            || !longitude.is_finite()
+            || !(-90.0..=90.0).contains(&latitude)
+            || !(-180.0..=180.0).contains(&longitude)
+        {
+            return Err(Error::Validation(format!(
+                "invalid WGS84 coordinate ({latitude}, {longitude})"
+            )));
+        }
+        let mut coordinate = (longitude.to_radians(), latitude.to_radians(), 0.0);
+        transform(&self.geographic, &self.projected, &mut coordinate)?;
+        ProjectedCoordinate::from_meters(coordinate.0, coordinate.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use adventuresim_world_schema::{GridCellSizeMeters, SpatialGridSpec};
+
+    use super::{ProjectedCoordinate, SpatialProjection};
+
+    #[test]
+    fn cell_assignment_uses_euclidean_division_at_boundaries() {
+        let grid = SpatialGridSpec::new(GridCellSizeMeters::new(1_000).unwrap());
+        for (x, expected) in [
+            (-1000.0, -1),
+            (-999.999, -1),
+            (-0.001, -1),
+            (0.0, 0),
+            (999.999, 0),
+            (1000.0, 1),
+        ] {
+            assert_eq!(
+                ProjectedCoordinate::from_meters(x, x)
+                    .unwrap()
+                    .cell(grid)
+                    .column(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn projection_rejects_nonfinite_and_out_of_range_coordinates() {
+        let projection = SpatialProjection::new().unwrap();
+        assert!(projection.project(f64::NAN, 10.0).is_err());
+        assert!(projection.project(91.0, 10.0).is_err());
+        assert!(projection.project(52.0, 181.0).is_err());
+        assert!(ProjectedCoordinate::from_meters(f64::INFINITY, 0.0).is_err());
+    }
+
+    #[test]
+    fn millimeter_quantization_rejects_positive_i64_overflow_boundary() {
+        let upper_exclusive_mm = 9_223_372_036_854_775_808.0;
+        assert!(ProjectedCoordinate::from_meters(upper_exclusive_mm / 1_000.0, 0.0).is_err());
+    }
+
+    #[test]
+    fn millimeter_quantization_accepts_nearest_representable_boundaries() {
+        let nearest_below_upper_mm = f64::from_bits(9_223_372_036_854_775_808.0_f64.to_bits() - 1);
+        let lower_inclusive_mm = -9_223_372_036_854_775_808.0;
+
+        let nearest_valid_meters = nearest_below_upper_mm / 1_000.0;
+        let expected_mm = (nearest_valid_meters * 1_000.0).round() as i64;
+        let positive =
+            ProjectedCoordinate::from_meters(nearest_valid_meters, lower_inclusive_mm / 1_000.0)
+                .unwrap();
+        assert_eq!(positive.easting_millimeters(), expected_mm);
+        assert!(positive.easting_millimeters() < i64::MAX);
+        assert_eq!(positive.northing_millimeters(), i64::MIN);
+    }
+
+    #[test]
+    fn wgs84_fixture_projects_to_a_stable_epsg3035_cell() {
+        let coordinate = SpatialProjection::new()
+            .unwrap()
+            .project(52.0, 10.0)
+            .unwrap();
+        assert_eq!(coordinate.easting_millimeters(), 4_321_000_000);
+        assert_eq!(coordinate.northing_millimeters(), 3_210_000_000);
+        let cell = coordinate.cell(SpatialGridSpec::default());
+        assert_eq!((cell.column(), cell.row()), (4_321, 3_210));
+    }
+}

--- a/crates/adventuresim-world-import/src/validation.rs
+++ b/crates/adventuresim-world-import/src/validation.rs
@@ -1,8 +1,9 @@
 use std::collections::HashSet;
 
 use adventuresim_world_schema::{
-    CompiledWorld, DroughtProfile, SettlementHydrology, SoilProfile, SurfaceGeology, TravelRoute,
-    TreeSpeciesProfile, WORLD_SCHEMA_VERSION, valid_sources_markdown,
+    CURRENT_INFERENCE_RULES_VERSION, CompiledWorld, DroughtProfile, SettlementHydrology,
+    SoilProfile, SurfaceGeology, TravelRoute, TreeSpeciesProfile, WORLD_SCHEMA_VERSION,
+    valid_sources_markdown,
 };
 
 use crate::{Error, Result};
@@ -12,6 +13,12 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
         return Err(Error::Validation(format!(
             "schema version {} is not supported (expected {WORLD_SCHEMA_VERSION})",
             world.metadata.schema_version
+        )));
+    }
+    if world.metadata.inference_rules_version != CURRENT_INFERENCE_RULES_VERSION {
+        return Err(Error::Validation(format!(
+            "inference rules version {} is not supported (expected {CURRENT_INFERENCE_RULES_VERSION})",
+            world.metadata.inference_rules_version
         )));
     }
 
@@ -485,6 +492,11 @@ fn elevation_counts_are_consistent(
 
 #[cfg(test)]
 mod tests {
+    use adventuresim_world_schema::{
+        CURRENT_INFERENCE_RULES_VERSION, CompiledWorld, SpatialGridSpec, WORLD_SCHEMA_VERSION,
+        WorldBuildReport, WorldMetadata,
+    };
+
     use super::elevation_counts_are_consistent;
     use super::forest_counts_are_consistent;
     use super::land_use_counts_are_consistent;
@@ -494,6 +506,47 @@ mod tests {
         hydrology_counts_are_consistent, religion_counts_are_consistent,
         soil_counts_are_consistent, tree_species_counts_are_consistent,
     };
+
+    fn empty_world(schema_version: u32, inference_rules_version: u32) -> CompiledWorld {
+        CompiledWorld {
+            metadata: WorldMetadata {
+                schema_version,
+                inference_rules_version,
+                spatial_grid: SpatialGridSpec::default(),
+                world_year: 1544,
+                sources: Vec::new(),
+                road_types: Vec::new(),
+            },
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            settlements: Vec::new(),
+            settlement_aliases: Vec::new(),
+            settlement_descriptions: Vec::new(),
+            report: WorldBuildReport::default(),
+        }
+    }
+
+    #[test]
+    fn metadata_validation_rejects_wrong_schema_and_inference_versions() {
+        assert!(
+            super::validate(&empty_world(
+                WORLD_SCHEMA_VERSION - 1,
+                CURRENT_INFERENCE_RULES_VERSION
+            ))
+            .unwrap_err()
+            .to_string()
+            .contains("schema version")
+        );
+        assert!(
+            super::validate(&empty_world(
+                WORLD_SCHEMA_VERSION,
+                CURRENT_INFERENCE_RULES_VERSION + 1
+            ))
+            .unwrap_err()
+            .to_string()
+            .contains("inference rules version")
+        );
+    }
 
     #[test]
     fn elevation_report_requires_complete_consistent_counts() {

--- a/crates/adventuresim-world-schema/src/lib.rs
+++ b/crates/adventuresim-world-schema/src/lib.rs
@@ -7,7 +7,8 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-pub const WORLD_SCHEMA_VERSION: u32 = 13;
+pub const WORLD_SCHEMA_VERSION: u32 = 14;
+pub const CURRENT_INFERENCE_RULES_VERSION: u32 = 1;
 pub const MAX_SOURCES_MARKDOWN_CHARS: usize = 32_768;
 
 /// Source and inference notes are deliberately unstructured Markdown for a
@@ -1744,9 +1745,187 @@ impl TravelRoute {
     }
 }
 
+/// The only canonical projected coordinate system used by world-data stages.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum SpatialGridCrs {
+    /// EPSG:3035, ETRS89 / LAEA Europe.
+    Etrs89LaeaEurope,
+}
+
+/// Validated square grid cell size in integer metres.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct GridCellSizeMeters(u32);
+
+impl GridCellSizeMeters {
+    pub const MIN: u32 = 250;
+    pub const MAX: u32 = 100_000;
+    pub const DEFAULT: u32 = 1_000;
+
+    pub fn new(meters: u32) -> Result<Self, SpatialGridSpecError> {
+        if !(Self::MIN..=Self::MAX).contains(&meters) || meters % 250 != 0 {
+            return Err(SpatialGridSpecError::InvalidCellSize(meters));
+        }
+        Ok(Self(meters))
+    }
+
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+impl Default for GridCellSizeMeters {
+    fn default() -> Self {
+        Self(Self::DEFAULT)
+    }
+}
+
+impl FromStr for GridCellSizeMeters {
+    type Err = SpatialGridSpecError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let meters = value
+            .parse::<u32>()
+            .map_err(|_| SpatialGridSpecError::InvalidCellSizeText(value.into()))?;
+        Self::new(meters)
+    }
+}
+
+impl fmt::Display for GridCellSizeMeters {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl<'de> Deserialize<'de> for GridCellSizeMeters {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Self::new(u32::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SpatialGridSpecError {
+    InvalidCellSize(u32),
+    InvalidCellSizeText(String),
+    NonCanonicalOrigin { easting_m: i64, northing_m: i64 },
+    RectangularCells { width_m: u32, height_m: u32 },
+}
+
+impl fmt::Display for SpatialGridSpecError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCellSize(value) => write!(
+                formatter,
+                "grid cell size {value} must be 250..=100000 metres and divisible by 250"
+            ),
+            Self::InvalidCellSizeText(value) => write!(
+                formatter,
+                "grid cell size {value:?} is not an unsigned integer number of metres"
+            ),
+            Self::NonCanonicalOrigin {
+                easting_m,
+                northing_m,
+            } => write!(
+                formatter,
+                "grid origin ({easting_m}, {northing_m}) must be the canonical (0, 0) metres"
+            ),
+            Self::RectangularCells { width_m, height_m } => write!(
+                formatter,
+                "grid cells must be square, not {width_m} by {height_m} metres"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SpatialGridSpecError {}
+
+/// Complete identity of the canonical, origin-aligned square spatial grid.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct SpatialGridSpec {
+    crs: SpatialGridCrs,
+    origin_easting_m: i64,
+    origin_northing_m: i64,
+    cell_width_m: GridCellSizeMeters,
+    cell_height_m: GridCellSizeMeters,
+}
+
+impl SpatialGridSpec {
+    pub fn new(cell_size: GridCellSizeMeters) -> Self {
+        Self {
+            crs: SpatialGridCrs::Etrs89LaeaEurope,
+            origin_easting_m: 0,
+            origin_northing_m: 0,
+            cell_width_m: cell_size,
+            cell_height_m: cell_size,
+        }
+    }
+
+    pub const fn crs(self) -> SpatialGridCrs {
+        self.crs
+    }
+    pub const fn origin_easting_m(self) -> i64 {
+        self.origin_easting_m
+    }
+    pub const fn origin_northing_m(self) -> i64 {
+        self.origin_northing_m
+    }
+    pub const fn cell_size_meters(self) -> GridCellSizeMeters {
+        self.cell_width_m
+    }
+}
+
+impl Default for SpatialGridSpec {
+    fn default() -> Self {
+        Self::new(GridCellSizeMeters::default())
+    }
+}
+
+impl<'de> Deserialize<'de> for SpatialGridSpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Wire {
+            crs: SpatialGridCrs,
+            origin_easting_m: i64,
+            origin_northing_m: i64,
+            cell_width_m: GridCellSizeMeters,
+            cell_height_m: GridCellSizeMeters,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        if wire.crs != SpatialGridCrs::Etrs89LaeaEurope {
+            return Err(serde::de::Error::custom("unsupported spatial grid CRS"));
+        }
+        if (wire.origin_easting_m, wire.origin_northing_m) != (0, 0) {
+            return Err(serde::de::Error::custom(
+                SpatialGridSpecError::NonCanonicalOrigin {
+                    easting_m: wire.origin_easting_m,
+                    northing_m: wire.origin_northing_m,
+                },
+            ));
+        }
+        if wire.cell_width_m != wire.cell_height_m {
+            return Err(serde::de::Error::custom(
+                SpatialGridSpecError::RectangularCells {
+                    width_m: wire.cell_width_m.get(),
+                    height_m: wire.cell_height_m.get(),
+                },
+            ));
+        }
+        Ok(Self::new(wire.cell_width_m))
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct WorldMetadata {
     pub schema_version: u32,
+    pub inference_rules_version: u32,
+    pub spatial_grid: SpatialGridSpec,
     pub world_year: i32,
     pub sources: Vec<SourceProvenance>,
     pub road_types: Vec<TravelEdgeKind>,
@@ -2147,6 +2326,50 @@ mod tests {
         assert_eq!(LanguageCode::from_str("deu").unwrap().as_str(), "deu");
         assert!(LanguageCode::from_str("DE").is_err());
         assert!(serde_json::from_str::<LanguageCode>("\"english\"").is_err());
+    }
+
+    #[test]
+    fn spatial_grid_sizes_cover_only_the_canonical_range_and_increment() {
+        use super::GridCellSizeMeters;
+        assert_eq!(GridCellSizeMeters::default().get(), 1_000);
+        assert_eq!(GridCellSizeMeters::new(250).unwrap().get(), 250);
+        assert_eq!(GridCellSizeMeters::new(100_000).unwrap().get(), 100_000);
+        for invalid in [0, 249, 251, 99_999, 100_001] {
+            assert!(GridCellSizeMeters::new(invalid).is_err());
+        }
+        assert!(serde_json::from_str::<GridCellSizeMeters>("251").is_err());
+    }
+
+    #[test]
+    fn spatial_grid_wire_values_cannot_bypass_invariants() {
+        use super::SpatialGridSpec;
+        let canonical = serde_json::to_value(SpatialGridSpec::default()).unwrap();
+        assert_eq!(
+            serde_json::from_value::<SpatialGridSpec>(canonical.clone()).unwrap(),
+            SpatialGridSpec::default()
+        );
+
+        let mutate = |field: &str, value| {
+            let mut wire = canonical.clone();
+            wire[field] = value;
+            serde_json::from_value::<SpatialGridSpec>(wire)
+        };
+        assert!(mutate("crs", serde_json::json!("Wgs84")).is_err());
+        assert!(mutate("origin_easting_m", serde_json::json!(1)).is_err());
+        assert!(mutate("origin_northing_m", serde_json::json!(-1)).is_err());
+        assert!(mutate("cell_height_m", serde_json::json!(2_000)).is_err());
+        assert!(mutate("cell_width_m", serde_json::json!(0)).is_err());
+    }
+
+    #[test]
+    fn old_world_metadata_cannot_default_new_identity_fields() {
+        let old = serde_json::json!({
+            "schema_version": 13,
+            "world_year": 1544,
+            "sources": [],
+            "road_types": []
+        });
+        assert!(serde_json::from_value::<super::WorldMetadata>(old).is_err());
     }
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,13 @@ import types shared by the compiler and strategic module. The strategic module
 accepts those records through reducers but never parses raw datasets or depends
 on native geospatial libraries.
 
+Every gridded enrichment shares the canonical `SpatialGridSpec` described in
+`docs/SPATIAL_GRID.md`. The complete spec and inference-rules version are
+serialized in world metadata, so either changing alters the content-addressed
+artifact identity. Source coverage extents remain source-manifest concerns.
+The grid is compiler metadata, not a SpacetimeDB table shape: no grid columns or
+tactical coordinates are persisted.
+
 Source modules first parse into importer-only draft types. The outer builder
 enriches that draft in dependency order and only then constructs the canonical
 world schema. For example, Viabundus supplies settlement identity and road
@@ -51,7 +58,8 @@ display/debug payload rather than a structured provenance API. No debug view
 renders it yet; any future renderer must treat it as untrusted Markdown and
 sanitize generated HTML.
 
-Each compiled artifact is identified by a content hash. An interrupted load may
+Each compiled artifact is identified by a content hash over its serialized
+metadata and records. An interrupted load may
 resume only with the same artifact; a different artifact requires a database
 reset. Successful loads explicitly complete their import session so later
 batches cannot mutate an already-loaded world.

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -163,6 +163,12 @@ Interrupted loads can be resumed with the identical compiled artifact. The
 module rejects a different artifact or any additional batches after completion;
 use `just publish-reset` before loading changed source data or a different year.
 
+The compiler defaults to the canonical 1,000 m spatial grid. Pass
+`--grid-cell-size-meters 250` (or another multiple of 250 from 250 through
+100,000) to deliberately build a different grid identity. See
+`docs/SPATIAL_GRID.md`; changing the size changes the artifact ID and therefore
+requires the normal explicit import reset when another artifact is active.
+
 The loader claims a one-time import identity before sending batches. For a
 production deployment, the operator must make that first call before allowing
 untrusted clients to connect.

--- a/docs/SPATIAL_GRID.md
+++ b/docs/SPATIAL_GRID.md
@@ -1,0 +1,43 @@
+# Canonical spatial grid
+
+World-data enrichment stages use one source-independent grid identity. Its CRS
+is EPSG:3035 (ETRS89 / LAEA Europe), its serialized origin is exactly `(0 m,
+0 m)`, and cells are square. The default cell size is 1,000 m. Deliberate
+alternatives must be integer metres from 250 through 100,000, inclusive, and
+divisible by 250. Alternate projections, origins, or rectangular cells are not
+valid world artifacts.
+
+`adventuresim-world-schema` owns the validated `SpatialGridSpec` wire type.
+Private fields and custom deserialization prevent malformed artifacts from
+bypassing its constructors. The importer owns WGS84-to-EPSG:3035 projection,
+millimetre quantization, and cell assignment. Euclidean division makes negative
+coordinates and exact cell boundaries deterministic. Raw TIFF, COG, vector,
+and source-manifest parsing stays in individual importer source modules.
+
+Coverage is not part of the shared grid. Each source manifest must state its
+own extent and distinguish these cases explicitly:
+
+- the requested cell is outside source coverage;
+- the cell is covered but all relevant observations are nodata;
+- the cell has usable observations.
+
+Stages must document and record any fallback instead of silently mapping
+outside-coverage or nodata states to zero.
+
+## Identity and future caches
+
+The world schema version, inference-rules version, and complete grid spec are
+serialized in metadata and therefore participate in the final BLAKE3 artifact
+ID. Old artifacts missing these fields fail deserialization; they are not
+assigned defaults.
+
+No intermediate cache framework exists yet. When one is introduced, every key
+must contain:
+
+1. world schema version and inference-rules version;
+2. the complete serialized grid spec;
+3. stage name and stage implementation/version;
+4. source checksums sorted by their stable source identity.
+
+Any mismatch means regeneration. Source coverage extents belong in the source
+manifest and will affect its checksum rather than expanding `SpatialGridSpec`.


### PR DESCRIPTION
## Summary

- bump the world schema to v14 and add a validated canonical EPSG:3035 spatial-grid identity to world metadata
- fix the grid origin at `(0 m, 0 m)`, use square 1 km cells by default, and allow only 250–100,000 m sizes divisible by 250
- propagate one validated grid through CLI, builder, every typestate stage, final artifact identity, and validation
- add importer-only deterministic WGS84 projection, nearest-millimetre quantization, and Euclidean cell assignment
- route EU-Hydro through the canonical projector and document nodata, coverage, regeneration, and future cache-key rules

## Why

Issues #67 and #68 need one source-independent alignment before Jung 1 km and SoilGrids 250 m data can be resampled deterministically. The complete grid spec and inference-rules version now participate in the serialized world and therefore its BLAKE3 artifact ID; old artifacts fail rather than receiving defaults.

Part of #62. This is strictly stacked on PR #61 (`codex/strategic-autoresolver`).

## Validation

- `cargo test -p adventuresim-world-schema --lib` — 18 passed
- `cargo test -p adventuresim-world-import` — 104 passed total, 8 source-dependent ignored
- `cargo check -p adventuresim-world-import -p adventuresim-stdb-module -p strategic-web`
- scoped formatting
- project-map regeneration/check
- `git diff --check`
- independent correctness and security/maintainability review
- targeted numeric-boundary re-review after remediation

## Compatibility and risks

This intentionally bumps the world schema from 13 to 14. Existing compiled artifacts and local imported worlds require regeneration/reset. No SpacetimeDB grid columns or tactical state were added. Real-source tests remain ignored unless their documented external datasets are available.