### PR TITLE
Bind world artifacts to canonical source manifests

### DIFF
--- a/crates/adventuresim-stdb-client/src/world_data_import_type.rs
+++ b/crates/adventuresim-stdb-client/src/world_data_import_type.rs
@@ -11,6 +11,7 @@ pub struct WorldDataImport {
     pub owner: __sdk::Identity,
     pub schema_version: u32,
     pub artifact_id: String,
+    pub manifest_digest: String,
     pub sources: String,
     pub completed: bool,
 }

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -524,6 +524,8 @@ pub struct WorldDataImport {
     pub owner: Identity,
     pub schema_version: u32,
     pub artifact_id: String,
+    /// Canonical source/rules/grid manifest digest for audit and cache boundaries.
+    pub manifest_digest: String,
     /// Unstructured Markdown describing the source distributions in this
     /// compiled artifact. Per-record inference details live on imported rows.
     pub sources: String,
@@ -538,6 +540,7 @@ pub fn begin_world_data_import(
     ctx: &ReducerContext,
     schema_version: u32,
     artifact_id: String,
+    manifest_digest: String,
     sources: String,
 ) -> Result<(), String> {
     if schema_version != WORLD_SCHEMA_VERSION {
@@ -547,6 +550,13 @@ pub fn begin_world_data_import(
     }
     if artifact_id.trim().is_empty() {
         return Err("World artifact ID must not be empty".into());
+    }
+    if manifest_digest.len() != 64
+        || !manifest_digest
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err("World manifest digest must be 64 lowercase hexadecimal characters".into());
     }
     if !valid_sources_markdown(&sources) {
         return Err("World source notes are empty, too large, or contain a NUL byte".into());
@@ -558,6 +568,7 @@ pub fn begin_world_data_import(
         Some(import)
             if import.schema_version == schema_version
                 && import.artifact_id == artifact_id
+                && import.manifest_digest == manifest_digest
                 && import.sources == sources =>
         {
             if import.completed {
@@ -576,6 +587,7 @@ pub fn begin_world_data_import(
                 owner: ctx.sender(),
                 schema_version,
                 artifact_id,
+                manifest_digest,
                 sources,
                 completed: false,
             });

--- a/crates/adventuresim-world-import/src/lib.rs
+++ b/crates/adventuresim-world-import/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod builder;
 mod draft;
 pub mod error;
+mod manifest;
 mod sources;
 pub mod spatial;
 mod validation;

--- a/crates/adventuresim-world-import/src/main.rs
+++ b/crates/adventuresim-world-import/src/main.rs
@@ -111,6 +111,23 @@ fn run(args: Args) -> Result<()> {
     artifact.push(b'\n');
     std::fs::write(&output, artifact)?;
     println!("{}", serde_json::to_string_pretty(&world.report)?);
+    println!(
+        "Source manifest {} ({} distributions):",
+        world.metadata.manifest_digest,
+        world.metadata.sources.len()
+    );
+    for source in &world.metadata.sources {
+        println!(
+            "  {}: {} [{}]",
+            source.id,
+            source.name,
+            if source.content_identity.is_reproducible() {
+                "reproducible"
+            } else {
+                "not reproducible"
+            }
+        );
+    }
     println!("Wrote compiled world to {}", output.display());
     if args.load {
         load_world(&world, &artifact_id, &args)?;
@@ -119,24 +136,14 @@ fn run(args: Args) -> Result<()> {
 }
 
 fn load_world(world: &CompiledWorld, artifact_id: &str, args: &Args) -> Result<()> {
-    let sources = world
-        .metadata
-        .sources
-        .iter()
-        .map(|source| {
-            format!(
-                "- **[{}]({}):** {}",
-                source.name, source.url, source.license
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let sources = manifest_audit_markdown(world)?;
     call_reducer(
         args,
         "begin_world_data_import",
         &[
             json!(world.metadata.schema_version),
             json!(artifact_id),
+            json!(world.metadata.manifest_digest),
             json!(sources),
         ],
     )?;
@@ -189,6 +196,38 @@ fn load_world(world: &CompiledWorld, artifact_id: &str, args: &Args) -> Result<(
     }
     call_reducer(args, "finish_world_data_import", &[json!(artifact_id)])?;
     Ok(())
+}
+
+fn manifest_audit_markdown(world: &CompiledWorld) -> Result<String> {
+    let mut output = String::new();
+    for source in &world.metadata.sources {
+        let canonical = serde_json::to_string(source)?;
+        let section = format!(
+            "## [{}]({})\n\nContent status: **{}**\n\n```json\n{}\n```\n\n",
+            source.name,
+            source.canonical_url,
+            if source.content_identity.is_reproducible() {
+                "reproducible"
+            } else {
+                "not reproducible"
+            },
+            canonical,
+        );
+        output.push_str(&section);
+        if !adventuresim_world_schema::valid_sources_markdown(&output)
+            || serde_json::to_string(&output)?.encode_utf16().count() > MAX_REDUCER_ARGUMENT_CHARS
+        {
+            return Err(Error::Validation(format!(
+                "complete serialized source-manifest audit exceeds the {MAX_REDUCER_ARGUMENT_CHARS}-character reducer transport budget; refusing to omit or truncate operational notices"
+            )));
+        }
+    }
+    if !adventuresim_world_schema::valid_sources_markdown(&output) {
+        return Err(Error::Validation(
+            "source-manifest audit Markdown is empty or invalid".into(),
+        ));
+    }
+    Ok(output)
 }
 
 fn serialize_batches<T>(
@@ -916,17 +955,19 @@ mod tests {
         PalmerDroughtSeverityIndex, PotentialVegetation, PotentialVegetationClass,
         SettlementDescriptionImport, SettlementDescriptionKind, SettlementImport,
         SettlementReligiousStatus, SoilAcidity, SoilBasisPoints, SoilDepth, SoilEvidence,
-        SoilFertility, SoilProfile, SoilProperties, SoilSubstrate, SoilWaterRegime,
-        SpatialGridSpec, StoneContentPercent, SurfaceGeology, SurfaceLithology,
-        TopsoilOrganicCarbon, TravelEdgeImport, TravelRoute, TreeSpeciesId, TreeSpeciesProfile,
-        UnconsolidatedDeposit, WORLD_SCHEMA_VERSION, Woodland, WorldBuildReport, WorldMetadata,
-        WrbReferenceGroup,
+        SoilFertility, SoilProfile, SoilProperties, SoilSubstrate, SoilWaterRegime, SourceAccess,
+        SourceContentIdentity, SourceLicense, SourcePreparation, SourceProvenance, SourceRelease,
+        SourceSpatialCoverage, SourceTemporalCoverage, SpatialGridSpec, StoneContentPercent,
+        SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport, TravelRoute,
+        TreeSpeciesId, TreeSpeciesProfile, UnconsolidatedDeposit, WORLD_SCHEMA_VERSION, Woodland,
+        WorldBuildReport, WorldMetadata, WrbReferenceGroup,
     };
     use clap::Parser;
 
     use super::{
         Args, MAX_REDUCER_ARGUMENT_CHARS, default_output, encode_settlement,
-        encode_settlement_description, encode_travel_edge, serialize_batches,
+        encode_settlement_description, encode_travel_edge, manifest_audit_markdown,
+        serialize_batches,
     };
 
     #[test]
@@ -949,6 +990,7 @@ mod tests {
                 inference_rules_version: CURRENT_INFERENCE_RULES_VERSION,
                 spatial_grid: SpatialGridSpec::new(GridCellSizeMeters::new(cell_size).unwrap()),
                 world_year: 1544,
+                manifest_digest: "0".repeat(64),
                 sources: Vec::new(),
                 road_types: Vec::new(),
             },
@@ -963,6 +1005,88 @@ mod tests {
         let fine_bytes = serde_json::to_vec(&world(250)).unwrap();
         assert_ne!(default_bytes, fine_bytes);
         assert_ne!(blake3::hash(&default_bytes), blake3::hash(&fine_bytes));
+    }
+
+    #[test]
+    fn import_audit_includes_every_notice_and_refuses_truncation() {
+        let source = SourceProvenance {
+            id: "fixture".into(),
+            name: "Fixture".into(),
+            release: SourceRelease::Immutable {
+                version: "1".into(),
+                released: "2020".into(),
+            },
+            canonical_url: "https://example.invalid/source".into(),
+            doi: Some("10.1/fixture".into()),
+            license: SourceLicense::CcBy4_0,
+            required_notices: vec!["first exact notice".into(), "second exact notice".into()],
+            access: SourceAccess::AnonymousDownload,
+            spatial: SourceSpatialCoverage::NotApplicable,
+            temporal: SourceTemporalCoverage::Timeless,
+            preparation: SourcePreparation {
+                recipe: "fixture".into(),
+                version: 1,
+            },
+            content_identity: SourceContentIdentity::RawSha256 {
+                sha256: "a".repeat(64),
+            },
+            notes_markdown: "Fixture notes.".into(),
+        };
+        let world = CompiledWorld {
+            metadata: WorldMetadata {
+                schema_version: WORLD_SCHEMA_VERSION,
+                inference_rules_version: CURRENT_INFERENCE_RULES_VERSION,
+                spatial_grid: SpatialGridSpec::default(),
+                world_year: 1544,
+                manifest_digest: "0".repeat(64),
+                sources: vec![source.clone()],
+                road_types: vec![],
+            },
+            nodes: vec![],
+            edges: vec![],
+            settlements: vec![],
+            settlement_aliases: vec![],
+            settlement_descriptions: vec![],
+            report: WorldBuildReport::default(),
+        };
+        let audit = manifest_audit_markdown(&world).unwrap();
+        for text in [
+            "fixture",
+            "Fixture",
+            "immutable",
+            "cc-by4-0",
+            "reproducible",
+            "10.1/fixture",
+            "first exact notice",
+            "second exact notice",
+            "Fixture notes.",
+        ] {
+            assert!(audit.contains(text));
+        }
+        for mutate in [
+            |source: &mut SourceProvenance| source.access = SourceAccess::ManualPreparation,
+            |source: &mut SourceProvenance| {
+                source.spatial = SourceSpatialCoverage::Geographic {
+                    crs: "EPSG:3035".into(),
+                    resolution: "1 km".into(),
+                    coverage: "Europe".into(),
+                }
+            },
+            |source: &mut SourceProvenance| source.temporal = SourceTemporalCoverage::Year(1544),
+            |source: &mut SourceProvenance| source.preparation.version = 2,
+        ] {
+            let mut changed = world.clone();
+            mutate(&mut changed.metadata.sources[0]);
+            assert_ne!(audit, manifest_audit_markdown(&changed).unwrap());
+        }
+        let mut oversized = world.clone();
+        oversized.metadata.sources[0].required_notices = vec!["\\".repeat(13_000)];
+        assert!(
+            manifest_audit_markdown(&oversized)
+                .unwrap_err()
+                .to_string()
+                .contains("refusing to omit or truncate")
+        );
     }
 
     #[test]

--- a/crates/adventuresim-world-import/src/manifest.rs
+++ b/crates/adventuresim-world-import/src/manifest.rs
@@ -1,0 +1,1042 @@
+use std::{
+    fs::{self, File},
+    io::{BufReader, Read},
+    path::Path,
+};
+
+use adventuresim_world_schema::{
+    CURRENT_INFERENCE_RULES_VERSION, SourceAccess, SourceContentIdentity, SourceLicense,
+    SourcePreparation, SourceProvenance, SourceRelease, SourceSpatialCoverage,
+    SourceTemporalCoverage, SpatialGridSpec, WORLD_SCHEMA_VERSION,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{Error, Result};
+
+const MAX_TEXT: usize = 4_096;
+const MAX_NOTICES: usize = 12;
+const MAX_SIDECAR_BYTES: u64 = 1024 * 1024;
+const VIABUNDUS_RECORD: &str = "https://zenodo.org/api/records/16611998";
+const VIABUNDUS_FILES: [&str; 5] = [
+    "alternativenames.csv",
+    "descriptions.csv",
+    "edges.csv",
+    "nodes.csv",
+    "population.csv",
+];
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ViabundusSidecar {
+    files: Vec<ViabundusFile>,
+    record_url: String,
+    version: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ViabundusFile {
+    name: String,
+    sha256: String,
+    url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<u64>,
+}
+
+pub(crate) fn sha256_file(path: &Path) -> Result<String> {
+    let mut reader = BufReader::new(File::open(path)?);
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn sha256_json(path: &Path) -> Result<String> {
+    let value: serde_json::Value = serde_json::from_slice(&fs::read(path)?).map_err(|error| {
+        Error::Validation(format!(
+            "invalid source manifest {}: {error}",
+            path.display()
+        ))
+    })?;
+    let canonical = serde_json::to_vec(&value)?;
+    Ok(format!("{:x}", Sha256::digest(canonical)))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn source(
+    id: &str,
+    name: &str,
+    release: SourceRelease,
+    canonical_url: &str,
+    doi: Option<&str>,
+    license: SourceLicense,
+    notices: &[&str],
+    access: SourceAccess,
+    spatial: SourceSpatialCoverage,
+    temporal: SourceTemporalCoverage,
+    recipe: &str,
+    recipe_version: u32,
+    content_identity: SourceContentIdentity,
+    notes_markdown: &str,
+) -> SourceProvenance {
+    SourceProvenance {
+        id: id.into(),
+        name: name.into(),
+        release,
+        canonical_url: canonical_url.into(),
+        doi: doi.map(str::to_owned),
+        license,
+        required_notices: notices.iter().map(|notice| (*notice).into()).collect(),
+        access,
+        spatial,
+        temporal,
+        preparation: SourcePreparation {
+            recipe: recipe.into(),
+            version: recipe_version,
+        },
+        content_identity,
+        notes_markdown: notes_markdown.into(),
+    }
+}
+
+pub(crate) fn viabundus(directory: &Path) -> Result<SourceProvenance> {
+    let manifest = directory.join(".viabundus-source.json");
+    let identity = if manifest.is_file() {
+        let metadata = fs::metadata(&manifest)?;
+        if metadata.len() > MAX_SIDECAR_BYTES {
+            return Err(Error::Validation(format!(
+                "Viabundus sidecar exceeds {MAX_SIDECAR_BYTES} bytes"
+            )));
+        }
+        let mut sidecar: ViabundusSidecar = serde_json::from_slice(&fs::read(&manifest)?)
+            .map_err(|error| Error::Validation(format!("invalid Viabundus sidecar: {error}")))?;
+        if sidecar.version != "2" || sidecar.record_url != VIABUNDUS_RECORD {
+            return Err(Error::Validation(
+                "Viabundus sidecar version or record URL is not canonical".into(),
+            ));
+        }
+        let mut names = std::collections::BTreeSet::new();
+        for file in &sidecar.files {
+            if Path::new(&file.name)
+                .file_name()
+                .and_then(|value| value.to_str())
+                != Some(file.name.as_str())
+                || !file.name.ends_with(".csv")
+                || !names.insert(file.name.clone())
+                || file.url.len() > MAX_TEXT
+                || !file.url.starts_with("https://")
+                || file.sha256.len() != 64
+                || !file
+                    .sha256
+                    .bytes()
+                    .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+            {
+                return Err(Error::Validation(
+                    "Viabundus sidecar contains an unsafe, duplicate, or malformed file entry"
+                        .into(),
+                ));
+            }
+        }
+        let expected_names = VIABUNDUS_FILES
+            .iter()
+            .copied()
+            .map(str::to_owned)
+            .collect::<std::collections::BTreeSet<_>>();
+        if sidecar.files.len() != VIABUNDUS_FILES.len() || names != expected_names {
+            return Err(Error::Validation(
+                "Viabundus sidecar does not inventory every consumed CSV".into(),
+            ));
+        }
+        sidecar
+            .files
+            .sort_by(|left, right| left.name.cmp(&right.name));
+        let mut fully_sized = true;
+        for required in VIABUNDUS_FILES {
+            let entry = sidecar
+                .files
+                .iter()
+                .find(|entry| entry.name == required)
+                .expect("checked inventory");
+            let path = directory.join(required);
+            let actual_size = fs::metadata(&path)?.len();
+            if entry.size.is_some_and(|size| size != actual_size)
+                || sha256_file(&path)? != entry.sha256
+            {
+                return Err(Error::Validation(format!(
+                    "Viabundus sidecar identity mismatch for {required}"
+                )));
+            }
+            fully_sized &= entry.size.is_some();
+        }
+        if fully_sized {
+            SourceContentIdentity::PreparedSnapshotSha256 {
+                sha256: format!("{:x}", Sha256::digest(serde_json::to_vec(&sidecar)?)),
+            }
+        } else {
+            SourceContentIdentity::ReleaseBlocked {
+                reason: "legacy Viabundus sidecar lacks verified byte sizes".into(),
+            }
+        }
+    } else {
+        SourceContentIdentity::ReleaseBlocked {
+            reason: "initializer sidecar .viabundus-source.json is absent".into(),
+        }
+    };
+    Ok(source(
+        "viabundus-v2",
+        "Viabundus Pre-modern Street Map 2",
+        SourceRelease::Immutable {
+            version: "2".into(),
+            released: "2025".into(),
+        },
+        "https://doi.org/10.5281/zenodo.16611998",
+        Some("10.5281/zenodo.16611998"),
+        SourceLicense::CcBySa4_0,
+        &[
+            "Attribute Viabundus and retain the CC BY-SA 4.0 notice on distributed adapted database material.",
+            "Adventure Simulator applies the conservative CC BY-SA treatment; compatibility with differently licensed combined outputs is unresolved and must not be presented as legal resolution.",
+        ],
+        SourceAccess::AnonymousDownload,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:4326".into(),
+            resolution: "route topology".into(),
+            coverage: "pre-modern European transport network".into(),
+        },
+        SourceTemporalCoverage::Years {
+            first: -500,
+            last: 2025,
+        },
+        "viabundus-csv-import",
+        1,
+        identity,
+        "[Viabundus v2](https://doi.org/10.5281/zenodo.16611998), conservatively treated as CC BY-SA 4.0.",
+    ))
+}
+
+pub(crate) fn elevation() -> SourceProvenance {
+    source(
+        "copernicus-dem-glo30",
+        "Copernicus DEM GLO-30",
+        SourceRelease::ReleaseBlocked {
+            reason: "manual tile selection has no checked content manifest".into(),
+        },
+        "https://doi.org/10.5270/ESA-c5d3d65",
+        Some("10.5270/ESA-c5d3d65"),
+        SourceLicense::CopernicusDem,
+        &[
+            "Credit: European Union, Copernicus DEM GLO-30.",
+            "Produced using Copernicus WorldDEM-30 © DLR e.V. 2010-2014 and © Airbus Defence and Space GmbH 2014-2018 provided under COPERNICUS by the European Union and ESA; all rights reserved.",
+            "Neither the European Commission nor ESA is liable for use of Copernicus data and information.",
+        ],
+        SourceAccess::AuthenticatedDownload,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:4326".into(),
+            resolution: "1 arc-second (approximately 30 m)".into(),
+            coverage: "global land".into(),
+        },
+        SourceTemporalCoverage::Timeless,
+        "glo30-direct-tile-sampling",
+        1,
+        SourceContentIdentity::ReleaseBlocked {
+            reason: "required GLO-30 tiles are manually selected and not content-pinned".into(),
+        },
+        "[Copernicus DEM GLO-30](https://doi.org/10.5270/ESA-c5d3d65).",
+    )
+}
+
+pub(crate) fn hyde() -> SourceProvenance {
+    source(
+        "hyde-3-2-1",
+        "History Database of the Global Environment 3.2.1",
+        SourceRelease::Immutable {
+            version: "3.2.1".into(),
+            released: "2017".into(),
+        },
+        "https://doi.org/10.17026/dans-25g-gez3",
+        Some("10.17026/dans-25g-gez3"),
+        SourceLicense::CcBy3_0,
+        &[
+            "Cite HYDE 3.2.1 and its DANS dataset record.",
+            "The source record and downloaded distribution carry conflicting rights signals (CC0 and attribution-oriented terms); this manifest records the conflict and does not claim legal resolution.",
+        ],
+        SourceAccess::ManualPreparation,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:4326".into(),
+            resolution: "5 arc-minutes".into(),
+            coverage: "global land".into(),
+        },
+        SourceTemporalCoverage::Years {
+            first: 1500,
+            last: 1600,
+        },
+        "hyde-ascii-linear-interpolation",
+        1,
+        SourceContentIdentity::ReleaseBlocked {
+            reason: "the seven local HYDE ASCII grids have no checked content manifest".into(),
+        },
+        "[HYDE 3.2.1](https://doi.org/10.17026/dans-25g-gez3).",
+    )
+}
+
+pub(crate) fn forest(directory: &Path) -> Result<SourceProvenance> {
+    let marker = directory.join("forest-cover-manifest.json");
+    let reason = if marker.is_file() {
+        "the preparation-format marker is present, but consumed raster tiles are not inventoried and content-pinned"
+    } else {
+        "forest preparation marker and consumed raster inventory are absent"
+    };
+    Ok(source(
+        "clms-forest-2018",
+        "Copernicus Land Monitoring Service Forest 2018",
+        SourceRelease::Immutable {
+            version: "2018".into(),
+            released: "2018".into(),
+        },
+        "https://doi.org/10.2909/82f93572-9888-47ef-97a1-5cac5985a26a",
+        Some("10.2909/82f93572-9888-47ef-97a1-5cac5985a26a"),
+        SourceLicense::CopernicusClms,
+        &[
+            "© European Union, Copernicus Land Monitoring Service; identify modifications made by Adventure Simulator.",
+            "Do not imply endorsement by the European Union or the Copernicus programme.",
+        ],
+        SourceAccess::AuthenticatedDownload,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:4326".into(),
+            resolution: "prepared 0.001 degree".into(),
+            coverage: "EEA-39".into(),
+        },
+        SourceTemporalCoverage::ModernProxy { year: 2018 },
+        "copernicus-forest-aggregation",
+        1,
+        SourceContentIdentity::ReleaseBlocked {
+            reason: reason.into(),
+        },
+        "[Copernicus HRL Forest 2018](https://doi.org/10.2909/82f93572-9888-47ef-97a1-5cac5985a26a), modified for settlement sampling.",
+    ))
+}
+
+pub(crate) fn jung(directory: &Path) -> Result<SourceProvenance> {
+    let manifest = directory.join("jung-pnv-manifest.json");
+    let identity = if manifest.is_file() {
+        SourceContentIdentity::PreparedSnapshotSha256 {
+            sha256: sha256_json(&manifest)?,
+        }
+    } else {
+        SourceContentIdentity::ReleaseBlocked {
+            reason: "Jung v1.1 manifest is absent at this synthetic/test boundary".into(),
+        }
+    };
+    Ok(source(
+        "jung-pnv-1-1",
+        "Jung/IIASA European potential vegetation v1.1",
+        SourceRelease::Immutable {
+            version: "1.1".into(),
+            released: "2025-01-10".into(),
+        },
+        "https://doi.org/10.5281/zenodo.14627466",
+        Some("10.5281/zenodo.14627466"),
+        SourceLicense::CcBy4_0,
+        &[
+            "Cite Jung et al. and the Zenodo v1.1 record.",
+            "Adventure Simulator converts model posterior means and categories into bounded gameplay vegetation evidence; these changes must be identified.",
+        ],
+        SourceAccess::AnonymousDownload,
+        SourceSpatialCoverage::Geographic {
+            crs: "ETRS89-LAEA parameters equivalent to EPSG:3035".into(),
+            resolution: "1 km".into(),
+            coverage: "Europe".into(),
+        },
+        SourceTemporalCoverage::Years {
+            first: 1990,
+            last: 2020,
+        },
+        "jung-cog-area-sampling",
+        1,
+        identity,
+        "[Jung/IIASA PNV v1.1](https://doi.org/10.5281/zenodo.14627466), modified into gameplay classes.",
+    ))
+}
+
+pub(crate) fn trees(archive: &Path) -> Result<SourceProvenance> {
+    Ok(source(
+        "eu-trees4f-v2",
+        "EU-Trees4F v2 current-climate ensemble",
+        SourceRelease::Immutable {
+            version: "2".into(),
+            released: "2022".into(),
+        },
+        "https://doi.org/10.6084/m9.figshare.17032328",
+        Some("10.6084/m9.figshare.17032328"),
+        SourceLicense::Cc0_1_0,
+        &[
+            "Cite the EU-Trees4F v2 Figshare dataset and associated publication even though the data are dedicated under CC0 1.0.",
+        ],
+        SourceAccess::AnonymousDownload,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:4326".into(),
+            resolution: "30 arc-seconds".into(),
+            coverage: "Europe".into(),
+        },
+        SourceTemporalCoverage::ModernProxy { year: 2020 },
+        "eu-trees4f-archive-sampling",
+        1,
+        SourceContentIdentity::RawSha256 {
+            sha256: sha256_file(archive)?,
+        },
+        "[EU-Trees4F v2](https://doi.org/10.6084/m9.figshare.17032328), CC0 with citation retained.",
+    ))
+}
+
+pub(crate) fn soil(
+    retrieved_at: String,
+    prepared_manifest_sha256: String,
+) -> Result<SourceProvenance> {
+    Ok(source(
+        "soilgrids-v2-rolling",
+        "ISRIC SoilGrids rolling version 2",
+        SourceRelease::Rolling {
+            observed_at: retrieved_at,
+        },
+        "https://www.isric.org/explore/soilgrids",
+        Some("10.17027/isric-soilgrids.2"),
+        SourceLicense::CcBy4_0,
+        &[
+            "Credit ISRIC — World Soil Information and cite SoilGrids version 2.",
+            "Adventure Simulator reprojects, aggregates, and converts SoilGrids predictions into bounded gameplay soil classes; these changes must be identified.",
+        ],
+        SourceAccess::AnonymousDownload,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:3035".into(),
+            resolution: "prepared canonical grid".into(),
+            coverage: "Viabundus settlement extent".into(),
+        },
+        SourceTemporalCoverage::ModernProxy { year: 2020 },
+        "soilgrids-wcs-prepare",
+        1,
+        SourceContentIdentity::PreparedSnapshotSha256 {
+            sha256: prepared_manifest_sha256,
+        },
+        "[ISRIC SoilGrids v2](https://www.isric.org/explore/soilgrids), rolling source captured as a prepared snapshot; raw rolling-latest reacquisition is not reproducible.",
+    ))
+}
+
+pub(crate) fn geology(_path: &Path) -> SourceProvenance {
+    source(
+        "egdi-surface-geology-1m",
+        "EGDI 1:1 Million pan-European Surface Geology",
+        SourceRelease::Immutable {
+            version: "EGDI-GE-1M-SURFACE".into(),
+            released: "2016-05-04".into(),
+        },
+        "https://metadata.europe-geology.eu/record/full/5729ffdf-2558-48fc-a5d2-645a0a010855",
+        None,
+        SourceLicense::CcBy4_0,
+        &[
+            "Attribute EGDI and contributing national geological surveys; identify Adventure Simulator's classification and sampling changes.",
+            "For Malta, include Geological Map of the Maltese Islands, Continental Shelf Department, Oil Exploration Directorate, Office of the Prime Minister, Malta, and retain the source disclaimer.",
+        ],
+        SourceAccess::ManualPreparation,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:3034".into(),
+            resolution: "1:1,000,000".into(),
+            coverage: "pan-European".into(),
+        },
+        SourceTemporalCoverage::Timeless,
+        "egdi-geopackage-point-sampling",
+        1,
+        SourceContentIdentity::ReleaseBlocked {
+            reason:
+                "the manual EGDI GeoPackage has no publisher checksum or checked content sidecar"
+                    .into(),
+        },
+        "[EGDI Surface Geology](https://metadata.europe-geology.eu/record/full/5729ffdf-2558-48fc-a5d2-645a0a010855), modified into gameplay classes; Malta notice applies.",
+    )
+}
+
+pub(crate) fn religion(path: &Path) -> Result<SourceProvenance> {
+    Ok(source(
+        "ieg-religion-1544-curated",
+        "IEG Maps of Confessional Europe (1500 and 1555)",
+        SourceRelease::Curated {
+            revision: "adventuresim-ieg-religion-1544-v1".into(),
+        },
+        "https://www.ieg-maps.uni-mainz.de/mapsp/mapconfession.htm",
+        None,
+        SourceLicense::RightsReserved,
+        &[
+            "© IEG Mainz / Andreas Kunz. The source images are not redistributed.",
+            "Only Adventure Simulator's coarse hand-curated 1544 bounding-region intermediate may be distributed from this repository; it is not a facsimile or precise historical boundary dataset.",
+        ],
+        SourceAccess::CuratedRepositoryAsset,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:4326".into(),
+            resolution: "coarse curated bounding regions".into(),
+            coverage: "Europe".into(),
+        },
+        SourceTemporalCoverage::Year(1544),
+        "ieg-map-curation",
+        1,
+        SourceContentIdentity::CuratedRevision {
+            revision: "adventuresim-ieg-religion-1544-v1".into(),
+            sha256: sha256_file(path)?,
+        },
+        "[IEG confessional maps](https://www.ieg-maps.uni-mainz.de/mapsp/mapconfession.htm); source images are not redistributed.",
+    ))
+}
+
+pub(crate) fn drought(path: &Path) -> Result<SourceProvenance> {
+    Ok(source(
+        "noaa-owda-v1",
+        "NOAA Old World Drought Atlas v1.0",
+        SourceRelease::Immutable {
+            version: "1.0".into(),
+            released: "2015".into(),
+        },
+        "https://www.ncei.noaa.gov/pub/data/paleo/drought/owda.nc",
+        Some("10.25921/rjm6-mq74"),
+        SourceLicense::NoaaPublicAccess,
+        &[
+            "Cite the NOAA/NCEI OWDA dataset DOI 10.25921/rjm6-mq74 and Cook et al. (2015), DOI 10.1126/sciadv.1500561.",
+            "Only bounded per-settlement derived values are distributed; do not redistribute the source grid or annual series as part of the compiled world.",
+        ],
+        SourceAccess::AnonymousDownload,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:4326".into(),
+            resolution: "0.5 degree point grid".into(),
+            coverage: "Old World drought reconstruction domain".into(),
+        },
+        SourceTemporalCoverage::Years {
+            first: 0,
+            last: 2012,
+        },
+        "owda-20-year-settlement-profile",
+        1,
+        SourceContentIdentity::RawSha256 {
+            sha256: sha256_file(path)?,
+        },
+        "[NOAA/NCEI OWDA v1.0](https://doi.org/10.25921/rjm6-mq74); compiled output is derived-only.",
+    ))
+}
+
+pub(crate) fn hydrology() -> SourceProvenance {
+    source(
+        "copernicus-eu-hydro-1-3",
+        "Copernicus EU-Hydro River Network Database v1.3",
+        SourceRelease::Immutable {
+            version: "1.3".into(),
+            released: "2020".into(),
+        },
+        "https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c",
+        Some("10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c"),
+        SourceLicense::CopernicusClms,
+        &[
+            "© European Union, Copernicus Land Monitoring Service; identify Adventure Simulator's clipping, classification, and inferred-crossing modifications.",
+            "Do not imply endorsement by the European Union or the Copernicus programme.",
+        ],
+        SourceAccess::AuthenticatedDownload,
+        SourceSpatialCoverage::Geographic {
+            crs: "EPSG:3035".into(),
+            resolution: "vector river network".into(),
+            coverage: "EEA-39".into(),
+        },
+        SourceTemporalCoverage::ModernProxy { year: 2012 },
+        "eu-hydro-geopackage-sampling",
+        1,
+        SourceContentIdentity::ReleaseBlocked {
+            reason: "the basin GeoPackage set has no checked inventory or content digest".into(),
+        },
+        "[Copernicus EU-Hydro v1.3](https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c), modified for gameplay.",
+    )
+}
+
+pub(crate) fn canonicalize(sources: &mut Vec<SourceProvenance>) -> Result<()> {
+    sources.sort_by(|left, right| left.id.cmp(&right.id));
+    for pair in sources.windows(2) {
+        if pair[0].id == pair[1].id {
+            return Err(Error::Validation(format!(
+                "duplicate source manifest id {}",
+                pair[0].id
+            )));
+        }
+    }
+    for source in sources.iter() {
+        validate_source(source)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_source(source: &SourceProvenance) -> Result<()> {
+    let valid_text =
+        |value: &str| !value.trim().is_empty() && value.len() <= MAX_TEXT && !value.contains('\0');
+    let text_fields = [
+        &source.id,
+        &source.name,
+        &source.canonical_url,
+        &source.preparation.recipe,
+        &source.notes_markdown,
+    ];
+    if text_fields.iter().any(|value| !valid_text(value)) {
+        return Err(Error::Validation(format!(
+            "source manifest {} has an empty, oversized, or NUL text field",
+            source.id
+        )));
+    }
+    if !source
+        .id
+        .bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err(Error::Validation(format!(
+            "source manifest id {} is not canonical kebab-case",
+            source.id
+        )));
+    }
+    if !source.canonical_url.starts_with("https://") || source.preparation.version == 0 {
+        return Err(Error::Validation(format!(
+            "source manifest {} has an invalid URL or recipe version",
+            source.id
+        )));
+    }
+    if source.doi.as_ref().is_some_and(|doi| {
+        !valid_text(doi) || !doi.starts_with("10.") || doi.chars().any(char::is_whitespace)
+    }) {
+        return Err(Error::Validation(format!(
+            "source manifest {} has an invalid DOI",
+            source.id
+        )));
+    }
+    let release_strings: Vec<&str> = match &source.release {
+        SourceRelease::Immutable { version, released } => vec![version, released],
+        SourceRelease::Curated { revision } => vec![revision],
+        SourceRelease::Rolling { observed_at } => vec![observed_at],
+        SourceRelease::ReleaseBlocked { reason } => vec![reason],
+    };
+    if release_strings.iter().any(|value| !valid_text(value)) {
+        return Err(Error::Validation(format!(
+            "source manifest {} has invalid release metadata",
+            source.id
+        )));
+    }
+    if let SourceSpatialCoverage::Geographic {
+        crs,
+        resolution,
+        coverage,
+    } = &source.spatial
+        && [crs, resolution, coverage]
+            .iter()
+            .any(|value| !valid_text(value))
+    {
+        return Err(Error::Validation(format!(
+            "source manifest {} has invalid spatial metadata",
+            source.id
+        )));
+    }
+    match source.temporal {
+        SourceTemporalCoverage::Year(year) | SourceTemporalCoverage::ModernProxy { year }
+            if !(-10_000..=10_000).contains(&year) =>
+        {
+            return Err(Error::Validation(format!(
+                "source manifest {} has invalid temporal coverage",
+                source.id
+            )));
+        }
+        SourceTemporalCoverage::Years { first, last }
+            if first > last || !(-10_000..=10_000).contains(&first) || last > 10_000 =>
+        {
+            return Err(Error::Validation(format!(
+                "source manifest {} has invalid temporal coverage",
+                source.id
+            )));
+        }
+        _ => {}
+    }
+    if source.required_notices.is_empty()
+        || source.required_notices.len() > MAX_NOTICES
+        || source.required_notices.iter().any(|notice| {
+            notice.trim().is_empty() || notice.len() > MAX_TEXT || notice.contains('\0')
+        })
+    {
+        return Err(Error::Validation(format!(
+            "source manifest {} has invalid required notices",
+            source.id
+        )));
+    }
+    let valid_sha = |sha: &str| {
+        sha.len() == 64
+            && sha
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    };
+    match &source.content_identity {
+        SourceContentIdentity::RawSha256 { sha256 }
+        | SourceContentIdentity::PreparedSnapshotSha256 { sha256 }
+        | SourceContentIdentity::CuratedRevision { sha256, .. }
+            if !valid_sha(sha256) =>
+        {
+            return Err(Error::Validation(format!(
+                "source manifest {} has an invalid SHA-256",
+                source.id
+            )));
+        }
+        SourceContentIdentity::CuratedRevision { revision, .. } if !valid_text(revision) => {
+            return Err(Error::Validation(format!(
+                "source manifest {} has an invalid curated revision",
+                source.id
+            )));
+        }
+        SourceContentIdentity::UnpinnedRollingObservation { observed_at }
+            if !valid_text(observed_at) =>
+        {
+            return Err(Error::Validation(format!(
+                "source manifest {} has an invalid observation",
+                source.id
+            )));
+        }
+        SourceContentIdentity::ReleaseBlocked { reason } if !valid_text(reason) => {
+            return Err(Error::Validation(format!(
+                "source manifest {} has an invalid blocker",
+                source.id
+            )));
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct Identity<'a> {
+    schema_version: u32,
+    inference_rules_version: u32,
+    world_year: i32,
+    spatial_grid: SpatialGridSpec,
+    sources: &'a [SourceProvenance],
+}
+
+pub(crate) fn digest(
+    year: i32,
+    grid: SpatialGridSpec,
+    sources: &[SourceProvenance],
+) -> Result<String> {
+    let bytes = serde_json::to_vec(&Identity {
+        schema_version: WORLD_SCHEMA_VERSION,
+        inference_rules_version: CURRENT_INFERENCE_RULES_VERSION,
+        world_year: year,
+        spatial_grid: grid,
+        sources,
+    })?;
+    Ok(blake3::hash(&bytes).to_hex().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use adventuresim_world_schema::{GridCellSizeMeters, SourceContentIdentity};
+
+    fn fixture() -> SourceProvenance {
+        hydrology()
+    }
+
+    fn viabundus_fixture(directory: &Path) -> ViabundusSidecar {
+        fs::create_dir_all(directory).unwrap();
+        let files = VIABUNDUS_FILES
+            .iter()
+            .map(|name| {
+                fs::write(directory.join(name), name.as_bytes()).unwrap();
+                ViabundusFile {
+                    name: (*name).into(),
+                    sha256: format!("{:x}", Sha256::digest(name.as_bytes())),
+                    url: format!("https://example.invalid/{name}"),
+                    size: Some(name.len() as u64),
+                }
+            })
+            .collect();
+        ViabundusSidecar {
+            files,
+            record_url: VIABUNDUS_RECORD.into(),
+            version: "2".into(),
+        }
+    }
+
+    fn write_viabundus(directory: &Path, sidecar: &ViabundusSidecar) {
+        fs::write(
+            directory.join(".viabundus-source.json"),
+            serde_json::to_vec(sidecar).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn canonicalization_is_order_independent_and_rejects_duplicates() {
+        let mut first = vec![hyde(), elevation()];
+        let mut second = vec![elevation(), hyde()];
+        canonicalize(&mut first).unwrap();
+        canonicalize(&mut second).unwrap();
+        assert_eq!(first, second);
+        assert_eq!(
+            digest(1544, SpatialGridSpec::default(), &first).unwrap(),
+            digest(1544, SpatialGridSpec::default(), &second).unwrap()
+        );
+
+        first.push(first[0].clone());
+        assert!(
+            canonicalize(&mut first)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate")
+        );
+    }
+
+    #[test]
+    fn identity_changes_for_every_manifest_field_and_build_dimension() {
+        let original = fixture();
+        let baseline = digest(
+            1544,
+            SpatialGridSpec::default(),
+            std::slice::from_ref(&original),
+        )
+        .unwrap();
+        let mut variants = Vec::new();
+        macro_rules! changed {
+            ($field:ident, $value:expr) => {{
+                let mut item = original.clone();
+                item.$field = $value;
+                variants.push(item);
+            }};
+        }
+        changed!(id, "different-id".into());
+        changed!(name, "different name".into());
+        changed!(
+            release,
+            SourceRelease::Curated {
+                revision: "different".into()
+            }
+        );
+        changed!(canonical_url, "https://example.invalid/different".into());
+        changed!(doi, None);
+        changed!(license, SourceLicense::CcBy4_0);
+        changed!(required_notices, vec!["different notice".into()]);
+        changed!(access, SourceAccess::ManualPreparation);
+        changed!(spatial, SourceSpatialCoverage::NotApplicable);
+        changed!(temporal, SourceTemporalCoverage::Timeless);
+        changed!(
+            preparation,
+            SourcePreparation {
+                recipe: "different".into(),
+                version: 2
+            }
+        );
+        changed!(
+            content_identity,
+            SourceContentIdentity::UnpinnedRollingObservation {
+                observed_at: "different".into()
+            }
+        );
+        changed!(notes_markdown, "different notes".into());
+        for variant in variants {
+            assert_ne!(
+                baseline,
+                digest(1544, SpatialGridSpec::default(), &[variant]).unwrap()
+            );
+        }
+        assert_ne!(
+            baseline,
+            digest(
+                1545,
+                SpatialGridSpec::default(),
+                std::slice::from_ref(&original)
+            )
+            .unwrap()
+        );
+        assert_ne!(
+            baseline,
+            digest(
+                1544,
+                SpatialGridSpec::new(GridCellSizeMeters::new(250).unwrap()),
+                std::slice::from_ref(&original)
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn unpinned_and_blocked_identities_are_not_reproducible() {
+        assert!(
+            !SourceContentIdentity::UnpinnedRollingObservation {
+                observed_at: "2026-01-01".into()
+            }
+            .is_reproducible()
+        );
+        assert!(
+            !SourceContentIdentity::ReleaseBlocked {
+                reason: "manual".into()
+            }
+            .is_reproducible()
+        );
+        assert!(
+            SourceContentIdentity::RawSha256 {
+                sha256: "a".repeat(64)
+            }
+            .is_reproducible()
+        );
+    }
+
+    #[test]
+    fn operational_notices_cover_all_integrated_sources() {
+        let sources = [
+            viabundus(Path::new("missing")).unwrap(),
+            elevation(),
+            hyde(),
+            forest(Path::new("missing")).unwrap(),
+            geology(Path::new("manual.gpkg")),
+            religion(
+                Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("../../assets/world-data/ieg-religion-1544.csv")
+                    .as_path(),
+            )
+            .unwrap(),
+            hydrology(),
+        ];
+        let joined = sources
+            .iter()
+            .flat_map(|source| &source.required_notices)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n");
+        for required in [
+            "CC BY-SA",
+            "liable",
+            "conflicting rights",
+            "modifications",
+            "Malta",
+            "not redistributed",
+            "endorsement",
+        ] {
+            assert!(
+                joined.contains(required),
+                "missing notice phrase {required}"
+            );
+        }
+    }
+
+    #[test]
+    fn fixture_digest_is_stable() {
+        assert_eq!(
+            digest(1544, SpatialGridSpec::default(), &[fixture()]).unwrap(),
+            "682682c499a4104e2f46c0d52155cc770280e5822bcc49c9ad8c7c4b74864f3b"
+        );
+    }
+
+    #[test]
+    fn viabundus_sidecar_is_bounded_strict_and_content_verified() {
+        let root = std::env::temp_dir().join(format!(
+            "adventuresim-viabundus-manifest-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let mut sidecar = viabundus_fixture(&root);
+        write_viabundus(&root, &sidecar);
+        assert!(viabundus(&root).unwrap().content_identity.is_reproducible());
+
+        sidecar.files[0].sha256 = "0".repeat(64);
+        write_viabundus(&root, &sidecar);
+        assert!(
+            viabundus(&root)
+                .unwrap_err()
+                .to_string()
+                .contains("mismatch")
+        );
+        sidecar = viabundus_fixture(&root);
+        sidecar.files.push(ViabundusFile {
+            name: sidecar.files[0].name.clone(),
+            sha256: "a".repeat(64),
+            url: "https://example.invalid/duplicate".into(),
+            size: Some(1),
+        });
+        write_viabundus(&root, &sidecar);
+        assert!(
+            viabundus(&root)
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate")
+        );
+        sidecar = viabundus_fixture(&root);
+        sidecar.files.push(ViabundusFile {
+            name: "unused.csv".into(),
+            sha256: "a".repeat(64),
+            url: "https://example.invalid/unused.csv".into(),
+            size: Some(1),
+        });
+        write_viabundus(&root, &sidecar);
+        assert!(
+            viabundus(&root)
+                .unwrap_err()
+                .to_string()
+                .contains("inventory")
+        );
+        sidecar = viabundus_fixture(&root);
+        sidecar.files[0].name = "../nodes.csv".into();
+        write_viabundus(&root, &sidecar);
+        assert!(viabundus(&root).unwrap_err().to_string().contains("unsafe"));
+        fs::write(
+            root.join(".viabundus-source.json"),
+            vec![b' '; MAX_SIDECAR_BYTES as usize + 1],
+        )
+        .unwrap();
+        assert!(
+            viabundus(&root)
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds")
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn geology_identity_is_path_independent() {
+        assert_eq!(
+            geology(Path::new("one/a.gpkg")),
+            geology(Path::new("two/b.gpkg"))
+        );
+    }
+
+    #[test]
+    fn nested_manifest_strings_and_temporal_ranges_fail_closed() {
+        let mut source = fixture();
+        source.release = SourceRelease::Immutable {
+            version: String::new(),
+            released: "2020".into(),
+        };
+        assert!(validate_source(&source).is_err());
+        source = fixture();
+        source.doi = Some("10.bad\0doi".into());
+        assert!(validate_source(&source).is_err());
+        source = fixture();
+        source.spatial = SourceSpatialCoverage::Geographic {
+            crs: "x".repeat(MAX_TEXT + 1),
+            resolution: "1 km".into(),
+            coverage: "Europe".into(),
+        };
+        assert!(validate_source(&source).is_err());
+        source = fixture();
+        source.temporal = SourceTemporalCoverage::Years {
+            first: 2020,
+            last: 1990,
+        };
+        assert!(validate_source(&source).is_err());
+
+        let mut value = serde_json::to_value(SourceRelease::Immutable {
+            version: "1".into(),
+            released: "2020".into(),
+        })
+        .unwrap();
+        value["immutable"]["extra"] = serde_json::json!(true);
+        assert!(serde_json::from_value::<SourceRelease>(value).is_err());
+    }
+}

--- a/crates/adventuresim-world-import/src/sources/drought.rs
+++ b/crates/adventuresim-world-import/src/sources/drought.rs
@@ -3,8 +3,7 @@
 use std::path::Path;
 
 use adventuresim_world_schema::{
-    DroughtHistory, DroughtProfile, PalmerDroughtSeverityIndex, SourceProvenance,
-    SummerHydroclimate,
+    DroughtHistory, DroughtProfile, PalmerDroughtSeverityIndex, SummerHydroclimate,
 };
 use netcdf_reader::{NcFile, NcFormat, NcSliceInfo, NcSliceInfoElem, NcType};
 
@@ -13,9 +12,6 @@ use crate::{
     draft::{DroughtSettlementDraft, ReligionSettlementDraft, WorldDraft, push_source_note},
 };
 
-const SOURCE_NAME: &str = "NOAA Old World Drought Atlas v1.0 (dataset DOI 10.25921/rjm6-mq74; Cook et al. paper DOI 10.1126/sciadv.1500561)";
-const SOURCE_URL: &str = "https://www.ncei.noaa.gov/pub/data/paleo/drought/owda.nc";
-const SOURCE_LICENSE: &str = "NOAA/NCEI public-access dataset; citation requested";
 const LONGITUDES: usize = 114;
 const LATITUDES: usize = 88;
 const YEARS: usize = 2_013;
@@ -30,7 +26,7 @@ pub(crate) fn enrich(
 ) -> Result<WorldDraft<DroughtSettlementDraft>> {
     let grid = OwdaGrid::open(netcdf_path, draft.year)?;
     if draft.settlements.is_empty() {
-        return finish(draft, Vec::new(), grid.valid_cells.len(), 0, 0);
+        return finish(draft, Vec::new(), grid.valid_cells.len(), 0, 0, netcdf_path);
     }
     let mut neighbor_samples = 0;
     let mut fallbacks = 0;
@@ -69,6 +65,7 @@ pub(crate) fn enrich(
         grid.valid_cells.len(),
         neighbor_samples,
         fallbacks,
+        netcdf_path,
     )
 }
 
@@ -130,6 +127,7 @@ fn finish(
     cells_read: usize,
     neighbor_samples: usize,
     fallbacks: usize,
+    netcdf_path: &Path,
 ) -> Result<WorldDraft<DroughtSettlementDraft>> {
     if profiles.len() != draft.settlements.len() {
         return Err(Error::Validation(
@@ -141,11 +139,9 @@ fn finish(
         .zip(profiles)
         .map(|(religious, drought)| DroughtSettlementDraft { religious, drought })
         .collect();
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if cells_read > 0 {
+        draft.sources.push(crate::manifest::drought(netcdf_path)?);
+    }
     draft.report.drought_grid_cells_read = cells_read;
     draft.report.drought_samples = settlements.len();
     draft.report.drought_neighbor_samples = neighbor_samples;

--- a/crates/adventuresim-world-import/src/sources/elevation.rs
+++ b/crates/adventuresim-world-import/src/sources/elevation.rs
@@ -7,7 +7,7 @@ use std::{
     path::Path,
 };
 
-use adventuresim_world_schema::{ElevationMeters, SourceProvenance};
+use adventuresim_world_schema::ElevationMeters;
 use tiff::{
     decoder::{Decoder, DecodingResult},
     tags::Tag,
@@ -18,9 +18,6 @@ use crate::{
     draft::{ElevatedSettlementDraft, SettlementDraft, WorldDraft, push_source_note},
 };
 
-const SOURCE_NAME: &str = "Copernicus DEM GLO-30";
-const SOURCE_URL: &str = "https://doi.org/10.5270/ESA-c5d3d65";
-const SOURCE_LICENSE: &str = "Copernicus DEM licence";
 const SEARCH_RADIUS_PIXELS: u32 = 8;
 const GLO30_TILE_HEIGHT: u32 = 3_600;
 const GLO30_TILE_WIDTHS: [u32; 3] = [1_800, 2_400, 3_600];
@@ -90,11 +87,9 @@ pub(crate) fn enrich(
         })
         .collect();
 
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if !by_tile.is_empty() {
+        draft.sources.push(crate::manifest::elevation());
+    }
     draft.report.elevation_tiles_read = by_tile.len();
     draft.report.elevation_samples = settlements.len();
     draft.report.elevation_fallback_samples = fallback_samples;

--- a/crates/adventuresim-world-import/src/sources/environment_synthesis.rs
+++ b/crates/adventuresim-world-import/src/sources/environment_synthesis.rs
@@ -33,6 +33,8 @@ enum NaturalCover {
 }
 
 pub(crate) fn finalize(mut draft: FinalizedSoilWorldDraft) -> Result<CompiledWorld> {
+    crate::manifest::canonicalize(&mut draft.sources)?;
+    let manifest_digest = crate::manifest::digest(draft.year, draft.spatial_grid, &draft.sources)?;
     let mut direct = 0;
     let mut derived = 0;
     let mut fallback = 0;
@@ -111,6 +113,7 @@ pub(crate) fn finalize(mut draft: FinalizedSoilWorldDraft) -> Result<CompiledWor
             inference_rules_version: CURRENT_INFERENCE_RULES_VERSION,
             spatial_grid: draft.spatial_grid,
             world_year: draft.year,
+            manifest_digest,
             sources: draft.sources,
             road_types: draft.road_types,
         },
@@ -497,8 +500,8 @@ mod tests {
     use crate::draft::{FinalizedSoilWorldDraft, LandUseEvidence};
     use adventuresim_world_schema::{
         DirectHistoricalVegetationCover, FerryRoute, FerryWaterway, LandUseFraction,
-        LandUseProfile, SourceProvenance, SpatialGridSpec, TravelEdgeImport, TravelEdgeKind,
-        TravelRoute, WorldBuildReport, WorldNodeImport,
+        LandUseProfile, SpatialGridSpec, TravelEdgeImport, TravelEdgeKind, TravelRoute,
+        WorldBuildReport, WorldNodeImport,
     };
 
     fn scores(winner: NaturalCover, advantage: i32) -> [(NaturalCover, i32); 6] {
@@ -639,11 +642,7 @@ mod tests {
         FinalizedSoilWorldDraft {
             year: 1544,
             spatial_grid: SpatialGridSpec::default(),
-            sources: vec![SourceProvenance {
-                name: "test".into(),
-                url: "https://example.invalid".into(),
-                license: "test".into(),
-            }],
+            sources: vec![crate::manifest::hydrology()],
             road_types: vec![TravelEdgeKind::Ferry],
             nodes: vec![
                 WorldNodeImport {

--- a/crates/adventuresim-world-import/src/sources/forest_cover.rs
+++ b/crates/adventuresim-world-import/src/sources/forest_cover.rs
@@ -7,9 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use adventuresim_world_schema::{
-    CanopyDensity, DominantLeafType, ForestCover, SourceProvenance, Woodland,
-};
+use adventuresim_world_schema::{CanopyDensity, DominantLeafType, ForestCover, Woodland};
 use serde::Deserialize;
 use tiff::{
     decoder::{Decoder, DecodingResult},
@@ -21,10 +19,6 @@ use crate::{
     draft::{ForestSettlementDraft, LandUseSettlementDraft, WorldDraft, push_source_note},
 };
 
-const SOURCE_NAME: &str = "Copernicus Land Monitoring Service Forest 2018";
-const SOURCE_URL: &str =
-    "https://land.copernicus.eu/en/products/high-resolution-layer-forests-and-tree-cover";
-const SOURCE_LICENSE: &str = "Copernicus data licence";
 const NODATA: u8 = 255;
 const MANIFEST_FILENAME: &str = "forest-cover-manifest.json";
 const PIXELS_PER_DEGREE: u32 = 1_000;
@@ -106,11 +100,9 @@ pub(crate) fn enrich(
             }
         })
         .collect::<Vec<_>>();
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if !by_tile.is_empty() {
+        draft.sources.push(crate::manifest::forest(directory)?);
+    }
     draft.report.forest_tiles_read = by_tile.len();
     draft.report.forest_samples = settlements.len();
     draft.report.forest_fallback_samples = fallbacks;

--- a/crates/adventuresim-world-import/src/sources/geology.rs
+++ b/crates/adventuresim-world-import/src/sources/geology.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use adventuresim_world_schema::{
     GeologicAgeEvidence, GeologicEra, GeologicLithologyEvidence, GeologicSetting, GeologicUnitId,
     IgneousRock, InferredGeologicSetting, MappedSurfaceGeology, MetamorphicRock, MixedLithology,
-    SedimentaryRock, SourceProvenance, SurfaceGeology, SurfaceLithology, UnconsolidatedDeposit,
+    SedimentaryRock, SurfaceGeology, SurfaceLithology, UnconsolidatedDeposit,
 };
 use geo::{Contains, Geometry, Point};
 use geozero::{ToGeo, wkb::GpkgWkb};
@@ -17,10 +17,6 @@ use crate::{
     draft::{GeologySettlementDraft, SoilPredictionSettlementDraft, WorldDraft, push_source_note},
 };
 
-const SOURCE_NAME: &str = "EGDI 1:1 Million pan-European Surface Geology";
-const SOURCE_URL: &str =
-    "https://metadata.europe-geology.eu/record/full/5729ffdf-2558-48fc-a5d2-645a0a010855";
-const SOURCE_LICENSE: &str = "Creative Commons Attribution 4.0 (CC BY 4.0)";
 const TABLE: &str = "GeologicUnitView";
 const GEOMETRY_COLUMN: &str = "geom";
 const EXPECTED_SRS: i64 = 3034;
@@ -30,7 +26,7 @@ pub(crate) fn enrich(
     geopackage: &Path,
 ) -> Result<WorldDraft<GeologySettlementDraft>> {
     if draft.settlements.is_empty() {
-        return finish(draft, Vec::new(), 0, 0);
+        return finish(draft, Vec::new(), 0, 0, geopackage);
     }
     let map = GeologyMap::open(geopackage)?;
     let projection = GeologyProjection::new()?;
@@ -45,7 +41,7 @@ pub(crate) fn enrich(
         });
         profiles.push(profile);
     }
-    finish(draft, profiles, map.features_read, fallbacks)
+    finish(draft, profiles, map.features_read, fallbacks, geopackage)
 }
 
 fn finish(
@@ -53,6 +49,7 @@ fn finish(
     profiles: Vec<SurfaceGeology>,
     features_read: usize,
     fallbacks: usize,
+    geopackage: &Path,
 ) -> Result<WorldDraft<GeologySettlementDraft>> {
     if profiles.len() != draft.settlements.len() {
         return Err(Error::Validation(
@@ -73,11 +70,9 @@ fn finish(
             GeologySettlementDraft { predicted, geology }
         })
         .collect();
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if features_read > 0 {
+        draft.sources.push(crate::manifest::geology(geopackage));
+    }
     draft.report.geology_features_read = features_read;
     draft.report.geology_samples = draft.report.settlements;
     draft.report.geology_fallback_samples = fallbacks;

--- a/crates/adventuresim-world-import/src/sources/hydrology.rs
+++ b/crates/adventuresim-world-import/src/sources/hydrology.rs
@@ -14,8 +14,8 @@ use adventuresim_world_schema::{
     CanalWatercourse, CrossingTraversal, CrossingWatercourse, EdgeEndpoint, EdgeProgressPermille,
     FerryRoute, FerryWaterway, FlowPersistence, FlowingWaterAccess, InlandWaterAccess,
     InlandWaterSize, LandRoute, LandWaterCrossing, MarineWaterAccess, RiverAccess,
-    RiverAndCanalAccess, RiverWatercourse, SettlementHydrology, SourceProvenance, StrahlerOrder,
-    TravelEdgeImport, TravelRoute, WaterDistanceMeters,
+    RiverAndCanalAccess, RiverWatercourse, SettlementHydrology, StrahlerOrder, TravelEdgeImport,
+    TravelRoute, WaterDistanceMeters,
 };
 use geo::{BoundingRect, Contains, Coord, Geometry, Line, LineString, Point};
 use geozero::{ToGeo, wkb::GpkgWkb};
@@ -30,10 +30,6 @@ use crate::{
     spatial::SpatialProjection,
 };
 
-const SOURCE_NAME: &str = "Copernicus EU-Hydro River Network Database v1.3";
-const SOURCE_URL: &str =
-    "https://land.copernicus.eu/en/products/eu-hydro/eu-hydro-river-network-database";
-const SOURCE_LICENSE: &str = "Copernicus Land Monitoring Service full and open data policy";
 const EXPECTED_SRS: i64 = 3035;
 const SETTLEMENT_ADJACENCY_METERS: f64 = 2_000.0;
 const SOURCE_MARGIN_METERS: f64 = 10_000.0;
@@ -112,11 +108,13 @@ pub(crate) fn enrich(
         })
         .collect::<Vec<_>>();
 
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if database.files_read > 0
+        || !database.features.is_empty()
+        || crossings > 0
+        || inferred_ferries > 0
+    {
+        draft.sources.push(crate::manifest::hydrology());
+    }
     draft.report.hydrology_files_read = database.files_read;
     draft.report.hydrology_features_read = database.features.len();
     draft.report.hydrology_settlement_samples = settlements.len();

--- a/crates/adventuresim-world-import/src/sources/land_use.rs
+++ b/crates/adventuresim-world-import/src/sources/land_use.rs
@@ -17,9 +17,6 @@ use crate::{
     },
 };
 
-const SOURCE_NAME: &str = "History Database of the Global Environment 3.2.1";
-const SOURCE_URL: &str = "https://doi.org/10.17026/dans-25g-gez3";
-const SOURCE_LICENSE: &str = "CC0-1.0";
 const START_YEAR: i32 = 1500;
 const END_YEAR: i32 = 1600;
 const HYDE_COLUMNS: usize = 4_320;
@@ -72,7 +69,6 @@ pub(crate) fn enrich(
         )));
     }
     if draft.settlements.is_empty() {
-        draft.sources.push(source_provenance());
         return Ok(WorldDraft {
             year: draft.year,
             spatial_grid: draft.spatial_grid,
@@ -159,11 +155,7 @@ pub(crate) fn enrich(
 }
 
 fn source_provenance() -> SourceProvenance {
-    SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    }
+    crate::manifest::hyde()
 }
 
 #[derive(Clone, Copy)]

--- a/crates/adventuresim-world-import/src/sources/potential_vegetation.rs
+++ b/crates/adventuresim-world-import/src/sources/potential_vegetation.rs
@@ -9,7 +9,7 @@ use std::{
 
 use adventuresim_world_schema::{
     ForestCover, PotentialVegetation, PotentialVegetationClass, PotentialVegetationPosterior,
-    SourceProvenance, SuitabilityBasisPoints,
+    SuitabilityBasisPoints,
 };
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -26,9 +26,6 @@ use crate::{
     spatial::SpatialProjection,
 };
 
-const SOURCE_NAME: &str = "Jung/IIASA Current and future European potential vegetation types v1.1";
-const SOURCE_URL: &str = "https://doi.org/10.5281/zenodo.14627466";
-const SOURCE_LICENSE: &str = "Creative Commons Attribution 4.0 International (CC BY 4.0)";
 const WIDTH: u32 = 5_583;
 const HEIGHT: u32 = 4_474;
 const WEST: f64 = 944_000.0;
@@ -167,7 +164,7 @@ fn enrich_verified(
     directory: &Path,
 ) -> Result<WorldDraft<PotentialVegetationSettlementDraft>> {
     if draft.settlements.is_empty() {
-        return finish(draft, Vec::new(), 0);
+        return finish(draft, Vec::new(), 0, directory);
     }
     let projection = SpatialProjection::new()?;
     let cell_size = f64::from(draft.spatial_grid.cell_size_meters().get());
@@ -227,13 +224,14 @@ fn enrich_verified(
             samples.push(PotentialVegetation::Inferred(infer_class(settlement)));
         }
     }
-    finish(draft, samples, files_read)
+    finish(draft, samples, files_read, directory)
 }
 
 fn finish(
     mut draft: WorldDraft<ForestSettlementDraft>,
     samples: Vec<PotentialVegetation>,
     files_read: usize,
+    directory: &Path,
 ) -> Result<WorldDraft<PotentialVegetationSettlementDraft>> {
     if samples.len() != draft.settlements.len() {
         return Err(Error::Validation(
@@ -258,11 +256,9 @@ fn finish(
         push_source_note(&mut forest, note);
         PotentialVegetationSettlementDraft { forest, potential_vegetation }
     }).collect();
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if files_read > 0 {
+        draft.sources.push(crate::manifest::jung(directory)?);
+    }
     draft.report.potential_vegetation_raster_files_read = files_read;
     draft.report.potential_vegetation_samples = settlements.len();
     draft.report.potential_vegetation_posterior_samples = posterior;

--- a/crates/adventuresim-world-import/src/sources/religion.rs
+++ b/crates/adventuresim-world-import/src/sources/religion.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use adventuresim_world_schema::{
     CatholicLutheranChurch, CatholicReformedChurch, LutheranReformedChurch, OfficialReligion,
-    SettlementReligiousStatus, SourceProvenance, WesternChristianArrangement,
+    SettlementReligiousStatus, WesternChristianArrangement,
 };
 use serde::Deserialize;
 
@@ -15,10 +15,6 @@ use crate::{
     draft::{GeologySettlementDraft, ReligionSettlementDraft, WorldDraft, push_source_note},
 };
 
-const SOURCE_NAME: &str = "IEG Maps of Confessional Europe (1500 and 1555)";
-const SOURCE_URL: &str = "https://www.ieg-maps.uni-mainz.de/mapsp/mapconfession.htm";
-const SOURCE_LICENSE: &str =
-    "IEG map rights: © IEG Mainz / Andreas Kunz; project-curated intermediate";
 const SUPPORTED_YEAR: i32 = 1544;
 
 #[derive(Debug, Deserialize)]
@@ -302,11 +298,9 @@ pub(crate) fn enrich(
             }
         })
         .collect();
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if !regions.is_empty() {
+        draft.sources.push(crate::manifest::religion(regions_path)?);
+    }
     draft.report.religion_regions_read = regions.len();
     draft.report.religion_samples = settlements.len();
     draft.report.religion_fallback_samples = fallbacks;

--- a/crates/adventuresim-world-import/src/sources/soil.rs
+++ b/crates/adventuresim-world-import/src/sources/soil.rs
@@ -14,8 +14,8 @@ use adventuresim_world_schema::{
     AgriculturalLimitation, AvailableWaterCapacity, CationExchangeCapacity, MineralSoil,
     MineralSoilTexture, OrganicSoil, PotentialVegetationClass, RockOutcropSoil, SoilAcidity,
     SoilBasisPoints, SoilEvidence, SoilFertility, SoilPrediction, SoilProfile, SoilProperties,
-    SoilSubstrate, SoilWaterRegime, SourceProvenance, StoneContentPercent, SurfaceGeology,
-    SurfaceLithology, TopsoilOrganicCarbon, WrbReferenceGroup,
+    SoilSubstrate, SoilWaterRegime, StoneContentPercent, SurfaceGeology, SurfaceLithology,
+    TopsoilOrganicCarbon, WrbReferenceGroup,
 };
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -31,9 +31,6 @@ use crate::{
     spatial::SpatialProjection,
 };
 
-const SOURCE_NAME: &str = "ISRIC SoilGrids rolling version 2";
-const SOURCE_URL: &str = "https://www.isric.org/explore/soilgrids";
-const SOURCE_LICENSE: &str = "CC BY 4.0";
 const MANIFEST: &str = "soilgrids-manifest.json";
 const MAX_MANIFEST_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_RASTER_BYTES: u64 = 512 * 1024 * 1024;
@@ -52,7 +49,7 @@ const PROPERTIES: [&str; 11] = [
     "sand", "silt", "clay", "cfvo", "soc", "phh2o", "cec", "bdod", "wv0033", "wv1500", "wrb",
 ];
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct Manifest {
     schema: u32,
@@ -72,7 +69,7 @@ struct Manifest {
     files: Vec<ManifestFile>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, serde::Serialize)]
 #[serde(deny_unknown_fields)]
 struct ManifestFile {
     property: String,
@@ -89,13 +86,27 @@ struct ManifestFile {
     prepared_sha256: String,
 }
 
+fn canonicalize_files(files: &mut [ManifestFile]) {
+    files.sort_by(|left, right| {
+        (&left.property, &left.depth, &left.quantile).cmp(&(
+            &right.property,
+            &right.depth,
+            &right.quantile,
+        ))
+    });
+}
+
 pub(crate) fn predict(
     draft: WorldDraft<TreeSpeciesSettlementDraft>,
     directory: &Path,
 ) -> Result<WorldDraft<SoilPredictionSettlementDraft>> {
     let manifest = validate_manifest(directory, draft.spatial_grid.cell_size_meters().get())?;
+    let manifest_identity = (
+        manifest.retrieved_at.clone(),
+        format!("{:x}", Sha256::digest(serde_json::to_vec(&manifest)?)),
+    );
     if draft.settlements.is_empty() {
-        return finish_predictions(draft, vec![], manifest.files.len(), 0);
+        return finish_predictions(draft, vec![], manifest.files.len(), 0, manifest_identity);
     }
     let projection = SpatialProjection::new()?;
     let points = draft
@@ -142,7 +153,13 @@ pub(crate) fn predict(
             },
         )
         .collect::<Result<Vec<_>>>()?;
-    finish_predictions(draft, predictions, manifest.files.len(), inferred)
+    finish_predictions(
+        draft,
+        predictions,
+        manifest.files.len(),
+        inferred,
+        manifest_identity,
+    )
 }
 
 fn finish_predictions(
@@ -150,6 +167,7 @@ fn finish_predictions(
     predictions: Vec<SoilPrediction>,
     rasters: usize,
     inferred: usize,
+    manifest_identity: (String, String),
 ) -> Result<WorldDraft<SoilPredictionSettlementDraft>> {
     if predictions.len() != draft.settlements.len() {
         return Err(Error::Validation(
@@ -164,11 +182,12 @@ fn finish_predictions(
         });
         SoilPredictionSettlementDraft { trees, prediction }
     }).collect();
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if rasters > 0 {
+        draft.sources.push(crate::manifest::soil(
+            manifest_identity.0,
+            manifest_identity.1,
+        )?);
+    }
     draft.report.soil_rasters_read = rasters;
     draft.report.soil_depth_layers_read = rasters.saturating_sub(3);
     draft.report.soil_samples = settlements.len();
@@ -500,7 +519,7 @@ fn validate_manifest(directory: &Path, cell_size: u32) -> Result<Manifest> {
             "SoilGrids manifest exceeds size limit".into(),
         ));
     }
-    let manifest: Manifest =
+    let mut manifest: Manifest =
         serde_json::from_slice(&fs::read(&path)?).map_err(|source| Error::JsonSource {
             path: path.clone(),
             source,
@@ -511,11 +530,13 @@ fn validate_manifest(directory: &Path, cell_size: u32) -> Result<Manifest> {
         || manifest.crs != "EPSG:3035"
         || manifest.origin_easting_meters != 0
         || manifest.origin_northing_meters != 0
+        || manifest.source_version != "latest"
         || manifest.cell_size_meters != cell_size
         || manifest.west >= manifest.east
         || manifest.south >= manifest.north
         || manifest.retrieved_at.trim().is_empty()
-        || manifest.source_version.trim().is_empty()
+        || manifest.retrieved_at.len() > 128
+        || manifest.retrieved_at.contains('\0')
         || !valid_hash(&manifest.generation)
         || manifest.files.len() != 207
     {
@@ -675,6 +696,7 @@ fn validate_manifest(directory: &Path, cell_size: u32) -> Result<Manifest> {
             )));
         }
     }
+    canonicalize_files(&mut manifest.files);
     Ok(manifest)
 }
 
@@ -1220,6 +1242,11 @@ mod tests {
             prepared_size: 1,
             prepared_sha256: "b".repeat(64),
         };
+        let mut later = file.clone();
+        later.property = "silt".into();
+        let mut reordered = vec![later, file.clone()];
+        canonicalize_files(&mut reordered);
+        assert_eq!(reordered[0].property, "sand");
         assert!(validate_unit(&file).is_ok());
         file.unit = "percent".into();
         assert!(validate_unit(&file).is_err());

--- a/crates/adventuresim-world-import/src/sources/tree_species.rs
+++ b/crates/adventuresim-world-import/src/sources/tree_species.rs
@@ -9,8 +9,8 @@ use std::{
 
 use adventuresim_world_schema::{
     HabitatSuitability, InferredTreeSpeciesProfile, ModeledTreeSpecies, ModeledTreeSpeciesProfile,
-    NativeRangeEvidence, PotentialVegetation, PotentialVegetationClass, SourceProvenance,
-    TreeSpeciesId, TreeSpeciesProfile,
+    NativeRangeEvidence, PotentialVegetation, PotentialVegetationClass, TreeSpeciesId,
+    TreeSpeciesProfile,
 };
 use proj4rs::{proj::Proj, transform::transform};
 use tiff::{
@@ -28,9 +28,6 @@ use crate::{
     },
 };
 
-const SOURCE_NAME: &str = "EU-Trees4F v2 current-climate ensemble";
-const SOURCE_URL: &str = "https://doi.org/10.6084/m9.figshare.17032328";
-const SOURCE_LICENSE: &str = "CC0 1.0";
 const ARCHIVE_ROOT: &str = "ens_clim/";
 const CURRENT_STEM: &str = "_ens-clim_cur2005_";
 const EXPECTED_RASTERS: usize = 201;
@@ -112,7 +109,7 @@ pub(crate) fn enrich(
     archive_path: &Path,
 ) -> Result<WorldDraft<TreeSpeciesSettlementDraft>> {
     if draft.settlements.is_empty() {
-        return finish(draft, Vec::new(), 0, 0);
+        return finish(draft, Vec::new(), 0, 0, archive_path);
     }
     let file = File::open(archive_path).map_err(|error| {
         if error.kind() == std::io::ErrorKind::NotFound {
@@ -199,7 +196,7 @@ pub(crate) fn enrich(
         };
         profiles.push(profile);
     }
-    finish(draft, profiles, rasters_read, fallbacks)
+    finish(draft, profiles, rasters_read, fallbacks, archive_path)
 }
 
 fn rank_modeled_candidates(
@@ -226,6 +223,7 @@ fn finish(
     profiles: Vec<TreeSpeciesProfile>,
     rasters_read: usize,
     fallbacks: usize,
+    archive_path: &Path,
 ) -> Result<WorldDraft<TreeSpeciesSettlementDraft>> {
     if profiles.len() != draft.settlements.len() {
         return Err(Error::Validation(
@@ -256,11 +254,9 @@ fn finish(
             }
         })
         .collect::<Vec<_>>();
-    draft.sources.push(SourceProvenance {
-        name: SOURCE_NAME.into(),
-        url: SOURCE_URL.into(),
-        license: SOURCE_LICENSE.into(),
-    });
+    if rasters_read > 0 {
+        draft.sources.push(crate::manifest::trees(archive_path)?);
+    }
     draft.report.tree_species_rasters_read = rasters_read;
     draft.report.tree_species_samples = settlements.len();
     draft.report.tree_species_fallback_samples = fallbacks;

--- a/crates/adventuresim-world-import/src/sources/viabundus/mod.rs
+++ b/crates/adventuresim-world-import/src/sources/viabundus/mod.rs
@@ -4,8 +4,7 @@ use std::{
 };
 
 use adventuresim_world_schema::{
-    EdgeEndpoint, SourceProvenance, SpatialGridSpec, TravelEdgeKind, WorldBuildReport,
-    WorldNodeImport,
+    EdgeEndpoint, SpatialGridSpec, TravelEdgeKind, WorldBuildReport, WorldNodeImport,
 };
 use serde::{Deserialize, Deserializer, de};
 
@@ -17,9 +16,7 @@ use crate::{
 mod descriptions;
 mod names;
 
-const SOURCE_NAME: &str = "Viabundus Pre-modern Street Map 2";
 const SOURCE_DOI: &str = "https://doi.org/10.5281/zenodo.16611998";
-const SOURCE_LICENSE: &str = "CC-BY-SA-4.0";
 
 #[derive(Debug, Deserialize)]
 struct RawNode {
@@ -316,11 +313,7 @@ pub(crate) fn compile(
     Ok(WorldDraft {
         year,
         spatial_grid,
-        sources: vec![SourceProvenance {
-            name: SOURCE_NAME.into(),
-            url: SOURCE_DOI.into(),
-            license: SOURCE_LICENSE.into(),
-        }],
+        sources: vec![crate::manifest::viabundus(directory)?],
         road_types: vec![TravelEdgeKind::Ferry, TravelEdgeKind::Land],
         report: WorldBuildReport {
             nodes: nodes.len(),

--- a/crates/adventuresim-world-import/src/validation.rs
+++ b/crates/adventuresim-world-import/src/validation.rs
@@ -22,6 +22,74 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
             world.metadata.inference_rules_version
         )));
     }
+    for source in &world.metadata.sources {
+        crate::manifest::validate_source(source)?;
+    }
+    if world
+        .metadata
+        .sources
+        .windows(2)
+        .any(|pair| pair[0].id >= pair[1].id)
+    {
+        return Err(Error::Validation(
+            "source manifests are duplicated or not in canonical id order".into(),
+        ));
+    }
+    let expected_manifest_digest = crate::manifest::digest(
+        world.metadata.world_year,
+        world.metadata.spatial_grid,
+        &world.metadata.sources,
+    )?;
+    if world.metadata.manifest_digest != expected_manifest_digest {
+        return Err(Error::Validation(
+            "world metadata manifest digest does not match its canonical manifest".into(),
+        ));
+    }
+    let report = &world.report;
+    let mut expected = std::collections::BTreeSet::new();
+    if !world.nodes.is_empty() || !world.edges.is_empty() || !world.settlements.is_empty() {
+        expected.insert("viabundus-v2");
+    }
+    for (used, id) in [
+        (report.elevation_tiles_read > 0, "copernicus-dem-glo30"),
+        (report.land_use_rasters_read > 0, "hyde-3-2-1"),
+        (report.forest_tiles_read > 0, "clms-forest-2018"),
+        (
+            report.potential_vegetation_raster_files_read > 0,
+            "jung-pnv-1-1",
+        ),
+        (report.tree_species_rasters_read > 0, "eu-trees4f-v2"),
+        (report.soil_rasters_read > 0, "soilgrids-v2-rolling"),
+        (report.geology_features_read > 0, "egdi-surface-geology-1m"),
+        (
+            report.religion_regions_read > 0,
+            "ieg-religion-1544-curated",
+        ),
+        (report.drought_grid_cells_read > 0, "noaa-owda-v1"),
+        (
+            report.hydrology_files_read > 0
+                || report.hydrology_features_read > 0
+                || report.hydrology_settlement_samples > 0
+                || report.hydrology_edge_crossings > 0
+                || report.hydrology_inferred_ferry_waterways > 0,
+            "copernicus-eu-hydro-1-3",
+        ),
+    ] {
+        if used {
+            expected.insert(id);
+        }
+    }
+    let actual = world
+        .metadata
+        .sources
+        .iter()
+        .map(|source| source.id.as_str())
+        .collect::<std::collections::BTreeSet<_>>();
+    if actual != expected {
+        return Err(Error::Validation(format!(
+            "canonical source manifest set does not match build evidence (expected {expected:?}, got {actual:?})"
+        )));
+    }
 
     let node_ids: HashSet<_> = world.nodes.iter().map(|node| node.id).collect();
     if node_ids.len() != world.nodes.len() {
@@ -570,13 +638,17 @@ mod tests {
     };
 
     fn empty_world(schema_version: u32, inference_rules_version: u32) -> CompiledWorld {
+        let spatial_grid = SpatialGridSpec::default();
+        let sources = Vec::new();
+        let manifest_digest = crate::manifest::digest(1544, spatial_grid, &sources).unwrap();
         CompiledWorld {
             metadata: WorldMetadata {
                 schema_version,
                 inference_rules_version,
-                spatial_grid: SpatialGridSpec::default(),
+                spatial_grid,
                 world_year: 1544,
-                sources: Vec::new(),
+                manifest_digest,
+                sources,
                 road_types: Vec::new(),
             },
             nodes: Vec::new(),
@@ -607,6 +679,37 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("inference rules version")
+        );
+    }
+
+    #[test]
+    fn build_report_cannot_claim_an_absent_source_manifest() {
+        let mut world = empty_world(WORLD_SCHEMA_VERSION, CURRENT_INFERENCE_RULES_VERSION);
+        world.report.elevation_tiles_read = 1;
+        world.report.elevation_samples = 1;
+        assert!(
+            super::validate(&world)
+                .unwrap_err()
+                .to_string()
+                .contains("does not match build evidence")
+        );
+    }
+
+    #[test]
+    fn build_report_rejects_an_extra_source_manifest() {
+        let mut world = empty_world(WORLD_SCHEMA_VERSION, CURRENT_INFERENCE_RULES_VERSION);
+        world.metadata.sources.push(crate::manifest::hydrology());
+        world.metadata.manifest_digest = crate::manifest::digest(
+            world.metadata.world_year,
+            world.metadata.spatial_grid,
+            &world.metadata.sources,
+        )
+        .unwrap();
+        assert!(
+            super::validate(&world)
+                .unwrap_err()
+                .to_string()
+                .contains("does not match build evidence")
         );
     }
 

--- a/crates/adventuresim-world-schema/src/lib.rs
+++ b/crates/adventuresim-world-schema/src/lib.rs
@@ -7,7 +7,7 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
-pub const WORLD_SCHEMA_VERSION: u32 = 17;
+pub const WORLD_SCHEMA_VERSION: u32 = 18;
 pub const CURRENT_INFERENCE_RULES_VERSION: u32 = 4;
 pub const MAX_SOURCES_MARKDOWN_CHARS: usize = 32_768;
 
@@ -2058,15 +2058,111 @@ pub struct WorldMetadata {
     pub inference_rules_version: u32,
     pub spatial_grid: SpatialGridSpec,
     pub world_year: i32,
+    /// BLAKE3 of the canonical schema/rules/year/grid/source-manifest tuple.
+    pub manifest_digest: String,
     pub sources: Vec<SourceProvenance>,
     pub road_types: Vec<TravelEdgeKind>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SourceProvenance {
+    /// Stable machine identifier. This is also the canonical sort key.
+    pub id: String,
     pub name: String,
-    pub url: String,
-    pub license: String,
+    pub release: SourceRelease,
+    pub canonical_url: String,
+    pub doi: Option<String>,
+    pub license: SourceLicense,
+    /// Exact operational attribution, change, endorsement, liability, and
+    /// redistribution notices which must accompany this distribution.
+    pub required_notices: Vec<String>,
+    pub access: SourceAccess,
+    pub spatial: SourceSpatialCoverage,
+    pub temporal: SourceTemporalCoverage,
+    pub preparation: SourcePreparation,
+    pub content_identity: SourceContentIdentity,
+    /// Human-facing Markdown retained alongside the typed manifest.
+    pub notes_markdown: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum SourceRelease {
+    Immutable { version: String, released: String },
+    Curated { revision: String },
+    Rolling { observed_at: String },
+    ReleaseBlocked { reason: String },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SourceLicense {
+    CcBy3_0,
+    CcBy4_0,
+    CcBySa4_0,
+    Cc0_1_0,
+    CopernicusDem,
+    CopernicusClms,
+    NoaaPublicAccess,
+    RightsReserved,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum SourceAccess {
+    AnonymousDownload,
+    AuthenticatedDownload,
+    CuratedRepositoryAsset,
+    ManualPreparation,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum SourceSpatialCoverage {
+    NotApplicable,
+    Geographic {
+        crs: String,
+        resolution: String,
+        coverage: String,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum SourceTemporalCoverage {
+    Timeless,
+    Year(i32),
+    Years { first: i32, last: i32 },
+    ModernProxy { year: i32 },
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourcePreparation {
+    pub recipe: String,
+    pub version: u32,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum SourceContentIdentity {
+    RawSha256 { sha256: String },
+    PreparedSnapshotSha256 { sha256: String },
+    CuratedRevision { revision: String, sha256: String },
+    UnpinnedRollingObservation { observed_at: String },
+    ReleaseBlocked { reason: String },
+}
+
+impl SourceContentIdentity {
+    pub const fn is_reproducible(&self) -> bool {
+        matches!(
+            self,
+            Self::RawSha256 { .. }
+                | Self::PreparedSnapshotSha256 { .. }
+                | Self::CuratedRevision { .. }
+        )
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,6 +26,11 @@ artifact identity. Source coverage extents remain source-manifest concerns.
 The grid is compiler metadata, not a SpacetimeDB table shape: no grid columns or
 tactical coordinates are persisted.
 
+World schema v18 replaces the old source labels with the typed canonical
+distribution manifests documented in `docs/SOURCE_MANIFESTS.md`. Their
+schema/rules/year/grid/source digest is the cache and build boundary and is
+retained by the import session alongside the complete artifact ID.
+
 Source modules first parse into importer-only draft types. The outer builder
 enriches that draft in dependency order and only then constructs the canonical
 world schema. For example, Viabundus supplies settlement identity and road

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -236,6 +236,13 @@ official archive is not currently available locally, so the parser and
 enrichment are verified against standards-compliant synthetic GeoPackages but
 the complete source distribution remains unverified.
 
+World schema v18 / inference rules v4 add typed canonical distribution
+manifests and a deterministic schema/rules/year/grid/source digest. The world
+compiler prints the sorted manifest and whether each source is reproducible.
+See `docs/SOURCE_MANIFESTS.md`; manual, rolling, credential-gated, or
+rights-conflicted sources remain explicit instead of receiving invented hashes
+or legal conclusions.
+
 World schema v17 / inference rules v4 add the final 1544 environmental
 synthesis. Its direct/derived/fallback and tie-break counters must reconcile to
 settlement count during validation. A complete official all-source audit is not

--- a/docs/FOREST_COVER.md
+++ b/docs/FOREST_COVER.md
@@ -34,6 +34,10 @@ mapping described here so a raw, stale, or differently prepared byte raster is
 not silently interpreted under this contract. Each used degree tile requires a
 pair named for its southwest corner:
 
+The marker is not a content inventory. Canonical provenance therefore remains
+release-blocked/non-reproducible until every consumed TCD/DLT tile has a checked
+size and SHA-256.
+
 - `TCD_N48_E002.tif`
 - `DLT_N48_E002.tif`
 

--- a/docs/HISTORICAL_LAND_USE.md
+++ b/docs/HISTORICAL_LAND_USE.md
@@ -6,7 +6,9 @@ the Global Environment), using the 1500 and 1600 CE slices around the game's
 
 - Dataset record: <https://doi.org/10.17026/dans-25g-gez3>
 - Method paper: <https://doi.org/10.5194/essd-9-927-2017>
-- Terms recorded by the repository: CC0 1.0
+- Conservative operational terms: CC BY 3.0 because the DANS record's CC0
+  signal conflicts with the bundled attribution-oriented README. This records
+  the stricter treatment and does not claim the conflict is legally resolved.
 
 The official archive is currently protected/restricted and the attempted
 download produced no source files. Consequently this integration is verified

--- a/docs/POTENTIAL_VEGETATION.md
+++ b/docs/POTENTIAL_VEGETATION.md
@@ -5,6 +5,8 @@ European potential vegetation types v1.1**, DOI
 [`10.5281/zenodo.14627466`](https://doi.org/10.5281/zenodo.14627466). The pinned
 version was published 2025-01-10 under CC BY 4.0 and covers continental Europe,
 including Turkey, at nominal 1 km grain.
+Canonical temporal metadata records the model-input window, 1990–2020, rather
+than presenting the publication year as a single observation year.
 
 Run `just init-jung-pnv` to download the categorical current raster plus the six
 current-class COGs into `target/world-data-sources/raw/jung-pnv/`. The atomic

--- a/docs/SOIL.md
+++ b/docs/SOIL.md
@@ -44,6 +44,9 @@ observational source SHA-256/size, ETag and Last-Modified when supplied, and
 exact prepared hashes. Because rolling source bytes can change between the
 observation and GDAL requests, those source fields do not bind the prepared
 bytes. The prepared SHA-256 is the authoritative local snapshot; future raw
+The canonical source manifest uses the strict preparation manifest's actual
+`retrieved_at` value and prepared-manifest digest. This identifies the local
+snapshot but does not claim that the rolling `latest` source is reacquirable.
 reacquisition is not claimed reproducible.
 
 Preparation requires both `gdalwarp` and `gdalinfo`. Every staged TIFF must pass

--- a/docs/SOURCE_MANIFESTS.md
+++ b/docs/SOURCE_MANIFESTS.md
@@ -1,0 +1,69 @@
+# World source manifests
+
+World schema v18 replaces the old name/URL/license labels with a canonical,
+typed manifest for every distribution used by the offline compiler. Each entry
+has a stable ID, release status, canonical URL and optional DOI, typed licence,
+operational notices, access method, spatial and temporal coverage, preparation
+recipe, and content identity. Human-readable Markdown remains alongside these
+fields for the in-game audit trail.
+
+The compiler sorts entries by stable ID and rejects duplicates, non-canonical
+order, empty or oversized fields, missing notices, malformed hashes, report
+claims without their source entry, and unknown serde fields. There is no
+`Unknown` identity. A source is either reproducible from a raw/prepared SHA-256
+or curated revision digest, or explicitly records an unpinned or
+release-blocked state. The latter states never report themselves as
+reproducible.
+
+## Identity and cache boundary
+
+The manifest digest is BLAKE3 over the world schema version, inference-rules
+version, world year, complete `SpatialGridSpec`, and sorted distribution
+manifests (including notices and preparation). Changing any field changes the
+digest. Source ordering, local paths, and file timestamps do not. The complete
+compiled artifact is still hashed separately; both IDs are retained by the
+SpacetimeDB import session. No separate world-data cache currently exists, so
+this digest defines the key that a future cache must use.
+
+The import session also retains complete deterministic audit Markdown for every
+used distribution: ID, name, release, licence, content status and identity,
+URL, DOI, notices, access, spatial and temporal coverage, preparation, and
+notes. Each typed source is embedded as canonical compact JSON. The compiler
+rejects the import before calling a reducer if the fully JSON-quoted argument
+would exceed the 24,000-character Windows transport budget; legal text is never
+silently truncated.
+
+The stored digest is compiler/operator-attested under the trusted first-caller
+import model. SpacetimeDB syntax-checks the digest and binds it to the import
+session, but it does not receive the typed manifest and therefore cannot
+recompute the digest. It is an audit/cache identity, not independent proof
+against a malicious or noncanonical client.
+
+## Operational notices and unresolved boundaries
+
+- **Viabundus:** retain attribution and CC BY-SA 4.0. The project applies a
+  conservative BY-SA treatment; compatibility with differently licensed
+  combined output remains unresolved.
+- **Copernicus DEM:** retain the prescribed Copernicus/WorldDEM production
+  credit and European Commission/ESA no-liability notice.
+- **HYDE:** cite the DANS record. Its CC0 and attribution-oriented rights
+  signals conflict; this is recorded, not resolved.
+- **Copernicus forest and EU-Hydro:** credit the European Union/Copernicus,
+  identify project modifications, and do not imply endorsement.
+- **Jung PNV, SoilGrids, and EGDI:** retain CC BY 4.0 attribution and identify
+  gameplay conversion changes. EGDI additionally retains the Maltese
+  contribution and disclaimer.
+- **EU-Trees4F:** retain dataset and publication citation despite CC0.
+- **IEG religion:** source images remain rights-reserved and are not
+  redistributed. Only the coarse curated intermediate is checked in.
+- **NOAA OWDA:** cite NCEI and Cook et al.; compiled output remains bounded
+  per-settlement derived data, not the grid or annual series.
+
+Current release blockers are explicit: GLO-30 tile selection, HYDE grids, EGDI,
+and EU-Hydro lack checked complete content inventories. The forest marker pins
+only the preparation format, so forest remains non-reproducible until every
+consumed raster is inventoried and hashed. SoilGrids is a rolling service whose
+strict prepared manifest supplies the actual retrieval timestamp and snapshot
+identity; that does not make raw `latest` reacquisition reproducible. These
+entries do not claim legal resolution or
+reproducibility that is not present.

--- a/docs/SPATIAL_GRID.md
+++ b/docs/SPATIAL_GRID.md
@@ -41,3 +41,5 @@ must contain:
 
 Any mismatch means regeneration. Source coverage extents belong in the source
 manifest and will affect its checksum rather than expanding `SpatialGridSpec`.
+The complete canonical manifest checksum and operational-notice contract are
+documented in `docs/SOURCE_MANIFESTS.md`.

--- a/docs/VIABUNDUS.md
+++ b/docs/VIABUNDUS.md
@@ -7,6 +7,12 @@ version 2 (released 25 April 2025), edited by Bart Holterman et al.
 - Project: <https://www.viabundus.eu>
 - License: [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)
 
+The initializer sidecar records the byte size and SHA-256 of each downloaded
+CSV. Import requires a bounded, deny-unknown v2 sidecar with the canonical
+Zenodo record, unique safe CSV names, and an inventory of every consumed CSV;
+it verifies consumed bytes before granting reproducible snapshot status.
+Legacy sidecars without sizes remain explicitly release-blocked.
+
 The upstream CSVs are downloaded locally into the Git-ignored `viabundus/`
 directory with `just init-viabundus`. The native Rust world compiler reads them
 from its source-specific `sources::viabundus` module, then enriches the draft

--- a/scripts/init_viabundus.py
+++ b/scripts/init_viabundus.py
@@ -16,7 +16,13 @@ from pathlib import Path
 
 RECORD_URL = "https://zenodo.org/api/records/16611998"
 VERSION = "2"
-REQUIRED_FILES = {"nodes.csv", "edges.csv", "population.csv"}
+REQUIRED_FILES = {
+    "nodes.csv",
+    "edges.csv",
+    "population.csv",
+    "alternativenames.csv",
+    "descriptions.csv",
+}
 USER_AGENT = "adventure-simulator-viabundus-initializer/1.0"
 
 
@@ -61,7 +67,7 @@ def download_file(file: dict[str, object], destination: Path) -> dict[str, str]:
     except (urllib.error.URLError, urllib.error.HTTPError) as error:
         raise RuntimeError(f"Could not download {name}: {error}") from error
 
-    return {"name": name, "sha256": digest.hexdigest(), "url": url}
+    return {"name": name, "sha256": digest.hexdigest(), "url": url, "size": destination.stat().st_size}
 
 
 def is_initialised(destination: Path) -> bool:


### PR DESCRIPTION
## Summary

- add typed, bounded canonical manifests for every integrated world-data distribution
- distinguish immutable, prepared, curated, rolling, and release-blocked content identities without Unknown states
- bind schema, inference rules, year, spatial grid, and the full canonical source set into artifact identity
- reconcile the exact source set bidirectionally with build evidence
- persist complete bounded source audit JSON and manifest digest on import sessions
- enforce consumed-byte verification for Viabundus and strict prepared-manifest handling for Jung and SoilGrids
- encode conservative attribution, redistribution, and unresolved-license notices
- regenerate schema-v18 bindings

## Scope

This advances #62's provenance and deterministic rebuild boundary. It does not claim unresolved source inventories or rights conflicts are solved: GLO-30, HYDE, forest, EGDI, and EU-Hydro remain explicitly release-blocked/unpinned where appropriate, SoilGrids raw latest reacquisition remains rolling, and Viabundus/HYDE publisher conflicts remain documented.

## Trust model

The SpacetimeDB digest is compiler/operator-attested under the trusted first-caller import model. The server syntax-checks and retains it but does not independently recompute the full offline manifest.

## Verification

- 116 importer library tests and 16 CLI/audit tests
- 19 schema tests
- 15 focused manifest/reconciliation tests
- warning-clean importer/module/client checks
- release WASM build and regenerated bindings
- project map and diff checks