### PR TITLE
Add fail-closed world source initializers

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -173,6 +173,20 @@ The loader claims a one-time import identity before sending batches. For a
 production deployment, the operator must make that first call before allowing
 untrusted clients to connect.
 
+### Remaining source initializer workflows
+
+The remaining accepted source workflows share `scripts/world_source_init.py`.
+Every source has `plan-*`, `init-*`, and `verify-*` targets. EU-Trees4F is the
+only newly automated anonymous immutable download (`tree-species`); it is
+size/hash checked and atomically published. Religion is a validation-only
+workflow and never mirrors the rights-reserved IEG images. GLO-30
+(`glo30`), Copernicus forest (`forest-cover`), and EU-Hydro (`hydrology`)
+perform redacted credential-file preflights but refuse network acquisition
+until exact product inventories are committed. HYDE and EGDI likewise provide
+deterministic plans and strict local-inventory verification while remaining
+release-blocked. `init-*` never turns missing pins or conflicting rights into
+guesses. See each source document for its exact blocker and command names.
+
 The compiler also currently requires manually downloaded Copernicus DEM
 GLO-30 `*_DEM.tif` tiles in
 `target/world-data-sources/raw/elevation/`. See `docs/ELEVATION.md` for source,

--- a/docs/ELEVATION.md
+++ b/docs/ELEVATION.md
@@ -9,9 +9,12 @@ terrain height is sufficiently stable for the game's plausibility-oriented
 - Product information: <https://dataspace.copernicus.eu/explore-data/data-collections/copernicus-contributing-missions/collections-description/COP-DEM>
 - Terms: Copernicus DEM licence
 
-The manually downloaded `*_DEM.tif` tiles belong in the Git-ignored
-`target/world-data-sources/raw/elevation/` directory. This source is not yet
-part of an initialization script while its suitability is being evaluated.
+The `*_DEM.tif` tiles belong in the Git-ignored
+`target/world-data-sources/raw/elevation/` directory. `just plan-glo30` prints
+the deterministic request and redacted `CDSE_TOKEN_FILE` preflight,
+`init-glo30` refuses until the complete tile inventory is pinned, and
+`verify-glo30` checks a strict local `source-inventory.json`. This
+release-blocked workflow never logs or stores a token.
 
 `sources::elevation` uses the pure-Rust `tiff` crate and does not require GDAL
 or PROJ. It groups settlements by one-degree GLO-30 tile, decodes only the 159

--- a/docs/FOREST_COVER.md
+++ b/docs/FOREST_COVER.md
@@ -10,11 +10,12 @@ about the exact historical tree cover around a settlement.
 - DLT dataset DOI: <https://doi.org/10.2909/82f93572-9888-47ef-97a1-5cac5985a26a>
 - Terms: Copernicus full, free, and open data policy
 
-The Copernicus download requires an authenticated data-service workflow that
-was not available while this integration was developed. The raw source
-directory is therefore empty, the integration is verified against synthetic
-GeoTIFF fixtures, and a full-source build is not claimed. It is not yet part of
-the data-initialization script.
+The Copernicus download requires authenticated CLMS access. `just
+plan-forest-cover` checks only whether `CLMS_TOKEN_FILE` names a bounded local
+credential file and redacts its value. Because product item IDs and every
+consumed tile identity are not pinned, `init-forest-cover` refuses network
+preparation. `verify-forest-cover` checks an exact local inventory. The source
+remains release-blocked and a full-source build is not claimed.
 
 ## Manual preparation contract
 

--- a/docs/GEOLOGY.md
+++ b/docs/GEOLOGY.md
@@ -25,8 +25,10 @@ OGC empty geometry) to have exactly one usable index entry.
 
 The official WFS can return GeoJSON samples, but the full layer contains more
 than 240,000 features. Preparing a local indexed GeoPackage avoids repeatedly
-downloading or scanning the service. This manual preparation is intentionally
-not part of data initialization until the source is accepted.
+downloading or scanning the service. The accepted aggregate still lacks a
+committed exact size and SHA-256. `just plan-geology` prints the fixed contract,
+`init-geology` refuses acquisition, and `verify-geology` validates a strict
+local `source-inventory.json`. The source remains release-blocked.
 
 ## Imported model
 

--- a/docs/HISTORICAL_LAND_USE.md
+++ b/docs/HISTORICAL_LAND_USE.md
@@ -10,10 +10,12 @@ the Global Environment), using the 1500 and 1600 CE slices around the game's
   signal conflicts with the bundled attribution-oriented README. This records
   the stricter treatment and does not claim the conflict is legally resolved.
 
-The official archive is currently protected/restricted and the attempted
-download produced no source files. Consequently this integration is verified
-against synthetic ESRI ASCII fixtures, not the full HYDE distribution, and it
-is not yet part of a data-initialization script.
+The official record exposes large archives but the seven consumed files do not
+have a committed exact size/SHA-256 inventory, and its CC0 and bundled
+attribution signals conflict. Consequently `just plan-hyde` is deterministic,
+`init-hyde` refuses acquisition, and `verify-hyde` only checks a supplied strict
+local inventory. The workflow does not resolve the rights conflict or claim a
+full-source audit.
 
 ## Manual preparation contract
 

--- a/docs/HYDROLOGY.md
+++ b/docs/HYDROLOGY.md
@@ -23,6 +23,12 @@ fixtures exercise the reader but are not a writable GeoPackage conformance
 suite. Do not describe a full-world hydrology audit as complete until the
 official archive has been run.
 
+`just plan-hydrology` performs a redacted `CLMS_TOKEN_FILE` preflight and
+prints the fixed v1.3 request contract. Because official archive/item IDs and
+the complete basin GeoPackage inventory are not pinned, `init-hydrology`
+refuses network acquisition. `verify-hydrology` validates a supplied strict
+local inventory; the source remains release-blocked.
+
 ## Parsed source features
 
 The compiler recognizes the official `River_Net_l`, `Canals_l`, `Ditches_l`,

--- a/docs/RELIGION.md
+++ b/docs/RELIGION.md
@@ -52,3 +52,9 @@ active in 1544: 4,590 matched one of the 14 prioritized regions and 1,451 used
 the Roman Catholic fallback. The matched set includes 155 settlements in the
 Upper Rhine multi-confessional approximation, confirming that its specific
 priority takes precedence over the broader Hessian region.
+
+`just verify-religion` validates the committed file's fixed 1,069-byte size,
+SHA-256, exact column order, ascending unique priorities, coordinate bounds,
+statuses, and 14-row revision. `plan-religion` reports that identity.
+`init-religion` always refuses so the rights-reserved GIF/PDF source images are
+never downloaded or mirrored.

--- a/docs/SOURCE_MANIFESTS.md
+++ b/docs/SOURCE_MANIFESTS.md
@@ -67,3 +67,17 @@ strict prepared manifest supplies the actual retrieval timestamp and snapshot
 identity; that does not make raw `latest` reacquisition reproducible. These
 entries do not claim legal resolution or
 reproducibility that is not present.
+
+`scripts/world_source_init.py` provides bounded plan/init/verify workflows for
+these accepted sources. Only the immutable EU-Trees4F archive is acquired; the
+authenticated or incompletely pinned sources fail closed until reviewed
+inventories are committed. The curated IEG CSV is validated in place and its
+rights-reserved reference images are never mirrored. Sidecars use sorted fixed
+metadata and actual sizes/hashes, reject unknown inventory fields, traversal,
+symlinks, redirects outside fixed hosts, oversized content, and partial or
+checksum-failing publication.
+
+The EU-Trees4F initializer pins the exact JRC ENS_CLIM archive. It retains the
+EU-Trees4F v2 Figshare citation and CC0 notice, but does not claim that a
+Figshare-hosted archive is byte-identical; confirming that relationship remains
+an explicit provenance blocker.

--- a/docs/TREE_SPECIES.md
+++ b/docs/TREE_SPECIES.md
@@ -9,11 +9,21 @@ treat them as observations from 1544.
 - Dataset and CC0 licence: <https://doi.org/10.6084/m9.figshare.17032328>
 - Data descriptor: <https://doi.org/10.1038/s41597-022-01128-5>
 - Archive SHA-256: `be115f771e5598e6fd180621e1a32922880cf7ac8e2cb59ba0eabd7f15bfeda4`
+- Archive size: `73,796,217` bytes
+- Pinned JRC ENS_CLIM URL: <https://ies-ows.jrc.ec.europa.eu/efdac/download/EU-Trees4F/EU-Trees4F_ens-clim.zip>
+
+The automated identity applies to that exact JRC ENS_CLIM archive. Its byte
+equivalence to a Figshare-hosted archive has not been established and remains
+an explicit confirmation blocker; the EU-Trees4F v2 Figshare citation and CC0
+notice are retained without making an equivalence claim.
 
 Keep `EU-Trees4F_ens-clim.zip` at
-`target/world-data-sources/raw/tree-species/`. Override it with
-`--tree-species-archive`. The archive remains a manually initialized source
-until its game usefulness is accepted.
+`target/world-data-sources/raw/tree-species/`. `just init-tree-species`
+downloads into a temporary candidate, verifies size and SHA-256, publishes a
+content-addressed generation and canonical sidecar, then atomically replaces
+the active archive. `--force` is required to replace an invalid existing file.
+Use `plan-tree-species` or `verify-tree-species` for non-mutating workflows.
+Override it with `--tree-species-archive`.
 
 ## Source semantics and parsing
 

--- a/justfile
+++ b/justfile
@@ -246,6 +246,56 @@ init-jung-pnv:
 init-soilgrids:
 	@python3 scripts/init_soilgrids.py
 
+# Plan, initialize, or verify the remaining accepted world-data sources.
+plan-glo30:
+	@python3 scripts/world_source_init.py glo30 --plan
+init-glo30:
+	@python3 scripts/world_source_init.py glo30 --init
+verify-glo30:
+	@python3 scripts/world_source_init.py glo30 --verify-only
+
+plan-hyde:
+	@python3 scripts/world_source_init.py hyde --plan
+init-hyde:
+	@python3 scripts/world_source_init.py hyde --init
+verify-hyde:
+	@python3 scripts/world_source_init.py hyde --verify-only
+
+plan-forest-cover:
+	@python3 scripts/world_source_init.py forest --plan
+init-forest-cover:
+	@python3 scripts/world_source_init.py forest --init
+verify-forest-cover:
+	@python3 scripts/world_source_init.py forest --verify-only
+
+plan-tree-species:
+	@python3 scripts/world_source_init.py trees4f --plan
+init-tree-species:
+	@python3 scripts/world_source_init.py trees4f --init
+verify-tree-species:
+	@python3 scripts/world_source_init.py trees4f --verify-only
+
+plan-geology:
+	@python3 scripts/world_source_init.py egdi --plan
+init-geology:
+	@python3 scripts/world_source_init.py egdi --init
+verify-geology:
+	@python3 scripts/world_source_init.py egdi --verify-only
+
+plan-religion:
+	@python3 scripts/world_source_init.py religion --plan
+init-religion:
+	@python3 scripts/world_source_init.py religion --init
+verify-religion:
+	@python3 scripts/world_source_init.py religion --verify-only
+
+plan-hydrology:
+	@python3 scripts/world_source_init.py eu-hydro --plan
+init-hydrology:
+	@python3 scripts/world_source_init.py eu-hydro --init
+verify-hydrology:
+	@python3 scripts/world_source_init.py eu-hydro --verify-only
+
 # Compile all initialized sources into the 1544 strategic world artifact.
 compile-world:
 	@cargo run --package adventuresim-world-import --

--- a/scripts/test_world_source_init.py
+++ b/scripts/test_world_source_init.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import world_source_init as init
+
+
+class Response(io.BytesIO):
+    def __init__(self, payload: bytes, *, length: int | None = None, url: str | None = None):
+        super().__init__(payload)
+        self.headers = {} if length is None else {"Content-Length": str(length)}
+        self._url = url or init.CONTRACTS["trees4f"].canonical_url
+
+    def geturl(self):
+        return self._url
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+class Opener:
+    def __init__(self, response):
+        self.response = response
+
+    def open(self, request, timeout):
+        return self.response
+
+
+class TrickleResponse(Response):
+    def read1(self, size):
+        return b"x"
+
+
+class InitializerTests(unittest.TestCase):
+    def inventory(self, root: Path, source: str, files: list[dict]) -> None:
+        contract = init.CONTRACTS[source]
+        (root / "source-inventory.json").write_text(json.dumps({
+            "schema": 1, "source": contract.source, "version": contract.version,
+            "files": files,
+        }), encoding="utf-8")
+
+    def test_redirect_allowlist_rejects_cross_host_and_query(self):
+        with self.assertRaisesRegex(RuntimeError, "allowlist"):
+            init.validate_url("https://evil.example/EU-Trees4F_ens-clim.zip", {"ies-ows.jrc.ec.europa.eu"}, "/efdac/")
+        with self.assertRaisesRegex(RuntimeError, "allowlist"):
+            init.validate_url("https://ies-ows.jrc.ec.europa.eu/efdac/file.zip?token=secret", {"ies-ows.jrc.ec.europa.eu"}, "/efdac/")
+
+    def test_oversize_and_partial_download_do_not_replace_valid_file(self):
+        payload = b"valid candidate"
+        pinned = {"name": "EU-Trees4F_ens-clim.zip", "size": len(payload), "sha256": hashlib.sha256(payload).hexdigest()}
+        with tempfile.TemporaryDirectory() as name, mock.patch.dict(init.TREES_FILE, pinned, clear=True):
+            root = Path(name)
+            current = root / pinned["name"]
+            current.write_bytes(b"old remains")
+            with mock.patch("world_source_init.urllib.request.build_opener", return_value=Opener(Response(payload, length=len(payload) + 1))):
+                with self.assertRaisesRegex(RuntimeError, "Content-Length"):
+                    init.download_trees(root, force=True)
+            self.assertEqual(current.read_bytes(), b"old remains")
+            with mock.patch("world_source_init.urllib.request.build_opener", return_value=Opener(Response(payload[:-1], length=None))):
+                with self.assertRaisesRegex(RuntimeError, "checksum"):
+                    init.download_trees(root, force=True)
+            self.assertEqual(current.read_bytes(), b"old remains")
+
+    def test_slow_download_hits_total_deadline(self):
+        payload = b"candidate"
+        pinned = {"name": "EU-Trees4F_ens-clim.zip", "size": len(payload), "sha256": hashlib.sha256(payload).hexdigest()}
+        with tempfile.TemporaryDirectory() as name, mock.patch.dict(init.TREES_FILE, pinned, clear=True), \
+                mock.patch("world_source_init.urllib.request.build_opener", return_value=Opener(Response(payload))), \
+                mock.patch("world_source_init.time.monotonic", side_effect=[0, 2]):
+            with self.assertRaisesRegex(RuntimeError, "deadline"):
+                init.download_trees(Path(name), deadline_seconds=1)
+
+    def test_slow_trickle_read1_hits_true_deadline(self):
+        payload = b"xx"
+        pinned = {"name": "EU-Trees4F_ens-clim.zip", "size": len(payload), "sha256": hashlib.sha256(payload).hexdigest()}
+        with tempfile.TemporaryDirectory() as name, mock.patch.dict(init.TREES_FILE, pinned, clear=True), \
+                mock.patch("world_source_init.urllib.request.build_opener", return_value=Opener(TrickleResponse(payload))), \
+                mock.patch("world_source_init.time.monotonic", side_effect=[0.0, 0.1, 0.2, 0.9, 1.1]):
+            with self.assertRaisesRegex(RuntimeError, "deadline"):
+                init.download_trees(Path(name), deadline_seconds=1)
+
+    def test_basename_rejects_ads_controls_reserved_and_normalized_duplicates(self):
+        for name in ("../x", "x/y", "x\\y", "x:y", "x ", "x.", "a\n.tif", "CON", "nul.txt", "COM1.gpkg", "LPT9.foo"):
+            with self.subTest(name=name), self.assertRaises(RuntimeError):
+                init.validate_basename(name)
+        self.assertEqual(init.validate_basename("EU_HYDRO-basin_01.gpkg"), "EU_HYDRO-basin_01.gpkg")
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            entries = [
+                {"name": "A.gpkg", "size": 1, "sha256": "0" * 64},
+                {"name": "a.gpkg", "size": 1, "sha256": "1" * 64},
+            ]
+            self.inventory(root, "eu-hydro", entries)
+            with self.assertRaisesRegex(RuntimeError, "normalized"):
+                init.load_inventory(root, init.CONTRACTS["eu-hydro"])
+
+    def test_open_inventory_structures_are_source_specific(self):
+        cases = (
+            ("glo30", ["junk.bin"], "GLO-30"),
+            ("forest", ["TCD_N48_E002.tif"], "pair"),
+            ("forest", ["TCD_N48_E002.tif", "DLT_N49_E002.tif"], "pair"),
+            ("eu-hydro", ["junk.bin"], "GeoPackage"),
+        )
+        for source, names, message in cases:
+            with self.subTest(source=source, names=names), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                self.inventory(root, source, [{"name": name, "size": 1, "sha256": "0" * 64} for name in sorted(names)])
+                with self.assertRaisesRegex(RuntimeError, message):
+                    init.load_inventory(root, init.CONTRACTS[source])
+        valid = {
+            "glo30": ["Copernicus_DSM_COG_10_N52_00_W002_00_DEM.tif"],
+            "forest": ["DLT_N48_E002.tif", "TCD_N48_E002.tif"],
+            "eu-hydro": ["EU_HYDRO_River_Net_Basin01.gpkg"],
+        }
+        for source, names in valid.items():
+            with self.subTest(valid=source), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                self.inventory(root, source, [{"name": name, "size": 1, "sha256": "0" * 64} for name in names])
+                self.assertEqual(len(init.load_inventory(root, init.CONTRACTS[source])), len(names))
+
+    def test_positive_coordinate_edges_are_not_importer_tiles(self):
+        invalid = {
+            "glo30": ["Copernicus_DSM_COG_10_N90_00_E180_00_DEM.tif"],
+            "forest": ["DLT_N90_E180.tif", "TCD_N90_E180.tif"],
+        }
+        for source, names in invalid.items():
+            with self.subTest(source=source), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                self.inventory(
+                    root,
+                    source,
+                    [{"name": name, "size": 1, "sha256": "0" * 64} for name in names],
+                )
+                with self.assertRaisesRegex(RuntimeError, "importer-compatible"):
+                    init.load_inventory(root, init.CONTRACTS[source])
+
+    def test_valid_active_repairs_missing_generation_and_rejects_reparse_escape(self):
+        payload = b"valid"
+        pinned = {"name": "EU-Trees4F_ens-clim.zip", "size": len(payload), "sha256": hashlib.sha256(payload).hexdigest()}
+        with tempfile.TemporaryDirectory() as name, mock.patch.dict(init.TREES_FILE, pinned, clear=True):
+            root = Path(name)
+            (root / pinned["name"]).write_bytes(payload)
+            init.download_trees(root)
+            generation = root / "generations" / pinned["sha256"] / pinned["name"]
+            self.assertEqual(generation.read_bytes(), payload)
+            generation.unlink()
+            with mock.patch("world_source_init.has_reparse_point", side_effect=lambda path: path.name == pinned["sha256"]):
+                with self.assertRaisesRegex(RuntimeError, "reparse"):
+                    init.download_trees(root)
+
+    def test_generation_resolved_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            escaped = root.parent / "escaped-generation"
+            with mock.patch.object(Path, "resolve", side_effect=[root, escaped]):
+                with self.assertRaisesRegex(RuntimeError, "escapes"):
+                    init.validated_directory_child(root, "generations")
+
+    def test_traversal_symlink_duplicate_and_extra_inventory_fail(self):
+        with tempfile.TemporaryDirectory() as name:
+            root = Path(name)
+            contract = init.CONTRACTS["hyde"]
+            self.inventory(root, "hyde", [{"name": "../escape", "size": 1, "sha256": "0" * 64}])
+            with self.assertRaises(RuntimeError):
+                init.load_inventory(root, contract)
+            duplicate = [{"name": "garea_cr.asc", "size": 1, "sha256": "0" * 64}] * 2
+            self.inventory(root, "hyde", duplicate)
+            with self.assertRaisesRegex(RuntimeError, "duplicate"):
+                init.load_inventory(root, contract)
+            self.inventory(root, "hyde", [{"name": "extra.asc", "size": 1, "sha256": "0" * 64}])
+            with self.assertRaisesRegex(RuntimeError, "missing or adds"):
+                init.load_inventory(root, contract)
+            outside = root.parent / "outside-world-source-test"
+            outside.write_bytes(b"x")
+            link = root / "garea_cr.asc"
+            try:
+                os.symlink(outside, link)
+            except OSError:
+                self.skipTest("symlinks unavailable")
+            with self.assertRaisesRegex(RuntimeError, "symbolic"):
+                init.safe_child(root, "garea_cr.asc")
+            outside.unlink(missing_ok=True)
+
+    def test_secret_preflight_is_redacted_and_absence_is_explicit(self):
+        contract = init.CONTRACTS["glo30"]
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIn("absent", init.credential_status(contract))
+        with tempfile.NamedTemporaryFile(delete=False) as stream:
+            stream.write(b"very-secret-token")
+            credential = stream.name
+        try:
+            with mock.patch.dict(os.environ, {"CDSE_TOKEN_FILE": credential}, clear=True):
+                status = init.credential_status(contract)
+                self.assertIn("redacted", status)
+                self.assertNotIn("very-secret-token", status)
+                self.assertNotIn(credential, status)
+        finally:
+            Path(credential).unlink(missing_ok=True)
+
+    def test_manifest_order_is_deterministic(self):
+        contract = init.CONTRACTS["hyde"]
+        value = init.canonical_manifest(contract, [
+            {"name": "z", "size": 1, "sha256": "0" * 64},
+            {"name": "a", "size": 1, "sha256": "1" * 64},
+        ], "release-blocked", "reason")
+        self.assertEqual([entry["name"] for entry in value["files"]], ["a", "z"])
+        self.assertEqual(json.dumps(value, sort_keys=True), json.dumps(value, sort_keys=True))
+
+    def test_contract_ids_and_versions_match_compiler_manifests(self):
+        expected = {
+            "glo30": ("copernicus-dem-glo30", "GLO-30"),
+            "hyde": ("hyde-3-2-1", "3.2.1"),
+            "forest": ("clms-forest-2018", "2018"),
+            "trees4f": ("eu-trees4f-v2", "2"),
+            "egdi": ("egdi-surface-geology-1m", "EGDI-GE-1M-SURFACE"),
+            "eu-hydro": ("copernicus-eu-hydro-1-3", "1.3"),
+        }
+        self.assertEqual({key: (value.source, value.version) for key, value in init.CONTRACTS.items()}, expected)
+
+    def test_curated_religion_tamper_and_schema_are_rejected(self):
+        init.verify_religion()
+        with tempfile.TemporaryDirectory() as name:
+            path = Path(name) / "religion.csv"
+            path.write_bytes(init.RELIGION_FILE.read_bytes() + b"tamper")
+            with self.assertRaisesRegex(RuntimeError, "digest"):
+                init.verify_religion(path)
+
+    def test_atomic_manifest_rollback(self):
+        with tempfile.TemporaryDirectory() as name:
+            path = Path(name) / "manifest.json"
+            path.write_text("old\n", encoding="utf-8")
+            with mock.patch("world_source_init.os.replace", side_effect=OSError("stop")):
+                with self.assertRaises(OSError):
+                    init.write_atomic(path, {"new": True})
+            self.assertEqual(path.read_text(encoding="utf-8"), "old\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/world_source_init.py
+++ b/scripts/world_source_init.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Plan, initialize, or verify accepted world-data source distributions.
+
+This module is deliberately fail closed.  A source without a checked immutable
+inventory can be planned and locally verified, but it cannot be downloaded.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+import shutil
+import stat as stat_module
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import urlparse
+
+CHUNK = 1024 * 1024
+MAX_MANIFEST_BYTES = 1024 * 1024
+MAX_FILE_BYTES = 3 * 1024 * 1024 * 1024
+MAX_TOTAL_BYTES = 4 * 1024 * 1024 * 1024
+CONNECT_TIMEOUT_SECONDS = 30
+TOTAL_TIMEOUT_SECONDS = 900
+USER_AGENT = "AdventureSimulator-world-init/1"
+
+
+@dataclass(frozen=True)
+class Contract:
+    source: str
+    version: str
+    access: str
+    license: str
+    canonical_url: str
+    doi: str | None
+    output: str
+    expected_names: tuple[str, ...]
+    crs: str
+    resolution: str
+    temporal: str
+    preparation: str
+    blocked_reason: str | None
+    credential_env: str | None = None
+
+
+CONTRACTS = {
+    "glo30": Contract("copernicus-dem-glo30", "GLO-30", "authenticated", "Copernicus DEM licence",
+        "https://doi.org/10.5270/ESA-c5d3d65", "10.5270/ESA-c5d3d65",
+        "target/world-data-sources/raw/elevation", (), "EPSG:4326", "1 arc-second",
+        "timeless terrain", "direct one-degree DEM tile sampling",
+        "required GLO-30 tile IDs and per-tile sizes/SHA-256 are not committed", "CDSE_TOKEN_FILE"),
+    "hyde": Contract("hyde-3-2-1", "3.2.1", "restricted-record", "rights conflict: CC0 record; attribution README",
+        "https://doi.org/10.17026/dans-25g-gez3", "10.17026/dans-25g-gez3",
+        "target/world-data-sources/raw/historical-land-use",
+        ("cropland1500AD.asc", "cropland1600AD.asc", "garea_cr.asc", "grazing1500AD.asc", "grazing1600AD.asc", "urban1500AD.asc", "urban1600AD.asc"),
+        "EPSG:4326", "5 arc-minute", "1500 and 1600 CE",
+        "extract seven corrected ESRI ASCII grids from the official baseline archive",
+        "the seven consumed files lack a committed immutable size/SHA-256 inventory and publisher rights signals conflict"),
+    "forest": Contract("clms-forest-2018", "2018", "authenticated", "Copernicus full, free and open data policy",
+        "https://land.copernicus.eu/en/products/high-resolution-layer-forests-and-tree-cover", "10.2909/82f93572-9888-47ef-97a1-5cac5985a26a",
+        "target/world-data-sources/raw/forest-cover", (), "EPSG:4326", "prepared 0.001-degree",
+        "2018", "prepare paired one-degree TCD/DLT UInt8 GeoTIFF tiles",
+        "required CLMS product items and complete TCD/DLT tile inventory are not committed", "CLMS_TOKEN_FILE"),
+    "trees4f": Contract("eu-trees4f-v2", "2", "anonymous", "CC0-1.0",
+        "https://ies-ows.jrc.ec.europa.eu/efdac/download/EU-Trees4F/EU-Trees4F_ens-clim.zip", "10.6084/m9.figshare.17032328",
+        "target/world-data-sources/raw/tree-species", ("EU-Trees4F_ens-clim.zip",),
+        "EPSG:4326 and EPSG:3035", "5 arc-minute and 10 km", "current-climate reference scenario",
+        "consume the pinned current-climate ensemble archive directly", None),
+    "egdi": Contract("egdi-surface-geology-1m", "EGDI-GE-1M-SURFACE", "licensed-anonymous-service", "CC BY 4.0 plus Maltese notice",
+        "https://metadata.europe-geology.eu/record/full/5729ffdf-2558-48fc-a5d2-645a0a010855", None,
+        "target/world-data-sources/raw/geology", ("GeologicUnitView.gpkg",), "EPSG:3034", "1:1,000,000",
+        "modern mapped geology", "export indexed GeologicUnitView GeoPackage from the EGDI service",
+        "the accepted aggregate lacks a committed exact byte size and SHA-256"),
+    "eu-hydro": Contract("copernicus-eu-hydro-1-3", "1.3", "authenticated", "Copernicus full, free and open data policy",
+        "https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c", "10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c",
+        "target/world-data-sources/raw/hydrology", (), "EPSG:3035", "vector river network",
+        "primarily 2006/2009/2012 imagery", "extract the pinned basin GeoPackage distribution",
+        "official archive/item IDs and complete basin GeoPackage inventory are not committed", "CLMS_TOKEN_FILE"),
+}
+
+TREES_FILE = {
+    "name": "EU-Trees4F_ens-clim.zip",
+    "size": 73_796_217,
+    "sha256": "be115f771e5598e6fd180621e1a32922880cf7ac8e2cb59ba0eabd7f15bfeda4",
+}
+RELIGION_FILE = Path("assets/world-data/ieg-religion-1544.csv")
+RELIGION_SIZE = 1_069
+RELIGION_SHA256 = "7172f286bad8ef9d0bb891dfe576b3c7978ce04de14eba254a300a81299aaa8e"
+RELIGION_HEADER = ("priority", "region", "min_latitude", "max_latitude", "min_longitude", "max_longitude", "status", "religions", "church")
+RELIGION_STATUSES = {"established", "multi_confessional", "parity", "locally_determined"}
+SAFE_BASENAME = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+WINDOWS_DEVICES = {"CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))}
+GLO30_NAME = re.compile(r"Copernicus_DSM_COG_10_([NS])(\d{2})_00_([EW])(\d{3})_00_DEM\.tif\Z")
+FOREST_NAME = re.compile(r"(TCD|DLT)_(([NS])(\d{2})_([EW])(\d{3}))\.tif\Z")
+
+
+class RedirectPolicy(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, request, fp, code, message, headers, new_url):
+        validate_url(new_url, {"ies-ows.jrc.ec.europa.eu"}, "/efdac/download/EU-Trees4F/")
+        return super().redirect_request(request, fp, code, message, headers, new_url)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(CHUNK), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def validate_basename(name: object) -> str:
+    if not isinstance(name, str) or not SAFE_BASENAME.fullmatch(name) or name.endswith((".", " ")) or ":" in name:
+        raise RuntimeError("inventory contains an unsafe filename")
+    if name.split(".", 1)[0].upper() in WINDOWS_DEVICES:
+        raise RuntimeError("inventory contains a reserved Windows device filename")
+    return name
+
+
+def has_reparse_point(path: Path) -> bool:
+    try:
+        stat = path.lstat()
+    except FileNotFoundError:
+        return False
+    return path.is_symlink() or bool(getattr(stat, "st_file_attributes", 0) & getattr(stat_module, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def validated_directory_child(root: Path, *parts: str, create: bool = False) -> Path:
+    resolved_root = root.resolve()
+    current = root
+    for part in parts:
+        validate_basename(part)
+        current = current / part
+        if has_reparse_point(current):
+            raise RuntimeError("source path contains a symlink, junction, or reparse point")
+        if create and not current.exists():
+            current.mkdir()
+        resolved = current.resolve()
+        if resolved_root not in resolved.parents:
+            raise RuntimeError("source path escapes its source directory")
+    return current.resolve()
+
+
+def validate_url(url: str, hosts: set[str], path_prefix: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.hostname not in hosts or not parsed.path.startswith(path_prefix) or parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise RuntimeError("source or redirect URL is outside the fixed HTTPS host/path allowlist")
+
+
+def safe_child(root: Path, name: str) -> Path:
+    validate_basename(name)
+    resolved_root = root.resolve()
+    lexical = resolved_root / name
+    if has_reparse_point(lexical):
+        raise RuntimeError("source files may not be symbolic links, junctions, or reparse points")
+    candidate = lexical.resolve()
+    if candidate.parent != resolved_root:
+        raise RuntimeError("inventory path escapes its source directory")
+    return candidate
+
+
+def canonical_manifest(contract: Contract, files: list[dict[str, object]], status: str, reason: str | None = None) -> dict[str, object]:
+    result: dict[str, object] = {
+        "schema": 1, "source": contract.source, "version": contract.version,
+        "status": status, "access": contract.access, "license": contract.license,
+        "canonical_url": contract.canonical_url, "doi": contract.doi,
+        "crs": contract.crs, "resolution": contract.resolution,
+        "temporal": contract.temporal, "preparation": contract.preparation,
+        "files": sorted(files, key=lambda value: str(value["name"])),
+    }
+    if reason is not None:
+        result["blocked_reason"] = reason
+    if contract.source == "eu-trees4f-v2":
+        result["distribution_note"] = "Identity pins the exact JRC ENS_CLIM archive; byte equivalence to a Figshare-hosted archive has not been established. Retain the EU-Trees4F v2 citation and CC0 notice."
+    return result
+
+
+def write_atomic(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, ensure_ascii=True, indent=2, sort_keys=True) + "\n"
+    handle, name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    os.close(handle)
+    temporary = Path(name)
+    try:
+        temporary.write_text(payload, encoding="utf-8")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def credential_status(contract: Contract) -> str:
+    if contract.credential_env is None:
+        return "not-required"
+    raw = os.environ.get(contract.credential_env)
+    if not raw:
+        return f"absent ({contract.credential_env})"
+    path = Path(raw)
+    if not path.is_file() or path.is_symlink() or path.stat().st_size == 0 or path.stat().st_size > 64 * 1024:
+        return f"invalid ({contract.credential_env})"
+    return f"present ({contract.credential_env}; value redacted)"
+
+
+def plan(contract: Contract) -> dict[str, object]:
+    files = ([TREES_FILE] if contract.source == "eu-trees4f-v2" else [{"name": name, "size": None, "sha256": None} for name in contract.expected_names])
+    result = canonical_manifest(contract, files, "ready" if contract.blocked_reason is None else "release-blocked", contract.blocked_reason)
+    result["credential_preflight"] = credential_status(contract)
+    result["output"] = contract.output
+    return result
+
+
+def load_inventory(directory: Path, contract: Contract) -> list[dict[str, object]]:
+    path = safe_child(directory, "source-inventory.json")
+    if not path.is_file() or path.stat().st_size > MAX_MANIFEST_BYTES:
+        raise RuntimeError("checked source-inventory.json is absent or oversized")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if set(value) != {"schema", "source", "version", "files"} or value["schema"] != 1 or value["source"] != contract.source or value["version"] != contract.version or not isinstance(value["files"], list):
+        raise RuntimeError("inventory schema/source/version mismatch or unknown fields")
+    files = value["files"]
+    names: set[str] = set()
+    destinations: set[str] = set()
+    for entry in files:
+        if set(entry) != {"name", "size", "sha256"} or not isinstance(entry["size"], int) or not 0 < entry["size"] <= MAX_FILE_BYTES or not isinstance(entry["sha256"], str) or len(entry["sha256"]) != 64 or any(c not in "0123456789abcdef" for c in entry["sha256"]):
+            raise RuntimeError("inventory has an unknown, malformed, or oversized entry")
+        name = validate_basename(entry["name"])
+        destination = str(safe_child(directory, name)).casefold()
+        if entry["name"] in names:
+            raise RuntimeError("inventory contains a duplicate filename")
+        if destination in destinations or name.casefold().rstrip(" .") in {existing.casefold().rstrip(" .") for existing in names}:
+            raise RuntimeError("inventory contains duplicate normalized destinations")
+        names.add(name)
+        destinations.add(destination)
+    if files != sorted(files, key=lambda entry: entry["name"]):
+        raise RuntimeError("inventory files are not in canonical filename order")
+    if contract.expected_names and names != set(contract.expected_names):
+        raise RuntimeError("inventory is missing or adds a consumed source file")
+    if not contract.expected_names and not files:
+        raise RuntimeError("inventory must pin at least one consumed source file")
+    if sum(entry["size"] for entry in files) > MAX_TOTAL_BYTES:
+        raise RuntimeError("inventory exceeds the total byte cap")
+    validate_source_inventory(contract, names)
+    return files
+
+
+def validate_source_inventory(contract: Contract, names: set[str]) -> None:
+    if contract.source == "copernicus-dem-glo30":
+        matches = [GLO30_NAME.fullmatch(name) for name in names]
+        if not names or any(
+            match is None
+            or int(match.group(2)) > 90
+            or int(match.group(4)) > 180
+            or (match.group(1) == "N" and int(match.group(2)) == 90)
+            or (match.group(3) == "E" and int(match.group(4)) == 180)
+            for match in matches
+        ):
+            raise RuntimeError("GLO-30 inventory must contain only importer-compatible DEM TIFF tile names")
+    elif contract.source == "clms-forest-2018":
+        pairs: dict[str, set[str]] = {}
+        for name in names:
+            match = FOREST_NAME.fullmatch(name)
+            if (
+                match is None
+                or int(match.group(4)) > 90
+                or int(match.group(6)) > 180
+                or (match.group(3) == "N" and int(match.group(4)) == 90)
+                or (match.group(5) == "E" and int(match.group(6)) == 180)
+            ):
+                raise RuntimeError("forest inventory must contain only importer-compatible TCD/DLT TIFF tile names")
+            pairs.setdefault(match.group(2), set()).add(match.group(1))
+        if not pairs or any(kinds != {"TCD", "DLT"} for kinds in pairs.values()):
+            raise RuntimeError("forest inventory must contain a complete TCD/DLT pair for every tile key")
+    elif contract.source == "copernicus-eu-hydro-1-3":
+        if not names or any(not name.lower().endswith(".gpkg") for name in names):
+            raise RuntimeError("EU-Hydro inventory must contain at least one safe GeoPackage filename")
+
+
+def verify_inventory(directory: Path, contract: Contract) -> list[dict[str, object]]:
+    entries = load_inventory(directory, contract)
+    for entry in entries:
+        path = safe_child(directory, str(entry["name"]))
+        if not path.is_file() or path.stat().st_size != entry["size"] or sha256(path) != entry["sha256"]:
+            raise RuntimeError(f"source identity mismatch: {entry['name']}")
+    return entries
+
+
+def set_remaining_timeout(response: object, seconds: float) -> None:
+    setter = getattr(response, "settimeout", None)
+    if callable(setter):
+        setter(max(0.001, seconds))
+        return
+    candidate = response
+    for attribute in ("fp", "raw", "_sock"):
+        candidate = getattr(candidate, attribute, None)
+        if candidate is None:
+            return
+        setter = getattr(candidate, "settimeout", None)
+        if callable(setter):
+            setter(max(0.001, seconds))
+            return
+
+
+def deadline_read(response: object, size: int, deadline: float) -> bytes:
+    before = time.monotonic()
+    if before >= deadline:
+        raise RuntimeError("EU-Trees4F retrieval exceeded its total deadline")
+    set_remaining_timeout(response, deadline - before)
+    reader = getattr(response, "read1", None)
+    block = reader(size) if callable(reader) else response.read(size)
+    if time.monotonic() > deadline:
+        raise RuntimeError("EU-Trees4F retrieval exceeded its total deadline")
+    return block
+
+
+def publish_tree_generation(directory: Path, candidate: Path) -> None:
+    generations = validated_directory_child(directory, "generations", create=True)
+    generation = validated_directory_child(generations, str(TREES_FILE["sha256"]), create=True)
+    generation_file = safe_child(generation, str(TREES_FILE["name"]))
+    if generation_file.is_file() and generation_file.stat().st_size == TREES_FILE["size"] and sha256(generation_file) == TREES_FILE["sha256"]:
+        return
+    if generation_file.exists() and has_reparse_point(generation_file):
+        raise RuntimeError("generation file is a symlink, junction, or reparse point")
+    handle, temporary_name = tempfile.mkstemp(prefix=".tree-generation.", suffix=".tmp", dir=generation)
+    temporary = Path(temporary_name)
+    try:
+        with candidate.open("rb") as source, os.fdopen(handle, "wb") as output:
+            shutil.copyfileobj(source, output, CHUNK)
+        if temporary.stat().st_size != TREES_FILE["size"] or sha256(temporary) != TREES_FILE["sha256"]:
+            raise RuntimeError("content-addressed generation verification failed")
+        os.replace(temporary, generation_file)
+    finally:
+        try:
+            os.close(handle)
+        except OSError:
+            pass
+        temporary.unlink(missing_ok=True)
+
+
+def download_trees(directory: Path, *, deadline_seconds: int = TOTAL_TIMEOUT_SECONDS, force: bool = False) -> None:
+    contract = CONTRACTS["trees4f"]
+    validate_url(contract.canonical_url, {"ies-ows.jrc.ec.europa.eu"}, "/efdac/download/EU-Trees4F/")
+    if has_reparse_point(directory):
+        raise RuntimeError("output directory may not be a symlink, junction, or reparse point")
+    directory.mkdir(parents=True, exist_ok=True)
+    current = safe_child(directory, TREES_FILE["name"])
+    if current.is_file() and current.stat().st_size == TREES_FILE["size"] and sha256(current) == TREES_FILE["sha256"]:
+        publish_tree_generation(directory, current)
+        write_atomic(directory / "source-manifest.json", canonical_manifest(contract, [TREES_FILE], "verified"))
+        return
+    if current.exists() and not force:
+        raise RuntimeError("existing EU-Trees4F archive is invalid; pass --force to replace it after a new candidate verifies")
+    deadline = time.monotonic() + deadline_seconds
+    handle, name = tempfile.mkstemp(prefix=".EU-Trees4F_ens-clim.", suffix=".part", dir=directory)
+    os.close(handle)
+    temporary = Path(name)
+    try:
+        request = urllib.request.Request(contract.canonical_url, headers={"User-Agent": USER_AGENT})
+        opener = urllib.request.build_opener(RedirectPolicy)
+        with opener.open(request, timeout=CONNECT_TIMEOUT_SECONDS) as response, temporary.open("wb") as output:
+            validate_url(response.geturl(), {"ies-ows.jrc.ec.europa.eu"}, "/efdac/download/EU-Trees4F/")
+            length = response.headers.get("Content-Length")
+            if length is not None and int(length) != TREES_FILE["size"]:
+                raise RuntimeError("EU-Trees4F Content-Length differs from the pinned size")
+            total = 0
+            while block := deadline_read(response, 64 * 1024, deadline):
+                total += len(block)
+                if total > TREES_FILE["size"]:
+                    raise RuntimeError("EU-Trees4F retrieval exceeded its pinned byte size")
+                output.write(block)
+        if temporary.stat().st_size != TREES_FILE["size"] or sha256(temporary) != TREES_FILE["sha256"]:
+            raise RuntimeError("EU-Trees4F archive checksum or size mismatch")
+        publish_tree_generation(directory, temporary)
+        os.replace(temporary, current)
+        write_atomic(directory / "source-manifest.json", canonical_manifest(contract, [TREES_FILE], "verified"))
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def verify_trees(directory: Path) -> None:
+    path = safe_child(directory, TREES_FILE["name"])
+    if not path.is_file() or path.stat().st_size != TREES_FILE["size"] or sha256(path) != TREES_FILE["sha256"]:
+        raise RuntimeError("EU-Trees4F archive is absent or differs from the pinned identity")
+
+
+def verify_religion(path: Path = RELIGION_FILE) -> None:
+    if path.is_symlink() or not path.is_file() or path.stat().st_size != RELIGION_SIZE or sha256(path) != RELIGION_SHA256:
+        raise RuntimeError("curated religion CSV revision digest/size mismatch")
+    with path.open("r", encoding="utf-8", newline="") as stream:
+        reader = csv.DictReader(stream)
+        if tuple(reader.fieldnames or ()) != RELIGION_HEADER:
+            raise RuntimeError("curated religion CSV schema/order mismatch")
+        priorities: set[int] = set()
+        previous = -1
+        rows = 0
+        for row in reader:
+            rows += 1
+            priority = int(row["priority"])
+            bounds = tuple(float(row[key]) for key in ("min_latitude", "max_latitude", "min_longitude", "max_longitude"))
+            if priority in priorities or priority <= previous or not (-90 <= bounds[0] < bounds[1] <= 90) or not (-180 <= bounds[2] < bounds[3] <= 180) or row["status"] not in RELIGION_STATUSES or not row["region"].strip():
+                raise RuntimeError("curated religion CSV ordering, bounds, or values are invalid")
+            priorities.add(priority)
+            previous = priority
+        if rows != 14:
+            raise RuntimeError("curated religion CSV must contain exactly 14 regions")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", choices=tuple(CONTRACTS) + ("religion",))
+    modes = parser.add_mutually_exclusive_group(required=True)
+    modes.add_argument("--plan", action="store_true")
+    modes.add_argument("--init", action="store_true")
+    modes.add_argument("--verify-only", action="store_true")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--force", action="store_true", help="replace only after a new candidate verifies")
+    args = parser.parse_args()
+    if args.source == "religion":
+        if args.init:
+            raise RuntimeError("IEG source images are rights-reserved and must never be downloaded or mirrored")
+        if args.plan:
+            print(json.dumps({"source": "ieg-religion-1544-curated", "status": "curated-committed", "path": str(RELIGION_FILE), "size": RELIGION_SIZE, "sha256": RELIGION_SHA256}, sort_keys=True))
+        else:
+            verify_religion(args.output_dir or RELIGION_FILE)
+            print("curated IEG religion intermediate verified")
+        return
+    contract = CONTRACTS[args.source]
+    directory = args.output_dir or Path(contract.output)
+    if args.plan:
+        print(json.dumps(plan(contract), indent=2, sort_keys=True))
+    elif args.init:
+        if contract.blocked_reason is not None:
+            raise RuntimeError(f"acquisition refused: {contract.blocked_reason}; commit a checked inventory before enabling network preparation")
+        download_trees(directory, force=args.force)
+        print(f"{contract.source} initialized and verified")
+    elif contract.source == "eu-trees4f-v2":
+        verify_trees(directory)
+        print(f"{contract.source} verified")
+    else:
+        entries = verify_inventory(directory, contract)
+        print(f"{contract.source} local inventory verified; release remains blocked")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add one bounded shared workflow with 21 explicit plan/init/verify targets
- automate the exact pinned JRC EU-Trees4F ENS_CLIM archive with atomic content-addressed publication
- verify the committed curated IEG religion intermediate without mirroring source images
- add strict credential/inventory plans for GLO-30, forest, and EU-Hydro
- add strict inventory-only workflows for HYDE and EGDI until immutable pins and rights metadata are resolved
- enforce redirect, deadline, byte, checksum, path, Windows alias, reparse-point, and rollback safety
- align initializer identities with canonical source manifests

## Scope

This advances #62 initialization without inventing metadata. GLO-30, forest, EU-Hydro, HYDE, and EGDI remain release-blocked until their exact accepted inventories are committed. The JRC ENS_CLIM archive is pinned independently; byte-equivalence to the full Figshare v2 distribution is not claimed.

## Verification

- 15 existing initializer tests
- 15 focused workflow/security tests; one Windows symlink test skips when OS privilege is unavailable
- all seven source plans and live religion verification
- 15 Rust manifest tests and importer check
- project map and diff checks