### PR TITLE
Add EU-Hydro access data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8159,6 +8159,7 @@ version = "0.1.0"
 dependencies = [
  "adventuresim-core",
  "adventuresim-stdb-client",
+ "adventuresim-world-schema",
  "anyhow",
  "axum",
  "axum-extra",

--- a/crates/adventuresim-stdb-client/src/canal_watercourse_type.rs
+++ b/crates/adventuresim-stdb-client/src/canal_watercourse_type.rs
@@ -4,17 +4,12 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
-
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct CanalWatercourse {
+    pub navigable: bool,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for CanalWatercourse {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/crossing_traversal_type.rs
+++ b/crates/adventuresim-stdb-client/src/crossing_traversal_type.rs
@@ -4,17 +4,15 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
-
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
+#[derive(Copy, Eq, Hash)]
+pub enum CrossingTraversal {
+    Bridge,
 
-    Ferry(FerryRoute),
+    Ford,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for CrossingTraversal {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/crossing_watercourse_type.rs
+++ b/crates/adventuresim-stdb-client/src/crossing_watercourse_type.rs
@@ -4,17 +4,19 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::canal_watercourse_type::CanalWatercourse;
+use super::river_watercourse_type::RiverWatercourse;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
+pub enum CrossingWatercourse {
+    River(RiverWatercourse),
 
-    Ferry(FerryRoute),
+    Canal(CanalWatercourse),
+
+    Ditch,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for CrossingWatercourse {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/edge_progress_permille_type.rs
+++ b/crates/adventuresim-stdb-client/src/edge_progress_permille_type.rs
@@ -4,17 +4,12 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
-
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct EdgeProgressPermille {
+    pub permille: u16,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for EdgeProgressPermille {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/ferry_route_type.rs
+++ b/crates/adventuresim-stdb-client/src/ferry_route_type.rs
@@ -4,17 +4,14 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::ferry_waterway_type::FerryWaterway;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct FerryRoute {
+    pub waterway: FerryWaterway,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for FerryRoute {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/ferry_waterway_type.rs
+++ b/crates/adventuresim-stdb-client/src/ferry_waterway_type.rs
@@ -4,17 +4,20 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::river_watercourse_type::RiverWatercourse;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
+pub enum FerryWaterway {
+    River(RiverWatercourse),
 
-    Ferry(FerryRoute),
+    InlandWater,
+
+    TidalWater,
+
+    CoastalWater,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for FerryWaterway {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/flow_persistence_type.rs
+++ b/crates/adventuresim-stdb-client/src/flow_persistence_type.rs
@@ -4,17 +4,17 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
-
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
+#[derive(Copy, Eq, Hash)]
+pub enum FlowPersistence {
+    Perennial,
 
-    Ferry(FerryRoute),
+    Intermittent,
+
+    Ephemeral,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for FlowPersistence {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/flowing_water_access_type.rs
+++ b/crates/adventuresim-stdb-client/src/flowing_water_access_type.rs
@@ -4,17 +4,17 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::river_access_type::RiverAccess;
+use super::river_and_canal_access_type::RiverAndCanalAccess;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
+pub enum FlowingWaterAccess {
+    River(RiverAccess),
 
-    Ferry(FerryRoute),
+    RiverAndCanal(RiverAndCanalAccess),
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for FlowingWaterAccess {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/inland_water_access_type.rs
+++ b/crates/adventuresim-stdb-client/src/inland_water_access_type.rs
@@ -4,17 +4,16 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::inland_water_size_type::InlandWaterSize;
+use super::water_distance_meters_type::WaterDistanceMeters;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct InlandWaterAccess {
+    pub distance: WaterDistanceMeters,
+    pub size: InlandWaterSize,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for InlandWaterAccess {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/inland_water_size_type.rs
+++ b/crates/adventuresim-stdb-client/src/inland_water_size_type.rs
@@ -4,17 +4,17 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
-
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
+#[derive(Copy, Eq, Hash)]
+pub enum InlandWaterSize {
+    Pond,
 
-    Ferry(FerryRoute),
+    Lake,
+
+    GreatLake,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for InlandWaterSize {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/land_route_type.rs
+++ b/crates/adventuresim-stdb-client/src/land_route_type.rs
@@ -4,17 +4,16 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::edge_endpoint_type::EdgeEndpoint;
+use super::land_water_crossing_type::LandWaterCrossing;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct LandRoute {
+    pub bridge: Option<EdgeEndpoint>,
+    pub water_crossings: Vec<LandWaterCrossing>,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for LandRoute {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/land_water_crossing_type.rs
+++ b/crates/adventuresim-stdb-client/src/land_water_crossing_type.rs
@@ -4,17 +4,18 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::crossing_traversal_type::CrossingTraversal;
+use super::crossing_watercourse_type::CrossingWatercourse;
+use super::edge_progress_permille_type::EdgeProgressPermille;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct LandWaterCrossing {
+    pub position: EdgeProgressPermille,
+    pub watercourse: CrossingWatercourse,
+    pub traversal: CrossingTraversal,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for LandWaterCrossing {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/marine_water_access_type.rs
+++ b/crates/adventuresim-stdb-client/src/marine_water_access_type.rs
@@ -4,17 +4,16 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::water_distance_meters_type::WaterDistanceMeters;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
+pub enum MarineWaterAccess {
+    Tidal(WaterDistanceMeters),
 
-    Ferry(FerryRoute),
+    OpenCoast(WaterDistanceMeters),
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for MarineWaterAccess {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/river_access_type.rs
+++ b/crates/adventuresim-stdb-client/src/river_access_type.rs
@@ -4,17 +4,18 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::flow_persistence_type::FlowPersistence;
+use super::strahler_order_type::StrahlerOrder;
+use super::water_distance_meters_type::WaterDistanceMeters;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct RiverAccess {
+    pub distance: WaterDistanceMeters,
+    pub order: StrahlerOrder,
+    pub persistence: FlowPersistence,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for RiverAccess {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/river_and_canal_access_type.rs
+++ b/crates/adventuresim-stdb-client/src/river_and_canal_access_type.rs
@@ -4,17 +4,17 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::river_access_type::RiverAccess;
+use super::water_distance_meters_type::WaterDistanceMeters;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct RiverAndCanalAccess {
+    pub river: RiverAccess,
+    pub canal_distance: WaterDistanceMeters,
+    pub canal_navigable: bool,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for RiverAndCanalAccess {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/river_watercourse_type.rs
+++ b/crates/adventuresim-stdb-client/src/river_watercourse_type.rs
@@ -4,17 +4,16 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::flow_persistence_type::FlowPersistence;
+use super::strahler_order_type::StrahlerOrder;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct RiverWatercourse {
+    pub order: StrahlerOrder,
+    pub persistence: FlowPersistence,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for RiverWatercourse {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/settlement_hydrology_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_hydrology_type.rs
@@ -4,17 +4,18 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
+use super::flowing_water_access_type::FlowingWaterAccess;
+use super::inland_water_access_type::InlandWaterAccess;
+use super::marine_water_access_type::MarineWaterAccess;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct SettlementHydrology {
+    pub flowing: Option<FlowingWaterAccess>,
+    pub inland: Option<InlandWaterAccess>,
+    pub marine: Option<MarineWaterAccess>,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for SettlementHydrology {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/settlement_import_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_import_type.rs
@@ -9,6 +9,7 @@ use super::elevation_meters_type::ElevationMeters;
 use super::forest_cover_type::ForestCover;
 use super::land_use_profile_type::LandUseProfile;
 use super::potential_vegetation_type::PotentialVegetation;
+use super::settlement_hydrology_type::SettlementHydrology;
 use super::settlement_religious_status_type::SettlementReligiousStatus;
 use super::soil_profile_type::SoilProfile;
 use super::surface_geology_type::SurfaceGeology;
@@ -33,6 +34,7 @@ pub struct SettlementImport {
     pub geology: SurfaceGeology,
     pub religious_status: SettlementReligiousStatus,
     pub drought: DroughtProfile,
+    pub hydrology: SettlementHydrology,
     pub scene_key: String,
 }
 

--- a/crates/adventuresim-stdb-client/src/settlement_table.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_table.rs
@@ -7,6 +7,7 @@ use super::elevation_meters_type::ElevationMeters;
 use super::forest_cover_type::ForestCover;
 use super::land_use_profile_type::LandUseProfile;
 use super::potential_vegetation_type::PotentialVegetation;
+use super::settlement_hydrology_type::SettlementHydrology;
 use super::settlement_religious_status_type::SettlementReligiousStatus;
 use super::settlement_type::Settlement;
 use super::soil_profile_type::SoilProfile;

--- a/crates/adventuresim-stdb-client/src/settlement_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_type.rs
@@ -9,6 +9,7 @@ use super::elevation_meters_type::ElevationMeters;
 use super::forest_cover_type::ForestCover;
 use super::land_use_profile_type::LandUseProfile;
 use super::potential_vegetation_type::PotentialVegetation;
+use super::settlement_hydrology_type::SettlementHydrology;
 use super::settlement_religious_status_type::SettlementReligiousStatus;
 use super::soil_profile_type::SoilProfile;
 use super::surface_geology_type::SurfaceGeology;
@@ -32,6 +33,7 @@ pub struct Settlement {
     pub geology: SurfaceGeology,
     pub religious_status: SettlementReligiousStatus,
     pub drought: DroughtProfile,
+    pub hydrology: SettlementHydrology,
     pub scene_key: String,
     pub religion_id: String,
     pub source_node_id: Option<u64>,

--- a/crates/adventuresim-stdb-client/src/strahler_order_type.rs
+++ b/crates/adventuresim-stdb-client/src/strahler_order_type.rs
@@ -4,17 +4,12 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
-
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct StrahlerOrder {
+    pub order: u8,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for StrahlerOrder {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-client/src/travel_edge_table.rs
+++ b/crates/adventuresim-stdb-client/src/travel_edge_table.rs
@@ -3,9 +3,8 @@
 
 #![allow(unused, clippy::all)]
 use super::edge_endpoint_type::EdgeEndpoint;
-use super::ferry_waterway_type::FerryWaterway;
-use super::land_water_crossing_type::LandWaterCrossing;
 use super::travel_edge_type::TravelEdge;
+use super::travel_route_type::TravelRoute;
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
 /// Table handle for the table `travel_edge`.

--- a/crates/adventuresim-stdb-client/src/travel_edge_table.rs
+++ b/crates/adventuresim-stdb-client/src/travel_edge_table.rs
@@ -3,6 +3,8 @@
 
 #![allow(unused, clippy::all)]
 use super::edge_endpoint_type::EdgeEndpoint;
+use super::ferry_waterway_type::FerryWaterway;
+use super::land_water_crossing_type::LandWaterCrossing;
 use super::travel_edge_type::TravelEdge;
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 

--- a/crates/adventuresim-stdb-client/src/travel_edge_type.rs
+++ b/crates/adventuresim-stdb-client/src/travel_edge_type.rs
@@ -5,6 +5,8 @@
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
 use super::edge_endpoint_type::EdgeEndpoint;
+use super::ferry_waterway_type::FerryWaterway;
+use super::land_water_crossing_type::LandWaterCrossing;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
@@ -14,6 +16,8 @@ pub struct TravelEdge {
     pub to_node_id: u64,
     pub kind: String,
     pub bridge_at: Option<EdgeEndpoint>,
+    pub water_crossings: Vec<LandWaterCrossing>,
+    pub ferry_waterway: Option<FerryWaterway>,
     pub toll_at: Option<EdgeEndpoint>,
     pub length_m: u32,
     pub slope_multiplier: f32,

--- a/crates/adventuresim-stdb-client/src/travel_edge_type.rs
+++ b/crates/adventuresim-stdb-client/src/travel_edge_type.rs
@@ -5,8 +5,7 @@
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
 use super::edge_endpoint_type::EdgeEndpoint;
-use super::ferry_waterway_type::FerryWaterway;
-use super::land_water_crossing_type::LandWaterCrossing;
+use super::travel_route_type::TravelRoute;
 
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
@@ -14,10 +13,7 @@ pub struct TravelEdge {
     pub id: u64,
     pub from_node_id: u64,
     pub to_node_id: u64,
-    pub kind: String,
-    pub bridge_at: Option<EdgeEndpoint>,
-    pub water_crossings: Vec<LandWaterCrossing>,
-    pub ferry_waterway: Option<FerryWaterway>,
+    pub route: TravelRoute,
     pub toll_at: Option<EdgeEndpoint>,
     pub length_m: u32,
     pub slope_multiplier: f32,

--- a/crates/adventuresim-stdb-client/src/water_distance_meters_type.rs
+++ b/crates/adventuresim-stdb-client/src/water_distance_meters_type.rs
@@ -4,17 +4,12 @@
 #![allow(unused, clippy::all)]
 use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 
-use super::ferry_route_type::FerryRoute;
-use super::land_route_type::LandRoute;
-
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
-pub enum TravelRoute {
-    Land(LandRoute),
-
-    Ferry(FerryRoute),
+pub struct WaterDistanceMeters {
+    pub meters: u16,
 }
 
-impl __sdk::InModule for TravelRoute {
+impl __sdk::InModule for WaterDistanceMeters {
     type Module = super::RemoteModule;
 }

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -1,16 +1,17 @@
 use adventuresim_core::{capability::aggregate_bounded_party_check, morale::fervor_event_occurs};
 use adventuresim_world_schema::{
-    AgriculturalLimitation, AvailableWaterCapacity, CanopyDensity, DominantLeafType,
-    DroughtHistory, DroughtProfile, EdgeEndpoint, ElevationMeters, FerryWaterway, ForestCover,
-    GeologicEra, GeologicUnitId, HabitatSuitability, InferredGeologicSetting,
-    InferredTreeSpeciesProfile, LandUseFraction, LandUseProfile, LandWaterCrossing,
-    MappedPotentialVegetation, MappedSoilProfile, MineralSoil, MineralSoilTexture,
-    ModeledTreeSpecies, ModeledTreeSpeciesProfile, OfficialReligion, PalmerDroughtSeverityIndex,
-    ParentMaterialCode, PotentialVegetation, PotentialVegetationFormation, SettlementHydrology,
-    SettlementImport, SettlementReligiousStatus, SoilDepth, SoilMappingUnit, SoilProfile,
-    SoilProperties, SoilSubstrate, SoilWaterRegime, StoneContentPercent, SurfaceGeology,
-    SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport, TravelRoute, TreeSpeciesId,
-    TreeSpeciesProfile, UnconsolidatedDeposit, WORLD_SCHEMA_VERSION, Woodland, WorldNodeImport,
+    AgriculturalLimitation, AvailableWaterCapacity, CanopyDensity, CrossingWatercourse,
+    DominantLeafType, DroughtHistory, DroughtProfile, EdgeEndpoint, ElevationMeters, FerryWaterway,
+    FlowingWaterAccess, ForestCover, GeologicEra, GeologicUnitId, HabitatSuitability,
+    InferredGeologicSetting, InferredTreeSpeciesProfile, LandUseFraction, LandUseProfile,
+    MappedPotentialVegetation, MappedSoilProfile, MarineWaterAccess, MineralSoil,
+    MineralSoilTexture, ModeledTreeSpecies, ModeledTreeSpeciesProfile, OfficialReligion,
+    PalmerDroughtSeverityIndex, ParentMaterialCode, PotentialVegetation,
+    PotentialVegetationFormation, SettlementHydrology, SettlementImport, SettlementReligiousStatus,
+    SoilDepth, SoilMappingUnit, SoilProfile, SoilProperties, SoilSubstrate, SoilWaterRegime,
+    StoneContentPercent, SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport,
+    TravelRoute, TreeSpeciesId, TreeSpeciesProfile, UnconsolidatedDeposit, WORLD_SCHEMA_VERSION,
+    Woodland, WorldNodeImport,
 };
 use spacetimedb::{Identity, ReducerContext, SpacetimeType, Table, reducer, table};
 
@@ -142,10 +143,7 @@ pub struct TravelEdge {
     pub from_node_id: u64,
     #[index(btree)]
     pub to_node_id: u64,
-    pub kind: String,
-    pub bridge_at: Option<EdgeEndpoint>,
-    pub water_crossings: Vec<LandWaterCrossing>,
-    pub ferry_waterway: Option<FerryWaterway>,
+    pub route: TravelRoute,
     pub toll_at: Option<EdgeEndpoint>,
     pub length_m: u32,
     pub slope_multiplier: f32,
@@ -283,18 +281,12 @@ pub fn import_travel_edges(
                 edge.id
             ));
         }
-        let (kind, bridge_at, water_crossings, ferry_waterway) = match edge.route {
-            TravelRoute::Land(route) => ("land", route.bridge, route.water_crossings, None),
-            TravelRoute::Ferry(route) => ("ferry", None, Vec::new(), Some(route.waterway)),
-        };
+        validate_travel_route(edge.id, &edge.route)?;
         let row = TravelEdge {
             id: edge.id,
             from_node_id: edge.from_node_id,
             to_node_id: edge.to_node_id,
-            kind: kind.into(),
-            bridge_at,
-            water_crossings,
-            ferry_waterway,
+            route: edge.route,
             toll_at: edge.toll,
             length_m: edge.length_m,
             slope_multiplier: edge.slope_multiplier,
@@ -426,6 +418,7 @@ pub fn import_settlements(
         let soil = reconstruct_soil_profile(&settlement.id, settlement.soil)?;
         let geology = reconstruct_geology_profile(&settlement.id, settlement.geology)?;
         let drought = reconstruct_drought_profile(&settlement.id, settlement.drought)?;
+        validate_settlement_hydrology(&settlement.id, settlement.hydrology)?;
         if ctx
             .db
             .world_node()
@@ -468,6 +461,86 @@ pub fn import_settlements(
         ensure_settlement_activity_inner(ctx, &settlement_id)?;
     }
     Ok(())
+}
+
+fn validate_travel_route(edge_id: u64, route: &TravelRoute) -> Result<(), String> {
+    match route {
+        TravelRoute::Land(route) => {
+            if route
+                .water_crossings
+                .windows(2)
+                .any(|pair| pair[0].position.get() > pair[1].position.get())
+            {
+                return Err(format!(
+                    "Travel edge {edge_id} has unsorted water crossings"
+                ));
+            }
+            for crossing in &route.water_crossings {
+                if adventuresim_world_schema::EdgeProgressPermille::new(crossing.position.get())
+                    .is_err()
+                    || !valid_crossing_watercourse(crossing.watercourse)
+                {
+                    return Err(format!(
+                        "Travel edge {edge_id} has an invalid water crossing"
+                    ));
+                }
+            }
+        }
+        TravelRoute::Ferry(route) => {
+            if let FerryWaterway::River(river) = route.waterway
+                && !valid_river_watercourse(river)
+            {
+                return Err(format!(
+                    "Travel edge {edge_id} has an invalid ferry waterway"
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn valid_crossing_watercourse(watercourse: CrossingWatercourse) -> bool {
+    match watercourse {
+        CrossingWatercourse::River(river) => valid_river_watercourse(river),
+        CrossingWatercourse::Canal(_) | CrossingWatercourse::Ditch => true,
+    }
+}
+
+fn valid_river_watercourse(river: adventuresim_world_schema::RiverWatercourse) -> bool {
+    adventuresim_world_schema::StrahlerOrder::new(river.order.get()).is_ok()
+}
+
+fn validate_settlement_hydrology(
+    settlement_id: &str,
+    hydrology: SettlementHydrology,
+) -> Result<(), String> {
+    let valid_distance = |distance: adventuresim_world_schema::WaterDistanceMeters| {
+        adventuresim_world_schema::WaterDistanceMeters::new(distance.get()).is_ok()
+    };
+    let valid_river = |river: adventuresim_world_schema::RiverAccess| {
+        valid_distance(river.distance)
+            && adventuresim_world_schema::StrahlerOrder::new(river.order.get()).is_ok()
+    };
+    let flowing_is_valid = match hydrology.flowing {
+        Some(FlowingWaterAccess::River(river)) => valid_river(river),
+        Some(FlowingWaterAccess::RiverAndCanal(access)) => {
+            valid_river(access.river) && valid_distance(access.canal_distance)
+        }
+        None => true,
+    };
+    let inland_is_valid = hydrology
+        .inland
+        .is_none_or(|access| valid_distance(access.distance));
+    let marine_is_valid = hydrology.marine.is_none_or(|access| match access {
+        MarineWaterAccess::Tidal(distance) | MarineWaterAccess::OpenCoast(distance) => {
+            valid_distance(distance)
+        }
+    });
+    if flowing_is_valid && inland_is_valid && marine_is_valid {
+        Ok(())
+    } else {
+        Err(format!("Settlement {settlement_id} has invalid hydrology"))
+    }
 }
 
 fn reconstruct_drought_profile(
@@ -3209,20 +3282,14 @@ fn travel_neighbors(ctx: &ReducerContext, node: u64) -> Vec<(u64, u32)> {
         .travel_edge()
         .from_node_id()
         .filter(&node)
-        .filter_map(|edge| {
-            matches!(edge.kind.as_str(), "land" | "ferry")
-                .then_some((edge.to_node_id, edge.length_m))
-        })
+        .map(|edge| (edge.to_node_id, edge.length_m))
         .collect();
     neighbors.extend(
         ctx.db
             .travel_edge()
             .to_node_id()
             .filter(&node)
-            .filter_map(|edge| {
-                matches!(edge.kind.as_str(), "land" | "ferry")
-                    .then_some((edge.from_node_id, edge.length_m))
-            }),
+            .map(|edge| (edge.from_node_id, edge.length_m)),
     );
     neighbors
 }

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -1,16 +1,16 @@
 use adventuresim_core::{capability::aggregate_bounded_party_check, morale::fervor_event_occurs};
 use adventuresim_world_schema::{
     AgriculturalLimitation, AvailableWaterCapacity, CanopyDensity, DominantLeafType,
-    DroughtHistory, DroughtProfile, EdgeEndpoint, ElevationMeters, ForestCover, GeologicEra,
-    GeologicUnitId, HabitatSuitability, InferredGeologicSetting, InferredTreeSpeciesProfile,
-    LandUseFraction, LandUseProfile, MappedPotentialVegetation, MappedSoilProfile, MineralSoil,
-    MineralSoilTexture, ModeledTreeSpecies, ModeledTreeSpeciesProfile, OfficialReligion,
-    PalmerDroughtSeverityIndex, ParentMaterialCode, PotentialVegetation,
-    PotentialVegetationFormation, SettlementImport, SettlementReligiousStatus, SoilDepth,
-    SoilMappingUnit, SoilProfile, SoilProperties, SoilSubstrate, SoilWaterRegime,
-    StoneContentPercent, SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport,
-    TravelRoute, TreeSpeciesId, TreeSpeciesProfile, UnconsolidatedDeposit, WORLD_SCHEMA_VERSION,
-    Woodland, WorldNodeImport,
+    DroughtHistory, DroughtProfile, EdgeEndpoint, ElevationMeters, FerryWaterway, ForestCover,
+    GeologicEra, GeologicUnitId, HabitatSuitability, InferredGeologicSetting,
+    InferredTreeSpeciesProfile, LandUseFraction, LandUseProfile, LandWaterCrossing,
+    MappedPotentialVegetation, MappedSoilProfile, MineralSoil, MineralSoilTexture,
+    ModeledTreeSpecies, ModeledTreeSpeciesProfile, OfficialReligion, PalmerDroughtSeverityIndex,
+    ParentMaterialCode, PotentialVegetation, PotentialVegetationFormation, SettlementHydrology,
+    SettlementImport, SettlementReligiousStatus, SoilDepth, SoilMappingUnit, SoilProfile,
+    SoilProperties, SoilSubstrate, SoilWaterRegime, StoneContentPercent, SurfaceGeology,
+    SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport, TravelRoute, TreeSpeciesId,
+    TreeSpeciesProfile, UnconsolidatedDeposit, WORLD_SCHEMA_VERSION, Woodland, WorldNodeImport,
 };
 use spacetimedb::{Identity, ReducerContext, SpacetimeType, Table, reducer, table};
 
@@ -105,6 +105,7 @@ pub struct Settlement {
     pub geology: SurfaceGeology,
     pub religious_status: SettlementReligiousStatus,
     pub drought: DroughtProfile,
+    pub hydrology: SettlementHydrology,
     pub scene_key: String,
     /// The single faith represented by this settlement's church and priest.
     pub religion_id: String,
@@ -143,6 +144,8 @@ pub struct TravelEdge {
     pub to_node_id: u64,
     pub kind: String,
     pub bridge_at: Option<EdgeEndpoint>,
+    pub water_crossings: Vec<LandWaterCrossing>,
+    pub ferry_waterway: Option<FerryWaterway>,
     pub toll_at: Option<EdgeEndpoint>,
     pub length_m: u32,
     pub slope_multiplier: f32,
@@ -280,9 +283,9 @@ pub fn import_travel_edges(
                 edge.id
             ));
         }
-        let (kind, bridge_at) = match edge.route {
-            TravelRoute::Land { bridge } => ("land", bridge),
-            TravelRoute::Ferry => ("ferry", None),
+        let (kind, bridge_at, water_crossings, ferry_waterway) = match edge.route {
+            TravelRoute::Land(route) => ("land", route.bridge, route.water_crossings, None),
+            TravelRoute::Ferry(route) => ("ferry", None, Vec::new(), Some(route.waterway)),
         };
         let row = TravelEdge {
             id: edge.id,
@@ -290,6 +293,8 @@ pub fn import_travel_edges(
             to_node_id: edge.to_node_id,
             kind: kind.into(),
             bridge_at,
+            water_crossings,
+            ferry_waterway,
             toll_at: edge.toll,
             length_m: edge.length_m,
             slope_multiplier: edge.slope_multiplier,
@@ -451,6 +456,7 @@ pub fn import_settlements(
             religion_id: settlement.religious_status.church().faith_id().into(),
             religious_status: settlement.religious_status,
             drought,
+            hydrology: settlement.hydrology,
             source_node_id: Some(settlement.source_node_id),
         };
         let settlement_id = row.id.clone();
@@ -4024,6 +4030,7 @@ pub fn seed_world(ctx: &ReducerContext) -> Result<(), String> {
                     )
                     .unwrap(),
                 ),
+                hydrology: SettlementHydrology::default(),
                 scene_key: scene.into(),
                 religion_id: religious_status.church().faith_id().into(),
                 source_node_id: None,

--- a/crates/adventuresim-world-import/src/builder.rs
+++ b/crates/adventuresim-world-import/src/builder.rs
@@ -5,8 +5,8 @@ use adventuresim_world_schema::CompiledWorld;
 use crate::{
     Result,
     sources::{
-        drought, elevation, forest_cover, geology, land_use, potential_vegetation, religion, soil,
-        tree_species, viabundus,
+        drought, elevation, forest_cover, geology, hydrology, land_use, potential_vegetation,
+        religion, soil, tree_species, viabundus,
     },
     validation,
 };
@@ -33,6 +33,7 @@ impl WorldBuilder {
         geology_geopackage: &Path,
         religion_regions: &Path,
         drought_netcdf: &Path,
+        hydrology_directory: &Path,
     ) -> Result<CompiledWorld> {
         let draft = viabundus::compile(viabundus_directory, self.year)?;
         let draft = elevation::enrich(draft, elevation_directory)?;
@@ -43,7 +44,8 @@ impl WorldBuilder {
         let draft = soil::enrich(draft, soil_directory)?;
         let draft = geology::enrich(draft, geology_geopackage)?;
         let draft = religion::enrich(draft, religion_regions)?;
-        let world = drought::enrich(draft, drought_netcdf)?;
+        let draft = drought::enrich(draft, drought_netcdf)?;
+        let world = hydrology::enrich(draft, hydrology_directory)?;
         validation::validate(&world)?;
         Ok(world)
     }

--- a/crates/adventuresim-world-import/src/draft.rs
+++ b/crates/adventuresim-world-import/src/draft.rs
@@ -1,7 +1,7 @@
 use adventuresim_world_schema::{
-    ElevationMeters, ForestCover, LandUseProfile, PotentialVegetation, SoilProfile,
-    SourceProvenance, TravelEdgeImport, TravelEdgeKind, TreeSpeciesProfile, WorldBuildReport,
-    WorldNodeImport,
+    DroughtProfile, EdgeEndpoint, ElevationMeters, ForestCover, LandUseProfile,
+    PotentialVegetation, SoilProfile, SourceProvenance, TravelEdgeKind, TreeSpeciesProfile,
+    WorldBuildReport, WorldNodeImport,
 };
 
 #[derive(Debug)]
@@ -10,9 +10,34 @@ pub(crate) struct WorldDraft<S> {
     pub(crate) sources: Vec<SourceProvenance>,
     pub(crate) road_types: Vec<TravelEdgeKind>,
     pub(crate) nodes: Vec<WorldNodeImport>,
-    pub(crate) edges: Vec<TravelEdgeImport>,
+    pub(crate) edges: Vec<TravelEdgeDraft>,
     pub(crate) settlements: Vec<S>,
     pub(crate) report: WorldBuildReport,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum TravelRouteDraft {
+    Land { bridge: Option<EdgeEndpoint> },
+    Ferry,
+}
+
+impl TravelRouteDraft {
+    pub(crate) const fn has_crossing(self) -> bool {
+        matches!(self, Self::Land { bridge: Some(_) } | Self::Ferry)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TravelEdgeDraft {
+    pub(crate) id: u64,
+    pub(crate) from_node_id: u64,
+    pub(crate) to_node_id: u64,
+    pub(crate) route: TravelRouteDraft,
+    pub(crate) toll: Option<EdgeEndpoint>,
+    pub(crate) length_m: u32,
+    pub(crate) slope_multiplier: f32,
+    pub(crate) certainty: u8,
+    pub(crate) section: String,
 }
 
 #[derive(Debug)]
@@ -73,4 +98,10 @@ pub(crate) struct GeologySettlementDraft {
 pub(crate) struct ReligionSettlementDraft {
     pub(crate) geologic: GeologySettlementDraft,
     pub(crate) religious_status: adventuresim_world_schema::SettlementReligiousStatus,
+}
+
+#[derive(Debug)]
+pub(crate) struct DroughtSettlementDraft {
+    pub(crate) religious: ReligionSettlementDraft,
+    pub(crate) drought: DroughtProfile,
 }

--- a/crates/adventuresim-world-import/src/main.rs
+++ b/crates/adventuresim-world-import/src/main.rs
@@ -5,14 +5,15 @@ use std::{
 
 use adventuresim_world_import::{Error, Result, WorldBuilder};
 use adventuresim_world_schema::{
-    AgriculturalLimitation, AvailableWaterCapacity, CompiledWorld, DominantLeafType,
-    DroughtHistory, DroughtProfile, EdgeEndpoint, ForestCover, GeologicAgeEvidence, GeologicEra,
-    GeologicLithologyEvidence, IgneousRock, MetamorphicRock, MineralSoilTexture, MixedLithology,
-    NativeRangeEvidence, PotentialVegetation, PotentialVegetationFormation, SedimentaryRock,
-    SettlementImport, SettlementReligiousStatus, SoilDepth, SoilProfile, SoilSubstrate,
-    SoilWaterRegime, SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon, TravelEdgeImport,
-    TravelRoute, TreeSpeciesProfile, UnconsolidatedDeposit, WesternChristianArrangement,
-    WorldNodeImport, WrbReferenceGroup,
+    AgriculturalLimitation, AvailableWaterCapacity, CompiledWorld, CrossingTraversal,
+    CrossingWatercourse, DominantLeafType, DroughtHistory, DroughtProfile, EdgeEndpoint,
+    FerryWaterway, FlowPersistence, FlowingWaterAccess, ForestCover, GeologicAgeEvidence,
+    GeologicEra, GeologicLithologyEvidence, IgneousRock, InlandWaterSize, MarineWaterAccess,
+    MetamorphicRock, MineralSoilTexture, MixedLithology, NativeRangeEvidence, PotentialVegetation,
+    PotentialVegetationFormation, SedimentaryRock, SettlementImport, SettlementReligiousStatus,
+    SoilDepth, SoilProfile, SoilSubstrate, SoilWaterRegime, SurfaceGeology, SurfaceLithology,
+    TopsoilOrganicCarbon, TravelEdgeImport, TravelRoute, TreeSpeciesProfile, UnconsolidatedDeposit,
+    WesternChristianArrangement, WorldNodeImport, WrbReferenceGroup,
 };
 use clap::Parser;
 use serde_json::{Value, json};
@@ -45,6 +46,8 @@ struct Args {
     religion_regions: PathBuf,
     #[arg(long, default_value_os_t = default_drought_netcdf())]
     drought_netcdf: PathBuf,
+    #[arg(long, default_value_os_t = default_hydrology_directory())]
+    hydrology_dir: PathBuf,
     #[arg(long, default_value_t = WORLD_YEAR)]
     year: i32,
     #[arg(long)]
@@ -86,6 +89,7 @@ fn run(args: Args) -> Result<()> {
         &args.geology_geopackage,
         &args.religion_regions,
         &args.drought_netcdf,
+        &args.hydrology_dir,
     )?;
     let output = args
         .output
@@ -190,11 +194,18 @@ fn encode_world_node(node: &WorldNodeImport) -> Result<Value> {
 }
 
 fn encode_travel_edge(edge: &TravelEdgeImport) -> Result<Value> {
-    let route = match edge.route {
-        TravelRoute::Land { bridge } => {
-            json!({ "Land": encode_endpoint(bridge) })
-        }
-        TravelRoute::Ferry => json!({ "Ferry": [] }),
+    let route = match &edge.route {
+        TravelRoute::Land(route) => json!({ "Land": {
+            "bridge": encode_endpoint(route.bridge),
+            "water_crossings": route.water_crossings.iter().map(|crossing| json!({
+                "position": { "permille": crossing.position.get() },
+                "watercourse": encode_crossing_watercourse(crossing.watercourse),
+                "traversal": enum_unit(match crossing.traversal { CrossingTraversal::Bridge => "Bridge", CrossingTraversal::Ford => "Ford" }),
+            })).collect::<Vec<_>>()
+        }}),
+        TravelRoute::Ferry(route) => json!({ "Ferry": {
+            "waterway": encode_ferry_waterway(route.waterway)
+        }}),
     };
     Ok(json!({
         "id": edge.id,
@@ -207,6 +218,37 @@ fn encode_travel_edge(edge: &TravelEdgeImport) -> Result<Value> {
         "certainty": edge.certainty,
         "section": edge.section,
     }))
+}
+
+fn encode_crossing_watercourse(watercourse: CrossingWatercourse) -> Value {
+    match watercourse {
+        CrossingWatercourse::River(river) => json!({ "River": {
+            "order": { "order": river.order.get() },
+            "persistence": encode_flow_persistence(river.persistence),
+        }}),
+        CrossingWatercourse::Canal(canal) => json!({ "Canal": { "navigable": canal.navigable } }),
+        CrossingWatercourse::Ditch => json!({ "Ditch": [] }),
+    }
+}
+
+fn encode_ferry_waterway(waterway: FerryWaterway) -> Value {
+    match waterway {
+        FerryWaterway::River(river) => json!({ "River": {
+            "order": { "order": river.order.get() },
+            "persistence": encode_flow_persistence(river.persistence),
+        }}),
+        FerryWaterway::InlandWater => json!({ "InlandWater": [] }),
+        FerryWaterway::TidalWater => json!({ "TidalWater": [] }),
+        FerryWaterway::CoastalWater => json!({ "CoastalWater": [] }),
+    }
+}
+
+fn encode_flow_persistence(persistence: FlowPersistence) -> Value {
+    enum_unit(match persistence {
+        FlowPersistence::Perennial => "Perennial",
+        FlowPersistence::Intermittent => "Intermittent",
+        FlowPersistence::Ephemeral => "Ephemeral",
+    })
 }
 
 fn encode_endpoint(endpoint: Option<EdgeEndpoint>) -> Value {
@@ -236,8 +278,41 @@ fn encode_settlement(settlement: &SettlementImport) -> Result<Value> {
         "geology": encode_geology(&settlement.geology),
         "religious_status": encode_religious_status(settlement.religious_status),
         "drought": encode_drought(settlement.drought),
+        "hydrology": encode_hydrology(settlement.hydrology),
         "scene_key": settlement.scene_key,
     }))
+}
+
+fn encode_hydrology(hydrology: adventuresim_world_schema::SettlementHydrology) -> Value {
+    let distance =
+        |value: adventuresim_world_schema::WaterDistanceMeters| json!({ "meters": value.get() });
+    let flowing = match hydrology.flowing {
+        Some(FlowingWaterAccess::River(river)) => json!({ "some": { "River": {
+            "distance": distance(river.distance), "order": { "order": river.order.get() },
+            "persistence": encode_flow_persistence(river.persistence)
+        }}}),
+        Some(FlowingWaterAccess::RiverAndCanal(access)) => json!({ "some": { "RiverAndCanal": {
+            "river": { "distance": distance(access.river.distance), "order": { "order": access.river.order.get() }, "persistence": encode_flow_persistence(access.river.persistence) },
+            "canal_distance": distance(access.canal_distance), "canal_navigable": access.canal_navigable
+        }}}),
+        None => json!({ "none": [] }),
+    };
+    let inland = match hydrology.inland {
+        Some(inland) => {
+            json!({ "some": { "distance": distance(inland.distance), "size": enum_unit(match inland.size {
+                InlandWaterSize::Pond => "Pond", InlandWaterSize::Lake => "Lake", InlandWaterSize::GreatLake => "GreatLake"
+            })}})
+        }
+        None => json!({ "none": [] }),
+    };
+    let marine = match hydrology.marine {
+        Some(MarineWaterAccess::Tidal(value)) => json!({ "some": { "Tidal": distance(value) }}),
+        Some(MarineWaterAccess::OpenCoast(value)) => {
+            json!({ "some": { "OpenCoast": distance(value) }})
+        }
+        None => json!({ "none": [] }),
+    };
+    json!({ "flowing": flowing, "inland": inland, "marine": marine })
 }
 
 fn encode_drought(profile: DroughtProfile) -> Value {
@@ -693,6 +768,10 @@ fn default_drought_netcdf() -> PathBuf {
     repository_root().join("target/world-data-sources/raw/climate/owda.nc")
 }
 
+fn default_hydrology_directory() -> PathBuf {
+    repository_root().join("target/world-data-sources/raw/hydrology")
+}
+
 fn default_output(year: i32) -> PathBuf {
     repository_root().join(format!("target/world-{year}.json"))
 }
@@ -704,10 +783,10 @@ mod tests {
         DroughtHistory, DroughtProfile, EdgeEndpoint, ElevationMeters, EuroVegMapUnitCode,
         ForestCover, GeologicAgeEvidence, GeologicEra, GeologicLithologyEvidence, GeologicSetting,
         GeologicUnitId, HabitatSuitability, IgneousRock, InferredGeologicSetting,
-        InferredTreeSpeciesProfile, LandUseFraction, LandUseProfile, MappedPotentialVegetation,
-        MappedSoilProfile, MappedSurfaceGeology, MineralSoil, MineralSoilTexture,
-        ModeledTreeSpecies, ModeledTreeSpeciesProfile, NativeRangeEvidence, OfficialReligion,
-        PalmerDroughtSeverityIndex, ParentMaterialCode, PotentialVegetation,
+        InferredTreeSpeciesProfile, LandRoute, LandUseFraction, LandUseProfile,
+        MappedPotentialVegetation, MappedSoilProfile, MappedSurfaceGeology, MineralSoil,
+        MineralSoilTexture, ModeledTreeSpecies, ModeledTreeSpeciesProfile, NativeRangeEvidence,
+        OfficialReligion, PalmerDroughtSeverityIndex, ParentMaterialCode, PotentialVegetation,
         PotentialVegetationFormation, SettlementImport, SettlementReligiousStatus, SoilDepth,
         SoilMappingUnit, SoilProfile, SoilProperties, SoilSubstrate, SoilWaterRegime,
         StoneContentPercent, SurfaceGeology, SurfaceLithology, TopsoilOrganicCarbon,
@@ -726,9 +805,10 @@ mod tests {
             id: 1,
             from_node_id: 2,
             to_node_id: 3,
-            route: TravelRoute::Land {
+            route: TravelRoute::Land(LandRoute {
                 bridge: Some(EdgeEndpoint::To),
-            },
+                water_crossings: Vec::new(),
+            }),
             toll: Some(EdgeEndpoint::From),
             length_m: 4,
             slope_multiplier: 1.0,
@@ -738,7 +818,7 @@ mod tests {
         let batches = serialize_batches(&[edge], 100, encode_travel_edge).unwrap();
         assert_eq!(
             batches[0][0]["route"],
-            serde_json::json!({ "Land": { "some": { "To": [] } } })
+            serde_json::json!({ "Land": { "bridge": { "some": { "To": [] } }, "water_crossings": [] } })
         );
         assert_eq!(
             batches[0][0]["toll"],
@@ -980,6 +1060,7 @@ mod tests {
                 )
                 .unwrap(),
             ),
+            hydrology: adventuresim_world_schema::SettlementHydrology::default(),
             scene_key: "village".into(),
         }
     }

--- a/crates/adventuresim-world-import/src/sources/drought.rs
+++ b/crates/adventuresim-world-import/src/sources/drought.rs
@@ -3,14 +3,13 @@
 use std::path::Path;
 
 use adventuresim_world_schema::{
-    CompiledWorld, DroughtHistory, DroughtProfile, PalmerDroughtSeverityIndex, SettlementImport,
-    SourceProvenance, WORLD_SCHEMA_VERSION, WorldMetadata,
+    DroughtHistory, DroughtProfile, PalmerDroughtSeverityIndex, SourceProvenance,
 };
 use netcdf_reader::{NcFile, NcFormat, NcSliceInfo, NcSliceInfoElem, NcType};
 
 use crate::{
     Error, Result,
-    draft::{ReligionSettlementDraft, WorldDraft},
+    draft::{DroughtSettlementDraft, ReligionSettlementDraft, WorldDraft},
 };
 
 const SOURCE_NAME: &str = "NOAA Old World Drought Atlas v1.0";
@@ -27,7 +26,7 @@ const MAX_NEIGHBOR_DISTANCE_DEGREES: f64 = 1.5;
 pub(crate) fn enrich(
     draft: WorldDraft<ReligionSettlementDraft>,
     netcdf_path: &Path,
-) -> Result<CompiledWorld> {
+) -> Result<WorldDraft<DroughtSettlementDraft>> {
     let grid = OwdaGrid::open(netcdf_path, draft.year)?;
     if draft.settlements.is_empty() {
         return finish(draft, Vec::new(), grid.valid_cells.len(), 0, 0);
@@ -74,44 +73,16 @@ fn finish(
     cells_read: usize,
     neighbor_samples: usize,
     fallbacks: usize,
-) -> Result<CompiledWorld> {
+) -> Result<WorldDraft<DroughtSettlementDraft>> {
     if profiles.len() != draft.settlements.len() {
         return Err(Error::Validation(
             "drought profiles do not match settlements".into(),
         ));
     }
-    let settlements: Vec<SettlementImport> = std::mem::take(&mut draft.settlements)
+    let settlements: Vec<DroughtSettlementDraft> = std::mem::take(&mut draft.settlements)
         .into_iter()
         .zip(profiles)
-        .map(|(religious, drought)| {
-            let geologic = religious.geologic;
-            let soil = geologic.soil;
-            let trees = soil.trees;
-            let vegetated = trees.vegetated;
-            let forest = vegetated.forest;
-            let land = forest.land;
-            let elevated = land.elevated;
-            let settlement = elevated.settlement;
-            SettlementImport {
-                id: settlement.id,
-                source_node_id: settlement.source_node_id,
-                name: settlement.name,
-                longitude: settlement.longitude,
-                latitude: settlement.latitude,
-                population_level: settlement.population_level,
-                population_estimate: settlement.population_estimate,
-                elevation: elevated.elevation,
-                land_use: land.land_use,
-                forest_cover: forest.forest_cover,
-                potential_vegetation: vegetated.potential_vegetation,
-                tree_species: trees.tree_species,
-                soil: soil.soil,
-                geology: geologic.geology,
-                religious_status: religious.religious_status,
-                drought,
-                scene_key: settlement.scene_key,
-            }
-        })
+        .map(|(religious, drought)| DroughtSettlementDraft { religious, drought })
         .collect();
     draft.sources.push(SourceProvenance {
         name: SOURCE_NAME.into(),
@@ -122,13 +93,10 @@ fn finish(
     draft.report.drought_samples = settlements.len();
     draft.report.drought_neighbor_samples = neighbor_samples;
     draft.report.drought_fallback_samples = fallbacks;
-    Ok(CompiledWorld {
-        metadata: WorldMetadata {
-            schema_version: WORLD_SCHEMA_VERSION,
-            world_year: draft.year,
-            sources: draft.sources,
-            road_types: draft.road_types,
-        },
+    Ok(WorldDraft {
+        year: draft.year,
+        sources: draft.sources,
+        road_types: draft.road_types,
         nodes: draft.nodes,
         edges: draft.edges,
         settlements,

--- a/crates/adventuresim-world-import/src/sources/hydrology.rs
+++ b/crates/adventuresim-world-import/src/sources/hydrology.rs
@@ -1,0 +1,1156 @@
+//! Copernicus EU-Hydro settlement-water and road-crossing enrichment.
+//!
+//! The reader consumes extracted basin GeoPackages in EPSG:3035. Raw source
+//! sentinel values are resolved at this boundary; the canonical schema has no
+//! unknown persistence, order, salinity, or route-waterway states.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use adventuresim_world_schema::{
+    CanalWatercourse, CompiledWorld, CrossingTraversal, CrossingWatercourse, EdgeEndpoint,
+    EdgeProgressPermille, FerryRoute, FerryWaterway, FlowPersistence, FlowingWaterAccess,
+    InlandWaterAccess, InlandWaterSize, LandRoute, LandWaterCrossing, MarineWaterAccess,
+    RiverAccess, RiverAndCanalAccess, RiverWatercourse, SettlementHydrology, SettlementImport,
+    SourceProvenance, StrahlerOrder, TravelEdgeImport, TravelRoute, WORLD_SCHEMA_VERSION,
+    WaterDistanceMeters, WorldMetadata,
+};
+use geo::{BoundingRect, Contains, Coord, Geometry, Line, LineString, Point};
+use geozero::{ToGeo, wkb::GpkgWkb};
+use proj4rs::{proj::Proj, transform::transform};
+use rusqlite::{Connection, OpenFlags};
+
+use crate::{
+    Error, Result,
+    draft::{DroughtSettlementDraft, TravelEdgeDraft, TravelRouteDraft, WorldDraft},
+};
+
+const SOURCE_NAME: &str = "Copernicus EU-Hydro River Network Database v1.3";
+const SOURCE_URL: &str =
+    "https://land.copernicus.eu/en/products/eu-hydro/eu-hydro-river-network-database";
+const SOURCE_LICENSE: &str = "Copernicus Land Monitoring Service full and open data policy";
+const EXPECTED_SRS: i64 = 3035;
+const SETTLEMENT_ADJACENCY_METERS: f64 = 2_000.0;
+const SOURCE_MARGIN_METERS: f64 = 10_000.0;
+const CROSSING_DEDUP_PERMILLE: u16 = 5;
+const INDEX_CELL_METERS: f64 = 10_000.0;
+
+pub(crate) fn enrich(
+    mut draft: WorldDraft<DroughtSettlementDraft>,
+    source_directory: &Path,
+) -> Result<CompiledWorld> {
+    let projection = HydrologyProjection::new()?;
+    let projected_nodes = draft
+        .nodes
+        .iter()
+        .map(|node| Ok((node.id, projection.project(node.latitude, node.longitude)?)))
+        .collect::<Result<HashMap<_, _>>>()?;
+    let bounds = world_bounds(projected_nodes.values().copied());
+    let database = HydrologyDatabase::open(source_directory, bounds)?;
+
+    let mut settlement_fallbacks = 0;
+    let hydrology = draft
+        .settlements
+        .iter()
+        .map(|settlement| {
+            let base = base_settlement(settlement);
+            let point = projected_nodes[&base.source_node_id];
+            let value = database.sample_settlement(point)?;
+            settlement_fallbacks += usize::from(value == SettlementHydrology::default());
+            Ok(value)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut crossings = 0;
+    let mut inferred_ferries = 0;
+    let edges = std::mem::take(&mut draft.edges)
+        .into_iter()
+        .map(|edge| {
+            let from = projected_nodes[&edge.from_node_id];
+            let to = projected_nodes[&edge.to_node_id];
+            let (route, edge_crossings, inferred) = database.enrich_route(edge.route, from, to)?;
+            crossings += edge_crossings;
+            inferred_ferries += usize::from(inferred);
+            Ok(finish_edge(edge, route))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let settlements = std::mem::take(&mut draft.settlements)
+        .into_iter()
+        .zip(hydrology)
+        .map(|(drought, hydrology)| finish_settlement(drought, hydrology))
+        .collect::<Vec<_>>();
+
+    draft.sources.push(SourceProvenance {
+        name: SOURCE_NAME.into(),
+        url: SOURCE_URL.into(),
+        license: SOURCE_LICENSE.into(),
+    });
+    draft.report.hydrology_files_read = database.files_read;
+    draft.report.hydrology_features_read = database.features.len();
+    draft.report.hydrology_settlement_samples = settlements.len();
+    draft.report.hydrology_settlement_fallback_samples = settlement_fallbacks;
+    draft.report.hydrology_edge_crossings = crossings;
+    draft.report.hydrology_inferred_ferry_waterways = inferred_ferries;
+    draft.report.route_crossings = edges
+        .iter()
+        .filter(|edge| edge.route.has_crossing())
+        .count();
+
+    Ok(CompiledWorld {
+        metadata: WorldMetadata {
+            schema_version: WORLD_SCHEMA_VERSION,
+            world_year: draft.year,
+            sources: draft.sources,
+            road_types: draft.road_types,
+        },
+        nodes: draft.nodes,
+        edges,
+        settlements,
+        report: draft.report,
+    })
+}
+
+fn finish_edge(edge: TravelEdgeDraft, route: TravelRoute) -> TravelEdgeImport {
+    TravelEdgeImport {
+        id: edge.id,
+        from_node_id: edge.from_node_id,
+        to_node_id: edge.to_node_id,
+        route,
+        toll: edge.toll,
+        length_m: edge.length_m,
+        slope_multiplier: edge.slope_multiplier,
+        certainty: edge.certainty,
+        section: edge.section,
+    }
+}
+
+fn finish_settlement(
+    drought: DroughtSettlementDraft,
+    hydrology: SettlementHydrology,
+) -> SettlementImport {
+    let religious = drought.religious;
+    let geologic = religious.geologic;
+    let soil = geologic.soil;
+    let trees = soil.trees;
+    let vegetated = trees.vegetated;
+    let forest = vegetated.forest;
+    let land = forest.land;
+    let elevated = land.elevated;
+    let settlement = elevated.settlement;
+    SettlementImport {
+        id: settlement.id,
+        source_node_id: settlement.source_node_id,
+        name: settlement.name,
+        longitude: settlement.longitude,
+        latitude: settlement.latitude,
+        population_level: settlement.population_level,
+        population_estimate: settlement.population_estimate,
+        elevation: elevated.elevation,
+        land_use: land.land_use,
+        forest_cover: forest.forest_cover,
+        potential_vegetation: vegetated.potential_vegetation,
+        tree_species: trees.tree_species,
+        soil: soil.soil,
+        geology: geologic.geology,
+        religious_status: religious.religious_status,
+        drought: drought.drought,
+        hydrology,
+        scene_key: settlement.scene_key,
+    }
+}
+
+fn base_settlement(draft: &DroughtSettlementDraft) -> &crate::draft::SettlementDraft {
+    &draft
+        .religious
+        .geologic
+        .soil
+        .trees
+        .vegetated
+        .forest
+        .land
+        .elevated
+        .settlement
+}
+
+struct HydrologyProjection {
+    geographic: Proj,
+    projected: Proj,
+}
+
+impl HydrologyProjection {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            geographic: Proj::from_proj_string(
+                "+proj=longlat +datum=WGS84 +ellps=WGS84 +no_defs +type=crs",
+            )?,
+            projected: Proj::from_proj_string(
+                "+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +ellps=GRS80 +units=m +no_defs +type=crs",
+            )?,
+        })
+    }
+
+    fn project(&self, latitude: f64, longitude: f64) -> Result<Point<f64>> {
+        if !latitude.is_finite()
+            || !longitude.is_finite()
+            || !(-90.0..=90.0).contains(&latitude)
+            || !(-180.0..=180.0).contains(&longitude)
+        {
+            return Err(Error::Validation(format!(
+                "invalid coordinate ({latitude}, {longitude}) for EU-Hydro"
+            )));
+        }
+        let mut coordinate = (longitude.to_radians(), latitude.to_radians(), 0.0);
+        transform(&self.geographic, &self.projected, &mut coordinate)?;
+        Ok(Point::new(coordinate.0, coordinate.1))
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Bounds {
+    min_x: f64,
+    min_y: f64,
+    max_x: f64,
+    max_y: f64,
+}
+
+fn world_bounds(points: impl Iterator<Item = Point<f64>>) -> Option<Bounds> {
+    points.fold(None, |bounds, point| {
+        Some(match bounds {
+            None => Bounds {
+                min_x: point.x() - SOURCE_MARGIN_METERS,
+                min_y: point.y() - SOURCE_MARGIN_METERS,
+                max_x: point.x() + SOURCE_MARGIN_METERS,
+                max_y: point.y() + SOURCE_MARGIN_METERS,
+            },
+            Some(bounds) => Bounds {
+                min_x: bounds.min_x.min(point.x() - SOURCE_MARGIN_METERS),
+                min_y: bounds.min_y.min(point.y() - SOURCE_MARGIN_METERS),
+                max_x: bounds.max_x.max(point.x() + SOURCE_MARGIN_METERS),
+                max_y: bounds.max_y.max(point.y() + SOURCE_MARGIN_METERS),
+            },
+        })
+    })
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FeatureKind {
+    River,
+    Canal,
+    Ditch,
+    InlandWater,
+    Tidal,
+    Coastal,
+}
+
+#[derive(Debug)]
+struct WaterFeature {
+    kind: FeatureKind,
+    geometry: Geometry<f64>,
+    order: StrahlerOrder,
+    persistence: FlowPersistence,
+    navigable: bool,
+    area_square_meters: f64,
+}
+
+struct HydrologyDatabase {
+    files_read: usize,
+    features: Vec<WaterFeature>,
+    spatial_grid: HashMap<(i32, i32), Vec<usize>>,
+}
+
+impl HydrologyDatabase {
+    fn open(directory: &Path, bounds: Option<Bounds>) -> Result<Self> {
+        if !directory.is_dir() {
+            return Err(Error::MissingSource(directory.to_path_buf()));
+        }
+        let mut paths = Vec::new();
+        collect_geopackages(directory, &mut paths)?;
+        paths.sort();
+        if paths.is_empty() {
+            return Err(Error::Validation(format!(
+                "{} contains no extracted EU-Hydro .gpkg files",
+                directory.display()
+            )));
+        }
+        let mut features = Vec::new();
+        for path in &paths {
+            read_geopackage(path, bounds, &mut features)?;
+        }
+        if !features
+            .iter()
+            .any(|feature| feature.kind == FeatureKind::River)
+        {
+            return Err(Error::Validation(
+                "EU-Hydro source contains no River_Net_l features in the world extent".into(),
+            ));
+        }
+        let spatial_grid = build_spatial_grid(&features);
+        Ok(Self {
+            files_read: paths.len(),
+            features,
+            spatial_grid,
+        })
+    }
+
+    fn sample_settlement(&self, point: Point<f64>) -> Result<SettlementHydrology> {
+        let candidates = self.candidates(Bounds {
+            min_x: point.x() - SETTLEMENT_ADJACENCY_METERS,
+            min_y: point.y() - SETTLEMENT_ADJACENCY_METERS,
+            max_x: point.x() + SETTLEMENT_ADJACENCY_METERS,
+            max_y: point.y() + SETTLEMENT_ADJACENCY_METERS,
+        });
+        let nearest = |kind| {
+            candidates
+                .iter()
+                .copied()
+                .filter(|feature| feature.kind == kind)
+                .filter_map(|feature| {
+                    geometry_distance(point, &feature.geometry)
+                        .filter(|distance| *distance <= SETTLEMENT_ADJACENCY_METERS)
+                        .map(|distance| (feature, distance))
+                })
+                .min_by(|left, right| left.1.total_cmp(&right.1))
+        };
+        let river = nearest(FeatureKind::River);
+        let canal = nearest(FeatureKind::Canal);
+        let flowing = river.map(|(river, distance)| {
+            let river = RiverAccess {
+                distance: water_distance(distance),
+                order: river.order,
+                persistence: river.persistence,
+            };
+            match canal {
+                Some((canal, canal_distance)) => {
+                    FlowingWaterAccess::RiverAndCanal(RiverAndCanalAccess {
+                        river,
+                        canal_distance: water_distance(canal_distance),
+                        canal_navigable: canal.navigable,
+                    })
+                }
+                None => FlowingWaterAccess::River(river),
+            }
+        });
+        let inland =
+            nearest(FeatureKind::InlandWater).map(|(feature, distance)| InlandWaterAccess {
+                distance: water_distance(distance),
+                size: inland_size(feature.area_square_meters),
+            });
+        let tidal = nearest(FeatureKind::Tidal);
+        let coastal = nearest(FeatureKind::Coastal);
+        let marine = match (tidal, coastal) {
+            (Some((_, tidal)), Some((_, coastal))) if tidal <= coastal => {
+                Some(MarineWaterAccess::Tidal(water_distance(tidal)))
+            }
+            (Some((_, tidal)), None) => Some(MarineWaterAccess::Tidal(water_distance(tidal))),
+            (_, Some((_, coastal))) => Some(MarineWaterAccess::OpenCoast(water_distance(coastal))),
+            (None, None) => None,
+        };
+        Ok(SettlementHydrology {
+            flowing,
+            inland,
+            marine,
+        })
+    }
+
+    fn enrich_route(
+        &self,
+        route: TravelRouteDraft,
+        from: Point<f64>,
+        to: Point<f64>,
+    ) -> Result<(TravelRoute, usize, bool)> {
+        let line = Line::new(from.0, to.0);
+        match route {
+            TravelRouteDraft::Land { bridge } => {
+                let mut crossings = self.line_crossings(line);
+                apply_bridge_evidence(&mut crossings, bridge);
+                add_unmapped_bridges(&mut crossings, bridge);
+                crossings.sort_by_key(|crossing| crossing.position);
+                crossings.dedup_by(|left, right| {
+                    left.position.get().abs_diff(right.position.get()) <= CROSSING_DEDUP_PERMILLE
+                        && left.watercourse == right.watercourse
+                });
+                let count = crossings.len();
+                Ok((
+                    TravelRoute::Land(LandRoute {
+                        bridge,
+                        water_crossings: crossings,
+                    }),
+                    count,
+                    false,
+                ))
+            }
+            TravelRouteDraft::Ferry => {
+                let midpoint = Point::new((from.x() + to.x()) / 2.0, (from.y() + to.y()) / 2.0);
+                let crossing = self.line_crossings(line).into_iter().next();
+                let waterway = crossing
+                    .map(|crossing| ferry_from_crossing(crossing.watercourse))
+                    .or_else(|| self.ferry_polygon(midpoint));
+                let inferred = waterway.is_none();
+                let waterway = waterway.unwrap_or(FerryWaterway::River(RiverWatercourse {
+                    order: StrahlerOrder::new(2).expect("constant is valid"),
+                    persistence: FlowPersistence::Perennial,
+                }));
+                Ok((TravelRoute::Ferry(FerryRoute { waterway }), 0, inferred))
+            }
+        }
+    }
+
+    fn line_crossings(&self, route: Line<f64>) -> Vec<LandWaterCrossing> {
+        let bounds = Bounds {
+            min_x: route.start.x.min(route.end.x),
+            min_y: route.start.y.min(route.end.y),
+            max_x: route.start.x.max(route.end.x),
+            max_y: route.start.y.max(route.end.y),
+        };
+        self.candidates(bounds)
+            .iter()
+            .copied()
+            .filter(|feature| {
+                matches!(
+                    feature.kind,
+                    FeatureKind::River | FeatureKind::Canal | FeatureKind::Ditch
+                )
+            })
+            .flat_map(|feature| {
+                geometry_line_intersections(route, &feature.geometry)
+                    .into_iter()
+                    .map(move |position| LandWaterCrossing {
+                        position: EdgeProgressPermille::new(position)
+                            .expect("intersection is clamped"),
+                        watercourse: feature_crossing(feature),
+                        traversal: plausible_traversal(feature),
+                    })
+            })
+            .collect()
+    }
+
+    fn ferry_polygon(&self, point: Point<f64>) -> Option<FerryWaterway> {
+        let candidates = self.candidates(Bounds {
+            min_x: point.x(),
+            min_y: point.y(),
+            max_x: point.x(),
+            max_y: point.y(),
+        });
+        [
+            (FeatureKind::Tidal, FerryWaterway::TidalWater),
+            (FeatureKind::Coastal, FerryWaterway::CoastalWater),
+            (FeatureKind::InlandWater, FerryWaterway::InlandWater),
+        ]
+        .into_iter()
+        .find_map(|(kind, waterway)| {
+            candidates
+                .iter()
+                .copied()
+                .any(|feature| feature.kind == kind && geometry_contains(&feature.geometry, point))
+                .then_some(waterway)
+        })
+    }
+
+    fn candidates(&self, bounds: Bounds) -> Vec<&WaterFeature> {
+        let (min_x, max_x) = grid_range(bounds.min_x, bounds.max_x);
+        let (min_y, max_y) = grid_range(bounds.min_y, bounds.max_y);
+        let mut indices = HashSet::new();
+        for x in min_x..=max_x {
+            for y in min_y..=max_y {
+                if let Some(cell) = self.spatial_grid.get(&(x, y)) {
+                    indices.extend(cell.iter().copied());
+                }
+            }
+        }
+        let mut indices = indices.into_iter().collect::<Vec<_>>();
+        indices.sort_unstable();
+        indices
+            .into_iter()
+            .map(|index| &self.features[index])
+            .collect()
+    }
+}
+
+fn build_spatial_grid(features: &[WaterFeature]) -> HashMap<(i32, i32), Vec<usize>> {
+    let mut grid: HashMap<(i32, i32), Vec<usize>> = HashMap::new();
+    for (index, feature) in features.iter().enumerate() {
+        let Some(rect) = feature.geometry.bounding_rect() else {
+            continue;
+        };
+        let (min_x, max_x) = grid_range(rect.min().x, rect.max().x);
+        let (min_y, max_y) = grid_range(rect.min().y, rect.max().y);
+        for x in min_x..=max_x {
+            for y in min_y..=max_y {
+                grid.entry((x, y)).or_default().push(index);
+            }
+        }
+    }
+    grid
+}
+
+fn grid_range(minimum: f64, maximum: f64) -> (i32, i32) {
+    (
+        (minimum / INDEX_CELL_METERS).floor() as i32,
+        (maximum / INDEX_CELL_METERS).floor() as i32,
+    )
+}
+
+fn water_distance(distance: f64) -> WaterDistanceMeters {
+    WaterDistanceMeters::new(distance.round().clamp(0.0, WaterDistanceMeters::MAX as f64) as u16)
+        .expect("distance is clamped")
+}
+
+fn inland_size(area: f64) -> InlandWaterSize {
+    if area >= 100_000_000.0 {
+        InlandWaterSize::GreatLake
+    } else if area >= 1_000_000.0 {
+        InlandWaterSize::Lake
+    } else {
+        InlandWaterSize::Pond
+    }
+}
+
+fn feature_crossing(feature: &WaterFeature) -> CrossingWatercourse {
+    match feature.kind {
+        FeatureKind::River => CrossingWatercourse::River(RiverWatercourse {
+            order: feature.order,
+            persistence: feature.persistence,
+        }),
+        FeatureKind::Canal => CrossingWatercourse::Canal(CanalWatercourse {
+            navigable: feature.navigable,
+        }),
+        FeatureKind::Ditch => CrossingWatercourse::Ditch,
+        _ => unreachable!("only linear watercourses are crossings"),
+    }
+}
+
+fn plausible_traversal(feature: &WaterFeature) -> CrossingTraversal {
+    match feature.kind {
+        FeatureKind::River if feature.order.get() <= 2 => CrossingTraversal::Ford,
+        _ => CrossingTraversal::Bridge,
+    }
+}
+
+fn ferry_from_crossing(crossing: CrossingWatercourse) -> FerryWaterway {
+    match crossing {
+        CrossingWatercourse::River(river) => FerryWaterway::River(river),
+        CrossingWatercourse::Canal(_) | CrossingWatercourse::Ditch => {
+            FerryWaterway::River(RiverWatercourse {
+                order: StrahlerOrder::new(2).expect("constant is valid"),
+                persistence: FlowPersistence::Perennial,
+            })
+        }
+    }
+}
+
+fn apply_bridge_evidence(crossings: &mut [LandWaterCrossing], bridge: Option<EdgeEndpoint>) {
+    for crossing in crossings {
+        let position = crossing.position.get();
+        if matches!(bridge, Some(EdgeEndpoint::From | EdgeEndpoint::Both)) && position <= 100
+            || matches!(bridge, Some(EdgeEndpoint::To | EdgeEndpoint::Both)) && position >= 900
+        {
+            crossing.traversal = CrossingTraversal::Bridge;
+        }
+    }
+}
+
+fn add_unmapped_bridges(crossings: &mut Vec<LandWaterCrossing>, bridge: Option<EdgeEndpoint>) {
+    let mut push = |position: u16| {
+        let endpoint_is_mapped = crossings.iter().any(|crossing| {
+            if position == 0 {
+                crossing.position.get() <= 100
+            } else {
+                crossing.position.get() >= 900
+            }
+        });
+        if endpoint_is_mapped {
+            return;
+        }
+        crossings.push(LandWaterCrossing {
+            position: EdgeProgressPermille::new(position).expect("constant is valid"),
+            watercourse: CrossingWatercourse::River(RiverWatercourse {
+                order: StrahlerOrder::new(2).expect("constant is valid"),
+                persistence: FlowPersistence::Perennial,
+            }),
+            traversal: CrossingTraversal::Bridge,
+        });
+    };
+    match bridge {
+        Some(EdgeEndpoint::From) => push(0),
+        Some(EdgeEndpoint::To) => push(1_000),
+        Some(EdgeEndpoint::Both) => {
+            push(0);
+            push(1_000);
+        }
+        None => {}
+    }
+}
+
+fn collect_geopackages(directory: &Path, output: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(directory)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_geopackages(&path, output)?;
+        } else if path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("gpkg"))
+        {
+            output.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn read_geopackage(
+    path: &Path,
+    bounds: Option<Bounds>,
+    output: &mut Vec<WaterFeature>,
+) -> Result<()> {
+    let connection =
+        Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(|source| {
+            Error::GeoPackage {
+                path: path.to_path_buf(),
+                source,
+            }
+        })?;
+    let application_id: i64 = connection
+        .pragma_query_value(None, "application_id", |row| row.get(0))
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if application_id != 0x4750_4b47 {
+        return Err(Error::Validation(format!(
+            "{} is not an OGC GeoPackage",
+            path.display()
+        )));
+    }
+    let mut tables = connection
+        .prepare(
+            "SELECT table_name, column_name, geometry_type_name, srs_id FROM gpkg_geometry_columns",
+        )
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let metadata = tables
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    for (table, geometry_column, geometry_type, srs) in metadata {
+        let Some(kind) = feature_kind(&table) else {
+            continue;
+        };
+        if srs != EXPECTED_SRS {
+            return Err(Error::Validation(format!(
+                "{} table {table} uses EPSG:{srs}; expected EPSG:{EXPECTED_SRS}",
+                path.display()
+            )));
+        }
+        let polygon = matches!(
+            kind,
+            FeatureKind::InlandWater | FeatureKind::Tidal | FeatureKind::Coastal
+        );
+        if polygon != geometry_type.to_ascii_uppercase().contains("POLYGON") {
+            return Err(Error::Validation(format!(
+                "{} table {table} has incompatible geometry type {geometry_type}",
+                path.display()
+            )));
+        }
+        read_feature_table(
+            &connection,
+            path,
+            &table,
+            &geometry_column,
+            kind,
+            bounds,
+            output,
+        )?;
+    }
+    Ok(())
+}
+
+fn feature_kind(table: &str) -> Option<FeatureKind> {
+    match table.to_ascii_lowercase().as_str() {
+        "river_net_l" | "river_net_lines" => Some(FeatureKind::River),
+        "canals_l" => Some(FeatureKind::Canal),
+        "ditches_l" => Some(FeatureKind::Ditch),
+        "inlandwater" => Some(FeatureKind::InlandWater),
+        "transit_p" | "transit_polygon" => Some(FeatureKind::Tidal),
+        "coastal_p" | "coastal_polygon" => Some(FeatureKind::Coastal),
+        _ => None,
+    }
+}
+
+fn read_feature_table(
+    connection: &Connection,
+    path: &Path,
+    table: &str,
+    geometry_column: &str,
+    kind: FeatureKind,
+    bounds: Option<Bounds>,
+    output: &mut Vec<WaterFeature>,
+) -> Result<()> {
+    let columns = table_columns(connection, path, table)?;
+    let value = |name: &str| {
+        if columns
+            .iter()
+            .any(|column| column.eq_ignore_ascii_case(name))
+        {
+            quote_identifier(
+                columns
+                    .iter()
+                    .find(|column| column.eq_ignore_ascii_case(name))
+                    .unwrap(),
+            )
+        } else {
+            "NULL".into()
+        }
+    };
+    let sql = format!(
+        "SELECT {}, {}, {}, {}, {} FROM {}",
+        quote_identifier(geometry_column),
+        value("STRAHLER"),
+        value("HYP"),
+        value("NVS"),
+        value("AREA_GEO"),
+        quote_identifier(table)
+    );
+    let mut statement = connection
+        .prepare(&sql)
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, Vec<u8>>(0)?,
+                row.get::<_, Option<i64>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+                row.get::<_, Option<f64>>(4)?,
+            ))
+        })
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    for row in rows {
+        let (geometry, order, persistence, navigability, area) =
+            row.map_err(|source| Error::GeoPackage {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        let geometry = GpkgWkb(geometry).to_geo().map_err(|error| {
+            Error::Validation(format!(
+                "{} table {table} has invalid GeoPackage geometry: {error}",
+                path.display()
+            ))
+        })?;
+        if bounds.is_some_and(|bounds| !geometry_overlaps_bounds(&geometry, bounds)) {
+            continue;
+        }
+        if persistence == Some(4) {
+            continue;
+        }
+        let area_square_meters = area
+            .filter(|value| value.is_finite() && *value >= 0.0)
+            .unwrap_or_else(|| geometry_area_hint(&geometry));
+        output.push(WaterFeature {
+            kind,
+            geometry,
+            order: StrahlerOrder::new(
+                order
+                    .and_then(|value| u8::try_from(value).ok())
+                    .filter(|value| (1..=StrahlerOrder::MAX).contains(value))
+                    .unwrap_or(1),
+            )
+            .expect("value is normalized"),
+            persistence: match persistence {
+                Some(2) => FlowPersistence::Intermittent,
+                Some(3) => FlowPersistence::Ephemeral,
+                _ => FlowPersistence::Perennial,
+            },
+            navigable: matches!(navigability, Some(1 | 3 | 4)),
+            area_square_meters,
+        });
+    }
+    Ok(())
+}
+
+fn table_columns(connection: &Connection, path: &Path, table: &str) -> Result<Vec<String>> {
+    let mut statement = connection
+        .prepare(&format!("PRAGMA table_info({})", quote_identifier(table)))
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    statement
+        .query_map([], |row| row.get(1))
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn geometry_overlaps_bounds(geometry: &Geometry<f64>, bounds: Bounds) -> bool {
+    geometry.bounding_rect().is_some_and(|rect| {
+        rect.max().x >= bounds.min_x
+            && rect.min().x <= bounds.max_x
+            && rect.max().y >= bounds.min_y
+            && rect.min().y <= bounds.max_y
+    })
+}
+
+fn geometry_area_hint(geometry: &Geometry<f64>) -> f64 {
+    geometry
+        .bounding_rect()
+        .map_or(0.0, |rect| rect.width() * rect.height())
+}
+
+fn geometry_contains(geometry: &Geometry<f64>, point: Point<f64>) -> bool {
+    match geometry {
+        Geometry::Polygon(polygon) => polygon.contains(&point),
+        Geometry::MultiPolygon(polygons) => polygons.contains(&point),
+        Geometry::GeometryCollection(collection) => {
+            collection.iter().any(|item| geometry_contains(item, point))
+        }
+        _ => false,
+    }
+}
+
+fn geometry_distance(point: Point<f64>, geometry: &Geometry<f64>) -> Option<f64> {
+    if geometry_contains(geometry, point) {
+        return Some(0.0);
+    }
+    match geometry {
+        Geometry::Line(line) => Some(point_segment_distance(point.0, *line)),
+        Geometry::LineString(line) => line_distance(point.0, line),
+        Geometry::MultiLineString(lines) => lines
+            .iter()
+            .filter_map(|line| line_distance(point.0, line))
+            .min_by(f64::total_cmp),
+        Geometry::Polygon(polygon) => line_distance(point.0, polygon.exterior()),
+        Geometry::MultiPolygon(polygons) => polygons
+            .iter()
+            .filter_map(|polygon| line_distance(point.0, polygon.exterior()))
+            .min_by(f64::total_cmp),
+        Geometry::Point(other) => {
+            Some(((point.x() - other.x()).powi(2) + (point.y() - other.y()).powi(2)).sqrt())
+        }
+        Geometry::GeometryCollection(collection) => collection
+            .iter()
+            .filter_map(|item| geometry_distance(point, item))
+            .min_by(f64::total_cmp),
+        _ => None,
+    }
+}
+
+fn line_distance(point: Coord<f64>, line: &LineString<f64>) -> Option<f64> {
+    line.lines()
+        .map(|segment| point_segment_distance(point, segment))
+        .min_by(f64::total_cmp)
+}
+
+fn point_segment_distance(point: Coord<f64>, segment: Line<f64>) -> f64 {
+    let dx = segment.end.x - segment.start.x;
+    let dy = segment.end.y - segment.start.y;
+    if dx == 0.0 && dy == 0.0 {
+        return ((point.x - segment.start.x).powi(2) + (point.y - segment.start.y).powi(2)).sqrt();
+    }
+    let t = (((point.x - segment.start.x) * dx + (point.y - segment.start.y) * dy)
+        / (dx * dx + dy * dy))
+        .clamp(0.0, 1.0);
+    ((point.x - (segment.start.x + t * dx)).powi(2)
+        + (point.y - (segment.start.y + t * dy)).powi(2))
+    .sqrt()
+}
+
+fn geometry_line_intersections(route: Line<f64>, geometry: &Geometry<f64>) -> Vec<u16> {
+    let mut output = Vec::new();
+    match geometry {
+        Geometry::Line(line) => push_intersection(route, *line, &mut output),
+        Geometry::LineString(line) => {
+            for segment in line.lines() {
+                push_intersection(route, segment, &mut output);
+            }
+        }
+        Geometry::MultiLineString(lines) => {
+            for line in lines {
+                for segment in line.lines() {
+                    push_intersection(route, segment, &mut output);
+                }
+            }
+        }
+        Geometry::GeometryCollection(collection) => {
+            for item in collection {
+                output.extend(geometry_line_intersections(route, item));
+            }
+        }
+        _ => {}
+    }
+    output
+}
+
+fn push_intersection(route: Line<f64>, water: Line<f64>, output: &mut Vec<u16>) {
+    use geo::line_intersection::{LineIntersection, line_intersection};
+    if let Some(intersection) = line_intersection(route, water) {
+        let point = match intersection {
+            LineIntersection::SinglePoint { intersection, .. } => intersection,
+            LineIntersection::Collinear { intersection } => intersection.start,
+        };
+        let dx = route.end.x - route.start.x;
+        let dy = route.end.y - route.start.y;
+        let denominator = dx * dx + dy * dy;
+        if denominator > 0.0 {
+            let progress =
+                ((point.x - route.start.x) * dx + (point.y - route.start.y) * dy) / denominator;
+            output.push((progress.clamp(0.0, 1.0) * 1_000.0).round() as u16);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use rusqlite::params;
+
+    use super::*;
+
+    #[test]
+    fn canal_access_cannot_exist_without_river_access() {
+        let access = FlowingWaterAccess::RiverAndCanal(RiverAndCanalAccess {
+            river: RiverAccess {
+                distance: WaterDistanceMeters::new(100).unwrap(),
+                order: StrahlerOrder::new(3).unwrap(),
+                persistence: FlowPersistence::Perennial,
+            },
+            canal_distance: WaterDistanceMeters::new(50).unwrap(),
+            canal_navigable: true,
+        });
+        assert!(matches!(access, FlowingWaterAccess::RiverAndCanal(_)));
+    }
+
+    #[test]
+    fn line_intersection_records_progress() {
+        let route = Line::new(Coord { x: 0.0, y: 0.0 }, Coord { x: 100.0, y: 0.0 });
+        let water = Geometry::Line(Line::new(
+            Coord { x: 25.0, y: -10.0 },
+            Coord { x: 25.0, y: 10.0 },
+        ));
+        assert_eq!(geometry_line_intersections(route, &water), vec![250]);
+    }
+
+    #[test]
+    fn bridge_evidence_supplies_missing_source_crossing() {
+        let mut crossings = Vec::new();
+        add_unmapped_bridges(&mut crossings, Some(EdgeEndpoint::Both));
+        assert_eq!(crossings.len(), 2);
+        assert!(
+            crossings
+                .iter()
+                .all(|crossing| crossing.traversal == CrossingTraversal::Bridge)
+        );
+    }
+
+    #[test]
+    fn geopackage_fixture_parses_adjacency_and_crossings() {
+        let fixture = Fixture::new();
+        let database = HydrologyDatabase::open(&fixture.directory, None).unwrap();
+        assert_eq!(database.files_read, 1);
+        assert_eq!(database.features.len(), 4);
+
+        let hydrology = database.sample_settlement(Point::new(50.0, 0.0)).unwrap();
+        let FlowingWaterAccess::RiverAndCanal(access) = hydrology.flowing.unwrap() else {
+            panic!("expected combined river and canal access");
+        };
+        assert_eq!(access.river.order.get(), 3);
+        assert_eq!(access.river.persistence, FlowPersistence::Intermittent);
+        assert!(access.canal_navigable);
+        assert!(hydrology.has_freshwater());
+        assert!(!hydrology.has_saltwater());
+
+        let (route, count, inferred) = database
+            .enrich_route(
+                TravelRouteDraft::Land { bridge: None },
+                Point::new(-100.0, 0.0),
+                Point::new(200.0, 0.0),
+            )
+            .unwrap();
+        let TravelRoute::Land(route) = route else {
+            panic!("expected land route")
+        };
+        assert_eq!(count, 2);
+        assert_eq!(route.water_crossings.len(), 2);
+        assert!(!inferred);
+    }
+
+    #[test]
+    fn raw_unknown_sentinels_are_resolved_at_source_boundary() {
+        let fixture = Fixture::new();
+        let connection = Connection::open(&fixture.path).unwrap();
+        connection
+            .execute(
+                "INSERT INTO River_Net_l VALUES (2, ?1, -9999, -9999, NULL, NULL)",
+                params![line_geopackage_geometry(300.0)],
+            )
+            .unwrap();
+        drop(connection);
+        let database = HydrologyDatabase::open(&fixture.directory, None).unwrap();
+        let feature = database
+            .features
+            .iter()
+            .find(|feature| {
+                geometry_distance(Point::new(300.0, 0.0), &feature.geometry) == Some(0.0)
+            })
+            .unwrap();
+        assert_eq!(feature.order.get(), 1);
+        assert_eq!(feature.persistence, FlowPersistence::Perennial);
+    }
+
+    #[test]
+    #[ignore = "requires extracted official EU-Hydro basin GeoPackages in EU_HYDRO_DIR"]
+    fn reads_downloaded_eu_hydro_distribution() {
+        let directory = std::env::var_os("EU_HYDRO_DIR").expect("set EU_HYDRO_DIR");
+        let database = HydrologyDatabase::open(Path::new(&directory), None).unwrap();
+        assert!(database.files_read > 0);
+        assert!(
+            database
+                .features
+                .iter()
+                .any(|feature| feature.kind == FeatureKind::River)
+        );
+        assert!(!database.spatial_grid.is_empty());
+    }
+
+    struct Fixture {
+        directory: PathBuf,
+        path: PathBuf,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let directory = std::env::temp_dir().join(format!(
+                "adventuresim-eu-hydro-{}-{nonce}",
+                std::process::id()
+            ));
+            fs::create_dir(&directory).unwrap();
+            let path = directory.join("fixture.gpkg");
+            let connection = Connection::open(&path).unwrap();
+            connection
+                .pragma_update(None, "application_id", 0x4750_4b47_i64)
+                .unwrap();
+            connection.execute_batch(
+                "CREATE TABLE gpkg_geometry_columns (table_name TEXT, column_name TEXT, geometry_type_name TEXT, srs_id INTEGER, z INTEGER, m INTEGER);
+                 CREATE TABLE River_Net_l (fid INTEGER PRIMARY KEY, geom BLOB, STRAHLER INTEGER, HYP INTEGER, NVS INTEGER, AREA_GEO REAL);
+                 CREATE TABLE Canals_l (fid INTEGER PRIMARY KEY, geom BLOB, STRAHLER INTEGER, HYP INTEGER, NVS INTEGER, AREA_GEO REAL);
+                 CREATE TABLE InlandWater (fid INTEGER PRIMARY KEY, geom BLOB, STRAHLER INTEGER, HYP INTEGER, NVS INTEGER, AREA_GEO REAL);
+                 CREATE TABLE Coastal_p (fid INTEGER PRIMARY KEY, geom BLOB, STRAHLER INTEGER, HYP INTEGER, NVS INTEGER, AREA_GEO REAL);
+                 INSERT INTO gpkg_geometry_columns VALUES ('River_Net_l', 'geom', 'LINESTRING', 3035, 0, 0);
+                 INSERT INTO gpkg_geometry_columns VALUES ('Canals_l', 'geom', 'LINESTRING', 3035, 0, 0);
+                 INSERT INTO gpkg_geometry_columns VALUES ('InlandWater', 'geom', 'POLYGON', 3035, 0, 0);
+                 INSERT INTO gpkg_geometry_columns VALUES ('Coastal_p', 'geom', 'POLYGON', 3035, 0, 0);"
+            ).unwrap();
+            connection
+                .execute(
+                    "INSERT INTO River_Net_l VALUES (1, ?1, 3, 2, 5, NULL)",
+                    params![line_geopackage_geometry(0.0)],
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO Canals_l VALUES (1, ?1, 2, 1, 1, NULL)",
+                    params![line_geopackage_geometry(100.0)],
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO InlandWater VALUES (1, ?1, NULL, NULL, NULL, 2000000.0)",
+                    params![square_geopackage_geometry(500.0, 0.0, 100.0)],
+                )
+                .unwrap();
+            connection
+                .execute(
+                    "INSERT INTO Coastal_p VALUES (1, ?1, NULL, NULL, NULL, 2000000.0)",
+                    params![square_geopackage_geometry(5000.0, 0.0, 100.0)],
+                )
+                .unwrap();
+            drop(connection);
+            Self { directory, path }
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.directory);
+        }
+    }
+
+    fn line_geopackage_geometry(x: f64) -> Vec<u8> {
+        let mut bytes = gpkg_header(x, x, -1000.0, 1000.0);
+        bytes.push(1);
+        bytes.extend_from_slice(&2_u32.to_le_bytes());
+        bytes.extend_from_slice(&2_u32.to_le_bytes());
+        for (x, y) in [(x, -1000.0_f64), (x, 1000.0)] {
+            bytes.extend_from_slice(&x.to_le_bytes());
+            bytes.extend_from_slice(&y.to_le_bytes());
+        }
+        bytes
+    }
+
+    fn square_geopackage_geometry(x: f64, y: f64, radius: f64) -> Vec<u8> {
+        let mut bytes = gpkg_header(x - radius, x + radius, y - radius, y + radius);
+        bytes.push(1);
+        bytes.extend_from_slice(&3_u32.to_le_bytes());
+        bytes.extend_from_slice(&1_u32.to_le_bytes());
+        bytes.extend_from_slice(&5_u32.to_le_bytes());
+        for (x, y) in [
+            (x - radius, y - radius),
+            (x + radius, y - radius),
+            (x + radius, y + radius),
+            (x - radius, y + radius),
+            (x - radius, y - radius),
+        ] {
+            bytes.extend_from_slice(&x.to_le_bytes());
+            bytes.extend_from_slice(&y.to_le_bytes());
+        }
+        bytes
+    }
+
+    fn gpkg_header(min_x: f64, max_x: f64, min_y: f64, max_y: f64) -> Vec<u8> {
+        let mut bytes = b"GP\0\x03".to_vec();
+        bytes.extend_from_slice(&(EXPECTED_SRS as i32).to_le_bytes());
+        for coordinate in [min_x, max_x, min_y, max_y] {
+            bytes.extend_from_slice(&coordinate.to_le_bytes());
+        }
+        bytes
+    }
+}

--- a/crates/adventuresim-world-import/src/sources/hydrology.rs
+++ b/crates/adventuresim-world-import/src/sources/hydrology.rs
@@ -21,7 +21,7 @@ use adventuresim_world_schema::{
 use geo::{BoundingRect, Contains, Coord, Geometry, Line, LineString, Point};
 use geozero::{ToGeo, wkb::GpkgWkb};
 use proj4rs::{proj::Proj, transform::transform};
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, OpenFlags, params};
 
 use crate::{
     Error, Result,
@@ -35,7 +35,8 @@ const SOURCE_LICENSE: &str = "Copernicus Land Monitoring Service full and open d
 const EXPECTED_SRS: i64 = 3035;
 const SETTLEMENT_ADJACENCY_METERS: f64 = 2_000.0;
 const SOURCE_MARGIN_METERS: f64 = 10_000.0;
-const CROSSING_DEDUP_PERMILLE: u16 = 5;
+const CROSSING_DEDUP_METERS: f64 = 5.0;
+const ENDPOINT_TOUCH_METERS: f64 = 5.0;
 const INDEX_CELL_METERS: f64 = 10_000.0;
 
 pub(crate) fn enrich(
@@ -51,7 +52,7 @@ pub(crate) fn enrich(
     let bounds = world_bounds(projected_nodes.values().copied());
     let database = HydrologyDatabase::open(source_directory, bounds)?;
 
-    let mut settlement_fallbacks = 0;
+    let mut landlocked_settlements = 0;
     let hydrology = draft
         .settlements
         .iter()
@@ -59,7 +60,7 @@ pub(crate) fn enrich(
             let base = base_settlement(settlement);
             let point = projected_nodes[&base.source_node_id];
             let value = database.sample_settlement(point)?;
-            settlement_fallbacks += usize::from(value == SettlementHydrology::default());
+            landlocked_settlements += usize::from(value == SettlementHydrology::default());
             Ok(value)
         })
         .collect::<Result<Vec<_>>>()?;
@@ -92,7 +93,7 @@ pub(crate) fn enrich(
     draft.report.hydrology_files_read = database.files_read;
     draft.report.hydrology_features_read = database.features.len();
     draft.report.hydrology_settlement_samples = settlements.len();
-    draft.report.hydrology_settlement_fallback_samples = settlement_fallbacks;
+    draft.report.hydrology_landlocked_settlements = landlocked_settlements;
     draft.report.hydrology_edge_crossings = crossings;
     draft.report.hydrology_inferred_ferry_waterways = inferred_ferries;
     draft.report.route_crossings = edges
@@ -365,15 +366,25 @@ impl HydrologyDatabase {
         let line = Line::new(from.0, to.0);
         match route {
             TravelRouteDraft::Land { bridge } => {
-                let mut crossings = self.line_crossings(line);
+                let route_length = line_length(line);
+                let mut crossings = self
+                    .line_crossings(line)
+                    .into_iter()
+                    .filter(|crossing| {
+                        (crossing.distance_from_start > ENDPOINT_TOUCH_METERS
+                            || matches!(bridge, Some(EdgeEndpoint::From | EdgeEndpoint::Both)))
+                            && (crossing.distance_to_end > ENDPOINT_TOUCH_METERS
+                                || matches!(bridge, Some(EdgeEndpoint::To | EdgeEndpoint::Both)))
+                    })
+                    .collect::<Vec<_>>();
                 apply_bridge_evidence(&mut crossings, bridge);
-                add_unmapped_bridges(&mut crossings, bridge);
-                crossings.sort_by_key(|crossing| crossing.position);
-                crossings.dedup_by(|left, right| {
-                    left.position.get().abs_diff(right.position.get()) <= CROSSING_DEDUP_PERMILLE
-                        && left.watercourse == right.watercourse
-                });
+                add_unmapped_bridges(&mut crossings, bridge, route_length);
+                sort_and_deduplicate_crossings(&mut crossings);
                 let count = crossings.len();
+                let crossings = crossings
+                    .into_iter()
+                    .map(|crossing| crossing.crossing)
+                    .collect();
                 Ok((
                     TravelRoute::Land(LandRoute {
                         bridge,
@@ -387,7 +398,7 @@ impl HydrologyDatabase {
                 let midpoint = Point::new((from.x() + to.x()) / 2.0, (from.y() + to.y()) / 2.0);
                 let crossing = self.line_crossings(line).into_iter().next();
                 let waterway = crossing
-                    .map(|crossing| ferry_from_crossing(crossing.watercourse))
+                    .map(|crossing| ferry_from_crossing(crossing.crossing.watercourse))
                     .or_else(|| self.ferry_polygon(midpoint));
                 let inferred = waterway.is_none();
                 let waterway = waterway.unwrap_or(FerryWaterway::River(RiverWatercourse {
@@ -399,7 +410,7 @@ impl HydrologyDatabase {
         }
     }
 
-    fn line_crossings(&self, route: Line<f64>) -> Vec<LandWaterCrossing> {
+    fn line_crossings(&self, route: Line<f64>) -> Vec<LocatedCrossing> {
         let bounds = Bounds {
             min_x: route.start.x.min(route.end.x),
             min_y: route.start.y.min(route.end.y),
@@ -418,11 +429,20 @@ impl HydrologyDatabase {
             .flat_map(|feature| {
                 geometry_line_intersections(route, &feature.geometry)
                     .into_iter()
-                    .map(move |position| LandWaterCrossing {
-                        position: EdgeProgressPermille::new(position)
-                            .expect("intersection is clamped"),
-                        watercourse: feature_crossing(feature),
-                        traversal: plausible_traversal(feature),
+                    .map(move |progress| {
+                        let length = line_length(route);
+                        LocatedCrossing {
+                            crossing: LandWaterCrossing {
+                                position: EdgeProgressPermille::new(
+                                    (progress * EdgeProgressPermille::MAX as f64).round() as u16,
+                                )
+                                .expect("intersection is clamped"),
+                                watercourse: feature_crossing(feature),
+                                traversal: plausible_traversal(feature),
+                            },
+                            distance_from_start: progress * length,
+                            distance_to_end: (1.0 - progress) * length,
+                        }
                     })
             })
             .collect()
@@ -468,6 +488,16 @@ impl HydrologyDatabase {
             .map(|index| &self.features[index])
             .collect()
     }
+}
+
+struct LocatedCrossing {
+    crossing: LandWaterCrossing,
+    distance_from_start: f64,
+    distance_to_end: f64,
+}
+
+fn line_length(line: Line<f64>) -> f64 {
+    ((line.end.x - line.start.x).powi(2) + (line.end.y - line.start.y).powi(2)).sqrt()
 }
 
 fn build_spatial_grid(features: &[WaterFeature]) -> HashMap<(i32, i32), Vec<usize>> {
@@ -542,47 +572,67 @@ fn ferry_from_crossing(crossing: CrossingWatercourse) -> FerryWaterway {
     }
 }
 
-fn apply_bridge_evidence(crossings: &mut [LandWaterCrossing], bridge: Option<EdgeEndpoint>) {
+fn apply_bridge_evidence(crossings: &mut [LocatedCrossing], bridge: Option<EdgeEndpoint>) {
     for crossing in crossings {
-        let position = crossing.position.get();
-        if matches!(bridge, Some(EdgeEndpoint::From | EdgeEndpoint::Both)) && position <= 100
-            || matches!(bridge, Some(EdgeEndpoint::To | EdgeEndpoint::Both)) && position >= 900
+        if matches!(bridge, Some(EdgeEndpoint::From | EdgeEndpoint::Both))
+            && crossing.distance_from_start <= ENDPOINT_TOUCH_METERS
+            || matches!(bridge, Some(EdgeEndpoint::To | EdgeEndpoint::Both))
+                && crossing.distance_to_end <= ENDPOINT_TOUCH_METERS
         {
-            crossing.traversal = CrossingTraversal::Bridge;
+            crossing.crossing.traversal = CrossingTraversal::Bridge;
         }
     }
 }
 
-fn add_unmapped_bridges(crossings: &mut Vec<LandWaterCrossing>, bridge: Option<EdgeEndpoint>) {
-    let mut push = |position: u16| {
+fn add_unmapped_bridges(
+    crossings: &mut Vec<LocatedCrossing>,
+    bridge: Option<EdgeEndpoint>,
+    route_length: f64,
+) {
+    let mut push = |position: u16, distance_from_start: f64, distance_to_end: f64| {
         let endpoint_is_mapped = crossings.iter().any(|crossing| {
             if position == 0 {
-                crossing.position.get() <= 100
+                crossing.distance_from_start <= ENDPOINT_TOUCH_METERS
             } else {
-                crossing.position.get() >= 900
+                crossing.distance_to_end <= ENDPOINT_TOUCH_METERS
             }
         });
         if endpoint_is_mapped {
             return;
         }
-        crossings.push(LandWaterCrossing {
-            position: EdgeProgressPermille::new(position).expect("constant is valid"),
-            watercourse: CrossingWatercourse::River(RiverWatercourse {
-                order: StrahlerOrder::new(2).expect("constant is valid"),
-                persistence: FlowPersistence::Perennial,
-            }),
-            traversal: CrossingTraversal::Bridge,
+        crossings.push(LocatedCrossing {
+            crossing: LandWaterCrossing {
+                position: EdgeProgressPermille::new(position).expect("constant is valid"),
+                watercourse: CrossingWatercourse::River(RiverWatercourse {
+                    order: StrahlerOrder::new(2).expect("constant is valid"),
+                    persistence: FlowPersistence::Perennial,
+                }),
+                traversal: CrossingTraversal::Bridge,
+            },
+            distance_from_start,
+            distance_to_end,
         });
     };
     match bridge {
-        Some(EdgeEndpoint::From) => push(0),
-        Some(EdgeEndpoint::To) => push(1_000),
+        Some(EdgeEndpoint::From) => push(0, 0.0, route_length),
+        Some(EdgeEndpoint::To) => push(1_000, route_length, 0.0),
         Some(EdgeEndpoint::Both) => {
-            push(0);
-            push(1_000);
+            push(0, 0.0, route_length);
+            push(1_000, route_length, 0.0);
         }
         None => {}
     }
+}
+
+fn sort_and_deduplicate_crossings(crossings: &mut Vec<LocatedCrossing>) {
+    crossings.sort_by(|left, right| {
+        left.distance_from_start
+            .total_cmp(&right.distance_from_start)
+    });
+    crossings.dedup_by(|left, right| {
+        (left.distance_from_start - right.distance_from_start).abs() <= CROSSING_DEDUP_METERS
+            && left.crossing.watercourse == right.crossing.watercourse
+    });
 }
 
 fn collect_geopackages(directory: &Path, output: &mut Vec<PathBuf>) -> Result<()> {
@@ -624,6 +674,19 @@ fn read_geopackage(
             path.display()
         )));
     }
+    let (organization, organization_srs): (String, i64) = connection
+        .query_row(
+            "SELECT organization, organization_coordsys_id FROM gpkg_spatial_ref_sys WHERE srs_id = ?1",
+            params![EXPECTED_SRS],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .map_err(|source| Error::GeoPackage { path: path.to_path_buf(), source })?;
+    if !organization.eq_ignore_ascii_case("EPSG") || organization_srs != EXPECTED_SRS {
+        return Err(Error::Validation(format!(
+            "{} does not bind GeoPackage SRS {EXPECTED_SRS} to EPSG:{EXPECTED_SRS}",
+            path.display()
+        )));
+    }
     let mut tables = connection
         .prepare(
             "SELECT table_name, column_name, geometry_type_name, srs_id FROM gpkg_geometry_columns",
@@ -654,17 +717,29 @@ fn read_geopackage(
         let Some(kind) = feature_kind(&table) else {
             continue;
         };
+        let contents_srs: i64 = connection
+            .query_row(
+                "SELECT srs_id FROM gpkg_contents WHERE table_name = ?1 AND data_type = 'features'",
+                params![table],
+                |row| row.get(0),
+            )
+            .map_err(|source| Error::GeoPackage {
+                path: path.to_path_buf(),
+                source,
+            })?;
         if srs != EXPECTED_SRS {
             return Err(Error::Validation(format!(
                 "{} table {table} uses EPSG:{srs}; expected EPSG:{EXPECTED_SRS}",
                 path.display()
             )));
         }
-        let polygon = matches!(
-            kind,
-            FeatureKind::InlandWater | FeatureKind::Tidal | FeatureKind::Coastal
-        );
-        if polygon != geometry_type.to_ascii_uppercase().contains("POLYGON") {
+        if contents_srs != EXPECTED_SRS {
+            return Err(Error::Validation(format!(
+                "{} table {table} is registered in gpkg_contents with EPSG:{contents_srs}; expected EPSG:{EXPECTED_SRS}",
+                path.display()
+            )));
+        }
+        if !source_geometry_type_matches(kind, &geometry_type) {
             return Err(Error::Validation(format!(
                 "{} table {table} has incompatible geometry type {geometry_type}",
                 path.display()
@@ -704,30 +779,64 @@ fn read_feature_table(
     bounds: Option<Bounds>,
     output: &mut Vec<WaterFeature>,
 ) -> Result<()> {
-    let columns = table_columns(connection, path, table)?;
+    let layout = table_layout(connection, path, table)?;
     let value = |name: &str| {
-        if columns
+        if layout
+            .columns
             .iter()
             .any(|column| column.eq_ignore_ascii_case(name))
         {
-            quote_identifier(
-                columns
-                    .iter()
-                    .find(|column| column.eq_ignore_ascii_case(name))
-                    .unwrap(),
+            format!(
+                "f.{}",
+                quote_identifier(
+                    layout
+                        .columns
+                        .iter()
+                        .find(|column| column.eq_ignore_ascii_case(name))
+                        .unwrap(),
+                )
             )
         } else {
             "NULL".into()
         }
     };
+    let rtree = format!("rtree_{table}_{geometry_column}");
+    let use_rtree = bounds.is_some()
+        && layout.integer_primary_key.is_some()
+        && table_exists(connection, path, &rtree)?
+        && rtree_is_registered(connection, path, table, geometry_column)?;
+    if use_rtree {
+        require_complete_rtree(
+            connection,
+            path,
+            table,
+            geometry_column,
+            layout.integer_primary_key.as_ref().unwrap(),
+            &rtree,
+        )?;
+    }
+    let from = if use_rtree {
+        format!(
+            "{} AS f JOIN {} AS r ON r.id = f.{}",
+            quote_identifier(table),
+            quote_identifier(&rtree),
+            quote_identifier(layout.integer_primary_key.as_ref().unwrap())
+        )
+    } else {
+        format!("{} AS f", quote_identifier(table))
+    };
+    let where_clause = if use_rtree {
+        " WHERE r.maxx >= ?1 AND r.minx <= ?2 AND r.maxy >= ?3 AND r.miny <= ?4"
+    } else {
+        ""
+    };
     let sql = format!(
-        "SELECT {}, {}, {}, {}, {} FROM {}",
+        "SELECT f.{}, {}, {}, {}, {} FROM {from}{where_clause}",
         quote_identifier(geometry_column),
         value("STRAHLER"),
         value("HYP"),
         value("NVS"),
         value("AREA_GEO"),
-        quote_identifier(table)
     );
     let mut statement = connection
         .prepare(&sql)
@@ -735,23 +844,51 @@ fn read_feature_table(
             path: path.to_path_buf(),
             source,
         })?;
-    let rows = statement
-        .query_map([], |row| {
-            Ok((
-                row.get::<_, Vec<u8>>(0)?,
-                row.get::<_, Option<i64>>(1)?,
-                row.get::<_, Option<i64>>(2)?,
-                row.get::<_, Option<i64>>(3)?,
-                row.get::<_, Option<f64>>(4)?,
-            ))
-        })
-        .map_err(|source| Error::GeoPackage {
-            path: path.to_path_buf(),
-            source,
-        })?;
-    for row in rows {
-        let (geometry, order, persistence, navigability, area) =
-            row.map_err(|source| Error::GeoPackage {
+    let mut rows = if let Some(bounds) = bounds.filter(|_| use_rtree) {
+        statement.query(params![
+            bounds.min_x,
+            bounds.max_x,
+            bounds.min_y,
+            bounds.max_y
+        ])
+    } else {
+        statement.query([])
+    }
+    .map_err(|source| Error::GeoPackage {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    while let Some(row) = rows.next().map_err(|source| Error::GeoPackage {
+        path: path.to_path_buf(),
+        source,
+    })? {
+        let geometry = row
+            .get::<_, Vec<u8>>(0)
+            .map_err(|source| Error::GeoPackage {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        let order = row
+            .get::<_, Option<i64>>(1)
+            .map_err(|source| Error::GeoPackage {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        let persistence = row
+            .get::<_, Option<i64>>(2)
+            .map_err(|source| Error::GeoPackage {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        let navigability = row
+            .get::<_, Option<i64>>(3)
+            .map_err(|source| Error::GeoPackage {
+                path: path.to_path_buf(),
+                source,
+            })?;
+        let area = row
+            .get::<_, Option<f64>>(4)
+            .map_err(|source| Error::GeoPackage {
                 path: path.to_path_buf(),
                 source,
             })?;
@@ -761,6 +898,12 @@ fn read_feature_table(
                 path.display()
             ))
         })?;
+        if !decoded_geometry_matches(kind, &geometry) {
+            return Err(Error::Validation(format!(
+                "{} table {table} contains geometry incompatible with its feature class",
+                path.display()
+            )));
+        }
         if bounds.is_some_and(|bounds| !geometry_overlaps_bounds(&geometry, bounds)) {
             continue;
         }
@@ -792,15 +935,52 @@ fn read_feature_table(
     Ok(())
 }
 
-fn table_columns(connection: &Connection, path: &Path, table: &str) -> Result<Vec<String>> {
+fn source_geometry_type_matches(kind: FeatureKind, geometry_type: &str) -> bool {
+    let geometry_type = geometry_type.to_ascii_uppercase();
+    match kind {
+        FeatureKind::River | FeatureKind::Canal | FeatureKind::Ditch => {
+            matches!(geometry_type.as_str(), "LINESTRING" | "MULTILINESTRING")
+        }
+        FeatureKind::InlandWater | FeatureKind::Tidal | FeatureKind::Coastal => {
+            matches!(geometry_type.as_str(), "POLYGON" | "MULTIPOLYGON")
+        }
+    }
+}
+
+fn decoded_geometry_matches(kind: FeatureKind, geometry: &Geometry<f64>) -> bool {
+    match kind {
+        FeatureKind::River | FeatureKind::Canal | FeatureKind::Ditch => {
+            matches!(
+                geometry,
+                Geometry::LineString(_) | Geometry::MultiLineString(_)
+            )
+        }
+        FeatureKind::InlandWater | FeatureKind::Tidal | FeatureKind::Coastal => {
+            matches!(geometry, Geometry::Polygon(_) | Geometry::MultiPolygon(_))
+        }
+    }
+}
+
+struct TableLayout {
+    columns: Vec<String>,
+    integer_primary_key: Option<String>,
+}
+
+fn table_layout(connection: &Connection, path: &Path, table: &str) -> Result<TableLayout> {
     let mut statement = connection
         .prepare(&format!("PRAGMA table_info({})", quote_identifier(table)))
         .map_err(|source| Error::GeoPackage {
             path: path.to_path_buf(),
             source,
         })?;
-    statement
-        .query_map([], |row| row.get(1))
+    let columns = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(5)?,
+            ))
+        })
         .map_err(|source| Error::GeoPackage {
             path: path.to_path_buf(),
             source,
@@ -809,7 +989,79 @@ fn table_columns(connection: &Connection, path: &Path, table: &str) -> Result<Ve
         .map_err(|source| Error::GeoPackage {
             path: path.to_path_buf(),
             source,
+        })?;
+    let integer_primary_key = columns
+        .iter()
+        .find(|(_, data_type, primary_key)| {
+            *primary_key > 0 && data_type.to_ascii_uppercase().contains("INT")
         })
+        .map(|(name, _, _)| name.clone());
+    Ok(TableLayout {
+        columns: columns.into_iter().map(|(name, _, _)| name).collect(),
+        integer_primary_key,
+    })
+}
+
+fn table_exists(connection: &Connection, path: &Path, table: &str) -> Result<bool> {
+    connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?1)",
+            params![table],
+            |row| row.get(0),
+        )
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn rtree_is_registered(
+    connection: &Connection,
+    path: &Path,
+    table: &str,
+    geometry_column: &str,
+) -> Result<bool> {
+    connection
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM gpkg_extensions WHERE table_name = ?1 AND column_name = ?2 AND extension_name = 'gpkg_rtree_index')",
+            params![table, geometry_column],
+            |row| row.get(0),
+        )
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn require_complete_rtree(
+    connection: &Connection,
+    path: &Path,
+    table: &str,
+    geometry_column: &str,
+    primary_key: &str,
+    rtree: &str,
+) -> Result<()> {
+    let sql = format!(
+        "SELECT COUNT(*) FROM {} AS f LEFT JOIN {} AS r ON r.id = f.{} WHERE f.{} IS NOT NULL AND r.id IS NULL",
+        quote_identifier(table),
+        quote_identifier(rtree),
+        quote_identifier(primary_key),
+        quote_identifier(geometry_column),
+    );
+    let missing: i64 = connection
+        .query_row(&sql, [], |row| row.get(0))
+        .map_err(|source| Error::GeoPackage {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    if missing == 0 {
+        Ok(())
+    } else {
+        Err(Error::Validation(format!(
+            "{} table {table} has {missing} geometries missing from its GeoPackage RTree",
+            path.display()
+        )))
+    }
 }
 
 fn quote_identifier(identifier: &str) -> String {
@@ -889,7 +1141,7 @@ fn point_segment_distance(point: Coord<f64>, segment: Line<f64>) -> f64 {
     .sqrt()
 }
 
-fn geometry_line_intersections(route: Line<f64>, geometry: &Geometry<f64>) -> Vec<u16> {
+fn geometry_line_intersections(route: Line<f64>, geometry: &Geometry<f64>) -> Vec<f64> {
     let mut output = Vec::new();
     match geometry {
         Geometry::Line(line) => push_intersection(route, *line, &mut output),
@@ -915,7 +1167,7 @@ fn geometry_line_intersections(route: Line<f64>, geometry: &Geometry<f64>) -> Ve
     output
 }
 
-fn push_intersection(route: Line<f64>, water: Line<f64>, output: &mut Vec<u16>) {
+fn push_intersection(route: Line<f64>, water: Line<f64>, output: &mut Vec<f64>) {
     use geo::line_intersection::{LineIntersection, line_intersection};
     if let Some(intersection) = line_intersection(route, water) {
         let point = match intersection {
@@ -928,7 +1180,7 @@ fn push_intersection(route: Line<f64>, water: Line<f64>, output: &mut Vec<u16>) 
         if denominator > 0.0 {
             let progress =
                 ((point.x - route.start.x) * dx + (point.y - route.start.y) * dy) / denominator;
-            output.push((progress.clamp(0.0, 1.0) * 1_000.0).round() as u16);
+            output.push(progress.clamp(0.0, 1.0));
         }
     }
 }
@@ -962,19 +1214,131 @@ mod tests {
             Coord { x: 25.0, y: -10.0 },
             Coord { x: 25.0, y: 10.0 },
         ));
-        assert_eq!(geometry_line_intersections(route, &water), vec![250]);
+        assert_eq!(geometry_line_intersections(route, &water), vec![0.25]);
     }
 
     #[test]
     fn bridge_evidence_supplies_missing_source_crossing() {
         let mut crossings = Vec::new();
-        add_unmapped_bridges(&mut crossings, Some(EdgeEndpoint::Both));
+        add_unmapped_bridges(&mut crossings, Some(EdgeEndpoint::Both), 100.0);
         assert_eq!(crossings.len(), 2);
         assert!(
             crossings
                 .iter()
-                .all(|crossing| crossing.traversal == CrossingTraversal::Bridge)
+                .all(|crossing| { crossing.crossing.traversal == CrossingTraversal::Bridge })
         );
+    }
+
+    #[test]
+    fn touching_water_at_road_endpoint_is_not_a_crossing_without_bridge_evidence() {
+        let fixture = Fixture::new();
+        let database = HydrologyDatabase::open(&fixture.directory, None).unwrap();
+        let (route, count, _) = database
+            .enrich_route(
+                TravelRouteDraft::Land { bridge: None },
+                Point::new(0.0, 0.0),
+                Point::new(200.0, 0.0),
+            )
+            .unwrap();
+        let TravelRoute::Land(route) = route else {
+            panic!("expected land route")
+        };
+        assert_eq!(count, 1);
+        assert_eq!(route.water_crossings[0].position.get(), 500);
+        assert!(matches!(
+            route.water_crossings[0].watercourse,
+            CrossingWatercourse::Canal(_)
+        ));
+    }
+
+    #[test]
+    fn long_edges_keep_crossings_that_are_close_only_in_relative_terms() {
+        let watercourse = CrossingWatercourse::River(RiverWatercourse {
+            order: StrahlerOrder::new(3).unwrap(),
+            persistence: FlowPersistence::Perennial,
+        });
+        let mut crossings = [400.0, 500.0]
+            .into_iter()
+            .map(|distance_from_start| LocatedCrossing {
+                crossing: LandWaterCrossing {
+                    position: EdgeProgressPermille::new(
+                        (distance_from_start / 100_000.0 * 1_000.0) as u16,
+                    )
+                    .unwrap(),
+                    watercourse: watercourse.clone(),
+                    traversal: CrossingTraversal::Bridge,
+                },
+                distance_from_start,
+                distance_to_end: 100_000.0 - distance_from_start,
+            })
+            .collect::<Vec<_>>();
+
+        sort_and_deduplicate_crossings(&mut crossings);
+
+        assert_eq!(crossings.len(), 2);
+    }
+
+    #[test]
+    fn long_edge_endpoint_bridge_does_not_consume_a_distant_crossing() {
+        let fixture = Fixture::new();
+        let database = HydrologyDatabase::open(&fixture.directory, None).unwrap();
+        let (route, count, _) = database
+            .enrich_route(
+                TravelRouteDraft::Land {
+                    bridge: Some(EdgeEndpoint::From),
+                },
+                Point::new(-5_000.0, 0.0),
+                Point::new(95_000.0, 0.0),
+            )
+            .unwrap();
+        let TravelRoute::Land(route) = route else {
+            panic!("expected land route")
+        };
+        assert_eq!(count, 3);
+        assert_eq!(route.water_crossings[0].position.get(), 0);
+        assert!(matches!(
+            route.water_crossings[0].watercourse,
+            CrossingWatercourse::River(RiverWatercourse {
+                order,
+                persistence: FlowPersistence::Perennial,
+            }) if order.get() == 2
+        ));
+        assert!(matches!(
+            route.water_crossings[1].watercourse,
+            CrossingWatercourse::River(RiverWatercourse {
+                order,
+                persistence: FlowPersistence::Intermittent,
+            }) if order.get() == 3
+        ));
+    }
+
+    #[test]
+    fn endpoint_bridge_evidence_preserves_mapped_watercourse_attributes() {
+        let fixture = Fixture::new();
+        let database = HydrologyDatabase::open(&fixture.directory, None).unwrap();
+        let (route, count, _) = database
+            .enrich_route(
+                TravelRouteDraft::Land {
+                    bridge: Some(EdgeEndpoint::From),
+                },
+                Point::new(0.0, 0.0),
+                Point::new(200.0, 0.0),
+            )
+            .unwrap();
+        let TravelRoute::Land(route) = route else {
+            panic!("expected land route")
+        };
+        assert_eq!(count, 2);
+        let river = &route.water_crossings[0];
+        assert_eq!(river.position.get(), 0);
+        assert_eq!(river.traversal, CrossingTraversal::Bridge);
+        assert!(matches!(
+            river.watercourse,
+            CrossingWatercourse::River(RiverWatercourse {
+                order,
+                persistence: FlowPersistence::Intermittent,
+            }) if order.get() == 3
+        ));
     }
 
     #[test]
@@ -1033,6 +1397,89 @@ mod tests {
     }
 
     #[test]
+    fn geopackage_rtree_filters_before_geometry_decoding() {
+        let fixture = Fixture::new();
+        let connection = Connection::open(&fixture.path).unwrap();
+        connection
+            .execute(
+                "INSERT INTO Coastal_p VALUES (2, X'00', NULL, NULL, NULL, NULL)",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO rtree_Coastal_p_geom VALUES (2, 10000, 10001, 10000, 10001)",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+        let database = HydrologyDatabase::open(
+            &fixture.directory,
+            Some(Bounds {
+                min_x: -200.0,
+                min_y: -200.0,
+                max_x: 200.0,
+                max_y: 200.0,
+            }),
+        )
+        .unwrap();
+        assert_eq!(database.features.len(), 2);
+        assert!(
+            database
+                .features
+                .iter()
+                .all(|feature| matches!(feature.kind, FeatureKind::River | FeatureKind::Canal))
+        );
+    }
+
+    #[test]
+    fn registered_rtree_must_cover_every_geometry() {
+        let fixture = Fixture::new();
+        let connection = Connection::open(&fixture.path).unwrap();
+        connection
+            .execute("DELETE FROM rtree_River_Net_l_geom", [])
+            .unwrap();
+        drop(connection);
+        let error = HydrologyDatabase::open(
+            &fixture.directory,
+            Some(Bounds {
+                min_x: -200.0,
+                min_y: -200.0,
+                max_x: 200.0,
+                max_y: 200.0,
+            }),
+        )
+        .err()
+        .expect("incomplete registered RTree must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("missing from its GeoPackage RTree")
+        );
+    }
+
+    #[test]
+    fn line_feature_class_rejects_point_geometry_metadata() {
+        let fixture = Fixture::new();
+        let connection = Connection::open(&fixture.path).unwrap();
+        connection
+            .execute(
+                "UPDATE gpkg_geometry_columns SET geometry_type_name = 'POINT' WHERE table_name = 'River_Net_l'",
+                [],
+            )
+            .unwrap();
+        drop(connection);
+        let error = HydrologyDatabase::open(&fixture.directory, None)
+            .err()
+            .expect("point river geometry must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("incompatible geometry type POINT")
+        );
+    }
+
+    #[test]
     #[ignore = "requires extracted official EU-Hydro basin GeoPackages in EU_HYDRO_DIR"]
     fn reads_downloaded_eu_hydro_distribution() {
         let directory = std::env::var_os("EU_HYDRO_DIR").expect("set EU_HYDRO_DIR");
@@ -1068,21 +1515,50 @@ mod tests {
             connection
                 .pragma_update(None, "application_id", 0x4750_4b47_i64)
                 .unwrap();
+            connection
+                .pragma_update(None, "user_version", 10_300_i64)
+                .unwrap();
             connection.execute_batch(
-                "CREATE TABLE gpkg_geometry_columns (table_name TEXT, column_name TEXT, geometry_type_name TEXT, srs_id INTEGER, z INTEGER, m INTEGER);
+                r#"CREATE TABLE gpkg_spatial_ref_sys (srs_name TEXT NOT NULL, srs_id INTEGER NOT NULL PRIMARY KEY, organization TEXT NOT NULL, organization_coordsys_id INTEGER NOT NULL, definition TEXT NOT NULL, description TEXT);
+                 CREATE TABLE gpkg_contents (table_name TEXT NOT NULL PRIMARY KEY, data_type TEXT NOT NULL, identifier TEXT UNIQUE, description TEXT DEFAULT '', last_change TEXT NOT NULL DEFAULT '2026-01-01T00:00:00.000Z', min_x REAL, min_y REAL, max_x REAL, max_y REAL, srs_id INTEGER);
+                 CREATE TABLE gpkg_geometry_columns (table_name TEXT NOT NULL, column_name TEXT NOT NULL, geometry_type_name TEXT NOT NULL, srs_id INTEGER NOT NULL, z INTEGER NOT NULL, m INTEGER NOT NULL, PRIMARY KEY (table_name, column_name));
+                 CREATE TABLE gpkg_extensions (table_name TEXT, column_name TEXT, extension_name TEXT NOT NULL, definition TEXT NOT NULL, scope TEXT NOT NULL, UNIQUE (table_name, column_name, extension_name));
                  CREATE TABLE River_Net_l (fid INTEGER PRIMARY KEY, geom BLOB, STRAHLER INTEGER, HYP INTEGER, NVS INTEGER, AREA_GEO REAL);
                  CREATE TABLE Canals_l (fid INTEGER PRIMARY KEY, geom BLOB, STRAHLER INTEGER, HYP INTEGER, NVS INTEGER, AREA_GEO REAL);
                  CREATE TABLE InlandWater (fid INTEGER PRIMARY KEY, geom BLOB, STRAHLER INTEGER, HYP INTEGER, NVS INTEGER, AREA_GEO REAL);
                  CREATE TABLE Coastal_p (fid INTEGER PRIMARY KEY, geom BLOB, STRAHLER INTEGER, HYP INTEGER, NVS INTEGER, AREA_GEO REAL);
+                 CREATE VIRTUAL TABLE rtree_River_Net_l_geom USING rtree(id, minx, maxx, miny, maxy);
+                 CREATE VIRTUAL TABLE rtree_Canals_l_geom USING rtree(id, minx, maxx, miny, maxy);
+                 CREATE VIRTUAL TABLE rtree_InlandWater_geom USING rtree(id, minx, maxx, miny, maxy);
+                 CREATE VIRTUAL TABLE rtree_Coastal_p_geom USING rtree(id, minx, maxx, miny, maxy);
+                 INSERT INTO gpkg_spatial_ref_sys VALUES ('Undefined Cartesian', -1, 'NONE', -1, 'undefined', 'undefined Cartesian coordinate reference system');
+                 INSERT INTO gpkg_spatial_ref_sys VALUES ('Undefined Geographic', 0, 'NONE', 0, 'undefined', 'undefined geographic coordinate reference system');
+                 INSERT INTO gpkg_spatial_ref_sys VALUES ('ETRS89 / LAEA Europe', 3035, 'EPSG', 3035, 'PROJCS["ETRS89 / LAEA Europe",GEOGCS["ETRS89",DATUM["European_Terrestrial_Reference_System_1989",SPHEROID["GRS 1980",6378137,298.257222101]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],PROJECTION["Lambert_Azimuthal_Equal_Area"],PARAMETER["latitude_of_center",52],PARAMETER["longitude_of_center",10],PARAMETER["false_easting",4321000],PARAMETER["false_northing",3210000],UNIT["metre",1],AXIS["Northing",NORTH],AXIS["Easting",EAST],AUTHORITY["EPSG","3035"]]', 'EPSG:3035 fixture');
+                 INSERT INTO gpkg_contents (table_name, data_type, identifier, min_x, min_y, max_x, max_y, srs_id) VALUES ('River_Net_l', 'features', 'River_Net_l', -1, -1000, 1, 1000, 3035);
+                 INSERT INTO gpkg_contents (table_name, data_type, identifier, min_x, min_y, max_x, max_y, srs_id) VALUES ('Canals_l', 'features', 'Canals_l', 99, -1000, 101, 1000, 3035);
+                 INSERT INTO gpkg_contents (table_name, data_type, identifier, min_x, min_y, max_x, max_y, srs_id) VALUES ('InlandWater', 'features', 'InlandWater', 400, -100, 600, 100, 3035);
+                 INSERT INTO gpkg_contents (table_name, data_type, identifier, min_x, min_y, max_x, max_y, srs_id) VALUES ('Coastal_p', 'features', 'Coastal_p', 4900, -100, 5100, 100, 3035);
                  INSERT INTO gpkg_geometry_columns VALUES ('River_Net_l', 'geom', 'LINESTRING', 3035, 0, 0);
                  INSERT INTO gpkg_geometry_columns VALUES ('Canals_l', 'geom', 'LINESTRING', 3035, 0, 0);
                  INSERT INTO gpkg_geometry_columns VALUES ('InlandWater', 'geom', 'POLYGON', 3035, 0, 0);
-                 INSERT INTO gpkg_geometry_columns VALUES ('Coastal_p', 'geom', 'POLYGON', 3035, 0, 0);"
+                 INSERT INTO gpkg_geometry_columns VALUES ('Coastal_p', 'geom', 'POLYGON', 3035, 0, 0);
+                 INSERT INTO gpkg_extensions VALUES ('River_Net_l', 'geom', 'gpkg_rtree_index', 'http://www.geopackage.org/spec/#extension_rtree', 'write-only');
+                 INSERT INTO gpkg_extensions VALUES ('Canals_l', 'geom', 'gpkg_rtree_index', 'http://www.geopackage.org/spec/#extension_rtree', 'write-only');
+                 INSERT INTO gpkg_extensions VALUES ('InlandWater', 'geom', 'gpkg_rtree_index', 'http://www.geopackage.org/spec/#extension_rtree', 'write-only');
+                 INSERT INTO gpkg_extensions VALUES ('Coastal_p', 'geom', 'gpkg_rtree_index', 'http://www.geopackage.org/spec/#extension_rtree', 'write-only');"#
             ).unwrap();
             connection
                 .execute(
                     "INSERT INTO River_Net_l VALUES (1, ?1, 3, 2, 5, NULL)",
                     params![line_geopackage_geometry(0.0)],
+                )
+                .unwrap();
+            connection
+                .execute_batch(
+                    "INSERT INTO rtree_River_Net_l_geom VALUES (1, 0, 0, -1000, 1000);
+                     INSERT INTO rtree_Canals_l_geom VALUES (1, 100, 100, -1000, 1000);
+                     INSERT INTO rtree_InlandWater_geom VALUES (1, 400, 600, -100, 100);
+                     INSERT INTO rtree_Coastal_p_geom VALUES (1, 4900, 5100, -100, 100);",
                 )
                 .unwrap();
             connection

--- a/crates/adventuresim-world-import/src/sources/mod.rs
+++ b/crates/adventuresim-world-import/src/sources/mod.rs
@@ -5,6 +5,7 @@ pub mod drought;
 pub mod elevation;
 pub mod forest_cover;
 pub mod geology;
+pub mod hydrology;
 pub mod land_use;
 pub mod potential_vegetation;
 pub mod religion;

--- a/crates/adventuresim-world-import/src/sources/viabundus.rs
+++ b/crates/adventuresim-world-import/src/sources/viabundus.rs
@@ -311,7 +311,7 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
             hydrology_files_read: 0,
             hydrology_features_read: 0,
             hydrology_settlement_samples: 0,
-            hydrology_settlement_fallback_samples: 0,
+            hydrology_landlocked_settlements: 0,
             hydrology_edge_crossings: 0,
             hydrology_inferred_ferry_waterways: 0,
             excluded_edges,

--- a/crates/adventuresim-world-import/src/sources/viabundus.rs
+++ b/crates/adventuresim-world-import/src/sources/viabundus.rs
@@ -4,14 +4,13 @@ use std::{
 };
 
 use adventuresim_world_schema::{
-    EdgeEndpoint, SourceProvenance, TravelEdgeImport, TravelEdgeKind, TravelRoute,
-    WorldBuildReport, WorldNodeImport,
+    EdgeEndpoint, SourceProvenance, TravelEdgeKind, WorldBuildReport, WorldNodeImport,
 };
 use serde::{Deserialize, Deserializer, de};
 
 use crate::{
     Error, Result,
-    draft::{SettlementDraft, WorldDraft},
+    draft::{SettlementDraft, TravelEdgeDraft, TravelRouteDraft, WorldDraft},
 };
 
 const SOURCE_NAME: &str = "Viabundus Pre-modern Street Map 2";
@@ -172,15 +171,15 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
         let from_node = &nodes_by_id[&from_node_id];
         let to_node = &nodes_by_id[&to_node_id];
         let route = match kind {
-            TravelEdgeKind::Ferry => TravelRoute::Ferry,
-            TravelEdgeKind::Land => TravelRoute::Land {
+            TravelEdgeKind::Ferry => TravelRouteDraft::Ferry,
+            TravelEdgeKind::Land => TravelRouteDraft::Land {
                 bridge: endpoints(
                     from_node.bridge.active_in(year),
                     to_node.bridge.active_in(year),
                 ),
             },
         };
-        edges.push(TravelEdgeImport {
+        edges.push(TravelEdgeDraft {
             id: required_number(&edges_path, "id", &raw.id)?,
             from_node_id,
             to_node_id,
@@ -309,6 +308,12 @@ pub(crate) fn compile(directory: &Path, year: i32) -> Result<WorldDraft<Settleme
             drought_samples: 0,
             drought_neighbor_samples: 0,
             drought_fallback_samples: 0,
+            hydrology_files_read: 0,
+            hydrology_features_read: 0,
+            hydrology_settlement_samples: 0,
+            hydrology_settlement_fallback_samples: 0,
+            hydrology_edge_crossings: 0,
+            hydrology_inferred_ferry_waterways: 0,
             excluded_edges,
         },
         nodes,

--- a/crates/adventuresim-world-import/src/validation.rs
+++ b/crates/adventuresim-world-import/src/validation.rs
@@ -70,17 +70,16 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
                 edge.id
             )));
         }
-        if let TravelRoute::Land(route) = &edge.route {
-            if route
+        if let TravelRoute::Land(route) = &edge.route
+            && route
                 .water_crossings
                 .windows(2)
                 .any(|pair| pair[0].position > pair[1].position)
-            {
-                return Err(Error::Validation(format!(
-                    "travel edge {} has unsorted water crossings",
-                    edge.id
-                )));
-            }
+        {
+            return Err(Error::Validation(format!(
+                "travel edge {} has unsorted water crossings",
+                edge.id
+            )));
         }
     }
 
@@ -236,7 +235,7 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
             world.report.hydrology_files_read,
             world.report.hydrology_features_read,
             world.report.hydrology_settlement_samples,
-            world.report.hydrology_settlement_fallback_samples,
+            world.report.hydrology_landlocked_settlements,
             world.report.hydrology_edge_crossings,
             world.report.hydrology_inferred_ferry_waterways,
             world
@@ -272,10 +271,10 @@ fn hydrology_counts_are_consistent(
     files: usize,
     features: usize,
     samples: usize,
-    fallbacks: usize,
+    landlocked: usize,
     crossings: usize,
     inferred_ferries: usize,
-    actual_fallbacks: usize,
+    actual_landlocked: usize,
     actual_crossings: usize,
     ferries: usize,
     settlements: usize,
@@ -283,7 +282,7 @@ fn hydrology_counts_are_consistent(
     files > 0
         && features > 0
         && samples == settlements
-        && fallbacks == actual_fallbacks
+        && landlocked == actual_landlocked
         && crossings == actual_crossings
         && inferred_ferries <= ferries
 }

--- a/crates/adventuresim-world-import/src/validation.rs
+++ b/crates/adventuresim-world-import/src/validation.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
 use adventuresim_world_schema::{
-    CompiledWorld, DroughtProfile, SoilProfile, SurfaceGeology, TreeSpeciesProfile,
-    WORLD_SCHEMA_VERSION,
+    CompiledWorld, DroughtProfile, SettlementHydrology, SoilProfile, SurfaceGeology, TravelRoute,
+    TreeSpeciesProfile, WORLD_SCHEMA_VERSION,
 };
 
 use crate::{Error, Result};
@@ -69,6 +69,18 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
                 "travel edge {} has an invalid slope multiplier",
                 edge.id
             )));
+        }
+        if let TravelRoute::Land(route) = &edge.route {
+            if route
+                .water_crossings
+                .windows(2)
+                .any(|pair| pair[0].position > pair[1].position)
+            {
+                return Err(Error::Validation(format!(
+                    "travel edge {} has unsorted water crossings",
+                    edge.id
+                )));
+            }
         }
     }
 
@@ -220,12 +232,60 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
                 .count(),
             world.settlements.len(),
         )
+        || !hydrology_counts_are_consistent(
+            world.report.hydrology_files_read,
+            world.report.hydrology_features_read,
+            world.report.hydrology_settlement_samples,
+            world.report.hydrology_settlement_fallback_samples,
+            world.report.hydrology_edge_crossings,
+            world.report.hydrology_inferred_ferry_waterways,
+            world
+                .settlements
+                .iter()
+                .filter(|settlement| settlement.hydrology == SettlementHydrology::default())
+                .count(),
+            world
+                .edges
+                .iter()
+                .map(|edge| match &edge.route {
+                    TravelRoute::Land(route) => route.water_crossings.len(),
+                    TravelRoute::Ferry(_) => 0,
+                })
+                .sum(),
+            world
+                .edges
+                .iter()
+                .filter(|edge| matches!(edge.route, TravelRoute::Ferry(_)))
+                .count(),
+            world.settlements.len(),
+        )
     {
         return Err(Error::Validation(
             "build report counts do not match the compiled world".into(),
         ));
     }
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn hydrology_counts_are_consistent(
+    files: usize,
+    features: usize,
+    samples: usize,
+    fallbacks: usize,
+    crossings: usize,
+    inferred_ferries: usize,
+    actual_fallbacks: usize,
+    actual_crossings: usize,
+    ferries: usize,
+    settlements: usize,
+) -> bool {
+    files > 0
+        && features > 0
+        && samples == settlements
+        && fallbacks == actual_fallbacks
+        && crossings == actual_crossings
+        && inferred_ferries <= ferries
 }
 
 fn drought_counts_are_consistent(
@@ -354,8 +414,8 @@ mod tests {
     use super::potential_vegetation_counts_are_consistent;
     use super::{
         drought_counts_are_consistent, geology_counts_are_consistent,
-        religion_counts_are_consistent, soil_counts_are_consistent,
-        tree_species_counts_are_consistent,
+        hydrology_counts_are_consistent, religion_counts_are_consistent,
+        soil_counts_are_consistent, tree_species_counts_are_consistent,
     };
 
     #[test]
@@ -440,5 +500,21 @@ mod tests {
         assert!(!drought_counts_are_consistent(0, 0, 0, 0, 0, 0));
         assert!(!drought_counts_are_consistent(5_414, 3, 2, 2, 2, 3));
         assert!(!drought_counts_are_consistent(5_414, 3, 1, 1, 0, 3));
+    }
+
+    #[test]
+    fn hydrology_report_requires_source_and_exact_classifications() {
+        assert!(hydrology_counts_are_consistent(
+            2, 30, 3, 1, 4, 1, 1, 4, 2, 3
+        ));
+        assert!(!hydrology_counts_are_consistent(
+            0, 30, 3, 1, 4, 1, 1, 4, 2, 3
+        ));
+        assert!(!hydrology_counts_are_consistent(
+            2, 30, 3, 1, 4, 1, 0, 4, 2, 3
+        ));
+        assert!(!hydrology_counts_are_consistent(
+            2, 30, 3, 1, 4, 3, 1, 4, 2, 3
+        ));
     }
 }

--- a/crates/adventuresim-world-schema/src/lib.rs
+++ b/crates/adventuresim-world-schema/src/lib.rs
@@ -1726,7 +1726,7 @@ pub struct WorldBuildReport {
     pub hydrology_files_read: usize,
     pub hydrology_features_read: usize,
     pub hydrology_settlement_samples: usize,
-    pub hydrology_settlement_fallback_samples: usize,
+    pub hydrology_landlocked_settlements: usize,
     pub hydrology_edge_crossings: usize,
     pub hydrology_inferred_ferry_waterways: usize,
     pub excluded_edges: std::collections::BTreeMap<String, usize>,
@@ -2018,5 +2018,19 @@ mod tests {
         assert!(GeologicUnitId::new("").is_none());
         assert!(GeologicUnitId::new(" leading-space").is_none());
         assert!(GeologicUnitId::new("x".repeat(256)).is_none());
+    }
+
+    #[test]
+    fn hydrology_wire_values_cannot_bypass_bounded_constructors() {
+        assert!(serde_json::from_str::<super::WaterDistanceMeters>(r#"{"meters":10000}"#).is_ok());
+        assert!(serde_json::from_str::<super::WaterDistanceMeters>(r#"{"meters":10001}"#).is_err());
+        assert!(serde_json::from_str::<super::StrahlerOrder>(r#"{"order":1}"#).is_ok());
+        assert!(serde_json::from_str::<super::StrahlerOrder>(r#"{"order":0}"#).is_err());
+        assert!(
+            serde_json::from_str::<super::EdgeProgressPermille>(r#"{"permille":1000}"#).is_ok()
+        );
+        assert!(
+            serde_json::from_str::<super::EdgeProgressPermille>(r#"{"permille":1001}"#).is_err()
+        );
     }
 }

--- a/crates/adventuresim-world-schema/src/lib.rs
+++ b/crates/adventuresim-world-schema/src/lib.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const WORLD_SCHEMA_VERSION: u32 = 11;
+pub const WORLD_SCHEMA_VERSION: u32 = 12;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
@@ -1402,23 +1402,269 @@ pub enum EdgeEndpoint {
     Both,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
-pub enum TravelRoute {
-    Land { bridge: Option<EdgeEndpoint> },
-    Ferry,
+pub struct WaterDistanceMeters {
+    meters: u16,
 }
 
-impl TravelRoute {
-    pub const fn kind(self) -> TravelEdgeKind {
-        match self {
-            Self::Land { .. } => TravelEdgeKind::Land,
-            Self::Ferry => TravelEdgeKind::Ferry,
+impl WaterDistanceMeters {
+    pub const MAX: u16 = 10_000;
+
+    pub fn new(meters: u16) -> Result<Self, String> {
+        if meters <= Self::MAX {
+            Ok(Self { meters })
+        } else {
+            Err(format!(
+                "water distance {meters} exceeds {} meters",
+                Self::MAX
+            ))
         }
     }
 
-    pub const fn has_crossing(self) -> bool {
-        matches!(self, Self::Land { bridge: Some(_) } | Self::Ferry)
+    pub const fn get(self) -> u16 {
+        self.meters
+    }
+}
+
+impl<'de> Deserialize<'de> for WaterDistanceMeters {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            meters: u16,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        Self::new(wire.meters).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct StrahlerOrder {
+    order: u8,
+}
+
+impl StrahlerOrder {
+    pub const MAX: u8 = 12;
+
+    pub fn new(order: u8) -> Result<Self, String> {
+        if (1..=Self::MAX).contains(&order) {
+            Ok(Self { order })
+        } else {
+            Err(format!(
+                "Strahler order {order} is outside 1..={}",
+                Self::MAX
+            ))
+        }
+    }
+
+    pub const fn get(self) -> u8 {
+        self.order
+    }
+}
+
+impl<'de> Deserialize<'de> for StrahlerOrder {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            order: u8,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        Self::new(wire.order).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub enum FlowPersistence {
+    Perennial,
+    Intermittent,
+    Ephemeral,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct RiverAccess {
+    pub distance: WaterDistanceMeters,
+    pub order: StrahlerOrder,
+    pub persistence: FlowPersistence,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct RiverAndCanalAccess {
+    pub river: RiverAccess,
+    pub canal_distance: WaterDistanceMeters,
+    pub canal_navigable: bool,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub enum FlowingWaterAccess {
+    River(RiverAccess),
+    RiverAndCanal(RiverAndCanalAccess),
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub enum InlandWaterSize {
+    Pond,
+    Lake,
+    GreatLake,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct InlandWaterAccess {
+    pub distance: WaterDistanceMeters,
+    pub size: InlandWaterSize,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub enum MarineWaterAccess {
+    Tidal(WaterDistanceMeters),
+    OpenCoast(WaterDistanceMeters),
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct SettlementHydrology {
+    pub flowing: Option<FlowingWaterAccess>,
+    pub inland: Option<InlandWaterAccess>,
+    pub marine: Option<MarineWaterAccess>,
+}
+
+impl SettlementHydrology {
+    pub const fn has_freshwater(self) -> bool {
+        self.flowing.is_some() || self.inland.is_some()
+    }
+
+    pub const fn has_saltwater(self) -> bool {
+        self.marine.is_some()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct EdgeProgressPermille {
+    permille: u16,
+}
+
+impl EdgeProgressPermille {
+    pub const MAX: u16 = 1_000;
+
+    pub fn new(value: u16) -> Result<Self, String> {
+        if value <= Self::MAX {
+            Ok(Self { permille: value })
+        } else {
+            Err(format!("edge progress {value} exceeds {}", Self::MAX))
+        }
+    }
+
+    pub const fn get(self) -> u16 {
+        self.permille
+    }
+}
+
+impl<'de> Deserialize<'de> for EdgeProgressPermille {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Wire {
+            permille: u16,
+        }
+        let wire = Wire::deserialize(deserializer)?;
+        Self::new(wire.permille).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub enum CrossingWatercourse {
+    River(RiverWatercourse),
+    Canal(CanalWatercourse),
+    Ditch,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct RiverWatercourse {
+    pub order: StrahlerOrder,
+    pub persistence: FlowPersistence,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct CanalWatercourse {
+    pub navigable: bool,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub enum CrossingTraversal {
+    Bridge,
+    Ford,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct LandWaterCrossing {
+    pub position: EdgeProgressPermille,
+    pub watercourse: CrossingWatercourse,
+    pub traversal: CrossingTraversal,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub enum FerryWaterway {
+    River(RiverWatercourse),
+    InlandWater,
+    TidalWater,
+    CoastalWater,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub enum TravelRoute {
+    Land(LandRoute),
+    Ferry(FerryRoute),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct LandRoute {
+    pub bridge: Option<EdgeEndpoint>,
+    pub water_crossings: Vec<LandWaterCrossing>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "spacetimedb", derive(spacetimedb::SpacetimeType))]
+pub struct FerryRoute {
+    pub waterway: FerryWaterway,
+}
+
+impl TravelRoute {
+    pub const fn kind(&self) -> TravelEdgeKind {
+        match self {
+            Self::Land(_) => TravelEdgeKind::Land,
+            Self::Ferry(_) => TravelEdgeKind::Ferry,
+        }
+    }
+
+    pub const fn has_crossing(&self) -> bool {
+        match self {
+            Self::Land(route) => route.bridge.is_some() || !route.water_crossings.is_empty(),
+            Self::Ferry(_) => true,
+        }
     }
 }
 
@@ -1477,6 +1723,12 @@ pub struct WorldBuildReport {
     pub drought_samples: usize,
     pub drought_neighbor_samples: usize,
     pub drought_fallback_samples: usize,
+    pub hydrology_files_read: usize,
+    pub hydrology_features_read: usize,
+    pub hydrology_settlement_samples: usize,
+    pub hydrology_settlement_fallback_samples: usize,
+    pub hydrology_edge_crossings: usize,
+    pub hydrology_inferred_ferry_waterways: usize,
     pub excluded_edges: std::collections::BTreeMap<String, usize>,
 }
 
@@ -1535,6 +1787,7 @@ pub struct SettlementImport {
     pub geology: SurfaceGeology,
     pub religious_status: SettlementReligiousStatus,
     pub drought: DroughtProfile,
+    pub hydrology: SettlementHydrology,
     pub scene_key: String,
 }
 

--- a/crates/strategic-web/Cargo.toml
+++ b/crates/strategic-web/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 adventuresim-core.workspace = true
 adventuresim-stdb-client.workspace = true
+adventuresim-world-schema.workspace = true
 anyhow = "1"
 axum = "0.8"
 axum-extra = { version = "0.10", features = ["cookie"] }

--- a/crates/strategic-web/src/routes/travel.rs
+++ b/crates/strategic-web/src/routes/travel.rs
@@ -4,7 +4,7 @@ use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::spacetimedb::{Settlement, TravelEdge, TravelKind};
+use crate::spacetimedb::{Settlement, TravelEdge};
 
 const WALKING_SPEED_KM_PER_HOUR: u64 = 5;
 
@@ -111,10 +111,7 @@ pub(crate) fn connected_destinations(
         .filter_map(|settlement| settlement.source_node_id.map(|node| (node, settlement)))
         .collect();
     let mut adjacency: HashMap<u64, Vec<(u64, u32)>> = HashMap::new();
-    for edge in edges
-        .iter()
-        .filter(|edge| matches!(edge.kind, TravelKind::Land | TravelKind::Ferry))
-    {
+    for edge in edges {
         adjacency
             .entry(edge.from_node_id)
             .or_default()

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -70,19 +70,11 @@ pub struct TravelEdge {
     pub id: u64,
     pub from_node_id: u64,
     pub to_node_id: u64,
-    pub kind: TravelKind,
+    pub route: adventuresim_world_schema::TravelRoute,
     pub length_m: u32,
     pub slope_multiplier: f32,
     pub certainty: u8,
     pub section: String,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-pub enum TravelKind {
-    #[serde(alias = "land", alias = "Land")]
-    Land,
-    #[serde(alias = "ferry", alias = "Ferry")]
-    Ferry,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -654,14 +646,5 @@ mod tests {
             serde_json::from_str::<MissionStatus>("\"Starting\"").unwrap(),
             MissionStatus::Pending
         );
-    }
-
-    #[test]
-    fn travel_kind_is_a_closed_set() {
-        assert_eq!(
-            serde_json::from_str::<TravelKind>("\"land\"").unwrap(),
-            TravelKind::Land
-        );
-        assert!(serde_json::from_str::<TravelKind>("\"teleport\"").is_err());
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -33,8 +33,10 @@ complete mapped-or-inferred soil profile. EGDI surface geology then uses an
 indexed local GeoPackage to attach a typed mapped-or-inferred lithology and age
 setting. The IEG stage then parses a curated 1544 legal-religion
 intermediate into an established, parity, multi-confessional, or municipally
-determined typed status. NOAA OWDA finally adds a bounded current-summer PDSI and typed twenty-year
-drought/wetness history before constructing the canonical settlement record.
+determined typed status. NOAA OWDA adds a bounded current-summer PDSI and typed
+twenty-year drought/wetness history. EU-Hydro is the final typestate stage: it
+adds settlement water access, converts draft roads into typed land crossings
+or ferry waterways, and only then constructs the canonical world records.
 The generic draft is a typestate boundary: each enrichment
 stage consumes only settlements that have all of its required predecessor data.
 This keeps source-specific placeholders out of canonical records and prevents

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -219,6 +219,13 @@ NOAA OWDA summer PDSI is read directly from the NetCDF-4 file at
 typed twenty-year profile, and full-file verification are documented in
 `docs/DROUGHT.md`; override the path with `--drought-netcdf`.
 
+Copernicus EU-Hydro v1.3 is read from extracted EPSG:3035 basin GeoPackages
+under `target/world-data-sources/raw/hydrology/`, as documented in
+`docs/HYDROLOGY.md`. Override that directory with `--hydrology-dir`. The
+official archive is not currently available locally, so the parser and
+enrichment are verified against standards-compliant synthetic GeoPackages but
+the complete source distribution remains unverified.
+
 ## Strategic UI
 
 The strategic UI is server-rendered by `crates/strategic-web`. Browser clients

--- a/docs/HYDROLOGY.md
+++ b/docs/HYDROLOGY.md
@@ -16,9 +16,12 @@ Download the basin GeoPackage distribution and extract its `.gpkg` files under
 accepted. Override the directory with `--hydrology-dir`.
 
 The official full archive is not currently present in the development data
-directory, so only the strict source boundary has been verified using real
-SQLite GeoPackage files with synthetic EPSG:3035 geometries. Do not describe a
-full-world hydrology audit as complete until the official archive has been run.
+directory, so only the strict source boundary has been verified using
+read-focused SQLite fixtures with GeoPackage core metadata, a real EPSG:3035
+definition, synthetic geometries, and manually populated RTree tables. The
+fixtures exercise the reader but are not a writable GeoPackage conformance
+suite. Do not describe a full-world hydrology audit as complete until the
+official archive has been run.
 
 ## Parsed source features
 
@@ -26,6 +29,9 @@ The compiler recognizes the official `River_Net_l`, `Canals_l`, `Ditches_l`,
 `InlandWater`, `Transit_p`, and `Coastal_p` feature classes. It also accepts
 the equivalent names exposed by the EEA map service. Relevant features are
 clipped to a ten-kilometer margin around the imported world before enrichment.
+When a basin GeoPackage provides the standard RTree extension, the SQL reader
+applies that envelope before decoding geometry; packages without it use a
+compatible full-table scan and the same exact geometry-bounds filter.
 
 For flowing water, `STRAHLER`, `HYP`, and `NVS` become bounded Strahler order,
 perennial/intermittent/ephemeral persistence, and navigability. Dry source

--- a/docs/HYDROLOGY.md
+++ b/docs/HYDROLOGY.md
@@ -1,0 +1,64 @@
+# Surface water and road crossings
+
+Settlement water access and travel-edge crossings are sourced from the
+**Copernicus EU-Hydro River Network Database v1.3**.
+
+- Product: <https://land.copernicus.eu/en/products/eu-hydro/eu-hydro-river-network-database>
+- DOI: <https://doi.org/10.2909/393359a7-7ebd-4a52-80ac-1a18d5f3db9c>
+- User guide: <https://land.copernicus.eu/en/technical-library/eu-hydro_user_guide>
+- Projection: ETRS89 / LAEA Europe (EPSG:3035).
+- Source period: primarily 2006, 2009, and 2012 imagery, supplemented by
+  EU-DEM drainage modeling. This is used as plausible geography for 1544, not
+  as evidence that every modern canal or watercourse existed then.
+
+Download the basin GeoPackage distribution and extract its `.gpkg` files under
+`target/world-data-sources/raw/hydrology/`. Nested basin directories are
+accepted. Override the directory with `--hydrology-dir`.
+
+The official full archive is not currently present in the development data
+directory, so only the strict source boundary has been verified using real
+SQLite GeoPackage files with synthetic EPSG:3035 geometries. Do not describe a
+full-world hydrology audit as complete until the official archive has been run.
+
+## Parsed source features
+
+The compiler recognizes the official `River_Net_l`, `Canals_l`, `Ditches_l`,
+`InlandWater`, `Transit_p`, and `Coastal_p` feature classes. It also accepts
+the equivalent names exposed by the EEA map service. Relevant features are
+clipped to a ten-kilometer margin around the imported world before enrichment.
+
+For flowing water, `STRAHLER`, `HYP`, and `NVS` become bounded Strahler order,
+perennial/intermittent/ephemeral persistence, and navigability. Dry source
+segments are omitted. Missing and sentinel attributes are resolved to
+plausible defaults while parsing; raw `-9999`, null, or unknown values never
+enter the canonical schema. `AREA_GEO` classifies inland water by gameplay
+size, with geometry bounds as a deterministic fallback.
+
+## Canonical settlement model
+
+A settlement independently records nearby flowing, inland, and marine access
+within two kilometers. Flowing access is either a river or a river with a
+nearby canal, so a canal-only settlement state cannot be represented. Inland
+water is fresh pond/lake/great-lake access. Marine water is either tidal
+(treated as brackish for gameplay) or open coast (salt water). Absence means
+the settlement is landlocked with respect to that category, not that salinity
+is unknown.
+
+These distinctions can drive fresh- and salt-water foods, harbor or fishing
+work, water transport, irrigation, flood scenes, and local encounter dressing.
+
+## Canonical edge model
+
+Hydrology finalizes the road draft. A land route owns zero or more typed
+river, canal, or ditch crossings, each with its position along the edge and a
+plausible bridge-or-ford traversal. A ferry instead owns exactly one river,
+inland-water, tidal-water, or coastal-water payload. Consequently a ferry with
+land crossings, or a land route with a ferry waterway, cannot be represented.
+
+Straight endpoint-to-endpoint geometry is used because Viabundus currently
+imports topology rather than complete road polylines. Existing Viabundus
+bridge endpoint evidence wins over the size-based bridge/ford inference. If a
+known bridge has no mapped EU-Hydro segment, the compiler supplies a plausible
+small perennial river crossing at that endpoint. Ferry edges without a nearby
+mapped water feature receive a plausible small perennial river rather than an
+unknown waterway.


### PR DESCRIPTION
## Summary

Adds the next historical world-data integration layer to the stacked import pipeline.
It targets its immediate predecessor so each source can be reviewed and merged in dependency order.

## Impact

Makes the branch's source data and deterministic world-building behavior available to subsequent stack branches.

## Validation

The restacked import pipeline, strategic module, and generated client bindings were checked locally.
