### PR TITLE
Add historical weapons and armor catalog

### DIFF
--- a/crates/adventuresim-stdb-module/src/character.rs
+++ b/crates/adventuresim-stdb-module/src/character.rs
@@ -320,14 +320,14 @@ pub(crate) fn insert_new_character(
 
     // Starter equip
     add_and_equip_item(ctx, character.id, "buckler", ItemSlot::LeftHolding)?;
-    add_and_equip_item(ctx, character.id, "short_sword", ItemSlot::RightHolding)?;
-    add_and_equip_item(ctx, character.id, "leather_armguard", ItemSlot::LeftArm)?;
-    add_and_equip_item(ctx, character.id, "leather_armguard", ItemSlot::RightArm)?;
-    add_and_equip_item(ctx, character.id, "leather_helmet", ItemSlot::Head)?;
-    add_and_equip_item(ctx, character.id, "leather_vest", ItemSlot::Chest)?;
-    add_and_equip_item(ctx, character.id, "leather_vest", ItemSlot::Stomach)?;
-    add_and_equip_item(ctx, character.id, "leather_cuisse", ItemSlot::LeftLeg)?;
-    add_and_equip_item(ctx, character.id, "leather_cuisse", ItemSlot::RightLeg)?;
+    add_and_equip_item(ctx, character.id, "katzbalger", ItemSlot::RightHolding)?;
+    add_and_equip_item(ctx, character.id, "quilted_sleeve", ItemSlot::LeftArm)?;
+    add_and_equip_item(ctx, character.id, "quilted_sleeve", ItemSlot::RightArm)?;
+    add_and_equip_item(ctx, character.id, "arming_cap", ItemSlot::Head)?;
+    add_and_equip_item(ctx, character.id, "arming_doublet", ItemSlot::Chest)?;
+    add_and_equip_item(ctx, character.id, "padded_skirt", ItemSlot::Stomach)?;
+    add_and_equip_item(ctx, character.id, "padded_chausses", ItemSlot::LeftLeg)?;
+    add_and_equip_item(ctx, character.id, "padded_chausses", ItemSlot::RightLeg)?;
 
     crate::strategic::create_solo_party_for_character(ctx, character.id)?;
     crate::capability::refresh_character_capability(ctx, character.id)?;

--- a/crates/adventuresim-stdb-module/src/item.rs
+++ b/crates/adventuresim-stdb-module/src/item.rs
@@ -83,6 +83,697 @@ pub struct Item {
     pub water_capacity_ml: u32,
 }
 
+/// A static item definition used to seed the strategic item table.
+///
+/// The values use the combat quantities documented in `wiki/tactical/Combat.md`.
+/// `base_value` is a relative gameplay price, not a claim about a historical
+/// market price; the historical basis and gameplay inferences are recorded in
+/// `docs/EQUIPMENT.md`.
+#[derive(Clone, Copy, Debug)]
+struct EquipmentDefinition {
+    id: &'static str,
+    weight: f32,
+    base_value: u32,
+    slot: ItemSlot,
+    kind: ItemKind,
+    accuracy: f32,
+    reach: f32,
+    block: f32,
+    coverage: f32,
+    penetration: f32,
+    resistance: f32,
+    padding: f32,
+    flexibility: f32,
+    range_of_motion: f32,
+    precise: bool,
+    balance: f32,
+    melee: bool,
+    ranged: bool,
+    blunt: bool,
+    slash: bool,
+    pierce: bool,
+}
+
+const fn weapon(
+    id: &'static str,
+    weight: f32,
+    base_value: u32,
+    accuracy: f32,
+    penetration: f32,
+    reach: f32,
+    balance: f32,
+    precise: bool,
+    blunt: bool,
+    slash: bool,
+    pierce: bool,
+    ranged: bool,
+) -> EquipmentDefinition {
+    EquipmentDefinition {
+        id,
+        weight,
+        base_value,
+        slot: ItemSlot::None,
+        kind: ItemKind::Weapon,
+        accuracy,
+        reach,
+        block: 0.0,
+        coverage: 0.0,
+        penetration,
+        resistance: 0.0,
+        padding: 0.0,
+        flexibility: 0.0,
+        range_of_motion: 0.0,
+        precise,
+        balance,
+        melee: !ranged,
+        ranged,
+        blunt,
+        slash,
+        pierce,
+    }
+}
+
+const fn armor(
+    id: &'static str,
+    weight: f32,
+    base_value: u32,
+    slot: ItemSlot,
+    coverage: f32,
+    resistance: f32,
+    padding: f32,
+    flexibility: f32,
+    range_of_motion: f32,
+) -> EquipmentDefinition {
+    EquipmentDefinition {
+        id,
+        weight,
+        base_value,
+        slot,
+        kind: ItemKind::Armor,
+        accuracy: 0.0,
+        reach: 0.0,
+        block: 0.0,
+        coverage,
+        penetration: 0.0,
+        resistance,
+        padding,
+        flexibility,
+        range_of_motion,
+        precise: false,
+        balance: 0.0,
+        melee: false,
+        ranged: false,
+        blunt: false,
+        slash: false,
+        pierce: false,
+    }
+}
+
+const fn shield(id: &'static str, weight: f32, base_value: u32, block: f32) -> EquipmentDefinition {
+    EquipmentDefinition {
+        id,
+        weight,
+        base_value,
+        slot: ItemSlot::None,
+        kind: ItemKind::Shield,
+        accuracy: 0.0,
+        reach: 0.0,
+        block,
+        coverage: 0.0,
+        penetration: 0.0,
+        resistance: 0.0,
+        padding: 0.0,
+        flexibility: 0.0,
+        range_of_motion: 0.0,
+        precise: false,
+        balance: 0.0,
+        melee: false,
+        ranged: false,
+        blunt: false,
+        slash: false,
+        pierce: false,
+    }
+}
+
+// Common civilian, militia, professional, elite, and older-serviceable arms.
+// Ranged reach is the current autoresolver range in metres; melee reach is in
+// metres. Weapon precision and penetration follow the Combat.md calibration.
+const WEAPONS: &[EquipmentDefinition] = &[
+    weapon(
+        "club", 1.2, 1, 0.5, 0.1, 0.7, 0.7, false, true, false, false, false,
+    ),
+    weapon(
+        "walking_staff",
+        1.5,
+        1,
+        0.8,
+        0.1,
+        1.8,
+        0.3,
+        false,
+        true,
+        false,
+        false,
+        false,
+    ),
+    weapon(
+        "hand_axe", 0.9, 4, 1.0, 1.0, 0.7, 0.65, false, false, true, false, false,
+    ),
+    weapon(
+        "flanged_mace",
+        1.2,
+        10,
+        0.7,
+        0.5,
+        0.75,
+        0.65,
+        false,
+        true,
+        false,
+        false,
+        false,
+    ),
+    weapon(
+        "war_hammer",
+        1.4,
+        14,
+        0.7,
+        0.5,
+        0.8,
+        0.55,
+        false,
+        true,
+        false,
+        true,
+        false,
+    ),
+    weapon(
+        "utility_knife",
+        0.2,
+        2,
+        1.5,
+        1.0,
+        0.3,
+        0.8,
+        false,
+        false,
+        true,
+        true,
+        false,
+    ),
+    weapon(
+        "baselard", 0.4, 6, 1.5, 1.0, 0.4, 0.75, false, false, true, true, false,
+    ),
+    weapon(
+        "rondel_dagger",
+        0.45,
+        12,
+        2.0,
+        4.0,
+        0.4,
+        0.8,
+        true,
+        false,
+        false,
+        true,
+        false,
+    ),
+    weapon(
+        "misericorde",
+        0.35,
+        14,
+        2.0,
+        4.0,
+        0.4,
+        0.75,
+        true,
+        false,
+        false,
+        true,
+        false,
+    ),
+    weapon(
+        "bauernwehr",
+        0.7,
+        8,
+        1.2,
+        1.0,
+        0.65,
+        0.7,
+        false,
+        false,
+        true,
+        true,
+        false,
+    ),
+    weapon(
+        "katzbalger",
+        1.1,
+        18,
+        1.5,
+        1.0,
+        0.8,
+        0.55,
+        false,
+        false,
+        true,
+        true,
+        false,
+    ),
+    weapon(
+        "arming_sword",
+        1.3,
+        28,
+        1.5,
+        1.0,
+        0.95,
+        0.5,
+        false,
+        false,
+        true,
+        true,
+        false,
+    ),
+    weapon(
+        "longsword",
+        1.5,
+        40,
+        1.5,
+        1.0,
+        1.25,
+        0.45,
+        false,
+        false,
+        true,
+        true,
+        false,
+    ),
+    weapon(
+        "messer", 1.2, 20, 1.2, 1.0, 1.0, 0.6, false, false, true, true, false,
+    ),
+    weapon(
+        "kriegsmesser",
+        1.6,
+        35,
+        1.0,
+        1.0,
+        1.25,
+        0.65,
+        false,
+        false,
+        true,
+        true,
+        false,
+    ),
+    weapon(
+        "rapier", 1.1, 45, 2.0, 4.0, 1.05, 0.45, true, false, false, true, false,
+    ),
+    weapon(
+        "zweihander",
+        2.8,
+        60,
+        0.7,
+        1.0,
+        1.8,
+        0.5,
+        false,
+        false,
+        true,
+        true,
+        false,
+    ),
+    weapon(
+        "hunting_spear",
+        1.5,
+        6,
+        1.5,
+        2.0,
+        2.2,
+        0.45,
+        false,
+        false,
+        false,
+        true,
+        false,
+    ),
+    weapon(
+        "military_pike",
+        4.0,
+        9,
+        1.3,
+        2.0,
+        4.2,
+        0.85,
+        false,
+        false,
+        false,
+        true,
+        false,
+    ),
+    weapon(
+        "halberd", 2.4, 24, 1.1, 2.0, 2.0, 0.75, false, true, true, true, false,
+    ),
+    weapon(
+        "self_bow", 0.8, 8, 1.5, 2.0, 60.0, 0.35, false, false, false, true, true,
+    ),
+    weapon(
+        "longbow", 1.0, 18, 1.8, 2.0, 120.0, 0.4, false, false, false, true, true,
+    ),
+    weapon(
+        "light_crossbow",
+        2.2,
+        28,
+        2.0,
+        4.0,
+        80.0,
+        0.45,
+        true,
+        false,
+        false,
+        true,
+        true,
+    ),
+    weapon(
+        "heavy_crossbow",
+        3.5,
+        50,
+        2.0,
+        4.0,
+        110.0,
+        0.5,
+        true,
+        false,
+        false,
+        true,
+        true,
+    ),
+    weapon(
+        "matchlock_arquebus",
+        4.5,
+        55,
+        1.5,
+        1.0,
+        90.0,
+        0.55,
+        false,
+        false,
+        false,
+        true,
+        true,
+    ),
+    weapon(
+        "hooked_arquebus",
+        7.0,
+        80,
+        1.2,
+        1.0,
+        130.0,
+        0.65,
+        false,
+        false,
+        false,
+        true,
+        true,
+    ),
+];
+
+const SHIELDS: &[EquipmentDefinition] = &[
+    shield("buckler", 1.0, 5, 1.5),
+    shield("targe", 2.5, 8, 2.5),
+    shield("heater_shield", 3.0, 10, 3.0),
+    shield("round_shield", 3.5, 10, 3.0),
+    shield("pavise", 8.0, 20, 5.0),
+];
+
+// Helmets deliberately receive more entries than other armor slots: helmets
+// remained independently useful, and armories retained older patterns.
+const ARMOR: &[EquipmentDefinition] = &[
+    armor(
+        "arming_cap",
+        0.35,
+        2,
+        ItemSlot::Head,
+        0.15,
+        20.0,
+        35.0,
+        0.4,
+        0.95,
+    ),
+    armor(
+        "mail_coif",
+        1.5,
+        18,
+        ItemSlot::Head,
+        0.65,
+        70.0,
+        30.0,
+        0.8,
+        0.85,
+    ),
+    armor(
+        "kettle_hat",
+        1.8,
+        20,
+        ItemSlot::Head,
+        0.6,
+        90.0,
+        25.0,
+        0.2,
+        0.75,
+    ),
+    armor(
+        "barbute",
+        2.5,
+        35,
+        ItemSlot::Head,
+        0.75,
+        95.0,
+        30.0,
+        0.15,
+        0.65,
+    ),
+    armor(
+        "sallet",
+        2.6,
+        40,
+        ItemSlot::Head,
+        0.8,
+        100.0,
+        30.0,
+        0.2,
+        0.65,
+    ),
+    armor(
+        "visored_sallet",
+        3.0,
+        50,
+        ItemSlot::Head,
+        0.9,
+        105.0,
+        35.0,
+        0.15,
+        0.55,
+    ),
+    armor(
+        "burgonet",
+        2.3,
+        55,
+        ItemSlot::Head,
+        0.75,
+        100.0,
+        30.0,
+        0.2,
+        0.7,
+    ),
+    armor(
+        "close_helmet",
+        3.0,
+        75,
+        ItemSlot::Head,
+        0.9,
+        110.0,
+        35.0,
+        0.15,
+        0.55,
+    ),
+    armor(
+        "quilted_sleeve",
+        0.6,
+        5,
+        ItemSlot::AnyArm,
+        0.45,
+        50.0,
+        40.0,
+        0.35,
+        0.9,
+    ),
+    armor(
+        "mail_sleeve",
+        1.8,
+        28,
+        ItemSlot::AnyArm,
+        0.65,
+        70.0,
+        30.0,
+        0.8,
+        0.8,
+    ),
+    armor(
+        "vambrace",
+        0.9,
+        35,
+        ItemSlot::AnyArm,
+        0.65,
+        95.0,
+        25.0,
+        0.15,
+        0.8,
+    ),
+    armor(
+        "padded_chausses",
+        1.2,
+        8,
+        ItemSlot::AnyLeg,
+        0.45,
+        50.0,
+        40.0,
+        0.35,
+        0.9,
+    ),
+    armor(
+        "mail_chausses",
+        3.5,
+        45,
+        ItemSlot::AnyLeg,
+        0.65,
+        70.0,
+        30.0,
+        0.8,
+        0.8,
+    ),
+    armor(
+        "greave",
+        1.4,
+        45,
+        ItemSlot::AnyLeg,
+        0.65,
+        95.0,
+        25.0,
+        0.15,
+        0.78,
+    ),
+    armor(
+        "arming_doublet",
+        2.5,
+        12,
+        ItemSlot::Chest,
+        0.6,
+        60.0,
+        45.0,
+        0.3,
+        0.88,
+    ),
+    armor(
+        "jack_of_plates",
+        5.0,
+        35,
+        ItemSlot::Chest,
+        0.7,
+        85.0,
+        35.0,
+        0.45,
+        0.8,
+    ),
+    armor(
+        "brigandine",
+        5.5,
+        50,
+        ItemSlot::Chest,
+        0.8,
+        100.0,
+        40.0,
+        0.4,
+        0.75,
+    ),
+    armor(
+        "mail_shirt",
+        6.0,
+        55,
+        ItemSlot::Chest,
+        0.75,
+        70.0,
+        35.0,
+        0.8,
+        0.82,
+    ),
+    armor(
+        "breastplate",
+        3.5,
+        70,
+        ItemSlot::Chest,
+        0.85,
+        120.0,
+        45.0,
+        0.05,
+        0.72,
+    ),
+    armor(
+        "cuirass",
+        6.0,
+        110,
+        ItemSlot::Chest,
+        0.9,
+        120.0,
+        50.0,
+        0.08,
+        0.65,
+    ),
+    armor(
+        "padded_skirt",
+        0.8,
+        5,
+        ItemSlot::Stomach,
+        0.45,
+        50.0,
+        40.0,
+        0.35,
+        0.92,
+    ),
+    armor(
+        "mail_skirt",
+        2.5,
+        30,
+        ItemSlot::Stomach,
+        0.65,
+        70.0,
+        30.0,
+        0.8,
+        0.85,
+    ),
+    armor(
+        "fauld",
+        1.6,
+        40,
+        ItemSlot::Stomach,
+        0.7,
+        95.0,
+        35.0,
+        0.2,
+        0.78,
+    ),
+    armor(
+        "tassets",
+        2.0,
+        55,
+        ItemSlot::Stomach,
+        0.75,
+        100.0,
+        35.0,
+        0.18,
+        0.75,
+    ),
+];
+
 #[reducer(init)]
 fn init_items(ctx: &ReducerContext) -> Result<(), String> {
     crate::time::initialize_time(ctx);
@@ -114,217 +805,32 @@ fn init_items(ctx: &ReducerContext) -> Result<(), String> {
     });
     define_clothing(ctx, "linen_tunic", 0.6);
 
-    define_shield(ctx, "buckler", 1.0, 1.0);
-
-    define_weapon(
-        ctx,
-        "short_sword",
-        1.5,
-        1.5,
-        1.0,
-        1.0,
-        0.5,
-        false,
-        true,
-        false,
-        false,
-        true,
-        true,
-    );
-    define_weapon(
-        ctx, "knife", 0.5, 2.0, 1.0, 1.0, 0.5, false, true, false, false, true, true,
-    );
-    define_weapon(
-        ctx,
-        "zweihander",
-        6.0,
-        0.6,
-        1.0,
-        2.0,
-        0.3,
-        false,
-        true,
-        false,
-        false,
-        true,
-        false,
-    );
-    define_weapon(
-        ctx, "club", 2.0, 0.5, 0.5, 1.0, 0.3, false, true, false, true, false, false,
-    );
-    define_weapon(
-        ctx,
-        "short_bow",
-        1.0,
-        1.2,
-        1.0,
-        20.0,
-        0.4,
-        false,
-        false,
-        true,
-        false,
-        false,
-        true,
-    );
-    define_weapon(
-        ctx,
-        "bot_multirole_weapon",
-        4.0,
-        2.0,
-        1.0,
-        2.0,
-        0.5,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-    );
-    define_weapon(
-        ctx, "rapier", 1.2, 2.0, 1.2, 1.8, 0.7, true, true, false, false, false, true,
-    );
-    define_weapon(
-        ctx, "rondel", 0.5, 2.0, 1.0, 0.6, 0.8, true, true, false, false, false, true,
-    );
-    define_weapon(
-        ctx,
-        "misericorde",
-        0.5,
-        2.0,
-        1.0,
-        0.7,
-        0.8,
-        true,
-        true,
-        false,
-        false,
-        false,
-        true,
-    );
-
-    define_armor(
-        ctx,
-        "leather_armguard",
-        0.5,
-        ItemSlot::AnyArm,
-        0.2,
-        60.0,
-        40.0,
-        1.0,
-        0.9,
-    );
-    define_armor(
-        ctx,
-        "leather_helmet",
-        0.5,
-        ItemSlot::Head,
-        0.3,
-        60.0,
-        40.0,
-        1.0,
-        0.9,
-    );
-    define_armor(
-        ctx,
-        "leather_vest",
-        0.5,
-        ItemSlot::Chest,
-        0.3,
-        60.0,
-        40.0,
-        1.0,
-        0.9,
-    );
-    define_armor(
-        ctx,
-        "leather_belt",
-        0.5,
-        ItemSlot::Stomach,
-        0.2,
-        60.0,
-        40.0,
-        1.0,
-        0.9,
-    );
-    define_armor(
-        ctx,
-        "leather_cuisse",
-        0.5,
-        ItemSlot::AnyLeg,
-        0.4,
-        60.0,
-        40.0,
-        1.0,
-        0.9,
-    );
-    define_armor(
-        ctx,
-        "steel_sallet",
-        2.0,
-        ItemSlot::Head,
-        0.7,
-        70.0,
-        40.0,
-        0.4,
-        0.3,
-    );
-    define_armor(
-        ctx,
-        "bot_plate_arm",
-        1.5,
-        ItemSlot::AnyArm,
-        0.9,
-        80.0,
-        60.0,
-        0.4,
-        0.4,
-    );
-    define_armor(
-        ctx,
-        "bot_plate_leg",
-        2.0,
-        ItemSlot::AnyLeg,
-        0.9,
-        80.0,
-        60.0,
-        0.4,
-        0.4,
-    );
-    define_armor(
-        ctx,
-        "bot_plate_chest",
-        3.0,
-        ItemSlot::Chest,
-        0.9,
-        80.0,
-        60.0,
-        0.4,
-        0.4,
-    );
-    define_armor(
-        ctx,
-        "bot_plate_stomach",
-        2.0,
-        ItemSlot::Stomach,
-        0.9,
-        80.0,
-        60.0,
-        0.4,
-        0.4,
-    );
-    define_armor(
-        ctx,
-        "bot_plate_helmet",
-        2.0,
-        ItemSlot::Head,
-        0.9,
-        80.0,
-        60.0,
-        0.4,
-        0.4,
-    );
+    for definition in WEAPONS.iter().chain(SHIELDS).chain(ARMOR) {
+        ctx.db.item().insert(Item {
+            id: definition.id.into(),
+            weight: definition.weight,
+            base_value: Some(definition.base_value),
+            slot: definition.slot,
+            kind: definition.kind,
+            accuracy: definition.accuracy,
+            reach: definition.reach,
+            block: definition.block,
+            coverage: definition.coverage,
+            penetration: definition.penetration,
+            resistance: definition.resistance,
+            padding: definition.padding,
+            flexibility: definition.flexibility,
+            range_of_motion: definition.range_of_motion,
+            precise: definition.precise,
+            balance: definition.balance,
+            melee: definition.melee,
+            ranged: definition.ranged,
+            blunt: definition.blunt,
+            slash: definition.slash,
+            pierce: definition.pierce,
+            ..Item::default()
+        });
+    }
 
     Ok(())
 }
@@ -333,7 +839,7 @@ fn init_items(ctx: &ReducerContext) -> Result<(), String> {
 /// numeric weapon-precision scale was introduced.
 #[reducer]
 pub fn calibrate_weapon_precision(ctx: &ReducerContext) {
-    for (item_id, accuracy) in [("club", 0.5), ("bot_multirole_weapon", 2.0)] {
+    for (item_id, accuracy) in [("club", 0.5), ("halberd", 1.1)] {
         if let Some(mut item) = ctx.db.item().id().find(item_id.to_string()) {
             item.accuracy = accuracy;
             ctx.db.item().id().update(item);
@@ -502,5 +1008,71 @@ pub fn change_inventory_item(
 
     if !is_found {
         add_inventory_item(ctx, character_id, item_id, by_quantity as u32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn historical_equipment_catalog_is_well_formed() {
+        let definitions: Vec<_> = WEAPONS.iter().chain(SHIELDS).chain(ARMOR).collect();
+        let mut ids = HashSet::new();
+
+        assert!(WEAPONS.len() > ARMOR.len());
+        assert_eq!(
+            ARMOR
+                .iter()
+                .filter(|definition| definition.slot == ItemSlot::Head)
+                .count(),
+            8
+        );
+
+        for definition in definitions {
+            assert!(
+                ids.insert(definition.id),
+                "duplicate item id: {}",
+                definition.id
+            );
+            assert!(definition.weight > 0.0, "{} has no weight", definition.id);
+            assert!(definition.base_value > 0, "{} has no value", definition.id);
+            assert!(
+                !definition.id.starts_with("bot_"),
+                "{} is a placeholder rather than historical equipment",
+                definition.id
+            );
+
+            match definition.kind {
+                ItemKind::Weapon => {
+                    assert_eq!(definition.slot, ItemSlot::None);
+                    assert!(definition.accuracy > 0.0);
+                    assert!(definition.reach > 0.0);
+                    assert!(definition.blunt || definition.slash || definition.pierce);
+                    assert_ne!(definition.melee, definition.ranged);
+                }
+                ItemKind::Armor => {
+                    assert!(matches!(
+                        definition.slot,
+                        ItemSlot::AnyArm
+                            | ItemSlot::AnyLeg
+                            | ItemSlot::Chest
+                            | ItemSlot::Stomach
+                            | ItemSlot::Head
+                    ));
+                    assert!((0.0..=1.0).contains(&definition.coverage));
+                    assert!(definition.resistance > 0.0);
+                    assert!(definition.padding > 0.0);
+                    assert!((0.0..=1.0).contains(&definition.flexibility));
+                    assert!((0.0..=1.0).contains(&definition.range_of_motion));
+                }
+                ItemKind::Shield => {
+                    assert_eq!(definition.slot, ItemSlot::None);
+                    assert!((1.0..=5.0).contains(&definition.block));
+                }
+                _ => unreachable!("equipment catalog contains a non-equipment item"),
+            }
+        }
     }
 }

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -113,7 +113,7 @@ impl EnemyArchetype {
                 reach: 0.8,
                 ranged_force_joules: 0.0,
                 armored: true,
-                drop: Some("short_sword"),
+                drop: Some("katzbalger"),
             },
             Self::Goblin => EnemyProfile {
                 ranged: true,
@@ -129,7 +129,7 @@ impl EnemyArchetype {
                 reach: 20.0,
                 ranged_force_joules: 40.0,
                 armored: false,
-                drop: Some("short_bow"),
+                drop: Some("self_bow"),
             },
             Self::Spider => EnemyProfile {
                 ranged: false,
@@ -370,11 +370,11 @@ mod healing_tests {
     fn enemy_archetypes_keep_combat_and_loot_classification_together() {
         let goblin = EnemyArchetype::from_label("forest goblins").profile();
         assert!(goblin.ranged);
-        assert_eq!(goblin.drop, Some("short_bow"));
+        assert_eq!(goblin.drop, Some("self_bow"));
 
         let bandit = EnemyArchetype::from_label("guild thieves").profile();
         assert!(bandit.armored);
-        assert_eq!(autoresolve_drop("guild thieves"), Some("short_sword"));
+        assert_eq!(autoresolve_drop("guild thieves"), Some("katzbalger"));
 
         assert_eq!(autoresolve_drop("giant spiders"), None);
         assert_eq!(autoresolve_drop("unknown menace"), Some("club"));
@@ -2698,21 +2698,16 @@ pub fn seed_bot_join_requests(
         skills.surgeon_hours = 1_000_000.0;
         skills.charisma_hours = 1_000_000.0;
         skills.faith_hours = 1_000_000.0;
-        crate::character::add_and_equip_item(
-            ctx,
-            id,
-            "bot_multirole_weapon",
-            crate::ItemSlot::RightHolding,
-        )?;
+        crate::character::add_and_equip_item(ctx, id, "halberd", crate::ItemSlot::RightHolding)?;
         if role.requirements.full_armor {
             for (item, slot) in [
-                ("bot_plate_arm", crate::ItemSlot::LeftArm),
-                ("bot_plate_arm", crate::ItemSlot::RightArm),
-                ("bot_plate_leg", crate::ItemSlot::LeftLeg),
-                ("bot_plate_leg", crate::ItemSlot::RightLeg),
-                ("bot_plate_chest", crate::ItemSlot::Chest),
-                ("bot_plate_stomach", crate::ItemSlot::Stomach),
-                ("bot_plate_helmet", crate::ItemSlot::Head),
+                ("vambrace", crate::ItemSlot::LeftArm),
+                ("vambrace", crate::ItemSlot::RightArm),
+                ("greave", crate::ItemSlot::LeftLeg),
+                ("greave", crate::ItemSlot::RightLeg),
+                ("cuirass", crate::ItemSlot::Chest),
+                ("fauld", crate::ItemSlot::Stomach),
+                ("close_helmet", crate::ItemSlot::Head),
             ] {
                 crate::character::add_and_equip_item(ctx, id, item, slot)?;
             }
@@ -2760,7 +2755,7 @@ pub fn seed_bot_join_requests(
                 crate::character::add_and_equip_item(
                     ctx,
                     id,
-                    "short_bow",
+                    "self_bow",
                     crate::ItemSlot::RightHolding,
                 )?;
             } else if requirements.ranged {

--- a/docs/EQUIPMENT.md
+++ b/docs/EQUIPMENT.md
@@ -1,0 +1,93 @@
+# Historical equipment catalog
+
+This document records the first equipment slice for issue #65: weapons,
+shields, and armor intended for northern Germany in approximately 1544. The
+definitions are the typed `WEAPONS`, `SHIELDS`, and `ARMOR` arrays in
+`crates/adventuresim-stdb-module/src/item.rs`. The strategic game and the
+autoresolver consume the same persisted `Item` records; there are no special
+NPC-only item rules.
+
+## Scope and historical basis
+
+The core professional infantry set is pike-and-shot equipment with halberds,
+sidearms, and armor. The German History in Documents and Images description of
+an approximately 1532--42 Landsknecht procession identifies the pike as the
+typical weapon. The Musée Lorrain's description of imperial Landsknecht
+equipment identifies pikes and halberds as the main bodies, supplemented by
+crossbowmen and arquebusiers, and notes Nuremberg mass production of infantry
+armor from the 1540s. The Met describes the halberd as especially associated
+with German Landsknechts, while noting the pike's role in massed sixteenth
+century formations.
+
+The catalog also deliberately includes usable older stock: the baselard,
+barbute, sallet, visored sallet, mail garments, heater shield, and longbow.
+These are not presented as the fashionable or preferred 1544 battlefield kit;
+they are plausible inherited, stored, civilian, militia, or second-hand goods.
+No later sixteenth-century weapons or armor types are included simply for
+variety.
+
+## Inventory
+
+| Category | Intended entries |
+| --- | --- |
+| Civilian and militia weapons | club, walking staff, hand axe, flanged mace, war hammer, utility knife, baselard, Bauernwehr, hunting spear, self bow |
+| Daggers and swords | rondel dagger, misericorde, Katzbalger, arming sword, longsword, messer, Kriegsmesser, rapier, Zweihänder |
+| Formation and ranged weapons | military pike, halberd, longbow, light crossbow, heavy crossbow, matchlock arquebus, hooked arquebus |
+| Shields | buckler, targe, heater shield, round shield, pavise |
+| Helmets | arming cap, mail coif, kettle hat, barbute, sallet, visored sallet, burgonet, close helmet |
+| Arm defenses | quilted sleeve, mail sleeve, vambrace |
+| Leg defenses | padded chausses, mail chausses, greave |
+| Torso defenses | arming doublet, jack of plates, brigandine, mail shirt, breastplate, cuirass |
+| Waist and upper-leg defenses | padded skirt, mail skirt, fauld, tassets |
+
+The catalog intentionally has more weapons than armor entries (26 weapons to
+24 armor pieces). Helmets receive eight entries because they were independently
+useful, highly varied, and more likely than a complete suit to persist in an
+armory.
+
+## Representation and gameplay inference
+
+The current item schema has one armor item per existing body slot, with no
+layering field. A `mail_shirt`, for example, is a chest-slot alternative to a
+brigandine rather than a simultaneous underlayer. This is an explicit temporary
+representation constraint, not a claim that period armor was worn in one
+layer. Adding layering, ammunition-specific projectile behavior, condition, or
+rust belongs to later schema and durability work.
+
+Weights are kilograms. The documented object weights below anchor the scale;
+the other weights are bounded gameplay estimates for ordinary serviceable
+examples, rather than claimed measurements of a particular surviving object.
+`base_value` is a relative gameplay value that represents material and skilled
+labor. It is not a historical price series.
+
+Combat-facing fields retain the meanings in [Combat](../wiki/tactical/Combat.md):
+
+- `accuracy` is the weapon precision multiplier; values use the documented
+  0.5 club/hammer, 1.0 axe, 1.5 sword/spear, and 2.0 purpose-built precision
+  calibration.
+- `penetration` is its armor-resistance coefficient; blunt weapons use 0.1--0.5,
+  ordinary edged weapons 1.0, spear and broadhead-like points 2.0, and narrow
+  armor-seeking points 4.0.
+- `reach` is metres. The present schema uses it for melee reach on melee items
+  and autoresolve range on ranged items.
+- `resistance` and `padding` are joules; `coverage`, `flexibility`, and
+  `range_of_motion` are 0--1. Plate favors resistance and coverage, mail loses
+  resistance under penetrating attacks through its high flexibility, and padded
+  clothing favors padding and mobility.
+
+These are deterministic gameplay inferences from the documented combat model
+and physical construction, not claims that period sources supplied those exact
+numbers. The catalog test rejects duplicate IDs, placeholder `bot_` entries,
+impossible slots, absent damage types, out-of-range armor values, and a
+weapons-to-armor ratio contrary to the intended inventory.
+
+## Sources
+
+- [German History in Documents and Images: marching Landsknechts, c. 1532--42](https://germanhistorydocs.org/de/von-den-reformationen-bis-zum-dreissigjaehrigen-krieg-1500-1648/marschierende-landsknechte-1-haelfte-des-16-jahrhunderts)
+- [Musée Lorrain: equipment of two imperial Landsknechts](https://musee-lorrain.nancy.fr/les-collections/catalogues-numeriques/la-lorraine-pour-horizon/une-premiere-lorraine-francaise/equipement-de-deux-lansquenets-imperiaux)
+- [The Met: German halberd](https://www.metmuseum.org/art/collection/search/25898)
+- [The Met: German breastplate, dated 1540, with documented 3.515 kg weight](https://www.metmuseum.org/art/collection/search/22292)
+- [The Met: German Augsburg burgonet, c. 1525--30, with documented 2.332 kg weight](https://www.metmuseum.org/art/collection/search/685229)
+- [The Met: Augsburg breastplate with tassets, c. 1530](https://www.metmuseum.org/art/collection/search/35917)
+- [The Met: German helmet, c. 1535](https://www.metmuseum.org/art/collection/search/24667)
+- [Wallace Collection: German sallet, c. 1515, explicitly a declining form](https://wallacelive.wallacecollection.org/eMP/eMuseumPlus?module=collection&objectId=60574&service=ExternalInterface)

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (590)
+## Files (591)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -544,6 +544,7 @@ development, or wiki document before changing a subsystem.
 - `docs/DEVELOPING.md` — Project documentation.
 - `docs/DROUGHT.md` — Project documentation.
 - `docs/ELEVATION.md` — Project documentation.
+- `docs/EQUIPMENT.md` — Project documentation.
 - `docs/FOREST_COVER.md` — Project documentation.
 - `docs/GEOLOGY.md` — Project documentation.
 - `docs/HISTORICAL_LAND_USE.md` — Project documentation.


### PR DESCRIPTION
## Summary

Adds the historical 1544 German weapons, armor, and helmet catalog used by strategic equipment systems.

## Impact

Expands non-fantasy equipment variety while preserving the existing combat parameter model.

## Validation

The restacked strategic module, generated client bindings, and world importer were checked locally.
