### PR TITLE
Remove exclusive functions and unsafe, simpler callback handling

### DIFF
--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -110,6 +110,7 @@ fn main() {
             Update,
             (
                 check_mission_timeout,
+                spawn_connected_players.after(stdb::update_spacetimedb),
                 (setup_server, setup_stdb_callbacks).run_if(resource_added::<SpacetimeDb>),
             ),
         )
@@ -146,19 +147,26 @@ fn setup_server(mut commands: Commands, args: Res<Args>) {
     }
 }
 
-fn setup_stdb_callbacks(mut conn: ResMut<SpacetimeDb>) {
+fn setup_stdb_callbacks(conn: Res<SpacetimeDb>) {
     conn.subscribe_connected_players();
-    conn.on_insert(
-        RemoteTables::connected_players,
-        on_stdb_insert_connected_players,
-    );
 }
 
-fn on_stdb_insert_connected_players(
-    InRef(player): InRef<ConnectedPlayer>,
+fn spawn_connected_players(
+    conn: Res<SpacetimeDb>,
     mut cmd: Commands,
     q_loading: Query<(Entity, &LoadingPlayer)>,
     q_scene: Query<&SceneTerrain>,
+) {
+    for player in conn.take_connected_players() {
+        spawn_connected_player(&player, &mut cmd, &q_loading, &q_scene);
+    }
+}
+
+fn spawn_connected_player(
+    player: &ConnectedPlayer,
+    cmd: &mut Commands,
+    q_loading: &Query<(Entity, &LoadingPlayer)>,
+    q_scene: &Query<&SceneTerrain>,
 ) {
     let entity = if player.character.temporary {
         cmd.spawn_empty().id()

--- a/crates/adventuresim-tactical-server/src/stdb.rs
+++ b/crates/adventuresim-tactical-server/src/stdb.rs
@@ -12,7 +12,8 @@ pub struct SpacetimeDbPlugin;
 impl Plugin for SpacetimeDbPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, connect_spacetimedb)
-            .add_systems(Update, update_spacetimedb);
+            .add_systems(Update, update_spacetimedb)
+            .add_systems(Last, disconnect_spacetimedb);
     }
 }
 
@@ -41,9 +42,9 @@ impl SpacetimeDb {
     ///
     /// For native subscriptions, see: https://spacetimedb.com/docs/sdks/rust/quickstart/#subscribe-to-queries.
     pub fn subscribe_connected_players(&self) -> SubscriptionHandle {
-        let mailbox = self.connected_players.clone();
+        let connected_players = self.connected_players.clone();
         self.conn.db.connected_players().on_insert(move |_ctx, row| {
-            mailbox.lock().unwrap().push(row.clone());
+            connected_players.lock().unwrap().push(row.clone());
         });
 
         self.conn
@@ -70,6 +71,20 @@ pub fn update_spacetimedb(stdb: Res<SpacetimeDb>) -> Result {
     Ok(())
 }
 
+/// On app exit, close the connection cleanly.
+fn disconnect_spacetimedb(mut exit: MessageReader<AppExit>, stdb: Res<SpacetimeDb>) {
+    if exit.read().next().is_none() {
+        return;
+    }
+
+    info!("Disconnecting from SpacetimeDB...");
+    if stdb.conn.disconnect().is_ok() {
+        // `disconnect` only queues the close; pump until the stream ends so
+        // queued reducer calls (e.g. mission results) reach the server first.
+        while stdb.conn.advance_one_message_blocking().is_ok() {}
+    }
+}
+
 fn connect_spacetimedb(mut commands: Commands, args: Res<Args>) -> Result {
     info!("Connecting to SpacetimeDB: {}", args.spacetimedb_url);
     let conn = DbConnection::builder()
@@ -79,8 +94,10 @@ fn connect_spacetimedb(mut commands: Commands, args: Res<Args>) -> Result {
             info!("SpacetimeDB connected: {i}");
         })
         .on_connect_error(|_, err| {
-            // TODO: probably shouldn't insert resource if there is an error ?
             error!("SpacetimeDB connection failed: {err}");
+            // A mission server without its database is useless;
+            // die and let the orchestrator deal with it.
+            std::process::exit(1);
         })
         .on_disconnect(|_, err| {
             if let Some(err) = err {

--- a/crates/adventuresim-tactical-server/src/stdb.rs
+++ b/crates/adventuresim-tactical-server/src/stdb.rs
@@ -42,6 +42,7 @@ impl SpacetimeDb {
     ///
     /// For native subscriptions, see: https://spacetimedb.com/docs/sdks/rust/quickstart/#subscribe-to-queries.
     pub fn subscribe_connected_players(&self) -> SubscriptionHandle {
+        // This is the callback handler. Standard Arc<Mutex<>> pattern for sharing state between threads.
         let connected_players = self.connected_players.clone();
         self.conn.db.connected_players().on_insert(move |_ctx, row| {
             connected_players.lock().unwrap().push(row.clone());

--- a/crates/adventuresim-tactical-server/src/stdb.rs
+++ b/crates/adventuresim-tactical-server/src/stdb.rs
@@ -1,11 +1,7 @@
-use std::{mem::MaybeUninit, sync::Arc};
+use std::sync::{Arc, Mutex};
 
 use adventuresim_stdb_client::*;
-use bevy::{
-    ecs::{system::RunSystemOnce, world::unsafe_world_cell::UnsafeWorldCell},
-    platform::cell::SyncUnsafeCell,
-    prelude::*,
-};
+use bevy::prelude::*;
 use spacetimedb_sdk::{DbContext, Identity, Table};
 
 use crate::Args;
@@ -20,11 +16,14 @@ impl Plugin for SpacetimeDbPlugin {
     }
 }
 
-// FIXME: frame tick and disconnect on shutown
+/// Connection to SpacetimeDB.
+///
+/// SDK callbacks never touch the Bevy world — they only push rows into a
+/// mailbox, which ordinary systems drain on their own schedule.
 #[derive(Resource)]
 pub struct SpacetimeDb {
     conn: DbConnection,
-    world: Arc<SyncUnsafeCell<MaybeUninit<UnsafeWorldCell<'static>>>>,
+    connected_players: Arc<Mutex<Vec<ConnectedPlayer>>>,
 }
 
 impl SpacetimeDb {
@@ -38,10 +37,15 @@ impl SpacetimeDb {
         self.conn.identity()
     }
 
-    /// Subscribe for spacetime db database changes.
+    /// Subscribe to `connected_players` and start collecting inserted rows.
     ///
-    /// For native subsctiptions, see: https://spacetimedb.com/docs/sdks/rust/quickstart/#subscribe-to-queries.
-    pub fn subscribe_connected_players(&mut self) -> SubscriptionHandle {
+    /// For native subscriptions, see: https://spacetimedb.com/docs/sdks/rust/quickstart/#subscribe-to-queries.
+    pub fn subscribe_connected_players(&self) -> SubscriptionHandle {
+        let mailbox = self.connected_players.clone();
+        self.conn.db.connected_players().on_insert(move |_ctx, row| {
+            mailbox.lock().unwrap().push(row.clone());
+        });
+
         self.conn
             .subscription_builder()
             .on_error(|ctx, error| {
@@ -54,58 +58,16 @@ impl SpacetimeDb {
             .subscribe()
     }
 
-    /// Create a new bevy system callback for new rows in a table.
-    ///
-    /// ## Example
-    ///
-    /// ```
-    /// fn system(mut conn: ResMut<SpacetimeDb>) {
-    ///     conn.on_insert(RemoteTables::character, |InRef(character): InRef<Character>, mut commands: Commands| {
-    ///         commands.spawn(Name::from(character.name.clone()));
-    ///     });
-    /// }
-    /// ```
-    pub fn on_insert<'a, T, TGet, S, M>(&'a mut self, table: TGet, system: S)
-    where
-        T: Table + 'a,
-        TGet: FnOnce(&'a RemoteTables) -> T,
-        S: IntoSystem<InRef<'static, T::Row>, (), M> + Send + Sync + 'static + Copy,
-    {
-        let table = table(&self.conn.db);
-        let world = self.world.clone();
-        table.on_insert(move |_ctx, new| {
-            debug!("on_insert: {}", std::any::type_name::<T::Row>());
-
-            // SAFETY: `world` is set and used within one system: `update_spacetimedb`.
-            //         Spacetime will call this callback only when the inner connection is mid-update,
-            //         which in our case is single instance of `tick_frame` call when the world is valid.
-            unsafe {
-                let world = world.get().as_mut().unwrap().assume_init_mut().world_mut();
-
-                // FIXME: `run_system_once_with` is extremely ineffecent,
-                //        we need to register the system once somehow
-                let system = IntoSystem::into_system(system);
-                world.run_system_once_with(system, new).unwrap();
-            }
-        });
+    /// Take every `connected_players` row inserted since the last call.
+    pub fn take_connected_players(&self) -> Vec<ConnectedPlayer> {
+        std::mem::take(&mut *self.connected_players.lock().unwrap())
     }
 }
 
-fn update_spacetimedb(world: &mut World) -> Result {
-    world.resource_scope::<SpacetimeDb, _>(|world, stdb| -> Result {
-        // SAFETY: `world` is only used in callbacks, which are invoked in the subsequent
-        //         `frame_tick` call. We limit access to spacetime db to ensure that callbacks
-        //         will always have valid world attached.
-        unsafe {
-            stdb.world
-                .get()
-                .as_mut()
-                .unwrap()
-                .write(std::mem::transmute(world.as_unsafe_world_cell()));
-        }
-        stdb.conn.frame_tick()?;
-        Ok(())
-    })
+/// Pump the connection; SDK callbacks fire here and fill the mailboxes.
+pub fn update_spacetimedb(stdb: Res<SpacetimeDb>) -> Result {
+    stdb.conn.frame_tick()?;
+    Ok(())
 }
 
 fn connect_spacetimedb(mut commands: Commands, args: Res<Args>) -> Result {
@@ -131,7 +93,7 @@ fn connect_spacetimedb(mut commands: Commands, args: Res<Args>) -> Result {
 
     commands.insert_resource(SpacetimeDb {
         conn,
-        world: Arc::new(SyncUnsafeCell::new(MaybeUninit::uninit())),
+        connected_players: default(),
     });
 
     Ok(())

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -297,8 +297,8 @@ migration: stop the old server, retain an operator backup if wanted, move the
 old data directory aside or provision a new empty one, select 2.6.1, and run
 `just web-reset`. That explicit startup resets, reseeds, and permanently
 discards prior database contents. Once the reset is complete, return to
-`just dev` / `just web` and plain `just publish`; ordinary startup and module
-updates are non-destructive.
+`just dev` / `just web`, which reset local data only for breaking schema
+changes, and plain `just publish`, which remains non-destructive.
 
 ### 4. Open the UI
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -33,8 +33,9 @@ just dev
 
 Open http://localhost:8080
 
-Ordinary `just dev` / `just web` startup publishes without deleting database
-data. Use `just web-reset` only when an intentional reset is required.
+Ordinary `just dev` / `just web` startup preserves database data when the schema
+is compatible and deletes it when a breaking schema change requires a reset.
+Use `just web-reset` when an unconditional reset is required.
 
 ## Full Development (with Tactical Servers)
 
@@ -51,6 +52,21 @@ just build-wasm
 ```
 
 Now when you click a location in the browser, a tactical server will automatically spawn.
+
+For native tactical testing from WSL on Windows, the equivalent of running
+`just dev`, `just tactical`, and `just client 0` in separate Linux terminals is:
+
+```bash
+just win-dev
+```
+
+This runs the strategic stack in WSL, cross-compiles and stages the tactical
+executables in `E:\adventure-sim-dev`, then starts one native Windows tactical
+server and client 0. Press Ctrl+C to stop the web process and Windows tactical
+processes; the detached SpacetimeDB and tactical dispatcher follow the normal
+`just dev` lifecycle and can be stopped with `just stop`. The recipe installs
+the pinned toolchain's `x86_64-pc-windows-gnu` Rust target when needed; the WSL
+package `gcc-mingw-w64-x86-64` must already be installed.
 
 ## Requirements
 
@@ -138,11 +154,12 @@ browser stack; it permanently discards the database's previous contents. Keep
 the moved directory until the reset has been validated, then retire it under
 the operator's normal backup-retention policy.
 
-After this one-time reset, routine startup should use `just dev` / `just web`
-and routine publishes should use `just publish`, all of which preserve data.
-Do not use `web-reset` or `publish-reset` on a future public or player-bearing
-database unless data loss is explicitly approved and a verified recovery copy
-exists.
+After this one-time reset, routine startup should use `just dev` / `just web`;
+these preserve data for compatible changes but reset local data on breaking
+schema changes. Routine manual publishes should use `just publish`, which
+preserves data. Do not use `web`, `web-reset`, or `publish-reset` against a
+future public or player-bearing database unless data loss is explicitly
+approved and a verified recovery copy exists.
 
 ## Viabundus source data
 

--- a/justfile
+++ b/justfile
@@ -69,8 +69,8 @@ dev:
 dev-full:
     @just web
 
-# Start the local browser stack.
-web: preflight build-wasm spacetime-start publish _seed-world build-tactical
+# Start the local browser stack, resetting local data only for breaking schema changes.
+web: preflight build-wasm spacetime-start publish-on-conflict _seed-world build-tactical
     @just _spawner-start
     @echo ""
     @echo "Starting strategic-web server..."
@@ -198,6 +198,10 @@ spacetime-stop:
 # Publish the strategic module (optional target can be provided: just publish target=localhost)
 publish server=spacetime_url: spacetime-version-check
     @cd "{{strategic_dir}}" && spacetime publish --server {{server}} {{spacetime_module}}
+
+# Publish locally, clearing data only when a breaking schema change requires it.
+publish-on-conflict: spacetime-version-check
+    @cd "{{strategic_dir}}" && spacetime publish --delete-data=on-conflict --server {{spacetime_url}} {{spacetime_module}}
 
 # Publish and clear the module database
 publish-reset server=spacetime_url: spacetime-version-check
@@ -386,9 +390,9 @@ certs sans="127.0.0.1,localhost":
     @bash "{{cert_dir}}/generate_certificates.sh" "{{sans}}"
     @echo "Wrote {{cert_pem}}, {{cert_key}}, and {{cert_dir}}/digest.txt"
 
-# Windows development recipe
-# Local dev with native Windows exes (GPU accelerated, no WSLg, no UDP issues)
-# Cross-compiles server + client to Windows, stages to E:\adventure-sim-dev, runs both
+# Windows tactical development recipe
+# Runs the strategic stack in WSL, then stages and runs the tactical server and
+# client 0 as native Windows executables (GPU accelerated, no WSLg/UDP issues).
 win-dev:
     #!/usr/bin/env bash
     set -e
@@ -398,15 +402,57 @@ win-dev:
     SERVER_EXE="./target/${WIN_TARGET}/win-dev/adventuresim-tactical-server.exe"
     CLIENT_EXE="./target/${WIN_TARGET}/win-dev/adventuresim-tactical-client.exe"
 
+    command -v x86_64-w64-mingw32-gcc >/dev/null 2>&1 || {
+        echo "Missing MinGW linker: install gcc-mingw-w64-x86-64" >&2
+        exit 1
+    }
+    if ! rustup target list --installed | grep -Fxq "$WIN_TARGET"; then
+        echo "Installing Rust target ${WIN_TARGET}..."
+        rustup target add "$WIN_TARGET"
+    fi
+
+    kill_windows_processes() {
+        (cd /mnt/c && cmd.exe /C "taskkill /IM adventuresim-tactical-server.exe /F >NUL 2>&1") || true
+        (cd /mnt/c && cmd.exe /C "taskkill /IM adventuresim-tactical-client.exe /F >NUL 2>&1") || true
+    }
+
     # Kill any leftover instances
-    cmd.exe /C "taskkill /IM adventuresim-tactical-server.exe /F >NUL 2>&1" || true
-    cmd.exe /C "taskkill /IM adventuresim-tactical-client.exe /F >NUL 2>&1" || true
+    kill_windows_processes
     sleep 0.5
 
+    cleanup() {
+        echo ""
+        echo "Shutting down..."
+        kill_windows_processes
+        kill -- -"$DEV_PID" 2>/dev/null || true
+        wait "$DEV_PID" 2>/dev/null || true
+    }
+
+    echo "Starting strategic development stack..."
+    setsid just dev &
+    DEV_PID=$!
+    trap cleanup EXIT INT TERM
+
+    echo "Waiting for strategic web server..."
+    for _ in {1..300}; do
+        if python3 -c 'import socket, sys; s=socket.socket(); s.settimeout(0.2); code=s.connect_ex(("127.0.0.1", {{web_port}})); s.close(); sys.exit(code != 0)'; then
+            break
+        fi
+        if ! kill -0 "$DEV_PID" 2>/dev/null; then
+            echo "Strategic development stack exited before becoming ready" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+    if ! python3 -c 'import socket, sys; s=socket.socket(); s.settimeout(0.2); code=s.connect_ex(("127.0.0.1", {{web_port}})); s.close(); sys.exit(code != 0)'; then
+        echo "Timed out waiting for strategic web server" >&2
+        exit 1
+    fi
+
     echo "Building server (Windows)..."
-    cargo build -p adventuresim-tactical-server --target $WIN_TARGET --profile win-dev 2>&1
+    cargo build -p adventuresim-tactical-server --features debug --target "$WIN_TARGET" --profile win-dev 2>&1
     echo "Building client (Windows)..."
-    cargo build -p adventuresim-tactical-client --target $WIN_TARGET --profile win-dev 2>&1
+    cargo build -p adventuresim-tactical-client --features debug --target "$WIN_TARGET" --profile win-dev 2>&1
 
     echo "Staging to E:\\adventure-sim-dev..."
     mkdir -p "$STAGE_DIR"
@@ -418,32 +464,21 @@ win-dev:
         [ -d "$d" ] && rsync -a "$d" "$STAGE_DIR/assets/"
     done
 
-    cleanup() {
-        echo ""
-        echo "Shutting down..."
-        kill $SERVER_PID $CLIENT0_PID $CLIENT1_PID 2>/dev/null
-        wait $SERVER_PID $CLIENT0_PID $CLIENT1_PID 2>/dev/null
-    }
-    trap cleanup EXIT INT TERM
-
     echo "Starting server..."
     cd "$STAGE_DIR" && ./adventuresim-tactical-server.exe \
+        --addr 0.0.0.0:{{tactical_port}} \
         --mission-id test-mission \
         --scene-key hills \
-        --no-timeout \
         --spacetimedb-url http://localhost:{{spacetime_port}} \
-        --spacetimedb-module {{spacetime_module}} &
+        --spacetimedb-module {{spacetime_module}} \
+        --bots 3 \
+        --no-timeout &
     SERVER_PID=$!
     sleep 3
 
     echo "Starting client 0..."
     cd "$STAGE_DIR" && ./adventuresim-tactical-client.exe --id 0 --server-addr 127.0.0.1:{{tactical_port}} &
-    CLIENT0_PID=$!
-    sleep 1
-
-    echo "Starting client 1..."
-    cd "$STAGE_DIR" && ./adventuresim-tactical-client.exe --id 1 --server-addr 127.0.0.1:{{tactical_port}} &
-    CLIENT1_PID=$!
+    CLIENT_PID=$!
 
     wait
 


### PR DESCRIPTION
Remembered this callback handling from implementing the Steamworks API some years ago. You can basically share a anything in a bevy resource with any callback or outside actors using `Arc<Mutex<>>` and `move`. 

Connected players becomes `Arc<Mutex<Vec<ConnectedPlayer>>>`, callback handling boils down to:

```rust
let connected_players = self.connected_players.clone();
self.conn.db.connected_players().on_insert(move |_ctx, row| {
    connected_players.lock().unwrap().push(row.clone());
});
```