### PR TITLE
Add inventory encumbrance meters

### DIFF
--- a/crates/adventuresim-core/src/equipment.rs
+++ b/crates/adventuresim-core/src/equipment.rs
@@ -3,9 +3,66 @@ use crate::{
     prelude::{LimbAttribute, PlayerAttributes},
 };
 
-const LOWER_MUSCLE_MASS_PER_LEG_STRENGTH: f32 = 5.0;
-const WEIGHT_CAPACITY_PER_LOWER_MUSCLE_MASS: f32 = 30.0;
+pub const LOWER_MUSCLE_MASS_PER_LEG_STRENGTH: f32 = 5.0;
+pub const WEIGHT_CAPACITY_PER_LOWER_MUSCLE_MASS: f32 = 30.0;
 const ARMOR_PENALTY_EXPONENT: i32 = 3;
+
+/// The carried burden and injury-adjusted carrying capacity used by the
+/// shared linear encumbrance rule.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct EncumbranceSummary {
+    pub burden_kg: f32,
+    pub capacity_kg: f32,
+}
+
+impl EncumbranceSummary {
+    pub fn new(burden_kg: f32, capacity_kg: f32) -> Self {
+        Self {
+            burden_kg: finite_nonnegative(burden_kg),
+            capacity_kg: finite_nonnegative(capacity_kg),
+        }
+    }
+
+    pub fn remaining_multiplier(self) -> f32 {
+        encumbrance_remaining_multiplier(self.burden_kg, self.capacity_kg)
+    }
+
+    pub fn penalty_fraction(self) -> f32 {
+        1.0 - self.remaining_multiplier()
+    }
+
+    pub fn combined(self, other: Self) -> Self {
+        Self::new(
+            self.burden_kg + other.burden_kg,
+            self.capacity_kg + other.capacity_kg,
+        )
+    }
+}
+
+fn finite_nonnegative(value: f32) -> f32 {
+    if value.is_finite() {
+        value.max(0.0)
+    } else {
+        0.0
+    }
+}
+
+pub fn encumbrance_capacity_kg(average_injury_adjusted_leg_strength: f32) -> f32 {
+    finite_nonnegative(average_injury_adjusted_leg_strength)
+        * LOWER_MUSCLE_MASS_PER_LEG_STRENGTH
+        * WEIGHT_CAPACITY_PER_LOWER_MUSCLE_MASS
+}
+
+/// Returns the multiplier left after encumbrance. A character with no usable
+/// capacity is fully penalized, including when the reported burden is zero.
+pub fn encumbrance_remaining_multiplier(burden_kg: f32, capacity_kg: f32) -> f32 {
+    let burden_kg = finite_nonnegative(burden_kg);
+    let capacity_kg = finite_nonnegative(capacity_kg);
+    if capacity_kg <= f32::EPSILON {
+        return 0.0;
+    }
+    (1.0 - burden_kg / capacity_kg).clamp(0.0, 1.0)
+}
 
 #[blanket::blanket(derive(Ref, Rc, Arc, Mut, Box, Cow))]
 #[ambassador::delegatable_trait]
@@ -72,10 +129,39 @@ pub trait PlayerEquipment {
             body,
             LimbWeights::both_legs(),
         );
-        let lower_muscle_mass = average_leg_strength * LOWER_MUSCLE_MASS_PER_LEG_STRENGTH;
-        let weight_capacity = WEIGHT_CAPACITY_PER_LOWER_MUSCLE_MASS * lower_muscle_mass;
+        let weight_capacity = encumbrance_capacity_kg(average_leg_strength);
+        encumbrance_remaining_multiplier(
+            body.body_weight() + self.inventory_weight(),
+            weight_capacity,
+        )
+    }
+}
 
-        let penalty = 1.0 - ((body.body_weight() + self.inventory_weight()) / weight_capacity);
-        penalty.clamp(0.0, 1.0)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linear_encumbrance_covers_key_points_and_overload() {
+        assert_eq!(encumbrance_remaining_multiplier(0.0, 100.0), 1.0);
+        assert_eq!(encumbrance_remaining_multiplier(50.0, 100.0), 0.5);
+        assert_eq!(encumbrance_remaining_multiplier(100.0, 100.0), 0.0);
+        assert_eq!(encumbrance_remaining_multiplier(125.0, 100.0), 0.0);
+        assert_eq!(encumbrance_remaining_multiplier(0.0, 0.0), 0.0);
+    }
+
+    #[test]
+    fn injury_adjusted_strength_maps_to_capacity() {
+        assert_eq!(encumbrance_capacity_kg(0.0), 0.0);
+        assert_eq!(encumbrance_capacity_kg(0.75), 112.5);
+        assert_eq!(encumbrance_capacity_kg(3.0), 450.0);
+    }
+
+    #[test]
+    fn summaries_combine_burdens_and_capacities_before_penalty() {
+        let party =
+            EncumbranceSummary::new(60.0, 100.0).combined(EncumbranceSummary::new(30.0, 200.0));
+        assert_eq!(party, EncumbranceSummary::new(90.0, 300.0));
+        assert!((party.penalty_fraction() - 0.3).abs() < f32::EPSILON);
     }
 }

--- a/crates/adventuresim-core/src/equipment.rs
+++ b/crates/adventuresim-core/src/equipment.rs
@@ -40,17 +40,21 @@ impl EncumbranceSummary {
 }
 
 fn finite_nonnegative(value: f32) -> f32 {
-    if value.is_finite() {
-        value.max(0.0)
-    } else {
+    if value.is_nan() || value <= 0.0 {
         0.0
+    } else if value.is_infinite() {
+        f32::MAX
+    } else {
+        value
     }
 }
 
 pub fn encumbrance_capacity_kg(average_injury_adjusted_leg_strength: f32) -> f32 {
-    finite_nonnegative(average_injury_adjusted_leg_strength)
-        * LOWER_MUSCLE_MASS_PER_LEG_STRENGTH
-        * WEIGHT_CAPACITY_PER_LOWER_MUSCLE_MASS
+    finite_nonnegative(
+        finite_nonnegative(average_injury_adjusted_leg_strength)
+            * LOWER_MUSCLE_MASS_PER_LEG_STRENGTH
+            * WEIGHT_CAPACITY_PER_LOWER_MUSCLE_MASS,
+    )
 }
 
 /// Returns the multiplier left after encumbrance. A character with no usable
@@ -163,5 +167,28 @@ mod tests {
             EncumbranceSummary::new(60.0, 100.0).combined(EncumbranceSummary::new(30.0, 200.0));
         assert_eq!(party, EncumbranceSummary::new(90.0, 300.0));
         assert!((party.penalty_fraction() - 0.3).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn positive_infinite_burden_is_saturated_and_fully_penalizing() {
+        let summary = EncumbranceSummary::new(f32::INFINITY, 100.0);
+        assert_eq!(summary.burden_kg, f32::MAX);
+        assert_eq!(summary.penalty_fraction(), 1.0);
+    }
+
+    #[test]
+    fn positive_infinite_capacity_is_saturated_without_becoming_zero() {
+        let summary = EncumbranceSummary::new(100.0, f32::INFINITY);
+        assert_eq!(summary.capacity_kg, f32::MAX);
+        assert_eq!(summary.remaining_multiplier(), 1.0);
+    }
+
+    #[test]
+    fn finite_sum_overflow_cannot_erase_an_overload() {
+        let combined = EncumbranceSummary::new(f32::MAX, 100.0)
+            .combined(EncumbranceSummary::new(f32::MAX, 100.0));
+        assert_eq!(combined.burden_kg, f32::MAX);
+        assert_eq!(combined.capacity_kg, 200.0);
+        assert_eq!(combined.penalty_fraction(), 1.0);
     }
 }

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -1,9 +1,12 @@
 //! Settlement route handlers
 
-use adventuresim_core::prelude::{
-    ProvisioningInputs, STANDARD_TRAVEL_RATION_ID, STANDARD_WATERSKIN_ID,
-    STRATEGIC_PROVISION_BUFFER_PERCENT, STRATEGIC_TRAVEL_KCAL_PER_DAY,
-    STRATEGIC_TRAVEL_WATER_ML_PER_DAY, Skill,
+use adventuresim_core::{
+    equipment::{EncumbranceSummary, encumbrance_capacity_kg},
+    prelude::{
+        ProvisioningInputs, STANDARD_TRAVEL_RATION_ID, STANDARD_WATERSKIN_ID,
+        STRATEGIC_PROVISION_BUFFER_PERCENT, STRATEGIC_TRAVEL_KCAL_PER_DAY,
+        STRATEGIC_TRAVEL_WATER_ML_PER_DAY, Skill,
+    },
 };
 use axum::{
     Form, Json, Router,
@@ -1822,6 +1825,16 @@ async fn party_member(
         .unwrap_or_default();
     let selected_targets = personal_inventory_targets(&state, selected.id).await;
     let active_targets = personal_inventory_targets(&state, active_character.id).await;
+    let encumbrance_rows =
+        EncumbranceRows::query(&state, &[selected.id, active_character.id]).await;
+    let selected_encumbrance =
+        personal_encumbrance(selected.id, &selected_inventory, &items, &encumbrance_rows);
+    let active_encumbrance = personal_encumbrance(
+        active_character.id,
+        &active_inventory,
+        &items,
+        &encumbrance_rows,
+    );
 
     if character_id == active_character.id {
         return Html(
@@ -1832,6 +1845,7 @@ async fn party_member(
                 &items,
                 &party_members,
                 active_equip.first(),
+                active_encumbrance,
             )
             .into_string(),
         );
@@ -1850,6 +1864,8 @@ async fn party_member(
             active_equip.first(),
             &selected_targets,
             &active_targets,
+            selected_encumbrance,
+            active_encumbrance,
         )
         .into_string(),
     )
@@ -1910,6 +1926,37 @@ async fn party_pool_inventory(
         .await
         .unwrap_or_default();
     let members = get_active_party_members(&state, Some(&character)).await;
+    let member_ids: Vec<u64> = members.iter().map(|member| member.id).collect();
+    let member_inventories = async {
+        let state_ref = &state;
+        let lookups = member_ids.iter().copied().map(|member_id| async move {
+            state_ref
+                .db
+                .query::<InventoryItem>(&format!(
+                    "SELECT * FROM inventory_item WHERE character_id = {member_id}"
+                ))
+                .await
+                .unwrap_or_default()
+        });
+        join_all(lookups)
+            .await
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+    };
+    let (all_inventories, encumbrance_rows) = tokio::join!(
+        member_inventories,
+        EncumbranceRows::query(&state, &member_ids),
+    );
+    let personal_encumbrance =
+        personal_encumbrance(character.id, &inventory, &items, &encumbrance_rows);
+    let party_encumbrance = party_encumbrance(
+        &members,
+        &all_inventories,
+        &pooled,
+        &items,
+        &encumbrance_rows,
+    );
     let stake = stakes
         .iter()
         .find(|stake| stake.character_id == character.id)
@@ -1927,6 +1974,8 @@ async fn party_pool_inventory(
             equip.first(),
             &personal_targets,
             &party_targets,
+            party_encumbrance,
+            personal_encumbrance,
         )
         .into_string(),
     )
@@ -3564,6 +3613,106 @@ async fn equipment_rest_recommendation(
     (field_minutes, smith_wait)
 }
 
+#[derive(Default)]
+struct EncumbranceRows {
+    attributes: Vec<CharacterAttributes>,
+    limbs: Vec<CharacterLimbs>,
+    conditions: Vec<CharacterCondition>,
+    needs: Vec<CharacterNeeds>,
+}
+
+impl EncumbranceRows {
+    async fn query(state: &AppState, character_ids: &[u64]) -> Self {
+        let unique_ids: std::collections::BTreeSet<u64> = character_ids.iter().copied().collect();
+        let lookups = unique_ids.into_iter().map(|character_id| async move {
+            tokio::join!(
+                query_single::<CharacterAttributes>(state, "character_attributes", character_id,),
+                query_single::<CharacterLimbs>(state, "character_limbs", character_id),
+                query_single::<CharacterCondition>(state, "character_condition", character_id),
+                query_single::<CharacterNeeds>(state, "character_needs", character_id),
+            )
+        });
+        let mut rows = Self::default();
+        for (attributes, limbs, condition, needs) in join_all(lookups).await {
+            rows.attributes.extend(attributes);
+            rows.limbs.extend(limbs);
+            rows.conditions.extend(condition);
+            rows.needs.extend(needs);
+        }
+        rows
+    }
+}
+
+fn item_stack_weight_kg(item_id: &str, quantity: u32, items: &[ItemDefinition]) -> f32 {
+    items
+        .iter()
+        .find(|definition| definition.id == item_id)
+        .map_or(0.0, |definition| {
+            definition.weight.max(0.0) * quantity as f32
+        })
+}
+
+fn personal_encumbrance(
+    character_id: u64,
+    inventory: &[InventoryItem],
+    items: &[ItemDefinition],
+    rows: &EncumbranceRows,
+) -> EncumbranceSummary {
+    let body_weight = rows
+        .conditions
+        .iter()
+        .find(|row| row.character_id == character_id)
+        .map_or(0.0, |row| row.body_weight_kg.max(0.0));
+    let water_weight = rows
+        .needs
+        .iter()
+        .find(|row| row.character_id == character_id)
+        .map_or(0.0, |row| row.carried_water_ml.max(0.0) / 1_000.0);
+    let inventory_weight = inventory
+        .iter()
+        .filter(|row| row.character_id == character_id)
+        .map(|row| item_stack_weight_kg(&row.item_id, row.qty, items))
+        .sum::<f32>();
+    let capacity = rows
+        .attributes
+        .iter()
+        .find(|row| row.character_id == character_id)
+        .zip(
+            rows.limbs
+                .iter()
+                .find(|row| row.character_id == character_id),
+        )
+        .map_or(0.0, |(attributes, limbs)| {
+            encumbrance_capacity_kg(
+                (attributes.left_leg_strength * limbs.left_leg_health.clamp(0.0, 1.0)
+                    + attributes.right_leg_strength * limbs.right_leg_health.clamp(0.0, 1.0))
+                    / 2.0,
+            )
+        });
+
+    EncumbranceSummary::new(body_weight + water_weight + inventory_weight, capacity)
+}
+
+fn party_encumbrance(
+    members: &[Character],
+    inventories: &[InventoryItem],
+    pooled: &[PartyInventoryItem],
+    items: &[ItemDefinition],
+    rows: &EncumbranceRows,
+) -> EncumbranceSummary {
+    let member_summary = members.iter().filter(|member| member.alive).fold(
+        EncumbranceSummary::default(),
+        |summary, member| {
+            summary.combined(personal_encumbrance(member.id, inventories, items, rows))
+        },
+    );
+    let pooled_weight = pooled
+        .iter()
+        .map(|row| item_stack_weight_kg(&row.item_id, row.quantity, items))
+        .sum::<f32>();
+    member_summary.combined(EncumbranceSummary::new(pooled_weight, 0.0))
+}
+
 async fn get_active_character(
     state: &AppState,
     character_id: Option<u64>,
@@ -3677,5 +3826,160 @@ mod herbalist_tests {
             medication_names: vec!["Catarrhal fever cordial".into()],
         };
         assert_eq!(herbalist_diagnosis_dtos(&row).len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod encumbrance_tests {
+    use super::{EncumbranceRows, party_encumbrance, personal_encumbrance};
+    use crate::spacetimedb::{
+        Character, CharacterAttributes, CharacterCondition, CharacterLimbs, CharacterNeeds,
+        InventoryItem, ItemDefinition, PartyInventoryItem,
+    };
+    use serde_json::json;
+
+    fn item(id: &str, weight: f32) -> ItemDefinition {
+        serde_json::from_value(json!({
+            "id": id,
+            "weight": weight,
+            "kind": "Weapon"
+        }))
+        .unwrap()
+    }
+
+    fn character(id: u64, alive: bool) -> Character {
+        Character {
+            id,
+            name: format!("Character {id}"),
+            xp: 0,
+            level: 1,
+            gold: 0,
+            current_settlement_id: None,
+            current_quest_location_id: None,
+            party_id: Some("party".into()),
+            age_years: 20,
+            alive,
+            temporary: false,
+        }
+    }
+
+    fn rows() -> EncumbranceRows {
+        EncumbranceRows {
+            attributes: vec![CharacterAttributes {
+                character_id: 1,
+                endurance: 0.0,
+                immunity: 0.0,
+                gut: 0.0,
+                precision: 0.0,
+                intelligence: 0.0,
+                instinct: 0.0,
+                eyesight: 0.0,
+                hearing: 0.0,
+                left_arm_strength: 0.0,
+                right_arm_strength: 0.0,
+                left_leg_strength: 4.0,
+                right_leg_strength: 2.0,
+                left_arm_agility: 0.0,
+                right_arm_agility: 0.0,
+                left_leg_agility: 0.0,
+                right_leg_agility: 0.0,
+            }],
+            limbs: vec![CharacterLimbs {
+                character_id: 1,
+                left_arm_health: 1.0,
+                right_arm_health: 1.0,
+                left_leg_health: 0.5,
+                right_leg_health: 1.0,
+                head_health: 1.0,
+                chest_health: 1.0,
+                stomach_health: 1.0,
+            }],
+            conditions: vec![
+                CharacterCondition {
+                    character_id: 1,
+                    body_weight_kg: 70.0,
+                    current_blood_ml: 5_000.0,
+                    maximum_blood_ml: 5_000.0,
+                    religion_id: None,
+                },
+                CharacterCondition {
+                    character_id: 2,
+                    body_weight_kg: 90.0,
+                    current_blood_ml: 5_000.0,
+                    maximum_blood_ml: 5_000.0,
+                    religion_id: None,
+                },
+            ],
+            needs: vec![CharacterNeeds {
+                character_id: 1,
+                food_balance_kcal: 0.0,
+                water_balance_ml: 0.0,
+                carried_water_ml: 2_500.0,
+            }],
+        }
+    }
+
+    #[test]
+    fn personal_summary_counts_body_water_quantity_and_injury_adjusted_capacity() {
+        let inventory = vec![InventoryItem {
+            id: 10,
+            character_id: 1,
+            item_id: "sword".into(),
+            qty: 3,
+        }];
+        let summary = personal_encumbrance(1, &inventory, &[item("sword", 4.0)], &rows());
+        assert_eq!(summary.burden_kg, 84.5);
+        assert_eq!(summary.capacity_kg, 300.0);
+    }
+
+    #[test]
+    fn party_summary_excludes_dead_members_and_adds_shared_pool_once() {
+        let inventories = vec![
+            InventoryItem {
+                id: 10,
+                character_id: 1,
+                item_id: "sword".into(),
+                qty: 3,
+            },
+            InventoryItem {
+                id: 11,
+                character_id: 2,
+                item_id: "sword".into(),
+                qty: 20,
+            },
+        ];
+        let pooled = vec![PartyInventoryItem {
+            id: 20,
+            party_id: "party".into(),
+            item_id: "sword".into(),
+            quantity: 2,
+        }];
+        let summary = party_encumbrance(
+            &[character(1, true), character(2, false)],
+            &inventories,
+            &pooled,
+            &[item("sword", 4.0)],
+            &rows(),
+        );
+        assert_eq!(summary.burden_kg, 92.5);
+        assert_eq!(summary.capacity_kg, 300.0);
+    }
+
+    #[test]
+    fn missing_rows_and_item_definitions_fail_closed_without_nan() {
+        let summary = personal_encumbrance(
+            99,
+            &[InventoryItem {
+                id: 30,
+                character_id: 99,
+                item_id: "unknown".into(),
+                qty: 4,
+            }],
+            &[],
+            &EncumbranceRows::default(),
+        );
+        assert_eq!(summary.burden_kg, 0.0);
+        assert_eq!(summary.capacity_kg, 0.0);
+        assert_eq!(summary.penalty_fraction(), 1.0);
     }
 }

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -15,7 +15,10 @@ use axum::{
     response::{Html, IntoResponse, Redirect, Response},
     routing::{get, post},
 };
-use futures_util::future::join_all;
+use futures_util::{
+    future::join_all,
+    stream::{self, StreamExt},
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -1926,28 +1929,28 @@ async fn party_pool_inventory(
         .await
         .unwrap_or_default();
     let members = get_active_party_members(&state, Some(&character)).await;
-    let member_ids: Vec<u64> = members.iter().map(|member| member.id).collect();
+    let (member_ids, encumbrance_ids) = encumbrance_query_ids(&members, character.id);
     let member_inventories = async {
         let state_ref = &state;
-        let lookups = member_ids.iter().copied().map(|member_id| async move {
-            state_ref
-                .db
-                .query::<InventoryItem>(&format!(
-                    "SELECT * FROM inventory_item WHERE character_id = {member_id}"
-                ))
-                .await
-                .unwrap_or_default()
-        });
-        join_all(lookups)
+        stream::iter(member_ids.iter().copied())
+            .map(|member_id| async move {
+                state_ref
+                    .db
+                    .query::<InventoryItem>(&format!(
+                        "SELECT * FROM inventory_item WHERE character_id = {member_id}"
+                    ))
+                    .await
+                    .unwrap_or_default()
+            })
+            .buffer_unordered(ENCUMBRANCE_QUERY_CONCURRENCY)
+            .collect::<Vec<_>>()
             .await
             .into_iter()
             .flatten()
             .collect::<Vec<_>>()
     };
-    let (all_inventories, encumbrance_rows) = tokio::join!(
-        member_inventories,
-        EncumbranceRows::query(&state, &member_ids),
-    );
+    let all_inventories = member_inventories.await;
+    let encumbrance_rows = EncumbranceRows::query(&state, &encumbrance_ids).await;
     let personal_encumbrance =
         personal_encumbrance(character.id, &inventory, &items, &encumbrance_rows);
     let party_encumbrance = party_encumbrance(
@@ -3621,19 +3624,43 @@ struct EncumbranceRows {
     needs: Vec<CharacterNeeds>,
 }
 
+const ENCUMBRANCE_QUERY_CONCURRENCY: usize = 4;
+
+fn encumbrance_query_ids(members: &[Character], active_character_id: u64) -> (Vec<u64>, Vec<u64>) {
+    let living_ids: std::collections::BTreeSet<u64> = members
+        .iter()
+        .filter(|member| member.alive)
+        .map(|member| member.id)
+        .collect();
+    let mut row_ids = living_ids.clone();
+    row_ids.insert(active_character_id);
+    (
+        living_ids.into_iter().collect(),
+        row_ids.into_iter().collect(),
+    )
+}
+
 impl EncumbranceRows {
     async fn query(state: &AppState, character_ids: &[u64]) -> Self {
         let unique_ids: std::collections::BTreeSet<u64> = character_ids.iter().copied().collect();
-        let lookups = unique_ids.into_iter().map(|character_id| async move {
-            tokio::join!(
-                query_single::<CharacterAttributes>(state, "character_attributes", character_id,),
-                query_single::<CharacterLimbs>(state, "character_limbs", character_id),
-                query_single::<CharacterCondition>(state, "character_condition", character_id),
-                query_single::<CharacterNeeds>(state, "character_needs", character_id),
-            )
-        });
+        let lookups = stream::iter(unique_ids)
+            .map(|character_id| async move {
+                tokio::join!(
+                    query_single::<CharacterAttributes>(
+                        state,
+                        "character_attributes",
+                        character_id,
+                    ),
+                    query_single::<CharacterLimbs>(state, "character_limbs", character_id),
+                    query_single::<CharacterCondition>(state, "character_condition", character_id,),
+                    query_single::<CharacterNeeds>(state, "character_needs", character_id),
+                )
+            })
+            .buffer_unordered(ENCUMBRANCE_QUERY_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
         let mut rows = Self::default();
-        for (attributes, limbs, condition, needs) in join_all(lookups).await {
+        for (attributes, limbs, condition, needs) in lookups {
             rows.attributes.extend(attributes);
             rows.limbs.extend(limbs);
             rows.conditions.extend(condition);
@@ -3831,7 +3858,10 @@ mod herbalist_tests {
 
 #[cfg(test)]
 mod encumbrance_tests {
-    use super::{EncumbranceRows, party_encumbrance, personal_encumbrance};
+    use super::{
+        ENCUMBRANCE_QUERY_CONCURRENCY, EncumbranceRows, encumbrance_query_ids, party_encumbrance,
+        personal_encumbrance,
+    };
     use crate::spacetimedb::{
         Character, CharacterAttributes, CharacterCondition, CharacterLimbs, CharacterNeeds,
         InventoryItem, ItemDefinition, PartyInventoryItem,
@@ -3963,6 +3993,17 @@ mod encumbrance_tests {
         );
         assert_eq!(summary.burden_kg, 92.5);
         assert_eq!(summary.capacity_kg, 300.0);
+    }
+
+    #[test]
+    fn query_ids_are_living_only_deduplicated_and_keep_active_personal_rows() {
+        let (inventory_ids, row_ids) = encumbrance_query_ids(
+            &[character(1, true), character(1, true), character(2, false)],
+            2,
+        );
+        assert_eq!(inventory_ids, vec![1]);
+        assert_eq!(row_ids, vec![1, 2]);
+        assert_eq!(ENCUMBRANCE_QUERY_CONCURRENCY, 4);
     }
 
     #[test]

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -3677,16 +3677,22 @@ impl EncumbranceRows {
         let unique_ids: std::collections::BTreeSet<u64> = character_ids.iter().copied().collect();
         let lookups = stream::iter(unique_ids)
             .map(|character_id| async move {
-                tokio::join!(
-                    query_single::<CharacterAttributes>(
-                        state,
-                        "character_attributes",
-                        character_id,
-                    ),
-                    query_single::<CharacterLimbs>(state, "character_limbs", character_id),
-                    query_single::<CharacterCondition>(state, "character_condition", character_id,),
-                    query_single::<CharacterNeeds>(state, "character_needs", character_id),
+                // Keep each member's four lookups sequential so the outer
+                // buffer is a bound on actual in-flight database calls.
+                let attributes = query_single::<CharacterAttributes>(
+                    state,
+                    "character_attributes",
+                    character_id,
                 )
+                .await;
+                let limbs =
+                    query_single::<CharacterLimbs>(state, "character_limbs", character_id).await;
+                let condition =
+                    query_single::<CharacterCondition>(state, "character_condition", character_id)
+                        .await;
+                let needs =
+                    query_single::<CharacterNeeds>(state, "character_needs", character_id).await;
+                (attributes, limbs, condition, needs)
             })
             .buffer_unordered(ENCUMBRANCE_QUERY_CONCURRENCY)
             .collect::<Vec<_>>()

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -1929,37 +1929,10 @@ async fn party_pool_inventory(
         .await
         .unwrap_or_default();
     let members = get_active_party_members(&state, Some(&character)).await;
-    let (member_ids, encumbrance_ids) = encumbrance_query_ids(&members, character.id);
-    let member_inventories = async {
-        let state_ref = &state;
-        stream::iter(member_ids.iter().copied())
-            .map(|member_id| async move {
-                state_ref
-                    .db
-                    .query::<InventoryItem>(&format!(
-                        "SELECT * FROM inventory_item WHERE character_id = {member_id}"
-                    ))
-                    .await
-                    .unwrap_or_default()
-            })
-            .buffer_unordered(ENCUMBRANCE_QUERY_CONCURRENCY)
-            .collect::<Vec<_>>()
-            .await
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>()
-    };
-    let all_inventories = member_inventories.await;
-    let encumbrance_rows = EncumbranceRows::query(&state, &encumbrance_ids).await;
-    let personal_encumbrance =
-        personal_encumbrance(character.id, &inventory, &items, &encumbrance_rows);
-    let party_encumbrance = party_encumbrance(
-        &members,
-        &all_inventories,
-        &pooled,
-        &items,
-        &encumbrance_rows,
-    );
+    let encumbrance = inventory_encumbrance_summaries(
+        &state, &character, &inventory, &members, &pooled, &items, true,
+    )
+    .await;
     let stake = stakes
         .iter()
         .find(|stake| stake.character_id == character.id)
@@ -1977,8 +1950,8 @@ async fn party_pool_inventory(
             equip.first(),
             &personal_targets,
             &party_targets,
-            party_encumbrance,
-            personal_encumbrance,
+            encumbrance.party,
+            encumbrance.personal,
         )
         .into_string(),
     )
@@ -3409,6 +3382,16 @@ async fn merchant_shop(
     let items = items.unwrap_or_default();
     let equip = equip.unwrap_or_default();
     let (personal_targets, party_targets, pooled) = trade_context;
+    let encumbrance = inventory_encumbrance_summaries(
+        &state,
+        character,
+        inventory,
+        &party_members,
+        &pooled,
+        &items,
+        !matches!(shop, MerchantShop::Herbalist),
+    )
+    .await;
     Html(
         live_merchant_shop_page(
             settlement,
@@ -3428,6 +3411,8 @@ async fn merchant_shop(
                 .unwrap_or_default()
                 .first()
                 .map_or(0, |time| time.minutes),
+            encumbrance.personal,
+            encumbrance.party,
         )
         .into_string(),
     )
@@ -3626,6 +3611,12 @@ struct EncumbranceRows {
 
 const ENCUMBRANCE_QUERY_CONCURRENCY: usize = 4;
 
+#[derive(Clone, Copy, Debug, Default)]
+struct InventoryEncumbranceSummaries {
+    personal: EncumbranceSummary,
+    party: EncumbranceSummary,
+}
+
 fn encumbrance_query_ids(members: &[Character], active_character_id: u64) -> (Vec<u64>, Vec<u64>) {
     let living_ids: std::collections::BTreeSet<u64> = members
         .iter()
@@ -3638,6 +3629,47 @@ fn encumbrance_query_ids(members: &[Character], active_character_id: u64) -> (Ve
         living_ids.into_iter().collect(),
         row_ids.into_iter().collect(),
     )
+}
+
+async fn inventory_encumbrance_summaries(
+    state: &AppState,
+    active_character: &Character,
+    active_inventory: &[InventoryItem],
+    members: &[Character],
+    pooled: &[PartyInventoryItem],
+    items: &[ItemDefinition],
+    include_party: bool,
+) -> InventoryEncumbranceSummaries {
+    let aggregate_members = include_party.then_some(members).unwrap_or_default();
+    let (member_ids, encumbrance_ids) =
+        encumbrance_query_ids(aggregate_members, active_character.id);
+    let all_inventories = stream::iter(member_ids)
+        .map(|member_id| async move {
+            if member_id == active_character.id {
+                active_inventory.to_vec()
+            } else {
+                state
+                    .db
+                    .query::<InventoryItem>(&format!(
+                        "SELECT * FROM inventory_item WHERE character_id = {member_id}"
+                    ))
+                    .await
+                    .unwrap_or_default()
+            }
+        })
+        .buffer_unordered(ENCUMBRANCE_QUERY_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    let rows = EncumbranceRows::query(state, &encumbrance_ids).await;
+    InventoryEncumbranceSummaries {
+        personal: personal_encumbrance(active_character.id, active_inventory, items, &rows),
+        party: include_party
+            .then(|| party_encumbrance(members, &all_inventories, pooled, items, &rows))
+            .unwrap_or_default(),
+    }
 }
 
 impl EncumbranceRows {

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,7 +92,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-1";
+                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-2";
                 link rel="stylesheet" href="/static/css/utilities.css?v=environment-12";
 
                 // Datastar

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,7 +92,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-5";
+                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-6";
                 link rel="stylesheet" href="/static/css/utilities.css?v=environment-12";
 
                 // Datastar

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,7 +92,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13";
+                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-1";
                 link rel="stylesheet" href="/static/css/utilities.css?v=environment-12";
 
                 // Datastar

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,7 +92,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-3";
+                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-4";
                 link rel="stylesheet" href="/static/css/utilities.css?v=environment-12";
 
                 // Datastar

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,7 +92,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-4";
+                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-5";
                 link rel="stylesheet" href="/static/css/utilities.css?v=environment-12";
 
                 // Datastar

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,7 +92,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-2";
+                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-3";
                 link rel="stylesheet" href="/static/css/utilities.css?v=environment-12";
 
                 // Datastar

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -6,6 +6,7 @@
 
 use adventuresim_core::{
     activity::{PRAYER_MORALE_LIMIT, PRAYER_MORALE_SCALE_MINUTES, settlement_population_scale},
+    equipment::EncumbranceSummary,
     prelude::Skill,
     strategic_schedule::{
         BASELINE_FATIGUE_PER_DAY, DailySchedule, FATIGUE_RESERVOIR_PER_PREVIEW_POINT,
@@ -979,10 +980,12 @@ pub fn party_inventory_page(
     active_equip: Option<&CharacterEquip>,
     selected_targets: &[InventoryQuantityTarget],
     active_targets: &[InventoryQuantityTarget],
+    selected_encumbrance: EncumbranceSummary,
+    active_encumbrance: EncumbranceSummary,
 ) -> Markup {
     let content = html! {
         aside class="left-sidebar" {
-            (party_trade_inventory_rail(selected, selected_inventory, items, active_character.id, "right", selected_equip, active_targets))
+            (party_trade_inventory_rail(selected, selected_inventory, items, active_character.id, "right", selected_equip, active_targets, selected_encumbrance))
         }
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(selected.id), false))
@@ -994,7 +997,7 @@ pub fn party_inventory_page(
             }
         }
         aside class="right-sidebar" {
-            (party_trade_inventory_rail(active_character, active_inventory, items, selected.id, "left", active_equip, selected_targets))
+            (party_trade_inventory_rail(active_character, active_inventory, items, selected.id, "left", active_equip, selected_targets, active_encumbrance))
         }
     };
     location.render_layout("Party", content, Some(&active_character.name))
@@ -1008,6 +1011,7 @@ pub fn party_discard_page(
     items: &[crate::spacetimedb::ItemDefinition],
     party_members: &[Character],
     equip: Option<&CharacterEquip>,
+    encumbrance: EncumbranceSummary,
 ) -> Markup {
     let content = html! {
         aside class="left-sidebar" {
@@ -1031,7 +1035,7 @@ pub fn party_discard_page(
             }
         }
         aside class="right-sidebar" {
-            (discard_inventory_rail(active_character, inventory, items, equip))
+            (discard_inventory_rail(active_character, inventory, items, equip, encumbrance))
         }
     };
     location.render_layout("Inventory", content, Some(&active_character.name))
@@ -1322,6 +1326,7 @@ fn party_trade_inventory_rail(
     direction: &str,
     equip: Option<&CharacterEquip>,
     recipient_targets: &[InventoryQuantityTarget],
+    encumbrance: EncumbranceSummary,
 ) -> Markup {
     let title = format!("{}'s inventory", character.name);
     html! {
@@ -1349,6 +1354,7 @@ fn party_trade_inventory_rail(
                 }))
                 (inventory_footer_controls(if direction == "left" { "party-left" } else { "party-right" }, "Transfer to targets", "Transfer everything"))
             }
+            (encumbrance_meter(encumbrance))
         }))
     }
 }
@@ -1358,6 +1364,7 @@ fn discard_inventory_rail(
     inventory: &[InventoryItem],
     items: &[crate::spacetimedb::ItemDefinition],
     equip: Option<&CharacterEquip>,
+    encumbrance: EncumbranceSummary,
 ) -> Markup {
     let title = format!("{}'s inventory", character.name);
     html! {
@@ -1392,6 +1399,7 @@ fn discard_inventory_rail(
                     }
                 }))
             }
+            (encumbrance_meter(encumbrance))
         }))
     }
 }
@@ -1550,6 +1558,8 @@ pub fn party_pool_page(
     equip: Option<&CharacterEquip>,
     personal_targets: &[InventoryQuantityTarget],
     party_targets: &[InventoryQuantityTarget],
+    party_encumbrance: EncumbranceSummary,
+    personal_encumbrance: EncumbranceSummary,
 ) -> Markup {
     let content = html! {
         aside class="left-sidebar" {
@@ -1578,6 +1588,7 @@ pub fn party_pool_page(
                     }
                 }))
                 (inventory_footer_controls("withdraw", "Withdraw to personal targets", "Withdraw everything"))
+                (encumbrance_meter(party_encumbrance))
             }))
         }
         main class="center-content settlement-main" {
@@ -1610,6 +1621,7 @@ pub fn party_pool_page(
                     }
                 }))
                 (inventory_footer_controls("deposit", "Deposit to party targets", "Deposit everything"))
+                (encumbrance_meter(personal_encumbrance))
             }))
         }
         form method="post" action=(format!("{}/party-inventory/deposit", location.base_path())) id="pool-transfer-offer" class="party-offer" hidden { button type="button" data-cancel-pool class="party-offer-cancel" { "Cancel" } button type="submit" disabled { "Offer" } }
@@ -1619,6 +1631,34 @@ pub fn party_pool_page(
 
 fn item_weight(item: Option<&crate::spacetimedb::ItemDefinition>) -> String {
     item.map_or_else(|| "—".to_owned(), |item| weight_display(item.weight))
+}
+
+fn encumbrance_meter(summary: EncumbranceSummary) -> Markup {
+    let penalty_percent = summary.penalty_fraction() * 100.0;
+    let weight_text = format!(
+        "Weight {:.1} / {:.1} kg",
+        summary.burden_kg, summary.capacity_kg
+    );
+    let penalty_text = format!("Penalty -{penalty_percent:.1}%");
+    let accessible_text = format!("{weight_text}; {penalty_text}");
+    html! {
+        div class="encumbrance" {
+            div class="encumbrance-copy" {
+                span { (weight_text) }
+                span { (penalty_text) }
+            }
+            div class="encumbrance-meter"
+                role="meter"
+                aria-label="Encumbrance"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow=(format!("{penalty_percent:.1}"))
+                aria-valuetext=(accessible_text) {
+                span class="encumbrance-marker"
+                    style=(format!("--encumbrance-position: {penalty_percent:.4}%")) {}
+            }
+        }
+    }
 }
 
 fn equipment_checkbox(
@@ -3550,10 +3590,12 @@ fn blood_recovery_minutes(condition: &CharacterCondition) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        CharacterCondition, LocationKind, MerchantShop, need_balance_meter, repair_custody_panel,
+        CharacterCondition, LocationKind, MerchantShop, encumbrance_meter, need_balance_meter,
+        repair_custody_panel,
         repair_submit_control, rest_default_minutes,
     };
     use crate::spacetimedb::ItemKind;
+    use adventuresim_core::equipment::EncumbranceSummary;
 
     #[test]
     fn herbalist_stock_template_includes_every_prepared_course_and_ingredients() {
@@ -3566,6 +3608,32 @@ mod tests {
     fn location_kind_rejects_unknown_path_segments() {
         assert_eq!("quest".parse(), Ok(LocationKind::Quest));
         assert!("merchant".parse::<LocationKind>().is_err());
+    }
+
+    #[test]
+    fn encumbrance_meter_formats_exact_text_and_accessible_linear_position() {
+        let markup = encumbrance_meter(EncumbranceSummary::new(85.36, 150.0)).into_string();
+        assert!(markup.contains("Weight 85.4 / 150.0 kg"));
+        assert!(markup.contains("Penalty -56.9%"));
+        assert!(markup.contains("role=\"meter\""));
+        assert!(markup.contains("aria-valuenow=\"56.9\""));
+        assert!(markup.contains("--encumbrance-position: 56.9067%"));
+    }
+
+    #[test]
+    fn overloaded_meter_keeps_burden_but_clamps_penalty_and_marker() {
+        let markup = encumbrance_meter(EncumbranceSummary::new(185.4, 150.0)).into_string();
+        assert!(markup.contains("Weight 185.4 / 150.0 kg"));
+        assert!(markup.contains("Penalty -100.0%"));
+        assert!(markup.contains("--encumbrance-position: 100.0000%"));
+    }
+
+    #[test]
+    fn encumbrance_css_uses_a_linear_midpoint_gradient_and_contrast_marker() {
+        let css = include_str!("../../static/css/strategic.css");
+        assert!(css.contains("linear-gradient(90deg, #238b45 0%, #f4d03f 50%, #c62828 100%)"));
+        assert!(css.contains(".encumbrance-marker"));
+        assert!(css.contains("background: #fff"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1665,18 +1665,22 @@ fn encumbrance_meter(summary: EncumbranceSummary) -> Markup {
     );
     html! {
         div class="encumbrance" {
-            span class="encumbrance-weight" aria-hidden="true" { (weight_text) }
-            div class="encumbrance-meter"
-                role="meter"
-                aria-label="Encumbrance"
-                aria-valuemin="0"
-                aria-valuemax="100"
-                aria-valuenow=(format!("{penalty_percent:.1}"))
-                aria-valuetext=(accessible_text) {
-                span class="encumbrance-marker"
-                    style=(format!("--encumbrance-position: {penalty_percent:.4}%")) {}
+            div class="encumbrance-values" aria-hidden="true" {
+                span class="encumbrance-weight" { (weight_text) }
+                span class="encumbrance-penalty" { (penalty_text) }
             }
-            span class="encumbrance-penalty" aria-hidden="true" { (penalty_text) }
+            div class="encumbrance-visual" {
+                div class="encumbrance-meter"
+                    role="meter"
+                    aria-label="Encumbrance"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    aria-valuenow=(format!("{penalty_percent:.1}"))
+                    aria-valuetext=(accessible_text) {
+                    span class="encumbrance-marker"
+                        style=(format!("--encumbrance-position: {penalty_percent:.4}%")) {}
+                }
+            }
         }
     }
 }
@@ -3639,8 +3643,15 @@ mod tests {
         assert!(!markup.contains(">Weight"));
         assert!(!markup.contains(">Penalty"));
         assert!(markup.contains("Weight 85.4 / 150.0 kilograms; Penalty -56.9%"));
-        assert!(markup.contains("class=\"encumbrance-weight\" aria-hidden=\"true\""));
-        assert!(markup.contains("class=\"encumbrance-penalty\" aria-hidden=\"true\""));
+        assert!(markup.contains("class=\"encumbrance-values\" aria-hidden=\"true\""));
+        assert!(markup.contains(
+            "<span class=\"encumbrance-weight\">85.4 / 150.0 kg</span><span class=\"encumbrance-penalty\">-56.9%</span>"
+        ));
+        assert!(
+            markup.contains(
+                "</div><div class=\"encumbrance-visual\"><div class=\"encumbrance-meter\""
+            )
+        );
         assert!(markup.contains("role=\"meter\""));
         assert!(markup.contains("aria-valuenow=\"56.9\""));
         assert!(markup.contains("--encumbrance-position: 56.9067%"));
@@ -3680,11 +3691,12 @@ mod tests {
         assert!(css.contains("overflow-y: auto"));
         assert!(css.contains("padding-left: 3.25rem"));
         assert!(css.contains("padding-right: 1.75rem"));
-        assert!(css.contains("grid-template-columns: auto minmax(2.5rem, 1fr) auto"));
         assert!(css.contains("container-type: inline-size"));
-        assert!(css.contains("@container (max-width: 18rem)"));
-        assert!(css.contains("@container (max-width: 11rem)"));
-        assert!(css.contains("grid-template-columns: auto minmax(0.75rem, 1fr) auto"));
+        assert!(css.contains("flex: 0 0 50%"));
+        assert!(css.contains("width: 50%"));
+        assert!(css.contains("font-size: clamp(0.55rem, 4cqi, 0.78rem)"));
+        assert!(css.contains(".encumbrance-meter"));
+        assert!(css.contains("width: 100%"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1665,7 +1665,7 @@ fn encumbrance_meter(summary: EncumbranceSummary) -> Markup {
     );
     html! {
         div class="encumbrance" {
-            span class="encumbrance-weight" { (weight_text) }
+            span class="encumbrance-weight" aria-hidden="true" { (weight_text) }
             div class="encumbrance-meter"
                 role="meter"
                 aria-label="Encumbrance"
@@ -1676,7 +1676,7 @@ fn encumbrance_meter(summary: EncumbranceSummary) -> Markup {
                 span class="encumbrance-marker"
                     style=(format!("--encumbrance-position: {penalty_percent:.4}%")) {}
             }
-            span class="encumbrance-penalty" { (penalty_text) }
+            span class="encumbrance-penalty" aria-hidden="true" { (penalty_text) }
         }
     }
 }
@@ -3639,6 +3639,8 @@ mod tests {
         assert!(!markup.contains(">Weight"));
         assert!(!markup.contains(">Penalty"));
         assert!(markup.contains("Weight 85.4 / 150.0 kilograms; Penalty -56.9%"));
+        assert!(markup.contains("class=\"encumbrance-weight\" aria-hidden=\"true\""));
+        assert!(markup.contains("class=\"encumbrance-penalty\" aria-hidden=\"true\""));
         assert!(markup.contains("role=\"meter\""));
         assert!(markup.contains("aria-valuenow=\"56.9\""));
         assert!(markup.contains("--encumbrance-position: 56.9067%"));
@@ -3676,9 +3678,13 @@ mod tests {
         assert!(css.contains(".sidebar-section:has(> .encumbrance-inventory-rail)"));
         assert!(css.contains(".encumbrance-inventory-scroll"));
         assert!(css.contains("overflow-y: auto"));
-        assert!(css.contains("padding-left: 1.75rem"));
+        assert!(css.contains("padding-left: 3.25rem"));
         assert!(css.contains("padding-right: 1.75rem"));
         assert!(css.contains("grid-template-columns: auto minmax(2.5rem, 1fr) auto"));
+        assert!(css.contains("container-type: inline-size"));
+        assert!(css.contains("@container (max-width: 18rem)"));
+        assert!(css.contains("@container (max-width: 11rem)"));
+        assert!(css.contains("grid-template-columns: auto minmax(0.75rem, 1fr) auto"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -3616,8 +3616,7 @@ mod tests {
     use super::{
         Character, CharacterCondition, LocationKind, MerchantShop, encumbrance_inventory_rail,
         encumbrance_meter, live_merchant_shop_page, need_balance_meter, repair_custody_panel,
-        repair_submit_control,
-        rest_default_minutes,
+        repair_submit_control, rest_default_minutes,
     };
     use crate::spacetimedb::ItemKind;
     use adventuresim_core::equipment::EncumbranceSummary;
@@ -3697,6 +3696,14 @@ mod tests {
         assert!(css.contains("font-size: clamp(0.55rem, 4cqi, 0.78rem)"));
         assert!(css.contains(".encumbrance-meter"));
         assert!(css.contains("width: 100%"));
+        assert!(css.contains("@container (max-width: 12rem)"));
+        assert!(css.contains("padding-inline: 0.2rem"));
+        assert!(css.contains("font-size: 0.5rem"));
+        assert!(css.contains("@container (max-width: 10rem)"));
+        assert!(css.contains("padding-inline: 0.1rem"));
+        assert!(css.contains("padding-right: 0.05rem"));
+        assert!(css.contains("padding-left: 0.05rem"));
+        assert!(css.contains("font-size: 0.43rem"));
     }
 
     #[test]
@@ -3725,7 +3732,6 @@ mod tests {
                 &[],
                 &[],
                 &[],
-                "dark-arcanum",
                 shop,
                 &[],
                 None,

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1420,6 +1420,8 @@ pub fn live_merchant_shop_page(
     smith: Option<&crate::spacetimedb::SettlementSmith>,
     repair_orders: &[crate::spacetimedb::RepairOrder],
     now_minutes: u64,
+    personal_encumbrance: EncumbranceSummary,
+    party_encumbrance: EncumbranceSummary,
 ) -> Markup {
     let title = shop.title();
     let service_id = shop.service_id();
@@ -1432,6 +1434,11 @@ pub fn live_merchant_shop_page(
             }
         })
         .unwrap_or(0);
+    let player_footer = if matches!(shop, MerchantShop::Herbalist) {
+        html! {}
+    } else {
+        inventory_footer_controls("sell", "Sell surplus", "Sell everything")
+    };
     let content = html! {
         aside class="left-sidebar smith-wares-column" { (sidebar_section(if matches!(shop, MerchantShop::Herbalist) { "Prepared medicines and ingredients" } else { "Merchant stock" }, html! {
             div class="smith-wares-scroll" {
@@ -1467,6 +1474,7 @@ pub fn live_merchant_shop_page(
             }
             div data-inventory-pane="player" {
             div class="sidebar-section" {
+                (encumbrance_inventory_rail(html! {
                 (trade_inventory_table(true, matches!(shop, MerchantShop::Weapons | MerchantShop::Armor).then(|| repair_all_header(settlement, service_id)), html! {
                     @for item in inventory {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1497,13 +1505,12 @@ pub fn live_merchant_shop_page(
                         }
                     }
                 }))
-                @if !matches!(shop, MerchantShop::Herbalist) {
-                    (inventory_footer_controls("sell", "Sell surplus", "Sell everything"))
-                }
+                }, player_footer, personal_encumbrance))
             }
             }
             @if !matches!(shop, MerchantShop::Herbalist) { div data-inventory-pane="party" hidden {
             div class="sidebar-section" {
+                (encumbrance_inventory_rail(html! {
                 (trade_inventory_table(false, None, html! {
                     @for item in pooled {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1529,7 +1536,7 @@ pub fn live_merchant_shop_page(
                         }
                     }
                 }))
-                (inventory_footer_controls("sell", "Sell surplus", "Sell everything"))
+                }, inventory_footer_controls("sell", "Sell surplus", "Sell everything"), party_encumbrance))
             }
             }
             }
@@ -1650,18 +1657,15 @@ fn encumbrance_inventory_rail(
 
 fn encumbrance_meter(summary: EncumbranceSummary) -> Markup {
     let penalty_percent = summary.penalty_fraction() * 100.0;
-    let weight_text = format!(
-        "Weight {:.1} / {:.1} kg",
+    let weight_text = format!("{:.1} / {:.1} kg", summary.burden_kg, summary.capacity_kg);
+    let penalty_text = format!("-{penalty_percent:.1}%");
+    let accessible_text = format!(
+        "Weight {:.1} / {:.1} kilograms; Penalty -{penalty_percent:.1}%",
         summary.burden_kg, summary.capacity_kg
     );
-    let penalty_text = format!("Penalty -{penalty_percent:.1}%");
-    let accessible_text = format!("{weight_text}; {penalty_text}");
     html! {
         div class="encumbrance" {
-            div class="encumbrance-copy" {
-                span { (weight_text) }
-                span { (penalty_text) }
-            }
+            span class="encumbrance-weight" { (weight_text) }
             div class="encumbrance-meter"
                 role="meter"
                 aria-label="Encumbrance"
@@ -1672,6 +1676,7 @@ fn encumbrance_meter(summary: EncumbranceSummary) -> Markup {
                 span class="encumbrance-marker"
                     style=(format!("--encumbrance-position: {penalty_percent:.4}%")) {}
             }
+            span class="encumbrance-penalty" { (penalty_text) }
         }
     }
 }
@@ -3605,8 +3610,9 @@ fn blood_recovery_minutes(condition: &CharacterCondition) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        CharacterCondition, LocationKind, MerchantShop, encumbrance_inventory_rail,
-        encumbrance_meter, need_balance_meter, repair_custody_panel, repair_submit_control,
+        Character, CharacterCondition, LocationKind, MerchantShop, encumbrance_inventory_rail,
+        encumbrance_meter, live_merchant_shop_page, need_balance_meter, repair_custody_panel,
+        repair_submit_control,
         rest_default_minutes,
     };
     use crate::spacetimedb::ItemKind;
@@ -3628,8 +3634,11 @@ mod tests {
     #[test]
     fn encumbrance_meter_formats_exact_text_and_accessible_linear_position() {
         let markup = encumbrance_meter(EncumbranceSummary::new(85.36, 150.0)).into_string();
-        assert!(markup.contains("Weight 85.4 / 150.0 kg"));
-        assert!(markup.contains("Penalty -56.9%"));
+        assert!(markup.contains(">85.4 / 150.0 kg<"));
+        assert!(markup.contains(">-56.9%<"));
+        assert!(!markup.contains(">Weight"));
+        assert!(!markup.contains(">Penalty"));
+        assert!(markup.contains("Weight 85.4 / 150.0 kilograms; Penalty -56.9%"));
         assert!(markup.contains("role=\"meter\""));
         assert!(markup.contains("aria-valuenow=\"56.9\""));
         assert!(markup.contains("--encumbrance-position: 56.9067%"));
@@ -3638,8 +3647,8 @@ mod tests {
     #[test]
     fn overloaded_meter_keeps_burden_but_clamps_penalty_and_marker() {
         let markup = encumbrance_meter(EncumbranceSummary::new(185.4, 150.0)).into_string();
-        assert!(markup.contains("Weight 185.4 / 150.0 kg"));
-        assert!(markup.contains("Penalty -100.0%"));
+        assert!(markup.contains(">185.4 / 150.0 kg<"));
+        assert!(markup.contains(">-100.0%<"));
         assert!(markup.contains("--encumbrance-position: 100.0000%"));
     }
 
@@ -3669,6 +3678,56 @@ mod tests {
         assert!(css.contains("overflow-y: auto"));
         assert!(css.contains("padding-left: 1.75rem"));
         assert!(css.contains("padding-right: 1.75rem"));
+        assert!(css.contains("grid-template-columns: auto minmax(2.5rem, 1fr) auto"));
+    }
+
+    #[test]
+    fn merchant_tabs_render_personal_and_party_encumbrance_as_applicable() {
+        let character = Character {
+            id: 1,
+            name: "Trader".into(),
+            xp: 0,
+            level: 1,
+            gold: 0,
+            current_settlement_id: Some("viabundus-1".into()),
+            current_quest_location_id: None,
+            party_id: Some("party".into()),
+            age_years: 20,
+            alive: true,
+            temporary: false,
+        };
+        let render = |shop| {
+            live_merchant_shop_page(
+                &settlement(),
+                &character,
+                &[],
+                &[],
+                &[],
+                None,
+                &[],
+                &[],
+                &[],
+                "dark-arcanum",
+                shop,
+                &[],
+                None,
+                &[],
+                0,
+                EncumbranceSummary::new(10.0, 100.0),
+                EncumbranceSummary::new(30.0, 200.0),
+            )
+            .into_string()
+        };
+        let merchant = render(MerchantShop::Weapons);
+        assert!(merchant.contains("data-inventory-pane=\"player\""));
+        assert!(merchant.contains("data-inventory-pane=\"party\""));
+        assert!(merchant.contains(">10.0 / 100.0 kg<"));
+        assert!(merchant.contains(">30.0 / 200.0 kg<"));
+
+        let herbalist = render(MerchantShop::Herbalist);
+        assert!(herbalist.contains(">10.0 / 100.0 kg<"));
+        assert!(!herbalist.contains("data-inventory-pane=\"party\""));
+        assert!(!herbalist.contains(">30.0 / 200.0 kg<"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1331,30 +1331,30 @@ fn party_trade_inventory_rail(
     let title = format!("{}'s inventory", character.name);
     html! {
         (sidebar_section(&title, html! {
-            @if inventory.is_empty() {
-                p class="text-muted small-copy" { "No items carried." }
-            } @else {
-                (trade_inventory_table(true, None, html! {
-                    @for item in inventory {
-                        @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
-                        @let definition = items.iter().find(|definition| definition.id == item.item_id);
-                        @let target = target_quantity(recipient_targets, &item.item_id);
-                            tr class=(if direction == "left" { "trade-inventory-row trade-row-player" } else { "trade-inventory-row trade-row-merchant" }) data-item-key=(&item.item_id) {
-                                td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
-                                td class="inventory-item-name" {
-                                    (item_name_with_quality(&item.item_id, definition))
-                                    @if !is_equipped { span class="inventory-row-actions" { button type="button" class=(format!("trade-transfer trade-transfer-{direction} party-draft-transfer")) data-dynamic-transfer data-default-transfer-mode="one" data-from=(character.id) data-to=(recipient_id) data-item=(item.id) data-key=(&item.item_id) data-count=(item.qty) data-target=(target) data-transfer-mode="one" data-label-one=(format!("Transfer one {}", item.item_id)) data-label-target=(format!("Transfer {} to target", item.item_id)) data-label-all=(format!("Transfer all {}", item.item_id)) aria-label=(format!("Transfer one {}", item.item_id)) title=(format!("Transfer one {}", item.item_id)) { (transfer_glyph(1)) } } }
+            (encumbrance_inventory_rail(html! {
+                @if inventory.is_empty() {
+                    p class="text-muted small-copy" { "No items carried." }
+                } @else {
+                    (trade_inventory_table(true, None, html! {
+                        @for item in inventory {
+                            @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
+                            @let definition = items.iter().find(|definition| definition.id == item.item_id);
+                            @let target = target_quantity(recipient_targets, &item.item_id);
+                                tr class=(if direction == "left" { "trade-inventory-row trade-row-player" } else { "trade-inventory-row trade-row-merchant" }) data-item-key=(&item.item_id) {
+                                    td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
+                                    td class="inventory-item-name" {
+                                        (item_name_with_quality(&item.item_id, definition))
+                                        @if !is_equipped { span class="inventory-row-actions" { button type="button" class=(format!("trade-transfer trade-transfer-{direction} party-draft-transfer")) data-dynamic-transfer data-default-transfer-mode="one" data-from=(character.id) data-to=(recipient_id) data-item=(item.id) data-key=(&item.item_id) data-count=(item.qty) data-target=(target) data-transfer-mode="one" data-label-one=(format!("Transfer one {}", item.item_id)) data-label-target=(format!("Transfer {} to target", item.item_id)) data-label-all=(format!("Transfer all {}", item.item_id)) aria-label=(format!("Transfer one {}", item.item_id)) title=(format!("Transfer one {}", item.item_id)) { (transfer_glyph(1)) } } }
+                                    }
+                                    td class="inventory-count" { (item.qty) }
+                                    td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) }
+                                    td class="inventory-weight" { (item_weight(definition)) }
+                                    td class="inventory-gold" { (item_value(definition)) }
                                 }
-                                td class="inventory-count" { (item.qty) }
-                                td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) }
-                                td class="inventory-weight" { (item_weight(definition)) }
-                                td class="inventory-gold" { (item_value(definition)) }
                             }
-                    }
-                }))
-                (inventory_footer_controls(if direction == "left" { "party-left" } else { "party-right" }, "Transfer to targets", "Transfer everything"))
-            }
-            (encumbrance_meter(encumbrance))
+                    }))
+                }
+            }, inventory_footer_controls(if direction == "left" { "party-left" } else { "party-right" }, "Transfer to targets", "Transfer everything"), encumbrance))
         }))
     }
 }
@@ -1369,37 +1369,38 @@ fn discard_inventory_rail(
     let title = format!("{}'s inventory", character.name);
     html! {
         (sidebar_section(&title, html! {
-            @if inventory.is_empty() {
-                p class="text-muted small-copy" { "No items carried." }
-            } @else {
-                (trade_inventory_table(true, None, html! {
-                    @for item in inventory {
-                        @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
-                        @let definition = items.iter().find(|definition| definition.id == item.item_id);
-                        tr class="trade-inventory-row trade-row-player" data-discard-source=(item.id) data-item-key=(&item.item_id) {
-                            td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
-                            td class="inventory-item-name" {
-                                (item_name_with_quality(&item.item_id, definition))
-                                @if !is_equipped {
-                                    button type="button" class="trade-transfer trade-transfer-left"
-                                        data-discard-item=(item.id) data-count=(item.qty)
-                                        data-dynamic-transfer data-default-transfer-mode="one" data-transfer-mode="one"
-                                        data-label-one=(format!("Discard one {}", item.item_id))
-                                        data-label-target=(format!("Discard {} down to target", item.item_id))
-                                        data-label-all=(format!("Discard all {}", item.item_id))
-                                        aria-label=(format!("Discard {}", item.item_id))
-                                        title=(format!("Discard one {}", item.item_id)) { (transfer_glyph(1)) }
+            (encumbrance_inventory_rail(html! {
+                @if inventory.is_empty() {
+                    p class="text-muted small-copy" { "No items carried." }
+                } @else {
+                    (trade_inventory_table(true, None, html! {
+                        @for item in inventory {
+                            @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
+                            @let definition = items.iter().find(|definition| definition.id == item.item_id);
+                            tr class="trade-inventory-row trade-row-player" data-discard-source=(item.id) data-item-key=(&item.item_id) {
+                                td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
+                                td class="inventory-item-name" {
+                                    (item_name_with_quality(&item.item_id, definition))
+                                    @if !is_equipped {
+                                        button type="button" class="trade-transfer trade-transfer-left"
+                                            data-discard-item=(item.id) data-count=(item.qty)
+                                            data-dynamic-transfer data-default-transfer-mode="one" data-transfer-mode="one"
+                                            data-label-one=(format!("Discard one {}", item.item_id))
+                                            data-label-target=(format!("Discard {} down to target", item.item_id))
+                                            data-label-all=(format!("Discard all {}", item.item_id))
+                                            aria-label=(format!("Discard {}", item.item_id))
+                                            title=(format!("Discard one {}", item.item_id)) { (transfer_glyph(1)) }
+                                    }
                                 }
+                                td class="inventory-count" { (item.qty) }
+                                td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) }
+                                td class="inventory-weight" { (item_weight(definition)) }
+                                td class="inventory-gold" { (item_value(definition)) }
                             }
-                            td class="inventory-count" { (item.qty) }
-                            td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) }
-                            td class="inventory-weight" { (item_weight(definition)) }
-                            td class="inventory-gold" { (item_value(definition)) }
                         }
-                    }
-                }))
-            }
-            (encumbrance_meter(encumbrance))
+                    }))
+                }
+            }, html! {}, encumbrance))
         }))
     }
 }
@@ -1564,31 +1565,31 @@ pub fn party_pool_page(
     let content = html! {
         aside class="left-sidebar" {
             (sidebar_section("Party inventory", html! {
-                div class="party-stake-summary" {
-                    span { "Your available stake" }
-                    strong { (stake) " gold" }
-                }
-                p class="small-copy text-muted" { "Withdrawals use your stake. Personal gold automatically covers an indivisible item's shortfall." }
-                (trade_inventory_table(false, None, html! {
-                    @for item in pooled {
-                        @let definition = items.iter().find(|definition| definition.id == item.item_id);
-                        @let value = definition.and_then(|definition| definition.base_value).unwrap_or(0) as u64;
-                        @let target = target_quantity(personal_targets, &item.item_id);
-                        @let current = inventory.iter().find(|personal| personal.item_id == item.item_id).map_or(0, |personal| personal.qty);
-                        tr class="trade-inventory-row" {
-                            td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
-                            td class="inventory-item-name" {
-                                (item_name_with_quality(&item.item_id, definition))
-                                span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="withdraw" data-transfer-mode="one" data-count=(item.quantity) data-current=(current) data-target=(target) data-label-one=(format!("Withdraw one {}", item.item_id)) data-label-target=(format!("Withdraw {} to target", item.item_id)) data-label-all=(format!("Withdraw all {}", item.item_id)) title=(if value > stake { format!("Withdraw one {}; {} personal gold required", item.item_id, value - stake) } else { format!("Withdraw one {} using your stake", item.item_id) }) aria-label=(format!("Withdraw one {}", item.item_id)) { (transfer_glyph(1)) } }
-                            }
-                            td class="inventory-count" { (quantity_target_control(item.quantity, target_quantity(party_targets, &item.item_id), &item.item_id, true)) }
-                            td class="inventory-weight" { (item_weight(definition)) }
-                            td class="inventory-gold" { (item_value(definition)) }
-                        }
+                (encumbrance_inventory_rail(html! {
+                    div class="party-stake-summary" {
+                        span { "Your available stake" }
+                        strong { (stake) " gold" }
                     }
-                }))
-                (inventory_footer_controls("withdraw", "Withdraw to personal targets", "Withdraw everything"))
-                (encumbrance_meter(party_encumbrance))
+                    p class="small-copy text-muted" { "Withdrawals use your stake. Personal gold automatically covers an indivisible item's shortfall." }
+                    (trade_inventory_table(false, None, html! {
+                        @for item in pooled {
+                            @let definition = items.iter().find(|definition| definition.id == item.item_id);
+                            @let value = definition.and_then(|definition| definition.base_value).unwrap_or(0) as u64;
+                            @let target = target_quantity(personal_targets, &item.item_id);
+                            @let current = inventory.iter().find(|personal| personal.item_id == item.item_id).map_or(0, |personal| personal.qty);
+                            tr class="trade-inventory-row" {
+                                td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
+                                td class="inventory-item-name" {
+                                    (item_name_with_quality(&item.item_id, definition))
+                                    span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="withdraw" data-transfer-mode="one" data-count=(item.quantity) data-current=(current) data-target=(target) data-label-one=(format!("Withdraw one {}", item.item_id)) data-label-target=(format!("Withdraw {} to target", item.item_id)) data-label-all=(format!("Withdraw all {}", item.item_id)) title=(if value > stake { format!("Withdraw one {}; {} personal gold required", item.item_id, value - stake) } else { format!("Withdraw one {} using your stake", item.item_id) }) aria-label=(format!("Withdraw one {}", item.item_id)) { (transfer_glyph(1)) } }
+                                }
+                                td class="inventory-count" { (quantity_target_control(item.quantity, target_quantity(party_targets, &item.item_id), &item.item_id, true)) }
+                                td class="inventory-weight" { (item_weight(definition)) }
+                                td class="inventory-gold" { (item_value(definition)) }
+                            }
+                        }
+                    }))
+                }, inventory_footer_controls("withdraw", "Withdraw to personal targets", "Withdraw everything"), party_encumbrance))
             }))
         }
         main class="center-content settlement-main" {
@@ -1598,30 +1599,30 @@ pub fn party_pool_page(
         }
         aside class="right-sidebar" {
             (sidebar_section(&format!("{}'s inventory", character.name), html! {
-                p class="small-copy text-muted" { "Add items at their objective gold value." }
-                (trade_inventory_table(true, None, html! {
-                    @for item in inventory {
-                        @let definition = items.iter().find(|definition| definition.id == item.item_id);
-                        @let equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
-                        @let target = target_quantity(party_targets, &item.item_id);
-                        @let current = pooled.iter().find(|pooled| pooled.item_id == item.item_id).map_or(0, |pooled| pooled.quantity);
-                        tr class="trade-inventory-row" {
-                            td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
-                            td class="inventory-item-name" {
-                                (item_name_with_quality(&item.item_id, definition))
-                                @if !equipped {
-                                    span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="deposit" data-transfer-mode="one" data-count=(item.qty) data-current=(current) data-target=(target) data-label-one=(format!("Deposit one {}", item.item_id)) data-label-target=(format!("Deposit {} to target", item.item_id)) data-label-all=(format!("Deposit all {}", item.item_id)) aria-label=(format!("Deposit one {}", item.item_id)) title=(format!("Deposit one {}", item.item_id)) { (transfer_glyph(1)) } }
+                (encumbrance_inventory_rail(html! {
+                    p class="small-copy text-muted" { "Add items at their objective gold value." }
+                    (trade_inventory_table(true, None, html! {
+                        @for item in inventory {
+                            @let definition = items.iter().find(|definition| definition.id == item.item_id);
+                            @let equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
+                            @let target = target_quantity(party_targets, &item.item_id);
+                            @let current = pooled.iter().find(|pooled| pooled.item_id == item.item_id).map_or(0, |pooled| pooled.quantity);
+                            tr class="trade-inventory-row" {
+                                td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
+                                td class="inventory-item-name" {
+                                    (item_name_with_quality(&item.item_id, definition))
+                                    @if !equipped {
+                                        span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="deposit" data-transfer-mode="one" data-count=(item.qty) data-current=(current) data-target=(target) data-label-one=(format!("Deposit one {}", item.item_id)) data-label-target=(format!("Deposit {} to target", item.item_id)) data-label-all=(format!("Deposit all {}", item.item_id)) aria-label=(format!("Deposit one {}", item.item_id)) title=(format!("Deposit one {}", item.item_id)) { (transfer_glyph(1)) } }
+                                    }
                                 }
+                                td class="inventory-count" { (quantity_target_control(item.qty, target_quantity(personal_targets, &item.item_id), &item.item_id, false)) }
+                                td class="inventory-equipped" { (equipment_checkbox(item, definition, equipped)) }
+                                td class="inventory-weight" { (item_weight(definition)) }
+                                td class="inventory-gold" { (item_value(definition)) }
                             }
-                            td class="inventory-count" { (quantity_target_control(item.qty, target_quantity(personal_targets, &item.item_id), &item.item_id, false)) }
-                            td class="inventory-equipped" { (equipment_checkbox(item, definition, equipped)) }
-                            td class="inventory-weight" { (item_weight(definition)) }
-                            td class="inventory-gold" { (item_value(definition)) }
                         }
-                    }
-                }))
-                (inventory_footer_controls("deposit", "Deposit to party targets", "Deposit everything"))
-                (encumbrance_meter(personal_encumbrance))
+                    }))
+                }, inventory_footer_controls("deposit", "Deposit to party targets", "Deposit everything"), personal_encumbrance))
             }))
         }
         form method="post" action=(format!("{}/party-inventory/deposit", location.base_path())) id="pool-transfer-offer" class="party-offer" hidden { button type="button" data-cancel-pool class="party-offer-cancel" { "Cancel" } button type="submit" disabled { "Offer" } }
@@ -1631,6 +1632,20 @@ pub fn party_pool_page(
 
 fn item_weight(item: Option<&crate::spacetimedb::ItemDefinition>) -> String {
     item.map_or_else(|| "—".to_owned(), |item| weight_display(item.weight))
+}
+
+fn encumbrance_inventory_rail(
+    content: Markup,
+    footer_controls: Markup,
+    summary: EncumbranceSummary,
+) -> Markup {
+    html! {
+        div class="encumbrance-inventory-rail" {
+            div class="encumbrance-inventory-scroll" { (content) }
+            (footer_controls)
+            (encumbrance_meter(summary))
+        }
+    }
 }
 
 fn encumbrance_meter(summary: EncumbranceSummary) -> Markup {
@@ -3590,9 +3605,9 @@ fn blood_recovery_minutes(condition: &CharacterCondition) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        CharacterCondition, LocationKind, MerchantShop, encumbrance_meter, need_balance_meter,
-        repair_custody_panel,
-        repair_submit_control, rest_default_minutes,
+        CharacterCondition, LocationKind, MerchantShop, encumbrance_inventory_rail,
+        encumbrance_meter, need_balance_meter, repair_custody_panel, repair_submit_control,
+        rest_default_minutes,
     };
     use crate::spacetimedb::ItemKind;
     use adventuresim_core::equipment::EncumbranceSummary;
@@ -3634,6 +3649,26 @@ mod tests {
         assert!(css.contains("linear-gradient(90deg, #238b45 0%, #f4d03f 50%, #c62828 100%)"));
         assert!(css.contains(".encumbrance-marker"));
         assert!(css.contains("background: #fff"));
+    }
+
+    #[test]
+    fn encumbrance_rail_scrolls_items_but_keeps_footer_and_meter_outside() {
+        let markup = encumbrance_inventory_rail(
+            maud::html! { table class="test-items" {} },
+            maud::html! { button class="test-footer" {} },
+            EncumbranceSummary::new(10.0, 100.0),
+        )
+        .into_string();
+        assert!(markup.contains(
+            "<div class=\"encumbrance-inventory-scroll\"><table class=\"test-items\"></table></div><button class=\"test-footer\"></button><div class=\"encumbrance\">"
+        ));
+
+        let css = include_str!("../../static/css/strategic.css");
+        assert!(css.contains(".sidebar-section:has(> .encumbrance-inventory-rail)"));
+        assert!(css.contains(".encumbrance-inventory-scroll"));
+        assert!(css.contains("overflow-y: auto"));
+        assert!(css.contains("padding-left: 1.75rem"));
+        assert!(css.contains("padding-right: 1.75rem"));
     }
 
     #[test]

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -360,6 +360,7 @@
   flex: 1 1 auto;
   flex-direction: column;
   min-height: 0;
+  container-type: inline-size;
 }
 
 .encumbrance-inventory-scroll {
@@ -377,8 +378,8 @@
 }
 
 .right-sidebar .encumbrance-inventory-scroll {
-  margin-left: -1.75rem;
-  padding-left: 1.75rem;
+  margin-left: -3.25rem;
+  padding-left: 3.25rem;
 }
 
 .encumbrance {
@@ -398,6 +399,24 @@
 .encumbrance-weight,
 .encumbrance-penalty {
   white-space: nowrap;
+}
+
+@container (max-width: 18rem) {
+  .encumbrance {
+    grid-template-columns: auto minmax(1.25rem, 1fr) auto;
+    gap: 0.25rem;
+    padding-inline: 0.35rem;
+    font-size: 0.68rem;
+  }
+}
+
+@container (max-width: 11rem) {
+  .encumbrance {
+    grid-template-columns: auto minmax(0.75rem, 1fr) auto;
+    gap: 0.12rem;
+    padding-inline: 0.2rem;
+    font-size: 0.58rem;
+  }
 }
 
 .encumbrance-meter {

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -338,6 +338,43 @@
   background: var(--panel-bg);
 }
 
+.encumbrance {
+  margin-top: 0.8rem;
+  padding-top: 0.65rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.encumbrance-copy {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.25rem 0.75rem;
+  margin-bottom: 0.35rem;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.encumbrance-meter {
+  position: relative;
+  height: 0.75rem;
+  border: 1px solid var(--text-primary);
+  border-radius: 999px;
+  background: linear-gradient(90deg, #238b45 0%, #f4d03f 50%, #c62828 100%);
+}
+
+.encumbrance-marker {
+  position: absolute;
+  top: -0.25rem;
+  bottom: -0.25rem;
+  left: clamp(0%, var(--encumbrance-position), 100%);
+  width: 0.2rem;
+  border: 1px solid #000;
+  border-radius: 0.15rem;
+  background: #fff;
+  box-shadow: 0 0 0 1px #fff, 0 0 0 2px #000;
+  transform: translateX(-50%);
+}
+
 .condition-bar {
   display: inline-flex;
   width: 5rem;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -345,6 +345,16 @@
   min-height: 0;
 }
 
+.inventory-owner-panel:has(.encumbrance-inventory-rail) {
+  display: flex;
+  flex-direction: column;
+}
+
+.inventory-owner-panel:has(.encumbrance-inventory-rail) > [data-inventory-pane] {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .encumbrance-inventory-rail {
   display: flex;
   flex: 1 1 auto;
@@ -372,21 +382,22 @@
 }
 
 .encumbrance {
+  display: grid;
   flex: 0 0 auto;
-  margin-top: 0.6rem;
-  padding: 0.55rem var(--padding) var(--padding);
+  grid-template-columns: auto minmax(2.5rem, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.45rem;
+  padding: 0.55rem var(--padding) 0.65rem;
   border-top: 1px solid var(--border-color);
   background: var(--sidebar-bg);
-}
-
-.encumbrance-copy {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  gap: 0.25rem 0.75rem;
-  margin-bottom: 0.35rem;
   font-size: 0.78rem;
   font-variant-numeric: tabular-nums;
+}
+
+.encumbrance-weight,
+.encumbrance-penalty {
+  white-space: nowrap;
 }
 
 .encumbrance-meter {

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -338,10 +338,45 @@
   background: var(--panel-bg);
 }
 
+.sidebar-section:has(> .encumbrance-inventory-rail) {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.encumbrance-inventory-rail {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.encumbrance-inventory-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-gutter: stable;
+}
+
+/* Keep center-facing row actions inside the scoped scroll viewport. */
+.left-sidebar .encumbrance-inventory-scroll {
+  margin-right: -1.75rem;
+  padding-right: 1.75rem;
+}
+
+.right-sidebar .encumbrance-inventory-scroll {
+  margin-left: -1.75rem;
+  padding-left: 1.75rem;
+}
+
 .encumbrance {
-  margin-top: 0.8rem;
-  padding-top: 0.65rem;
+  flex: 0 0 auto;
+  margin-top: 0.6rem;
+  padding: 0.55rem var(--padding) var(--padding);
   border-top: 1px solid var(--border-color);
+  background: var(--sidebar-bg);
 }
 
 .encumbrance-copy {

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -383,44 +383,48 @@
 }
 
 .encumbrance {
-  display: grid;
+  display: flex;
   flex: 0 0 auto;
-  grid-template-columns: auto minmax(2.5rem, 1fr) auto;
   align-items: center;
-  gap: 0.5rem;
   margin-top: 0.45rem;
   padding: 0.55rem var(--padding) 0.65rem;
   border-top: 1px solid var(--border-color);
   background: var(--sidebar-bg);
-  font-size: 0.78rem;
   font-variant-numeric: tabular-nums;
+}
+
+.encumbrance-values,
+.encumbrance-visual {
+  box-sizing: border-box;
+  flex: 0 0 50%;
+  width: 50%;
+  min-width: 0;
+}
+
+.encumbrance-values {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding-right: 0.35rem;
+  font-size: clamp(0.55rem, 4cqi, 0.78rem);
+  line-height: 1.25;
+}
+
+.encumbrance-visual {
+  display: flex;
+  align-items: center;
+  padding-left: 0.35rem;
 }
 
 .encumbrance-weight,
 .encumbrance-penalty {
+  max-width: 100%;
   white-space: nowrap;
-}
-
-@container (max-width: 18rem) {
-  .encumbrance {
-    grid-template-columns: auto minmax(1.25rem, 1fr) auto;
-    gap: 0.25rem;
-    padding-inline: 0.35rem;
-    font-size: 0.68rem;
-  }
-}
-
-@container (max-width: 11rem) {
-  .encumbrance {
-    grid-template-columns: auto minmax(0.75rem, 1fr) auto;
-    gap: 0.12rem;
-    padding-inline: 0.2rem;
-    font-size: 0.58rem;
-  }
 }
 
 .encumbrance-meter {
   position: relative;
+  width: 100%;
   height: 0.75rem;
   border: 1px solid var(--text-primary);
   border-radius: 999px;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -422,6 +422,37 @@
   white-space: nowrap;
 }
 
+@container (max-width: 12rem) {
+  .encumbrance {
+    padding-inline: 0.2rem;
+  }
+
+  .encumbrance-values {
+    padding-right: 0.1rem;
+    font-size: 0.5rem;
+    line-height: 1.15;
+  }
+
+  .encumbrance-visual {
+    padding-left: 0.1rem;
+  }
+}
+
+@container (max-width: 10rem) {
+  .encumbrance {
+    padding-inline: 0.1rem;
+  }
+
+  .encumbrance-values {
+    padding-right: 0.05rem;
+    font-size: 0.43rem;
+  }
+
+  .encumbrance-visual {
+    padding-left: 0.05rem;
+  }
+}
+
 .encumbrance-meter {
   position: relative;
   width: 100%;

--- a/wiki/shared/Encumbrance.md
+++ b/wiki/shared/Encumbrance.md
@@ -1,7 +1,6 @@
 ```rs
 const LOWER_MUSCLE_MASS_PER_LEG_STRENGTH = 5
 const WEIGHT_CAPACITY_PER_LOWER_MUSCLE_MASS = 30
-# todo: should this be linear or nonlinear?
 fn encumbrance_term(character):
 	average_leg_strength = (character.legs.left.strength + character.legs.right.strength) / 2
 	lower_muscle_mass = average_leg_strength * LOWER_MUSCLE_MASS_PER_LEG_STRENGTH
@@ -9,4 +8,24 @@ fn encumbrance_term(character):
 	return 1 - ((player.calculate_body_weight() + player.inventory.calculate_weight()) / weight_capacity)
 ```
 
-The inventory term includes every carried item, including equipped items. The recruitment Athletics tag combines climbing and swimming performance and uses this same shared encumbrance penalty, so a packed inventory lowers the recommendation.
+Encumbrance is linear. The term above is the remaining multiplier, clamped
+between 0 and 1; the displayed penalty is `1 - encumbrance_term`. A character
+at half capacity therefore has a 50% penalty, and reaching or exceeding
+capacity gives the maximum 100% penalty.
+
+The burden includes body weight, carried water at 1 kg per litre, and every
+carried inventory row multiplied by its quantity. Equipped items are already
+inventory rows and count exactly once. Injury-adjusted capacity uses the
+average of left and right leg strength after multiplying each leg by its
+current health.
+
+Inventory rails show the exact burden and capacity to one decimal place, the
+exact penalty to one decimal percent, and a green-to-yellow-to-red meter whose
+marker follows the same linear penalty. The party chest shows an aggregate:
+all living party members' burdens and capacities are summed, with the shared
+chest burden added once. Dead members contribute neither burden nor capacity,
+but the shared chest remains part of the aggregate.
+
+The recruitment Athletics tag combines climbing and swimming performance and
+uses this same shared encumbrance penalty, so a packed inventory lowers the
+recommendation.

--- a/wiki/shared/Encumbrance.md
+++ b/wiki/shared/Encumbrance.md
@@ -19,12 +19,14 @@ inventory rows and count exactly once. Injury-adjusted capacity uses the
 average of left and right leg strength after multiplying each leg by its
 current health.
 
-Inventory rails show the exact burden and capacity to one decimal place, the
-exact penalty to one decimal percent, and a green-to-yellow-to-red meter whose
-marker follows the same linear penalty. The party chest shows an aggregate:
-all living party members' burdens and capacities are summed, with the shared
-chest burden added once. Dead members contribute neither burden nor capacity,
-but the shared chest remains part of the aggregate.
+Inventory rails show one compact row with the exact burden and capacity to one
+decimal place on the left, a green-to-yellow-to-red meter in the middle, and
+the exact penalty to one decimal percent on the right. The marker follows the
+same linear penalty. Merchant Player tabs use the personal summary; merchant
+Party tabs use the living-party aggregate. The party chest also shows this
+aggregate: all living party members' burdens and capacities are summed, with
+the shared chest burden added once. Dead members contribute neither burden nor
+capacity, but the shared chest remains part of the aggregate.
 
 The recruitment Athletics tag combines climbing and swimming performance and
 uses this same shared encumbrance penalty, so a packed inventory lowers the

--- a/wiki/shared/Encumbrance.md
+++ b/wiki/shared/Encumbrance.md
@@ -19,10 +19,11 @@ inventory rows and count exactly once. Injury-adjusted capacity uses the
 average of left and right leg strength after multiplying each leg by its
 current health.
 
-Inventory rails show one compact row with the exact burden and capacity to one
-decimal place on the left, a green-to-yellow-to-red meter in the middle, and
-the exact penalty to one decimal percent on the right. The marker follows the
-same linear penalty. Merchant Player tabs use the personal summary; merchant
+Inventory rails split the summary into equal-width halves. The left half shows
+the exact burden and capacity to one decimal place with the exact penalty to
+one decimal percent directly below it. The right half is a stable-width
+green-to-yellow-to-red meter whose marker follows the same linear penalty.
+Merchant Player tabs use the personal summary; merchant
 Party tabs use the living-party aggregate. The party chest also shows this
 aggregate: all living party members' burdens and capacities are summed, with
 the shared chest burden added once. Dead members contribute neither burden nor


### PR DESCRIPTION
## Summary

- centralize the authoritative linear encumbrance calculation in `adventuresim-core`
- show exact personal encumbrance at the bottom of character inventory rails
- show living-party aggregate encumbrance at the bottom of the shared party inventory
- show the same personal and living-party aggregate summaries in merchant Player and Party tabs
- render an accessible green-to-yellow-to-red linear meter with an exact-position marker
- keep the meter visible while long inventory lists scroll independently
- keep the meter width stable in a fixed 50/50 layout, with weight and penalty stacked in the left half
- document the linear equation and aggregate semantics in the wiki

## Implementation notes

Personal burden includes body weight, every carried inventory item (including equipped items exactly once), quantities, and carried water at 1 kg/L. Capacity uses injury-adjusted average leg strength.

Party burden and capacity aggregate living members, with shared inventory burden added once. Dead members contribute neither personal burden nor capacity. Values and penalties are rendered to one decimal place; overload remains visible while the penalty and marker clamp to 100%.

Party data loading excludes dead members, deduplicates IDs, and caps actual in-flight database requests at four. Merchant Herbalist pages remain player-only and avoid party aggregation.

The compact summary uses two equal-width columns: exact burden/capacity and penalty are stacked in the left half, while the gradient meter fills the right half. Responsive rail-scoped rules preserve the split without clipping exact values at narrow desktop widths. Visible shorthand values are hidden from assistive technology because the meter exposes the complete descriptive value once.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p adventuresim-core` - 119 unit tests and 4 doctests passed
- `cargo check -p strategic-web`
- `cargo test -p strategic-web` - 77 tests passed
- `python scripts/update_project_map.py --check`
- `git diff --check`
- two independent read-only reviews, with accepted findings remediated
- headed Playwright verification at 1280x720 and 800x720 on character inventory, party inventory, General Market Player/Party tabs, and Herbalist Player inventory
- confirmed the fixed 50/50 summary keeps the meter width stable, weight and penalty occupy separate lines, merchant row actions remain reachable, and narrow rails do not overlap the meter

## Demo

Run:

```powershell
just web-isolated encumbrance-demo 23300
```

Then select **Wounded Demo** and inspect:

- `/locations/settlement/riverdale/party/9999999999999999/inventory`
- `/locations/settlement/riverdale/party-inventory`
- `/settlements/riverdale/merchants`
- `/settlements/riverdale/herbalist`

Staged transfers intentionally do not preview encumbrance changes until submitted and server-rendered.
