### PR TITLE
Rework character condition meters

### DIFF
--- a/crates/adventuresim-stdb-module/src/condition.rs
+++ b/crates/adventuresim-stdb-module/src/condition.rs
@@ -97,7 +97,9 @@ pub struct CharacterStrategicCondition {
     pub fatigue: f32,
     pub hunger: f32,
     pub thirst: f32,
+    /// Positive physiological food reserve, expressed in travel days.
     pub food_days: f32,
+    /// Positive physiological hydration reserve, expressed in travel days.
     pub water_days: f32,
     pub water_capacity_ml: u32,
     pub incapacitation: f32,
@@ -181,6 +183,14 @@ fn inventory_quantity(ctx: &ReducerContext, character_id: u64, item_id: &str) ->
         .filter((character_id, item_id))
         .map(|entry| entry.quantity)
         .sum()
+}
+
+fn food_reserve_days(needs: &CharacterNeeds) -> f32 {
+    needs.food_balance_kcal.max(0.0) / TRAVEL_CALORIES_PER_DAY
+}
+
+fn water_reserve_days(needs: &CharacterNeeds) -> f32 {
+    needs.water_balance_ml.max(0.0) / TRAVEL_WATER_ML_PER_DAY
 }
 
 fn water_capacity_ml(ctx: &ReducerContext, character_id: u64) -> u32 {
@@ -936,10 +946,8 @@ fn evaluate_strategic_condition(
             fatigue: incapacitation.fatigue,
             hunger: incapacitation.hunger,
             thirst: incapacitation.thirst,
-            food_days: (needs.food_balance_kcal.max(0.0) / TRAVEL_CALORIES_PER_DAY)
-                + inventory_quantity(ctx, character_id, TRAVEL_RATION_ID) as f32,
-            water_days: (needs.water_balance_ml.max(0.0) + needs.carried_water_ml)
-                / TRAVEL_WATER_ML_PER_DAY,
+            food_days: food_reserve_days(&needs),
+            water_days: water_reserve_days(&needs),
             water_capacity_ml: water_capacity,
             incapacitation: incapacitation.total(),
             check_multiplier: incapacitation.check_multiplier(),
@@ -1661,8 +1669,9 @@ pub fn set_character_religion(
 #[cfg(test)]
 mod tests {
     use super::{
-        ProjectedMoraleSource, accumulated_leisure_morale, condition_projection_member_ids,
-        holy_day_demand_has_expired, leisure_morale_effect, rank_morale_sources,
+        CharacterNeeds, ProjectedMoraleSource, accumulated_leisure_morale,
+        condition_projection_member_ids, food_reserve_days, holy_day_demand_has_expired,
+        leisure_morale_effect, rank_morale_sources, water_reserve_days,
     };
 
     #[test]
@@ -1680,6 +1689,19 @@ mod tests {
         DailySchedule, LEISURE_MORALE_LIMIT, settlement_leisure_outcome,
     };
     use adventuresim_core::strategic_time::MINUTES_PER_DAY;
+
+    #[test]
+    fn condition_reserve_days_exclude_carried_provisions() {
+        let needs = CharacterNeeds {
+            character_id: 1,
+            food_balance_kcal: 3_000.0,
+            water_balance_ml: 1_000.0,
+            carried_water_ml: 40_000.0,
+        };
+
+        assert_eq!(food_reserve_days(&needs), 0.5);
+        assert_eq!(water_reserve_days(&needs), 0.25);
+    }
 
     #[test]
     fn holy_day_demands_expire_after_their_day_or_on_departure() {

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -822,7 +822,9 @@ pub struct CharacterStrategicCondition {
     pub fatigue: f32,
     pub hunger: f32,
     pub thirst: f32,
+    /// Positive physiological food reserve in travel days; excludes inventory.
     pub food_days: f32,
+    /// Positive physiological hydration reserve in travel days; excludes carried water.
     pub water_days: f32,
     pub water_capacity_ml: u32,
     pub incapacitation: f32,

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -154,7 +154,7 @@ fn page_shell(
                     script src="/static/service-quests.js?v=herbalist-care-2" defer {}
                     script src="/static/chat-resize.js?v=floating-chat-3" defer {}
                     script src="/static/local-chat.js?v=herbalist-private-1" defer {}
-                    script src="/static/strategic-condition.js?v=strategic-condition-2" defer {}
+                    script src="/static/strategic-condition.js?v=strategic-condition-3" defer {}
                     script src="/static/travel-planner.js?v=journey-state-1" defer {}
                 }
             }

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -2572,7 +2572,7 @@ fn strategic_condition_rail(
     html! {
         (sidebar_section("Condition", html! {
             div class=(if condition.fear > 0.0 { "morale-meter is-fearful" } else { "morale-meter" }) tabindex="0" style=(meter_style) aria-label=(format!(
-                "Morale {:.1}; fear {}; personal share of party morale restoration {:.1}%",
+                "Morale {:.1}; fear {}; inspiration {:.1}%",
                 condition.morale,
                 percent(condition.fear),
                 condition.morale_bonus * 100.0,
@@ -2589,7 +2589,7 @@ fn strategic_condition_rail(
                 div class="morale-meter-labels" {
                     span { "100% fear" }
                     span { "Neutral" }
-                    span { (format!("{:.1}% ally lift", condition.morale_bonus * 100.0)) }
+                    span { (format!("{:.1}% inspiration", condition.morale_bonus * 100.0)) }
                 }
                 div class="morale-source-popup" role="tooltip" {
                     strong { "Morale sources" }
@@ -2652,8 +2652,8 @@ fn strategic_condition_rail(
                 }
             }
             div class="need-balance-meters" aria-label="Food and water reserves" {
-                (need_balance_meter("Food", "meal", "Hunger", "hunger", condition.food_days, condition.hunger))
-                (need_balance_meter("Water", "water-drop", "Thirst", "thirst", condition.water_days, condition.thirst))
+                (need_balance_meter("Food", "meal", "Hunger", "Full", "hunger", condition.food_days, condition.hunger))
+                (need_balance_meter("Water", "water-drop", "Thirst", "Hydrated", "thirst", condition.water_days, condition.thirst))
             }
         }))
     }
@@ -2663,6 +2663,7 @@ fn need_balance_meter(
     label: &str,
     icon: &str,
     deficit_label: &str,
+    reserve_label: &str,
     color: &str,
     reserve_days: f32,
     incapacitation: f32,
@@ -2692,7 +2693,7 @@ fn need_balance_meter(
             div class="need-balance-labels" aria-hidden="true" {
                 span { (deficit_label) }
                 span { "0" }
-                span { "Reserve" }
+                span { (reserve_label) }
             }
         }
     }
@@ -3551,12 +3552,26 @@ mod tests {
     #[test]
     fn need_meter_places_reserve_right_and_incapacitation_left() {
         let reserve =
-            need_balance_meter("Food", "meal", "Hunger", "hunger", 0.5, 0.0).into_string();
+            need_balance_meter("Food", "meal", "Hunger", "Full", "hunger", 0.5, 0.0).into_string();
         assert!(reserve.contains("--need-reserve: 50.0%; --need-deficit: 0.0%"));
         assert!(reserve.contains("aria-valuenow=\"50\""));
+        assert!(reserve.contains(">Full</span>"));
+
+        let hydration = need_balance_meter(
+            "Water",
+            "water-drop",
+            "Thirst",
+            "Hydrated",
+            "thirst",
+            1.0,
+            0.0,
+        )
+        .into_string();
+        assert!(hydration.contains(">Hydrated</span>"));
 
         let deficit =
-            need_balance_meter("Food", "meal", "Hunger", "hunger", 0.0, 1.0 / 9.0).into_string();
+            need_balance_meter("Food", "meal", "Hunger", "Full", "hunger", 0.0, 1.0 / 9.0)
+                .into_string();
         assert!(deficit.contains("--need-reserve: 0.0%; --need-deficit: 11.1%"));
         assert!(deficit.contains("aria-valuenow=\"-11\""));
     }

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -2545,9 +2545,33 @@ fn strategic_condition_rail(
     }
     .round();
     let meter_style = format!("--morale-fear: {fear_fill}%; --morale-bonus: {bonus_fill}%");
+    let incapacitation_segments = [
+        ("Pain", "broken-heart", "pain", condition.pain),
+        (
+            "Blood loss",
+            "bleeding-wound",
+            "blood",
+            condition.blood_loss,
+        ),
+        ("Fear", "terror", "fear", condition.fear),
+        ("Fatigue", "night-sleep", "fatigue", condition.fatigue),
+        ("Hunger", "meal", "hunger", condition.hunger),
+        ("Thirst", "water-drop", "thirst", condition.thirst),
+    ];
+    let incapacitation_sources = [
+        ("Pain", "broken-heart", "pain", condition.pain),
+        (
+            "Blood loss",
+            "bleeding-wound",
+            "blood",
+            condition.blood_loss,
+        ),
+        ("Fear", "terror", "fear", condition.fear),
+        ("Fatigue", "night-sleep", "fatigue", condition.fatigue),
+    ];
     html! {
         (sidebar_section("Condition", html! {
-            div class="morale-meter" tabindex="0" style=(meter_style) aria-label=(format!(
+            div class=(if condition.fear > 0.0 { "morale-meter is-fearful" } else { "morale-meter" }) tabindex="0" style=(meter_style) aria-label=(format!(
                 "Morale {:.1}; fear {}; personal share of party morale restoration {:.1}%",
                 condition.morale,
                 percent(condition.fear),
@@ -2598,20 +2622,79 @@ fn strategic_condition_rail(
                     "Faith, a strong same-faith cohort, and surplus morale raise Fervor. Party Charisma restrains it. Higher Fervor makes conviction demands and settlement incidents more likely."
                 }
             }
-            dl class="character-bio strategic-condition-summary" {
-                div { dt { "Status" } dd { (condition.status.to_uppercase()) } }
-                div { dt class="metric-label" { (decorative_game_icon("coma")) span { "Incapacitation" } } dd { (percent(condition.incapacitation)) } }
-                div { dt class="metric-label" { (decorative_game_icon("broken-heart")) span { "Pain" } } dd { (percent(condition.pain)) } }
-                div { dt class="metric-label" { (decorative_game_icon("bleeding-wound")) span { "Blood loss" } } dd { (percent(condition.blood_loss)) } }
-                div { dt class="metric-label" { (decorative_game_icon("terror")) span { "Fear" } } dd { (percent(condition.fear)) } }
-                div { dt class="metric-label" { (decorative_game_icon("night-sleep")) span { "Fatigue" } } dd { (percent(condition.fatigue)) } }
-                div { dt class="metric-label" { (decorative_game_icon("meal")) span { "Hunger" } } dd { (percent(condition.hunger)) } }
-                div { dt class="metric-label" { (decorative_game_icon("water-drop")) span { "Thirst" } } dd { (percent(condition.thirst)) } }
-                div { dt class="metric-label" { (decorative_game_icon("bread")) span { "Food" } } dd { (format!("{:.1} travel days", condition.food_days.max(0.0))) } }
-                div { dt class="metric-label" { (decorative_game_icon("waterskin")) span { "Water" } } dd { (format!("{:.1} travel days / {:.1} L capacity", condition.water_days.max(0.0), condition.water_capacity_ml as f32 / 1_000.0)) } }
-                div { dt class="metric-label" { (decorative_game_icon("check-mark")) span { "Check effectiveness" } } dd { (percent(condition.check_multiplier)) } }
+            div class="incapacitation-overview" tabindex="0" title=(format!("{} incapacitation", percent(condition.incapacitation))) {
+                div class="incapacitation-heading" {
+                    strong class="metric-label" { (decorative_game_icon("coma")) span { "Incapacitation" } }
+                    span class="incapacitation-status" { (&condition.status) }
+                }
+                div class="incapacitation-total-track" role="meter"
+                    aria-label=(format!("Incapacitation {}; {}", percent(condition.incapacitation), condition.status))
+                    aria-valuemin="0" aria-valuemax="100"
+                    aria-valuenow=(condition.incapacitation.clamp(0.0, 1.0) * 100.0) {
+                    @for (_, _, color, value) in incapacitation_segments {
+                        span class=(format!("incapacitation-segment incapacitation-{color}"))
+                            style=(format!("--incap-amount: {:.1}%", value.max(0.0) * 100.0)) {}
+                    }
+                }
+            }
+            div class="incapacitation-sources" aria-label="Sources of incapacitation" {
+                @for (label, icon, color, value) in incapacitation_sources {
+                    div class=(format!("incapacitation-source incapacitation-{color}"))
+                        title=(format!("{label}: {} incapacitation", percent(value))) {
+                        strong class="metric-label" { (decorative_game_icon(icon)) span { (label) } }
+                        div class="incapacitation-source-track" role="meter"
+                            aria-label=(format!("{label}: {} incapacitation", percent(value)))
+                            aria-valuemin="0" aria-valuemax="100"
+                            aria-valuenow=(value.clamp(0.0, 1.0) * 100.0) {
+                            span style=(format!("--incap-amount: {:.1}%", value.clamp(0.0, 1.0) * 100.0)) {}
+                        }
+                    }
+                }
+            }
+            div class="need-balance-meters" aria-label="Food and water reserves" {
+                (need_balance_meter("Food", "meal", "Hunger", "hunger", condition.food_days, condition.hunger))
+                (need_balance_meter("Water", "water-drop", "Thirst", "thirst", condition.water_days, condition.thirst))
             }
         }))
+    }
+}
+
+fn need_balance_meter(
+    label: &str,
+    icon: &str,
+    deficit_label: &str,
+    color: &str,
+    reserve_days: f32,
+    incapacitation: f32,
+) -> Markup {
+    let reserve_days = reserve_days.max(0.0);
+    let reserve_fill = (reserve_days * 100.0).clamp(0.0, 100.0);
+    let deficit_fill = (incapacitation.max(0.0) * 100.0).clamp(0.0, 100.0);
+    let signed_value = if deficit_fill > 0.0 {
+        -deficit_fill
+    } else {
+        reserve_fill
+    };
+    let description = format!(
+        "{label}: {reserve_days:.1} travel days reserve; {deficit_label} {deficit_fill:.0}% incapacitation"
+    );
+    html! {
+        div class=(format!("need-balance incapacitation-{color}"))
+            style=(format!("--need-reserve: {reserve_fill:.1}%; --need-deficit: {deficit_fill:.1}%"))
+            title=(&description) {
+            strong class="metric-label" { (decorative_game_icon(icon)) span { (label) } }
+            div class="need-balance-track" role="meter" aria-label=(description)
+                aria-valuemin="-100" aria-valuemax="100" aria-valuenow=(format!("{signed_value:.0}")) {
+                span class="need-balance-half need-balance-deficit" { span {} }
+                span class="need-balance-half need-balance-reserve" { span {} }
+                i aria-hidden="true" {}
+            }
+            div class="need-balance-labels" aria-hidden="true" {
+                span { (deficit_label) }
+                span { "0" }
+                span { "Reserve" }
+            }
+        }
     }
 }
 
@@ -3431,7 +3514,7 @@ fn blood_recovery_minutes(condition: &CharacterCondition) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        CharacterCondition, LocationKind, MerchantShop, repair_custody_panel,
+        CharacterCondition, LocationKind, MerchantShop, need_balance_meter, repair_custody_panel,
         repair_submit_control, rest_default_minutes,
     };
     use crate::spacetimedb::ItemKind;
@@ -3463,6 +3546,19 @@ mod tests {
             rest_default_minutes(None, None, Some(&condition), 0, 0),
             Some(2_880)
         );
+    }
+
+    #[test]
+    fn need_meter_places_reserve_right_and_incapacitation_left() {
+        let reserve =
+            need_balance_meter("Food", "meal", "Hunger", "hunger", 0.5, 0.0).into_string();
+        assert!(reserve.contains("--need-reserve: 50.0%; --need-deficit: 0.0%"));
+        assert!(reserve.contains("aria-valuenow=\"50\""));
+
+        let deficit =
+            need_balance_meter("Food", "meal", "Hunger", "hunger", 0.0, 1.0 / 9.0).into_string();
+        assert!(deficit.contains("--need-reserve: 0.0%; --need-deficit: 11.1%"));
+        assert!(deficit.contains("aria-valuenow=\"-11\""));
     }
 
     #[test]

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -1764,6 +1764,15 @@ button.party-portrait-action {
   outline: none;
 }
 
+:root {
+  --incap-pain: #d973a2;
+  --incap-blood: #c84747;
+  --incap-fear: #4f83cc;
+  --incap-fatigue: #202020;
+  --incap-hunger: #b57a35;
+  --incap-thirst: #3f9fa8;
+}
+
 .morale-meter-heading,
 .morale-meter-labels {
   display: grid;
@@ -1789,10 +1798,12 @@ button.party-portrait-action {
 .morale-meter-fear {
   background: linear-gradient(
     to left,
-    var(--danger) 0 var(--morale-fear),
+    var(--incap-fear) 0 var(--morale-fear),
     transparent var(--morale-fear) 100%
   );
 }
+
+.morale-meter.is-fearful .morale-meter-heading .game-icon { color: var(--incap-fear); }
 
 .morale-meter-bonus {
   background: linear-gradient(
@@ -1902,6 +1913,175 @@ button.party-portrait-action {
   opacity: 1;
   transform: translateY(0);
 }
+
+.incapacitation-overview {
+  padding-top: 0.45rem;
+  outline: none;
+}
+
+.incapacitation-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.incapacitation-heading .game-icon {
+  background: conic-gradient(
+    var(--incap-pain),
+    var(--incap-blood),
+    var(--incap-fear),
+    var(--incap-fatigue),
+    var(--incap-hunger),
+    var(--incap-thirst),
+    var(--incap-pain)
+  );
+}
+
+.incapacitation-status {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 800;
+  text-transform: capitalize;
+}
+
+.incapacitation-total-track,
+.incapacitation-source-track {
+  position: relative;
+  display: flex;
+  height: 0.7rem;
+  overflow: hidden;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+}
+
+.incapacitation-segment {
+  flex: 0 0 var(--incap-amount);
+  height: 100%;
+  background: var(--incap-color);
+}
+
+.incapacitation-sources {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 0.7rem;
+  margin-top: 0.65rem;
+}
+
+.incapacitation-source {
+  min-width: 0;
+  color: var(--text-secondary);
+}
+
+.incapacitation-source .metric-label {
+  margin-bottom: 0.2rem;
+  font-size: var(--font-size-xs);
+}
+
+.incapacitation-source .game-icon { color: var(--incap-color); }
+.incapacitation-fatigue .game-icon {
+  filter: drop-shadow(0 0 1px color-mix(in srgb, var(--text-primary) 70%, transparent));
+}
+
+.incapacitation-source-track { height: 0.48rem; }
+.incapacitation-source-track::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: color-mix(in srgb, var(--text-primary) 45%, transparent);
+  content: "";
+}
+.incapacitation-source-track span {
+  display: block;
+  width: var(--incap-amount);
+  height: 100%;
+  background: var(--incap-color);
+}
+
+.incapacitation-pain { --incap-color: var(--incap-pain); }
+.incapacitation-blood { --incap-color: var(--incap-blood); }
+.incapacitation-fear { --incap-color: var(--incap-fear); }
+.incapacitation-fatigue { --incap-color: var(--incap-fatigue); }
+.incapacitation-hunger { --incap-color: var(--incap-hunger); }
+.incapacitation-thirst { --incap-color: var(--incap-thirst); }
+
+.need-balance-meters {
+  display: grid;
+  gap: 0.65rem;
+  margin-top: 0.8rem;
+}
+
+.need-balance {
+  color: var(--text-secondary);
+}
+
+.need-balance > .metric-label {
+  margin-bottom: 0.25rem;
+  font-size: var(--font-size-xs);
+}
+
+.need-balance .game-icon { color: var(--incap-color); }
+
+.need-balance-track {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  height: 0.55rem;
+  overflow: hidden;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+}
+
+.need-balance-half {
+  position: relative;
+  overflow: hidden;
+}
+
+.need-balance-half > span {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+}
+
+.need-balance-deficit > span {
+  right: 0;
+  width: var(--need-deficit);
+  background: var(--incap-color);
+}
+
+.need-balance-reserve > span {
+  left: 0;
+  width: var(--need-reserve);
+  background: var(--success);
+}
+
+.need-balance-track > i {
+  position: absolute;
+  z-index: 1;
+  top: -0.15rem;
+  bottom: -0.15rem;
+  left: 50%;
+  width: 2px;
+  background: var(--text-primary);
+  transform: translateX(-1px);
+}
+
+.need-balance-labels {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.35rem;
+  margin-top: 0.2rem;
+  color: var(--text-muted);
+  font-size: 0.62rem;
+}
+
+.need-balance-labels span:nth-child(2) { text-align: center; }
+.need-balance-labels span:last-child { text-align: right; }
 
 .religious-demand h3 { margin: 0 0 0.45rem; font-family: var(--font-heading); }
 .religious-demand p { margin: 0 0 0.55rem; }

--- a/crates/strategic-web/static/strategic-condition.js
+++ b/crates/strategic-web/static/strategic-condition.js
@@ -11,13 +11,15 @@
       return;
     }
 
+    const styles = getComputedStyle(wheel);
+    const color = (name, fallback) => styles.getPropertyValue(`--incap-${name}`).trim() || fallback;
     const components = [
-      ["pain", condition.pain, "#d973a2"],
-      ["blood loss", condition.blood_loss, "#c84747"],
-      ["fear", condition.fear, "#4f83cc"],
-      ["fatigue", condition.fatigue, "#202020"],
-      ["hunger", condition.hunger, "#b57a35"],
-      ["thirst", condition.thirst, "#3f9fa8"],
+      ["pain", condition.pain, color("pain", "#d973a2")],
+      ["blood loss", condition.blood_loss, color("blood", "#c84747")],
+      ["fear", condition.fear, color("fear", "#4f83cc")],
+      ["fatigue", condition.fatigue, color("fatigue", "#202020")],
+      ["hunger", condition.hunger, color("hunger", "#b57a35")],
+      ["thirst", condition.thirst, color("thirst", "#3f9fa8")],
     ];
     let cursor = 0;
     const stops = [];

--- a/wiki/shared/Energy.md
+++ b/wiki/shared/Energy.md
@@ -35,3 +35,9 @@ days beyond the food reserve. Unsupported thirst reaches it after one marching
 day beyond the hydration reserve. Both curves are quadratic, begin only below
 zero reserve, and combine with pain, blood loss, fear, and fatigue. They do not
 currently kill a character.
+
+The character panel presents each signed physiological balance as a centered
+meter. Positive reserve fills right, normalized to the ordinary one-day
+reserve. Once the balance crosses zero, hunger or thirst fills left according
+to its quadratic incapacitation contribution. Carried rations and water are not
+included; they affect the meter only when automatically consumed.

--- a/wiki/tactical/Combat.md
+++ b/wiki/tactical/Combat.md
@@ -80,6 +80,8 @@ to 40 joules per kilogram of ranged weapon, giving the one-kilogram short bow a
 ## Incapacitation
 A character's incapacitation represents the sum of all disabling effects on them and corresponds to the state of their animation. When above half, they are "staggered" and each additional 1% of incapacitation causes a 2% penalty to movement and attribute checks, and when above 100% they are completely incapacitated (which also causes knockdown). Most negative effects that a character has can affect their incapacitation, past a certain threshold. Your incapacitation is displayed as a wheel in the center of the screen. If it is at 0%, the wheel is invisible, and as it increases it starts from 12 o'clock and extends as an arc clockwise. Each factor that contributes to incapacitation has a different color to differentiate them.
 
+The strategic character panel uses the same colors for its segmented incapacitation meter, source meters, and source icons. Hunger and thirst share centered meters with their physiological reserves: reserve fills right, while incapacitation fills left after crossing zero. Exact percentages remain available on hover and to assistive technology, while the default view emphasizes the relative contribution of each source.
+
 Each of the following factors range from 0% to at least 100%.
 ### Imbalance (white)
 > Halbe: This was written in terms of energy, but might make more sense in terms of momentum.


### PR DESCRIPTION
## Summary

- replace numeric incapacitation diagnostics with compact, color-coded source meters
- use the same source palette for the character panel and portrait wheel
- combine food reserve/hunger and hydration reserve/thirst into centered bidirectional meters
- exclude carried rations and water from the physiological reserve projection

## Why

The previous right panel mixed overall condition, individual incapacitation sources, carried provisions, and derived diagnostics as raw numbers. This made it difficult to understand which conditions contribute to incapacitation and blurred the distinction between bodily reserve and inventory.

The new presentation gives each statistic one visual job. Reserve fills right from zero, hunger or thirst incapacitation fills left, and source colors remain consistent with the incapacitation wheel.

## User impact

Players can learn the sources of incapacitation from consistent meter and icon colors. Food and Water now communicate bodily reserve only; carried provisions affect these meters only when consumed.

## Validation

- `cargo check -p strategic-web`
- `cargo test -p adventuresim-core -p strategic-web` (113 core tests, 69 web tests)
- `just build-strategic`
- `just verify-db-client`
- `node --check crates/strategic-web/static/strategic-condition.js`
- `cargo fmt --all -- --check`
- `git diff --check`
- live Wounded Demo browser verification with no console warnings or errors
