### PR TITLE
Add reusable inventory browser controls

### DIFF
--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -521,6 +521,38 @@ pub struct ItemDefinition {
     pub slot: ItemSlot,
     pub kind: ItemKind,
     #[serde(default)]
+    pub accuracy: f32,
+    #[serde(default)]
+    pub reach: f32,
+    #[serde(default)]
+    pub block: f32,
+    #[serde(default)]
+    pub coverage: f32,
+    #[serde(default)]
+    pub penetration: f32,
+    #[serde(default)]
+    pub resistance: f32,
+    #[serde(default)]
+    pub padding: f32,
+    #[serde(default)]
+    pub flexibility: f32,
+    #[serde(default)]
+    pub range_of_motion: f32,
+    #[serde(default)]
+    pub precise: bool,
+    #[serde(default)]
+    pub balance: f32,
+    #[serde(default)]
+    pub melee: bool,
+    #[serde(default)]
+    pub ranged: bool,
+    #[serde(default)]
+    pub blunt: bool,
+    #[serde(default)]
+    pub slash: bool,
+    #[serde(default)]
+    pub pierce: bool,
+    #[serde(default)]
     pub base_value: Option<u32>,
     #[serde(default)]
     pub nutrition_kcal: f32,
@@ -540,6 +572,43 @@ pub struct ItemDefinition {
     pub edge_sensitivity: f32,
     #[serde(default)]
     pub handling_sensitivity: f32,
+}
+
+impl Default for ItemDefinition {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            weight: 0.0,
+            slot: ItemSlot::None,
+            kind: ItemKind::Simple,
+            accuracy: 0.0,
+            reach: 0.0,
+            block: 0.0,
+            coverage: 0.0,
+            penetration: 0.0,
+            resistance: 0.0,
+            padding: 0.0,
+            flexibility: 0.0,
+            range_of_motion: 0.0,
+            precise: false,
+            balance: 0.0,
+            melee: false,
+            ranged: false,
+            blunt: false,
+            slash: false,
+            pierce: false,
+            base_value: None,
+            nutrition_kcal: 0.0,
+            water_capacity_ml: 0,
+            quality: 0,
+            durability_yield: 0.0,
+            durability_fracture: 0.0,
+            durability_wear: 0.0,
+            durability_failure_share: 0.0,
+            edge_sensitivity: 0.0,
+            handling_sensitivity: 0.0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/strategic-web/src/templates/inventory_browser.rs
+++ b/crates/strategic-web/src/templates/inventory_browser.rs
@@ -32,6 +32,7 @@ impl InventoryColumnSet {
 pub struct InventoryBrowser<'a> {
     /// Stable URL-state namespace. Left and right panels must never share it.
     pub namespace: &'a str,
+    pub show_quantities: bool,
     pub show_equipped: bool,
     pub show_condition: bool,
     pub optional_columns: InventoryColumnSet,
@@ -67,23 +68,28 @@ impl InventoryBrowser<'_> {
                         }
                     }
                 }
-                div class="inventory-browser-table-scroll" tabindex="0" aria-label="Scrollable inventory table" {
+                div class="inventory-browser-table-frame" {
                 table class=(table_class) {
                     colgroup {
                         col class="inventory-column-type";
                         col class="inventory-column-item";
-                        col class="inventory-column-count";
-                        col class="inventory-column-target";
+                        @if self.show_quantities {
+                            col class="inventory-column-count";
+                            col class="inventory-column-target";
+                        }
                         @if self.show_equipped { col class="inventory-column-equipped"; }
                         @if self.show_condition { col class="inventory-column-durability"; }
                         col class="inventory-column-weight";
                         col class="inventory-column-gold";
+                        col class="inventory-column-actions";
                     }
                     thead { tr {
                         (sortable_icon_header("type", "inventory-column-type", "Item type", game_icon("Item type", "knapsack")))
                         (sortable_text_header("name", "Item", "inventory-column-item"))
-                        (sortable_text_header("quantity", "#", "inventory-column-count"))
-                        (sortable_text_header("target", "#?", "inventory-column-target"))
+                        @if self.show_quantities {
+                            (sortable_text_header("quantity", "#", "inventory-column-count"))
+                            (sortable_text_header("target", "#?", "inventory-column-target"))
+                        }
                         @if self.show_equipped {
                             (sortable_icon_header("equipped", "inventory-column-equipped", "Equipped", game_icon("Equipped", "check-mark")))
                         }
@@ -97,6 +103,7 @@ impl InventoryBrowser<'_> {
                         }
                         (sortable_icon_header("weight", "inventory-column-weight", "Weight", game_icon("Weight", "weight")))
                         (sortable_icon_header("value", "inventory-column-gold", "Currency", game_icon("Currency", "coins")))
+                        th class="inventory-actions-header" aria-label="Inventory actions" {}
                     } }
                     tbody { (self.rows) }
                 }
@@ -122,6 +129,7 @@ mod tests {
     fn renders_independent_state_namespace_and_quantity_target_headers() {
         let rendered = InventoryBrowser {
             namespace: "trade-left",
+            show_quantities: true,
             show_equipped: false,
             show_condition: false,
             optional_columns: InventoryColumnSet::Weapons,
@@ -133,14 +141,15 @@ mod tests {
         assert!(rendered.contains("data-inventory-sort=\"quantity\""));
         assert!(rendered.contains("data-inventory-sort=\"target\""));
         assert!(rendered.contains("accuracy,reach,penetration,damage,block"));
-        assert!(rendered.contains("inventory-browser-table-scroll"));
-        assert!(rendered.contains("aria-label=\"Scrollable inventory table\""));
+        assert!(rendered.contains("inventory-browser-table-frame"));
+        assert!(rendered.contains("inventory-actions-header"));
     }
 
     #[test]
     fn condition_header_is_a_dedicated_sort_control() {
         let rendered = InventoryBrowser {
             namespace: "smith",
+            show_quantities: true,
             show_equipped: true,
             show_condition: true,
             optional_columns: InventoryColumnSet::Weapons,
@@ -151,5 +160,23 @@ mod tests {
         assert!(rendered.contains("data-inventory-sort=\"durability\""));
         assert!(rendered.contains("hammer-nails.svg"));
         assert!(!rendered.contains("repair-all"));
+    }
+
+    #[test]
+    fn merchant_inventory_can_hide_quantity_and_target_columns() {
+        let rendered = InventoryBrowser {
+            namespace: "merchant-left",
+            show_quantities: false,
+            show_equipped: false,
+            show_condition: false,
+            optional_columns: InventoryColumnSet::Weapons,
+            rows: html! {},
+        }
+        .render()
+        .into_string();
+        assert!(!rendered.contains("inventory-column-count"));
+        assert!(!rendered.contains("inventory-column-target"));
+        assert!(!rendered.contains("data-inventory-sort=\"quantity\""));
+        assert!(!rendered.contains("data-inventory-sort=\"target\""));
     }
 }

--- a/crates/strategic-web/src/templates/inventory_browser.rs
+++ b/crates/strategic-web/src/templates/inventory_browser.rs
@@ -1,0 +1,128 @@
+//! Shared, progressively enhanced inventory browser presentation.
+//!
+//! Reducer-specific row controls remain supplied by each workflow, while this
+//! component owns the browser contract: panel identity, searchable/sortable
+//! columns, optional-column availability, and the quantity/target split.
+
+use maud::{Markup, html};
+
+use super::game_icon;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InventoryColumnSet {
+    Basic,
+    Weapons,
+    Armor,
+    All,
+}
+
+impl InventoryColumnSet {
+    fn names(self) -> &'static str {
+        match self {
+            Self::Basic => "",
+            Self::Weapons => "accuracy,reach,penetration,damage,block",
+            Self::Armor => "coverage,resistance,padding,flexibility,range-of-motion",
+            Self::All => {
+                "accuracy,reach,penetration,damage,block,coverage,resistance,padding,flexibility,range-of-motion"
+            }
+        }
+    }
+}
+
+pub struct InventoryBrowser<'a> {
+    /// Stable URL-state namespace. Left and right panels must never share it.
+    pub namespace: &'a str,
+    pub show_equipped: bool,
+    pub condition_header: Option<Markup>,
+    pub optional_columns: InventoryColumnSet,
+    pub rows: Markup,
+}
+
+impl InventoryBrowser<'_> {
+    pub fn render(self) -> Markup {
+        let show_condition = self.condition_header.is_some();
+        let table_class = if show_condition {
+            "trade-inventory-table smith-player-inventory-table"
+        } else {
+            "trade-inventory-table"
+        };
+        html! {
+            div class="inventory-browser" data-inventory-browser=(self.namespace)
+                data-optional-columns=(self.optional_columns.names()) {
+                div class="inventory-browser-toolbar" {
+                    label class="inventory-browser-search" {
+                        span class="sr-only" { "Search items by name" }
+                        input type="search" data-inventory-search placeholder="Search items" autocomplete="off"
+                            aria-label="Search items by name";
+                    }
+                    details class="inventory-column-picker" {
+                        summary data-inventory-columns aria-label="Choose visible columns" title="Choose visible columns" {
+                            span aria-hidden="true" { "⚙" }
+                        }
+                        fieldset {
+                            legend { "Columns" }
+                            div data-inventory-column-options {}
+                        }
+                    }
+                }
+                table class=(table_class) {
+                    colgroup {
+                        col class="inventory-column-type";
+                        col class="inventory-column-item";
+                        col class="inventory-column-count";
+                        col class="inventory-column-target";
+                        @if self.show_equipped { col class="inventory-column-equipped"; }
+                        @if show_condition { col class="inventory-column-durability"; }
+                        col class="inventory-column-weight";
+                        col class="inventory-column-gold";
+                    }
+                    thead { tr {
+                        (sortable_icon_header("type", "inventory-column-type", "Item type", game_icon("Item type", "knapsack")))
+                        (sortable_text_header("name", "Item", "inventory-column-item"))
+                        (sortable_text_header("quantity", "#", "inventory-column-count"))
+                        (sortable_text_header("target", "#?", "inventory-column-target"))
+                        @if self.show_equipped {
+                            (sortable_icon_header("equipped", "inventory-column-equipped", "Equipped", game_icon("Equipped", "check-mark")))
+                        }
+                        @if let Some(condition_header) = self.condition_header {
+                            th scope="col" class="inventory-column-durability" { button type="button" data-inventory-sort="durability" aria-label="Sort by durability" { (condition_header) span class="inventory-sort-indicator" aria-hidden="true" {} } }
+                        }
+                        (sortable_icon_header("weight", "inventory-column-weight", "Weight", game_icon("Weight", "weight")))
+                        (sortable_icon_header("value", "inventory-column-gold", "Currency", game_icon("Currency", "coins")))
+                    } }
+                    tbody { (self.rows) }
+                }
+            }
+        }
+    }
+}
+
+fn sortable_text_header(key: &str, label: &str, class: &str) -> Markup {
+    html! { th scope="col" class=(class) { button type="button" data-inventory-sort=(key) aria-label=(format!("Sort by {label}")) { (label) span class="inventory-sort-indicator" aria-hidden="true" {} } } }
+}
+
+fn sortable_icon_header(key: &str, class: &str, label: &str, icon: Markup) -> Markup {
+    html! { th scope="col" class=(class) title=(label) { button type="button" data-inventory-sort=(key) aria-label=(format!("Sort by {label}")) { (icon) span class="inventory-sort-indicator" aria-hidden="true" {} } } }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_independent_state_namespace_and_quantity_target_headers() {
+        let rendered = InventoryBrowser {
+            namespace: "trade-left",
+            show_equipped: false,
+            condition_header: None,
+            optional_columns: InventoryColumnSet::Weapons,
+            rows: html! {},
+        }
+        .render()
+        .into_string();
+        assert!(rendered.contains("data-inventory-browser=\"trade-left\""));
+        assert!(rendered.contains("data-inventory-sort=\"quantity\""));
+        assert!(rendered.contains("data-inventory-sort=\"target\""));
+        assert!(rendered.contains("accuracy,reach,penetration,damage,block"));
+    }
+}

--- a/crates/strategic-web/src/templates/inventory_browser.rs
+++ b/crates/strategic-web/src/templates/inventory_browser.rs
@@ -85,7 +85,13 @@ impl InventoryBrowser<'_> {
                             (sortable_icon_header("equipped", "inventory-column-equipped", "Equipped", game_icon("Equipped", "check-mark")))
                         }
                         @if let Some(condition_header) = self.condition_header {
-                            th scope="col" class="inventory-column-durability" { button type="button" data-inventory-sort="durability" aria-label="Sort by durability" { (condition_header) span class="inventory-sort-indicator" aria-hidden="true" {} } }
+                            th scope="col" class="inventory-column-durability" {
+                                button type="button" data-inventory-sort="durability" aria-label="Sort by durability" {
+                                    span class="sr-only" { "Durability" }
+                                    span class="inventory-sort-indicator" aria-hidden="true" {}
+                                }
+                                (condition_header)
+                            }
                         }
                         (sortable_icon_header("weight", "inventory-column-weight", "Weight", game_icon("Weight", "weight")))
                         (sortable_icon_header("value", "inventory-column-gold", "Currency", game_icon("Currency", "coins")))
@@ -124,5 +130,20 @@ mod tests {
         assert!(rendered.contains("data-inventory-sort=\"quantity\""));
         assert!(rendered.contains("data-inventory-sort=\"target\""));
         assert!(rendered.contains("accuracy,reach,penetration,damage,block"));
+    }
+
+    #[test]
+    fn condition_header_controls_are_siblings_of_the_sort_button() {
+        let rendered = InventoryBrowser {
+            namespace: "smith",
+            show_equipped: true,
+            condition_header: Some(html! { form class="repair-all" { button { "Repair" } } }),
+            optional_columns: InventoryColumnSet::Weapons,
+            rows: html! {},
+        }
+        .render()
+        .into_string();
+        assert!(rendered.contains("</button><form class=\"repair-all\">"));
+        assert!(!rendered.contains("<button type=\"button\" data-inventory-sort=\"durability\" aria-label=\"Sort by durability\"><span class=\"sr-only\">Durability</span><span class=\"inventory-sort-indicator\" aria-hidden=\"true\"></span><form"));
     }
 }

--- a/crates/strategic-web/src/templates/inventory_browser.rs
+++ b/crates/strategic-web/src/templates/inventory_browser.rs
@@ -33,38 +33,41 @@ pub struct InventoryBrowser<'a> {
     /// Stable URL-state namespace. Left and right panels must never share it.
     pub namespace: &'a str,
     pub show_equipped: bool,
-    pub condition_header: Option<Markup>,
+    pub show_condition: bool,
     pub optional_columns: InventoryColumnSet,
     pub rows: Markup,
 }
 
 impl InventoryBrowser<'_> {
     pub fn render(self) -> Markup {
-        let show_condition = self.condition_header.is_some();
-        let table_class = if show_condition {
+        let optional_columns = self.optional_columns.names();
+        let table_class = if self.show_condition {
             "trade-inventory-table smith-player-inventory-table"
         } else {
             "trade-inventory-table"
         };
         html! {
             div class="inventory-browser" data-inventory-browser=(self.namespace)
-                data-optional-columns=(self.optional_columns.names()) {
+                data-optional-columns=(optional_columns) {
                 div class="inventory-browser-toolbar" {
                     label class="inventory-browser-search" {
                         span class="sr-only" { "Search items by name" }
                         input type="search" data-inventory-search placeholder="Search items" autocomplete="off"
                             aria-label="Search items by name";
                     }
-                    details class="inventory-column-picker" {
-                        summary data-inventory-columns aria-label="Choose visible columns" title="Choose visible columns" {
-                            span aria-hidden="true" { "⚙" }
-                        }
-                        fieldset {
-                            legend { "Columns" }
-                            div data-inventory-column-options {}
+                    @if !optional_columns.is_empty() {
+                        details class="inventory-column-picker" {
+                            summary data-inventory-columns aria-label="Choose visible columns" title="Choose visible columns" {
+                                span aria-hidden="true" { "⚙" }
+                            }
+                            fieldset {
+                                legend { "Columns" }
+                                div data-inventory-column-options {}
+                            }
                         }
                     }
                 }
+                div class="inventory-browser-table-scroll" tabindex="0" aria-label="Scrollable inventory table" {
                 table class=(table_class) {
                     colgroup {
                         col class="inventory-column-type";
@@ -72,7 +75,7 @@ impl InventoryBrowser<'_> {
                         col class="inventory-column-count";
                         col class="inventory-column-target";
                         @if self.show_equipped { col class="inventory-column-equipped"; }
-                        @if show_condition { col class="inventory-column-durability"; }
+                        @if self.show_condition { col class="inventory-column-durability"; }
                         col class="inventory-column-weight";
                         col class="inventory-column-gold";
                     }
@@ -84,19 +87,19 @@ impl InventoryBrowser<'_> {
                         @if self.show_equipped {
                             (sortable_icon_header("equipped", "inventory-column-equipped", "Equipped", game_icon("Equipped", "check-mark")))
                         }
-                        @if let Some(condition_header) = self.condition_header {
+                        @if self.show_condition {
                             th scope="col" class="inventory-column-durability" {
                                 button type="button" data-inventory-sort="durability" aria-label="Sort by durability" {
-                                    span class="sr-only" { "Durability" }
+                                    (game_icon("Durability", "hammer-nails"))
                                     span class="inventory-sort-indicator" aria-hidden="true" {}
                                 }
-                                (condition_header)
                             }
                         }
                         (sortable_icon_header("weight", "inventory-column-weight", "Weight", game_icon("Weight", "weight")))
                         (sortable_icon_header("value", "inventory-column-gold", "Currency", game_icon("Currency", "coins")))
                     } }
                     tbody { (self.rows) }
+                }
                 }
             }
         }
@@ -120,7 +123,7 @@ mod tests {
         let rendered = InventoryBrowser {
             namespace: "trade-left",
             show_equipped: false,
-            condition_header: None,
+            show_condition: false,
             optional_columns: InventoryColumnSet::Weapons,
             rows: html! {},
         }
@@ -130,20 +133,23 @@ mod tests {
         assert!(rendered.contains("data-inventory-sort=\"quantity\""));
         assert!(rendered.contains("data-inventory-sort=\"target\""));
         assert!(rendered.contains("accuracy,reach,penetration,damage,block"));
+        assert!(rendered.contains("inventory-browser-table-scroll"));
+        assert!(rendered.contains("aria-label=\"Scrollable inventory table\""));
     }
 
     #[test]
-    fn condition_header_controls_are_siblings_of_the_sort_button() {
+    fn condition_header_is_a_dedicated_sort_control() {
         let rendered = InventoryBrowser {
             namespace: "smith",
             show_equipped: true,
-            condition_header: Some(html! { form class="repair-all" { button { "Repair" } } }),
+            show_condition: true,
             optional_columns: InventoryColumnSet::Weapons,
             rows: html! {},
         }
         .render()
         .into_string();
-        assert!(rendered.contains("</button><form class=\"repair-all\">"));
-        assert!(!rendered.contains("<button type=\"button\" data-inventory-sort=\"durability\" aria-label=\"Sort by durability\"><span class=\"sr-only\">Durability</span><span class=\"inventory-sort-indicator\" aria-hidden=\"true\"></span><form"));
+        assert!(rendered.contains("data-inventory-sort=\"durability\""));
+        assert!(rendered.contains("hammer-nails.svg"));
+        assert!(!rendered.contains("repair-all"));
     }
 }

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,8 +92,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=inventory-panels-1";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-7";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-7";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-8";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-8";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
@@ -104,7 +104,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/live-regions.js?v=inventory-browser-5" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
-                    script src="/static/inventory-browser.js?v=inventory-browser-7" defer {}
+                    script src="/static/inventory-browser.js?v=inventory-browser-8" defer {}
                     script src="/static/party-trade.js?v=inventory-browser-7" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -104,6 +104,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/live-regions.js?v=schedule-pending-2" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
+                    script src="/static/inventory-browser.js?v=inventory-browser-1" defer {}
                     script src="/static/party-trade.js?v=inventory-dynamic-transfer-2" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,8 +92,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=inventory-panels-1";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-9";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-9";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-10";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-10";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,7 +92,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=environment-13-encumbrance-6";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-3";
                 link rel="stylesheet" href="/static/css/utilities.css?v=environment-12";
 
                 // Datastar
@@ -101,11 +101,11 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 script src="/static/medical-examination.js?v=one-shot-1" defer {}
                 @if scripts != ScriptProfile::Entry {
                     script src="/static/live-state.js?v=sse-3" defer {}
-                    script src="/static/live-regions.js?v=schedule-pending-2" defer {}
+                    script src="/static/live-regions.js?v=inventory-browser-2" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
-                    script src="/static/inventory-browser.js?v=inventory-browser-1" defer {}
-                    script src="/static/party-trade.js?v=inventory-dynamic-transfer-2" {}
+                    script src="/static/inventory-browser.js?v=inventory-browser-2" defer {}
+                    script src="/static/party-trade.js?v=inventory-browser-2" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,8 +92,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=inventory-panels-1";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-12";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-12";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-13";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-13";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
@@ -105,7 +105,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 }
                 @if scripts == ScriptProfile::Strategic {
                     script src="/static/inventory-browser.js?v=inventory-browser-8" defer {}
-                    script src="/static/party-trade.js?v=inventory-browser-7" {}
+                    script src="/static/party-trade.js?v=inventory-browser-8" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,8 +92,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-3";
-                link rel="stylesheet" href="/static/css/utilities.css?v=environment-12";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-6";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-6";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
@@ -101,11 +101,11 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 script src="/static/medical-examination.js?v=one-shot-1" defer {}
                 @if scripts != ScriptProfile::Entry {
                     script src="/static/live-state.js?v=sse-3" defer {}
-                    script src="/static/live-regions.js?v=inventory-browser-2" defer {}
+                    script src="/static/live-regions.js?v=inventory-browser-5" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
-                    script src="/static/inventory-browser.js?v=inventory-browser-2" defer {}
-                    script src="/static/party-trade.js?v=inventory-browser-2" {}
+                    script src="/static/inventory-browser.js?v=inventory-browser-6" defer {}
+                    script src="/static/party-trade.js?v=inventory-browser-6" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,8 +92,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=inventory-panels-1";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-8";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-8";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-9";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-9";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,8 +92,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=inventory-panels-1";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-13";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-13";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-14";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-14";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,8 +92,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=inventory-panels-1";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-10";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-10";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-12";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-12";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -90,10 +90,10 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/base.css?v=environment-12";
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
-                link rel="stylesheet" href="/static/css/layout.css?v=environment-12";
+                link rel="stylesheet" href="/static/css/layout.css?v=inventory-panels-1";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-6";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-6";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-7";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-7";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
@@ -104,8 +104,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/live-regions.js?v=inventory-browser-5" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
-                    script src="/static/inventory-browser.js?v=inventory-browser-6" defer {}
-                    script src="/static/party-trade.js?v=inventory-browser-6" {}
+                    script src="/static/inventory-browser.js?v=inventory-browser-7" defer {}
+                    script src="/static/party-trade.js?v=inventory-browser-7" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -92,8 +92,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=inventory-panels-1";
                 link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-14";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-14";
+                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-15";
+                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-15";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}

--- a/crates/strategic-web/src/templates/mod.rs
+++ b/crates/strategic-web/src/templates/mod.rs
@@ -1,6 +1,7 @@
 //! Maud HTML templates
 
 mod components;
+mod inventory_browser;
 mod layout;
 
 pub mod character;

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -186,7 +186,7 @@ pub fn quest_location_page(
                                 @let definition = items.iter().find(|item| item.id == entry.item_id);
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);
                                 @let current = pooled.iter().find(|pooled| pooled.item_id == entry.item_id).map_or(0, |pooled| pooled.quantity);
-                                @let target = targets.iter().find(|target| target.item_id == entry.item_id).map_or(0, |target| target.quantity);
+                                @let target = inventory_target(targets, &entry.item_id);
                                 tr class="trade-inventory-row" data-loot-row data-count=(entry.quantity) data-current=(current) data-target=(target) {
                                     td class="inventory-item-type" { (item_type_icon(&entry.item_id)) }
                                     td class="inventory-item-name" { (super::settlement::item_name_with_quality(&entry.item_id, definition)) span class="inventory-row-actions" {
@@ -227,7 +227,8 @@ pub fn quest_location_page(
                             @for entry in pooled {
                                 @let definition = items.iter().find(|item| item.id == entry.item_id);
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);
-                                tr class="trade-inventory-row" {
+                                @let target = inventory_target(targets, &entry.item_id);
+                                tr class="trade-inventory-row" data-target=(target) {
                                     td class="inventory-item-type" { (item_type_icon(&entry.item_id)) }
                                     td class="inventory-item-name" { (super::settlement::item_name_with_quality(&entry.item_id, definition)) }
                                     td class="inventory-count" { (entry.quantity) }
@@ -248,6 +249,13 @@ pub fn quest_location_page(
         content,
         logged_in_as,
     )
+}
+
+fn inventory_target(targets: &[InventoryQuantityTarget], item_id: &str) -> u32 {
+    targets
+        .iter()
+        .find(|target| target.item_id == item_id)
+        .map_or(0, |target| target.quantity)
 }
 
 fn loot_stage_form(quest_id: &str) -> Markup {
@@ -289,5 +297,18 @@ mod tests {
         assert!(markup.contains("The bandit fell."));
         assert!(!markup.contains("autoresolve-report"));
         assert!(!markup.contains("chat-channel-badge"));
+    }
+
+    #[test]
+    fn quest_party_rows_use_the_matching_inventory_target() {
+        let targets = [InventoryQuantityTarget {
+            id: "7:true:sword".into(),
+            owner_character_id: 7,
+            party_scope: true,
+            item_id: "sword".into(),
+            quantity: 4,
+        }];
+        assert_eq!(inventory_target(&targets, "sword"), 4);
+        assert_eq!(inventory_target(&targets, "shield"), 0);
     }
 }

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -181,7 +181,7 @@ pub fn quest_location_page(
                         None,
                     ))
                 } @else {
-                    (InventoryBrowser { namespace: "quest-loot-left", show_equipped: false, condition_header: None, optional_columns: InventoryColumnSet::All, rows: html! {
+                    (InventoryBrowser { namespace: "quest-loot-left", show_equipped: false, show_condition: false, optional_columns: InventoryColumnSet::All, rows: html! {
                             @for entry in loot {
                                 @let definition = items.iter().find(|item| item.id == entry.item_id);
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);
@@ -223,7 +223,7 @@ pub fn quest_location_page(
                 @if pooled.is_empty() {
                     (empty_state("The party chest is empty.", None, None))
                 } @else {
-                    (InventoryBrowser { namespace: "quest-party-right", show_equipped: false, condition_header: None, optional_columns: InventoryColumnSet::All, rows: html! {
+                    (InventoryBrowser { namespace: "quest-party-right", show_equipped: false, show_condition: false, optional_columns: InventoryColumnSet::All, rows: html! {
                             @for entry in pooled {
                                 @let definition = items.iter().find(|item| item.id == entry.item_id);
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -181,7 +181,7 @@ pub fn quest_location_page(
                         None,
                     ))
                 } @else {
-                    (InventoryBrowser { namespace: "quest-loot-left", show_equipped: false, show_condition: false, optional_columns: InventoryColumnSet::All, rows: html! {
+                    (InventoryBrowser { namespace: "quest-loot-left", show_quantities: true, show_equipped: false, show_condition: false, optional_columns: InventoryColumnSet::All, rows: html! {
                             @for entry in loot {
                                 @let definition = items.iter().find(|item| item.id == entry.item_id);
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);
@@ -223,7 +223,7 @@ pub fn quest_location_page(
                 @if pooled.is_empty() {
                     (empty_state("The party chest is empty.", None, None))
                 } @else {
-                    (InventoryBrowser { namespace: "quest-party-right", show_equipped: false, show_condition: false, optional_columns: InventoryColumnSet::All, rows: html! {
+                    (InventoryBrowser { namespace: "quest-party-right", show_quantities: true, show_equipped: false, show_condition: false, optional_columns: InventoryColumnSet::All, rows: html! {
                             @for entry in pooled {
                                 @let definition = items.iter().find(|item| item.id == entry.item_id);
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -2,7 +2,8 @@
 
 use maud::{Markup, html};
 
-use super::{empty_state, item_type_header, item_type_icon, sidebar_section};
+use super::inventory_browser::{InventoryBrowser, InventoryColumnSet};
+use super::{empty_state, item_type_icon, sidebar_section};
 use crate::routes::travel::TravelDestination;
 use crate::spacetimedb::{
     AutoresolveReport, BattleLootItem, InventoryQuantityTarget, ItemDefinition, PartyInventoryItem,
@@ -180,9 +181,7 @@ pub fn quest_location_page(
                         None,
                     ))
                 } @else {
-                    table class="trade-inventory-table" {
-                        thead { tr { (item_type_header()) th { "Item" } th { "#" } th { "Value" } } }
-                        tbody {
+                    (InventoryBrowser { namespace: "quest-loot-left", show_equipped: false, condition_header: None, optional_columns: InventoryColumnSet::All, rows: html! {
                             @for entry in loot {
                                 @let definition = items.iter().find(|item| item.id == entry.item_id);
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);
@@ -190,15 +189,15 @@ pub fn quest_location_page(
                                 @let target = targets.iter().find(|target| target.item_id == entry.item_id).map_or(0, |target| target.quantity);
                                 tr class="trade-inventory-row" data-loot-row data-count=(entry.quantity) data-current=(current) data-target=(target) {
                                     td class="inventory-item-type" { (item_type_icon(&entry.item_id)) }
-                                    td { (super::settlement::item_name_with_quality(&entry.item_id, definition)) span class="inventory-row-actions" {
+                                    td class="inventory-item-name" { (super::settlement::item_name_with_quality(&entry.item_id, definition)) span class="inventory-row-actions" {
                                         button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-loot-stage=(entry.id) data-transfer-mode="one" data-label-one=(format!("Move one {}", entry.item_id)) data-label-target=(format!("Move {} to target", entry.item_id)) data-label-all=(format!("Move all {}", entry.item_id)) aria-label=(format!("Move one {}", entry.item_id)) title=(format!("Move one {}", entry.item_id)) { (super::settlement::transfer_glyph(1)) }
                                     } }
                                     td class="inventory-count" { (entry.quantity) }
-                                    td { (u64::from(value) * u64::from(entry.quantity)) }
+                                    td class="inventory-weight" { (definition.map_or_else(|| "—".to_string(), |item| item.weight.to_string())) }
+                                    td class="inventory-gold" { (u64::from(value) * u64::from(entry.quantity)) }
                                 }
                             }
-                        }
-                    }
+                    }}.render())
                     (loot_stage_form(&quest.id))
                     (super::settlement::inventory_footer_controls("loot", "Move loot to targets", "Move all loot"))
                 }
@@ -224,21 +223,19 @@ pub fn quest_location_page(
                 @if pooled.is_empty() {
                     (empty_state("The party chest is empty.", None, None))
                 } @else {
-                    table class="trade-inventory-table" {
-                        thead { tr { (item_type_header()) th { "Item" } th { "#" } th { "Value" } } }
-                        tbody {
+                    (InventoryBrowser { namespace: "quest-party-right", show_equipped: false, condition_header: None, optional_columns: InventoryColumnSet::All, rows: html! {
                             @for entry in pooled {
                                 @let definition = items.iter().find(|item| item.id == entry.item_id);
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);
-                                tr {
+                                tr class="trade-inventory-row" {
                                     td class="inventory-item-type" { (item_type_icon(&entry.item_id)) }
-                                    td { (super::settlement::item_name_with_quality(&entry.item_id, definition)) }
-                                    td { (entry.quantity) }
-                                    td { (u64::from(value) * u64::from(entry.quantity)) }
+                                    td class="inventory-item-name" { (super::settlement::item_name_with_quality(&entry.item_id, definition)) }
+                                    td class="inventory-count" { (entry.quantity) }
+                                    td class="inventory-weight" { (definition.map_or_else(|| "—".to_string(), |item| item.weight.to_string())) }
+                                    td class="inventory-gold" { (u64::from(value) * u64::from(entry.quantity)) }
                                 }
                             }
-                        }
-                    }
+                    }}.render())
                 }
             }))
         }

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -4850,6 +4850,10 @@ mod tests {
         assert!(css.contains("66%, 74%"));
         assert!(!css.contains("left: -7rem;"));
         assert!(css.contains(".smith-wares-scroll .trade-inventory-table"));
+        assert!(css.contains("--inventory-merchant-action-overhang"));
+        assert!(css.contains("+ 8px)"));
+        assert!(css.contains("padding-right: var(--inventory-merchant-action-overhang);"));
+        assert!(css.contains("scrollbar-gutter: stable;"));
         assert!(css.contains("overflow-x: clip;"));
         assert!(css.contains("col.inventory-column-item { width: auto; }"));
         assert!(css.contains(".smith-player-inventory-table"));

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1351,7 +1351,13 @@ fn party_trade_inventory_rail(
                                     td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                                     td class="inventory-item-name" {
                                         (item_name_with_quality(&item.item_id, definition))
-                                        @if !is_equipped { span class="inventory-row-actions" { button type="button" class=(format!("trade-transfer trade-transfer-{direction} party-draft-transfer")) data-dynamic-transfer data-default-transfer-mode="one" data-from=(character.id) data-to=(recipient_id) data-item=(item.id) data-key=(&item.item_id) data-count=(item.qty) data-target=(target) data-transfer-mode="one" data-label-one=(format!("Transfer one {}", item.item_id)) data-label-target=(format!("Transfer {} to target", item.item_id)) data-label-all=(format!("Transfer all {}", item.item_id)) aria-label=(format!("Transfer one {}", item.item_id)) title=(format!("Transfer one {}", item.item_id)) { (transfer_glyph(1)) } } }
+                                        span class="inventory-row-actions" {
+                                            @if is_equipped {
+                                                (disabled_transfer_button(direction, "Equipped items cannot be transferred"))
+                                            } @else {
+                                                button type="button" class=(format!("trade-transfer trade-transfer-{direction} party-draft-transfer")) data-dynamic-transfer data-default-transfer-mode="one" data-from=(character.id) data-to=(recipient_id) data-item=(item.id) data-key=(&item.item_id) data-count=(item.qty) data-target=(target) data-transfer-mode="one" data-label-one=(format!("Transfer one {}", item.item_id)) data-label-target=(format!("Transfer {} to target", item.item_id)) data-label-all=(format!("Transfer all {}", item.item_id)) aria-label=(format!("Transfer one {}", item.item_id)) title=(format!("Transfer one {}", item.item_id)) { (transfer_glyph(1)) }
+                                            }
+                                        }
                                     }
                                     td class="inventory-count" { (item.qty) }
                                     td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) }
@@ -1388,8 +1394,11 @@ fn discard_inventory_rail(
                                 td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                                 td class="inventory-item-name" {
                                     (item_name_with_quality(&item.item_id, definition))
-                                    @if !is_equipped {
-                                        button type="button" class="trade-transfer trade-transfer-left"
+                                    span class="inventory-row-actions" {
+                                        @if is_equipped {
+                                            (disabled_transfer_button("left", "Equipped items cannot be discarded"))
+                                        } @else {
+                                            button type="button" class="trade-transfer trade-transfer-left"
                                             data-discard-item=(item.id) data-count=(item.qty)
                                             data-dynamic-transfer data-default-transfer-mode="one" data-transfer-mode="one"
                                             data-label-one=(format!("Discard one {}", item.item_id))
@@ -1397,6 +1406,7 @@ fn discard_inventory_rail(
                                             data-label-all=(format!("Discard all {}", item.item_id))
                                             aria-label=(format!("Discard {}", item.item_id))
                                             title=(format!("Discard one {}", item.item_id)) { (transfer_glyph(1)) }
+                                        }
                                     }
                                 }
                                 td class="inventory-count" { (item.qty) }
@@ -1632,8 +1642,12 @@ pub fn party_pool_page(
                                 td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                                 td class="inventory-item-name" {
                                     (item_name_with_quality(&item.item_id, definition))
-                                    @if !equipped {
-                                        span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="deposit" data-transfer-mode="one" data-count=(item.qty) data-current=(current) data-target=(target) data-label-one=(format!("Deposit one {}", item.item_id)) data-label-target=(format!("Deposit {} to target", item.item_id)) data-label-all=(format!("Deposit all {}", item.item_id)) aria-label=(format!("Deposit one {}", item.item_id)) title=(format!("Deposit one {}", item.item_id)) { (transfer_glyph(1)) } }
+                                    span class="inventory-row-actions" {
+                                        @if equipped {
+                                            (disabled_transfer_button("left", "Equipped items cannot be deposited"))
+                                        } @else {
+                                            button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="deposit" data-transfer-mode="one" data-count=(item.qty) data-current=(current) data-target=(target) data-label-one=(format!("Deposit one {}", item.item_id)) data-label-target=(format!("Deposit {} to target", item.item_id)) data-label-all=(format!("Deposit all {}", item.item_id)) aria-label=(format!("Deposit one {}", item.item_id)) title=(format!("Deposit one {}", item.item_id)) { (transfer_glyph(1)) }
+                                        }
                                     }
                                 }
                                 td class="inventory-count" { (quantity_target_control(item.qty, target_quantity(personal_targets, &item.item_id), &item.item_id, false)) }
@@ -1841,6 +1855,12 @@ pub(crate) fn transfer_glyph(count: usize) -> Markup {
     html! { span class=(format!("inventory-transfer-glyph arrows-{count}")) aria-hidden="true" { @for _ in 0..count { i {} } } }
 }
 
+fn disabled_transfer_button(direction: &str, explanation: &str) -> Markup {
+    html! {
+        button type="button" class=(format!("trade-transfer trade-transfer-{direction}")) disabled title=(explanation) aria-label=(explanation) { (transfer_glyph(1)) }
+    }
+}
+
 fn merchant_buy_controls(item_id: &str, price: u32, target: u32, available: u32) -> Markup {
     html! { span class="inventory-row-actions" {
         button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-buy=(item_id) data-merchant-buy-price=(price) data-transfer-mode="one" data-target=(target) data-count=(available) data-label-one=(format!("Buy one {item_id}")) data-label-target=(format!("Buy {item_id} to target")) data-label-all=(format!("Buy all {item_id}")) aria-label=(format!("Buy one {item_id}")) title=(format!("Buy one {item_id}")) { (transfer_glyph(1)) }
@@ -1868,10 +1888,13 @@ fn merchant_sell_repair_controls(
     can_sell: bool,
     repair: Option<Markup>,
 ) -> Markup {
-    html! { div class="inventory-row-actions smith-player-actions" {
+    let has_repair = repair.is_some();
+    html! { div class=(if has_repair { "inventory-row-actions smith-player-actions" } else { "inventory-row-actions" }) {
         @if let Some(repair) = repair { (repair) }
         @if can_sell {
             button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-sell=(id) data-item-name=(item_id) data-merchant-sell-price=(price) data-transfer-mode="one" data-count=(quantity) data-target=(target) data-label-one=(format!("Sell one {item_id}")) data-label-target=(format!("Sell surplus {item_id}")) data-label-all=(format!("Sell all {item_id}")) aria-label=(format!("Sell one {item_id}")) title=(format!("Sell one {item_id}")) { (transfer_glyph(1)) }
+        } @else if has_repair {
+            (disabled_transfer_button("left", "Equipped items cannot be sold"))
         }
     } }
 }
@@ -3938,6 +3961,29 @@ mod tests {
         assert!(rendered.contains("smith-player-actions"));
         assert!(rendered.contains("row-repair-form"));
         assert!(!rendered.contains("data-merchant-sell"));
+        assert!(rendered.contains("Equipped items cannot be sold"));
+        assert!(rendered.contains("trade-transfer trade-transfer-left"));
+        assert!(rendered.contains("disabled"));
+    }
+
+    #[test]
+    fn non_smith_sell_controls_do_not_reserve_a_repair_slot() {
+        let rendered = merchant_sell_repair_controls(4, "shirt", 3, 1, 0, true, None).into_string();
+
+        assert!(rendered.starts_with("<div class=\"inventory-row-actions\">"));
+        assert!(!rendered.contains("smith-player-actions"));
+        assert!(rendered.contains("data-merchant-sell"));
+    }
+
+    #[test]
+    fn unavailable_transfer_button_keeps_a_disabled_action_slot() {
+        let rendered =
+            disabled_transfer_button("left", "Equipped items cannot be transferred").into_string();
+
+        assert!(rendered.contains("trade-transfer trade-transfer-left"));
+        assert!(rendered.contains("Equipped items cannot be transferred"));
+        assert!(rendered.contains("disabled"));
+        assert!(rendered.contains("inventory-transfer-glyph"));
     }
 
     #[test]
@@ -4821,6 +4867,11 @@ mod tests {
             utilities.contains(".right-sidebar .inventory-actions-cell > .inventory-row-actions")
         );
         assert!(utilities.contains("background:var(--inventory-row-background"));
+        assert!(utilities.contains("top:0; bottom:0;"));
+        assert!(utilities.contains(
+            ".trade-inventory-row:not(:last-child) .inventory-row-actions { bottom:-1px; }"
+        ));
+        assert!(utilities.contains(".inventory-row-actions .trade-transfer:disabled"));
         assert!(utilities.contains("left:100%; padding-left:var(--inventory-action-bridge);"));
         assert!(utilities.contains("right:100%; padding-right:var(--inventory-action-bridge);"));
         assert!(css.contains(".inventory-browser-table-frame"));

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -18,6 +18,7 @@ use adventuresim_core::{
 use maud::{Markup, html};
 use std::{collections::BTreeSet, fmt, str::FromStr};
 
+use super::inventory_browser::{InventoryBrowser, InventoryColumnSet};
 use super::{
     decorative_game_icon, empty_state, game_icon, item_type_header, item_type_icon,
     population_description, quest_location_layout_with_session, settlement_layout_with_session,
@@ -249,6 +250,10 @@ impl MerchantShop {
             ),
         }
     }
+
+    fn shows_inventory(self, kind: crate::spacetimedb::ItemKind) -> bool {
+        kind == crate::spacetimedb::ItemKind::Currency || self.stocks(kind)
+    }
 }
 
 pub fn alchemy_page(
@@ -302,7 +307,9 @@ pub fn alchemy_page(
                     href=(format!("/locations/settlement/{}/alchemy?recipe={}&scope=party", settlement.id, selected.item_id)) { "Party" }
             }
             (sidebar_section("Required ingredients", html! {
-                (trade_inventory_table(false, None, html! {
+                table class="trade-inventory-table" {
+                    (trade_inventory_table_header(false, None))
+                    tbody {
                     @for ingredient in selected.ingredients {
                         @let definition = items.iter().find(|item| item.id == ingredient.item_id);
                         @let quantity = if party_scope {
@@ -319,7 +326,8 @@ pub fn alchemy_page(
                             td class="inventory-gold" { (format!("need {}", ingredient.quantity)) }
                         }
                     }
-                }))
+                    }
+                }
                 p class="small-copy text-muted" { "Targets can be raised here for future purchasing. Crafting consumes the listed quantities from the selected inventory." }
             }))
         }
@@ -1017,9 +1025,8 @@ pub fn party_discard_page(
         aside class="left-sidebar" {
             (sidebar_section("Discard", html! {
                 p class="text-muted small-copy" data-discard-empty { "Stage carried items here before discarding them." }
-                table class="trade-inventory-table" data-discard-table hidden {
-                    (trade_inventory_table_header(false, None))
-                    tbody data-discard-list {}
+                div data-discard-table hidden {
+                    (trade_inventory_table("discard-left", InventoryColumnSet::All, false, None, html! {}))
                 }
             }))
         }
@@ -1335,7 +1342,7 @@ fn party_trade_inventory_rail(
                 @if inventory.is_empty() {
                     p class="text-muted small-copy" { "No items carried." }
                 } @else {
-                    (trade_inventory_table(true, None, html! {
+                    (trade_inventory_table(if direction == "left" { "party-transfer-right" } else { "party-transfer-left" }, InventoryColumnSet::All, true, None, html! {
                         @for item in inventory {
                             @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1373,7 +1380,7 @@ fn discard_inventory_rail(
                 @if inventory.is_empty() {
                     p class="text-muted small-copy" { "No items carried." }
                 } @else {
-                    (trade_inventory_table(true, None, html! {
+                    (trade_inventory_table("discard-right", InventoryColumnSet::All, true, None, html! {
                         @for item in inventory {
                             @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1442,8 +1449,9 @@ pub fn live_merchant_shop_page(
     let content = html! {
         aside class="left-sidebar smith-wares-column" { (sidebar_section(if matches!(shop, MerchantShop::Herbalist) { "Prepared medicines and ingredients" } else { "Merchant stock" }, html! {
             div class="smith-wares-scroll" {
-            (trade_inventory_table(false, None, html! {
-                @for item in items.iter().filter(|item| shop.stocks(item.kind)) {
+            (trade_inventory_table("merchant-left", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, None, html! {
+                @for item in items.iter().filter(|item| shop.shows_inventory(item.kind)) {
+                    @let is_currency = item.kind == crate::spacetimedb::ItemKind::Currency;
                     @let medication_recipe = adventuresim_core::disease::medication_recipe_for_item(&item.id);
                     @let buy_price = medication_recipe.map_or_else(
                         || adventuresim_core::strategic_economy::merchant_buy_price(item.base_value.unwrap_or(1)),
@@ -1451,7 +1459,7 @@ pub fn live_merchant_shop_page(
                     );
                     @let sell_price = (item.base_value.unwrap_or(1) as f32 / 1.25).floor().max(1.0) as u32;
                     @let target = target_quantity(personal_targets, &item.id);
-                    tr class="trade-inventory-row trade-row-merchant" data-merchant-item=(&item.id) data-merchant-sell-price=(sell_price) data-herbalist-medication-name=[medication_recipe.map(|recipe| recipe.name)] { td class="inventory-item-type" { (item_type_icon(&item.id)) } td class="inventory-item-name" { @if let Some(recipe) = medication_recipe { (recipe.name) } @else { (item_name_with_quality(&item.id, Some(item))) } (merchant_buy_controls(&item.id, buy_price, target, 999)) } td class="inventory-count" { "999" } td class="inventory-weight" { (weight_display(item.weight)) } td class="inventory-gold" { (buy_price) } }
+                    tr class="trade-inventory-row trade-row-merchant" data-merchant-item=(&item.id) data-merchant-sell-price=(sell_price) data-herbalist-medication-name=[medication_recipe.map(|recipe| recipe.name)] { td class="inventory-item-type" { (item_type_icon(&item.id)) } td class="inventory-item-name" { @if let Some(recipe) = medication_recipe { (recipe.name) } @else { (item_name_with_quality(&item.id, Some(item))) } @if !is_currency { (merchant_buy_controls(&item.id, buy_price, target, 999)) } } td class="inventory-count" { "999" } td class="inventory-weight" { (weight_display(item.weight)) } td class="inventory-gold" { (buy_price) } }
                 }
             }))
             (inventory_footer_controls("buy", "Buy to targets", "Buy everything"))
@@ -1475,8 +1483,8 @@ pub fn live_merchant_shop_page(
             div data-inventory-pane="player" {
             div class="sidebar-section" {
                 (encumbrance_inventory_rail(html! {
-                (trade_inventory_table(true, matches!(shop, MerchantShop::Weapons | MerchantShop::Armor).then(|| repair_all_header(settlement, service_id)), html! {
-                    @for item in inventory {
+                (trade_inventory_table("merchant-player-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, true, matches!(shop, MerchantShop::Weapons | MerchantShop::Armor).then(|| repair_all_header(settlement, service_id)), html! {
+                    @for item in inventory.iter().filter(|item| items.iter().find(|definition| definition.id == item.item_id).is_some_and(|definition| shop.shows_inventory(definition.kind))) {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
                         @let is_currency = definition.is_some_and(|definition| definition.kind == crate::spacetimedb::ItemKind::Currency);
                         @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
@@ -1492,7 +1500,7 @@ pub fn live_merchant_shop_page(
                         td class="inventory-item-name" { (item_name_with_quality(&item.item_id, definition)) @if !matches!(shop, MerchantShop::Herbalist) && (can_sell || service_matches) { (merchant_sell_repair_controls(item.id, &item.item_id, sell_price, item.qty, target, can_sell, service_matches.then(|| repair_submit_control(settlement, service_id, item.id, condition, repair_skill)))) } }
                         td class="inventory-count" { (quantity_target_control(item.qty, target, &item.item_id, false)) } td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) } td class="inventory-durability" { @if durable_item { (condition_bar(condition, service_matches.then_some(repair_skill))) } @else { "—" } } td class="inventory-weight" { (item_weight(definition)) } td class="inventory-gold" { (sell_price) }
                     }}
-                    @for target in personal_targets.iter().filter(|target| target.quantity > 0 && !inventory.iter().any(|item| item.item_id == target.item_id)) {
+                    @for target in personal_targets.iter().filter(|target| target.quantity > 0 && !inventory.iter().any(|item| item.item_id == target.item_id) && items.iter().find(|definition| definition.id == target.item_id).is_some_and(|definition| shop.shows_inventory(definition.kind))) {
                         @let definition = items.iter().find(|definition| definition.id == target.item_id);
                         tr class="trade-inventory-row trade-row-player" data-merchant-item=(&target.item_id) data-inventory-quantity="0" data-target=(target.quantity) {
                             td class="inventory-item-type" { (item_type_icon(&target.item_id)) }
@@ -1511,8 +1519,8 @@ pub fn live_merchant_shop_page(
             @if !matches!(shop, MerchantShop::Herbalist) { div data-inventory-pane="party" hidden {
             div class="sidebar-section" {
                 (encumbrance_inventory_rail(html! {
-                (trade_inventory_table(false, None, html! {
-                    @for item in pooled {
+                (trade_inventory_table("merchant-party-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, None, html! {
+                    @for item in pooled.iter().filter(|item| items.iter().find(|definition| definition.id == item.item_id).is_some_and(|definition| shop.shows_inventory(definition.kind))) {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
                         @let is_currency = definition.is_some_and(|definition| definition.kind == crate::spacetimedb::ItemKind::Currency);
                         @let sell_price = definition.map_or(0, |definition| (definition.base_value.unwrap_or(1) as f32 / 1.25).floor().max(1.0) as u32);
@@ -1525,7 +1533,7 @@ pub fn live_merchant_shop_page(
                             td class="inventory-gold" { (sell_price) }
                         }
                     }
-                    @for target in party_targets.iter().filter(|target| target.quantity > 0 && !pooled.iter().any(|item| item.item_id == target.item_id)) {
+                    @for target in party_targets.iter().filter(|target| target.quantity > 0 && !pooled.iter().any(|item| item.item_id == target.item_id) && items.iter().find(|definition| definition.id == target.item_id).is_some_and(|definition| shop.shows_inventory(definition.kind))) {
                         @let definition = items.iter().find(|definition| definition.id == target.item_id);
                         tr class="trade-inventory-row trade-row-player" data-merchant-item=(&target.item_id) data-inventory-quantity="0" data-target=(target.quantity) {
                             td class="inventory-item-type" { (item_type_icon(&target.item_id)) }
@@ -1578,7 +1586,7 @@ pub fn party_pool_page(
                         strong { (stake) " gold" }
                     }
                     p class="small-copy text-muted" { "Withdrawals use your stake. Personal gold automatically covers an indivisible item's shortfall." }
-                    (trade_inventory_table(false, None, html! {
+                    (trade_inventory_table("party-pool-left", InventoryColumnSet::All, false, None, html! {
                         @for item in pooled {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
                             @let value = definition.and_then(|definition| definition.base_value).unwrap_or(0) as u64;
@@ -1608,7 +1616,7 @@ pub fn party_pool_page(
             (sidebar_section(&format!("{}'s inventory", character.name), html! {
                 (encumbrance_inventory_rail(html! {
                     p class="small-copy text-muted" { "Add items at their objective gold value." }
-                    (trade_inventory_table(true, None, html! {
+                    (trade_inventory_table("party-pool-right", InventoryColumnSet::All, true, None, html! {
                         @for item in inventory {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
                             @let equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
@@ -1737,8 +1745,34 @@ pub(super) fn item_name_with_quality(
         5 => "Quality 5 — royal or heroic commission",
         _ => unreachable!(),
     });
+    let damage_types = definition.map(|item| {
+        [
+            item.blunt.then_some("Blunt"),
+            item.slash.then_some("Slash"),
+            item.pierce.then_some("Pierce"),
+        ]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(", ")
+    });
     html! {
-        span class=(quality.map_or_else(|| "inventory-item-label".to_string(), |quality| format!("inventory-item-label item-quality-{quality}"))) title=[label] {
+        span class=(quality.map_or_else(|| "inventory-item-label".to_string(), |quality| format!("inventory-item-label item-quality-{quality}"))) title=[label]
+            data-item-name=(item_id)
+            data-item-kind=[definition.map(|item| format!("{:?}", item.kind).to_ascii_lowercase())]
+            data-stat-accuracy=[definition.map(|item| weight_display(item.accuracy))]
+            data-stat-reach=[definition.map(|item| weight_display(item.reach))]
+            data-stat-penetration=[definition.map(|item| weight_display(item.penetration))]
+            data-stat-damage=[damage_types]
+            data-stat-block=[definition.map(|item| weight_display(item.block))]
+            data-stat-coverage=[definition.map(|item| weight_display(item.coverage))]
+            data-stat-resistance=[definition.map(|item| weight_display(item.resistance))]
+            data-stat-padding=[definition.map(|item| weight_display(item.padding))]
+            data-stat-flexibility=[definition.map(|item| weight_display(item.flexibility))]
+            data-stat-range-of-motion=[definition.map(|item| weight_display(item.range_of_motion))]
+            data-detail-slot=[definition.map(|item| format!("{:?}", item.slot))]
+            data-detail-balance=[definition.map(|item| weight_display(item.balance))]
+            data-detail-mode=[definition.map(|item| match (item.melee, item.ranged, item.precise) { (true, true, true) => "Melee, ranged, precise", (true, true, false) => "Melee and ranged", (true, false, true) => "Melee, precise", (false, true, true) => "Ranged, precise", (true, false, false) => "Melee", (false, true, false) => "Ranged", (false, false, true) => "Precise", _ => "—" }.to_string())] {
             (item_id)
         }
     }
@@ -1753,26 +1787,20 @@ fn weight_display(weight: f32) -> String {
 }
 
 fn trade_inventory_table(
+    namespace: &str,
+    optional_columns: InventoryColumnSet,
     show_equipped: bool,
     condition_header: Option<Markup>,
     rows: Markup,
 ) -> Markup {
-    let show_condition = condition_header.is_some();
-    html! {
-        table class=(if show_condition { "trade-inventory-table smith-player-inventory-table" } else { "trade-inventory-table" }) {
-            colgroup {
-                col class="inventory-column-type";
-                col class="inventory-column-item";
-                col class="inventory-column-count";
-                @if show_equipped { col class="inventory-column-equipped"; }
-                @if show_condition { col class="inventory-column-durability"; }
-                col class="inventory-column-weight";
-                col class="inventory-column-gold";
-            }
-            (trade_inventory_table_header(show_equipped, condition_header))
-            tbody { (rows) }
-        }
+    InventoryBrowser {
+        namespace,
+        show_equipped,
+        condition_header,
+        optional_columns,
+        rows,
     }
+    .render()
 }
 
 fn target_quantity(targets: &[InventoryQuantityTarget], item_id: &str) -> u32 {
@@ -1784,8 +1812,7 @@ fn target_quantity(targets: &[InventoryQuantityTarget], item_id: &str) -> u32 {
 
 fn quantity_target_control(quantity: u32, target: u32, item_id: &str, party_scope: bool) -> Markup {
     html! {
-        span class="inventory-target-control" data-target-control data-item-id=(item_id) data-party-scope=(party_scope) title=(format!("Carrying {quantity}; target {target}")) {
-            span class="inventory-target-prefix" { (quantity) "/" }
+        span class="inventory-target-control" data-target-control data-quantity=(quantity) data-item-id=(item_id) data-party-scope=(party_scope) title=(format!("Carrying {quantity}; target {target}")) {
             span class="inventory-target-denominator" {
                 button type="button" class="inventory-target-step inventory-target-up" data-target-step="1" aria-label=(format!("Increase {} target", item_id)) { "⌃" }
                 span class="inventory-target-value" data-target-value { (target) }
@@ -2018,6 +2045,12 @@ pub(crate) fn inventory_footer_controls(
     } }
 }
 
+fn currency_header(label: &str) -> Markup {
+    game_icon(label, "coins")
+}
+
+// Kept for one-sided placeholder/service tables that are intentionally not
+// inventory browsers.
 fn trade_inventory_table_header(show_equipped: bool, condition_header: Option<Markup>) -> Markup {
     html! { thead { tr {
         (item_type_header())
@@ -2028,10 +2061,6 @@ fn trade_inventory_table_header(show_equipped: bool, condition_header: Option<Ma
         th scope="col" class="inventory-column-weight" title="Weight" { (game_icon("Weight", "weight")) }
         th scope="col" class="inventory-column-gold" title="Currency" { (currency_header("Currency")) }
     } } }
-}
-
-fn currency_header(label: &str) -> Markup {
-    game_icon(label, "coins")
 }
 
 fn party_skills_rail(
@@ -3914,6 +3943,7 @@ mod tests {
             durability_failure_share: 0.0,
             edge_sensitivity: 0.0,
             handling_sensitivity: 0.0,
+            ..Default::default()
         };
 
         let rendered = item_name_with_quality(&definition.id, Some(&definition)).into_string();
@@ -3940,6 +3970,8 @@ mod tests {
     #[test]
     fn smith_player_inventory_uses_the_compact_seven_column_table() {
         let rendered = trade_inventory_table(
+            "test",
+            InventoryColumnSet::Weapons,
             true,
             Some(repair_all_header(&settlement(), "weapons")),
             html! {},
@@ -4129,6 +4161,7 @@ mod tests {
             durability_failure_share: 0.0,
             edge_sensitivity: 0.0,
             handling_sensitivity: 0.0,
+            ..Default::default()
         };
         let enabled = equipment_checkbox(&inventory, Some(&definition), false).into_string();
         assert!(enabled.contains("data-equipment-toggle"));
@@ -4140,7 +4173,9 @@ mod tests {
 
     #[test]
     fn merchant_stock_table_keeps_quantity_weight_and_gold_columns() {
-        let rendered = trade_inventory_table(false, None, html! {}).into_string();
+        let rendered =
+            trade_inventory_table("test", InventoryColumnSet::Basic, false, None, html! {})
+                .into_string();
         assert!(rendered.contains("<colgroup>"));
         assert!(rendered.contains("inventory-column-count"));
         assert!(rendered.contains("inventory-column-type"));
@@ -4154,6 +4189,8 @@ mod tests {
     #[test]
     fn inventory_type_header_and_row_share_the_first_column() {
         let rendered = trade_inventory_table(
+            "test",
+            InventoryColumnSet::Basic,
             false,
             None,
             html! {
@@ -4217,6 +4254,7 @@ mod tests {
                 durability_failure_share: 0.0,
                 edge_sensitivity: 0.0,
                 handling_sensitivity: 0.0,
+                ..Default::default()
             },
             crate::spacetimedb::ItemDefinition {
                 id: "cuirass".into(),
@@ -4233,6 +4271,7 @@ mod tests {
                 durability_failure_share: 0.0,
                 edge_sensitivity: 0.0,
                 handling_sensitivity: 0.0,
+                ..Default::default()
             },
         ];
         let weapons = repair_custody_panel(

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1026,7 +1026,7 @@ pub fn party_discard_page(
             (sidebar_section("Discard", html! {
                 p class="text-muted small-copy" data-discard-empty { "Stage carried items here before discarding them." }
                 div data-discard-table hidden {
-                    (trade_inventory_table("discard-left", InventoryColumnSet::All, false, false, html! {}))
+                    (trade_inventory_table("discard-left", InventoryColumnSet::All, true, false, false, html! {}))
                 }
             }))
         }
@@ -1342,7 +1342,7 @@ fn party_trade_inventory_rail(
                 @if inventory.is_empty() {
                     p class="text-muted small-copy" { "No items carried." }
                 } @else {
-                    (trade_inventory_table(if direction == "left" { "party-transfer-right" } else { "party-transfer-left" }, InventoryColumnSet::All, true, false, html! {
+                    (trade_inventory_table(if direction == "left" { "party-transfer-right" } else { "party-transfer-left" }, InventoryColumnSet::All, true, true, false, html! {
                         @for item in inventory {
                             @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1380,7 +1380,7 @@ fn discard_inventory_rail(
                 @if inventory.is_empty() {
                     p class="text-muted small-copy" { "No items carried." }
                 } @else {
-                    (trade_inventory_table("discard-right", InventoryColumnSet::All, true, false, html! {
+                    (trade_inventory_table("discard-right", InventoryColumnSet::All, true, true, false, html! {
                         @for item in inventory {
                             @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1455,7 +1455,7 @@ pub fn live_merchant_shop_page(
     let content = html! {
         aside class="left-sidebar smith-wares-column" { (sidebar_section(if matches!(shop, MerchantShop::Herbalist) { "Prepared medicines and ingredients" } else { "Merchant stock" }, html! {
             div class="smith-wares-scroll" {
-            (trade_inventory_table("merchant-left", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, false, html! {
+            (trade_inventory_table("merchant-left", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, false, false, html! {
                 @for item in items.iter().filter(|item| shop.shows_inventory(item.kind)) {
                     @let is_currency = item.kind == crate::spacetimedb::ItemKind::Currency;
                     @let medication_recipe = adventuresim_core::disease::medication_recipe_for_item(&item.id);
@@ -1465,7 +1465,7 @@ pub fn live_merchant_shop_page(
                     );
                     @let sell_price = (item.base_value.unwrap_or(1) as f32 / 1.25).floor().max(1.0) as u32;
                     @let target = target_quantity(personal_targets, &item.id);
-                    tr class="trade-inventory-row trade-row-merchant" data-merchant-item=(&item.id) data-merchant-sell-price=(sell_price) data-herbalist-medication-name=[medication_recipe.map(|recipe| recipe.name)] { td class="inventory-item-type" { (item_type_icon(&item.id)) } td class="inventory-item-name" { (item_name_with_display(medication_recipe.map_or(item.id.as_str(), |recipe| recipe.name), Some(item))) @if !is_currency { (merchant_buy_controls(&item.id, buy_price, target, 999)) } } td class="inventory-count" { "999" } td class="inventory-weight" { (weight_display(item.weight)) } td class="inventory-gold" { (buy_price) } }
+                    tr class="trade-inventory-row trade-row-merchant" data-merchant-item=(&item.id) data-merchant-sell-price=(sell_price) data-herbalist-medication-name=[medication_recipe.map(|recipe| recipe.name)] { td class="inventory-item-type" { (item_type_icon(&item.id)) } td class="inventory-item-name" { (item_name_with_display(medication_recipe.map_or(item.id.as_str(), |recipe| recipe.name), Some(item))) @if !is_currency { (merchant_buy_controls(&item.id, buy_price, target, 999)) } } td class="inventory-count" hidden { "999" } td class="inventory-weight" { (weight_display(item.weight)) } td class="inventory-gold" { (buy_price) } }
                 }
             }))
             (inventory_footer_controls("buy", "Buy to targets", "Buy everything"))
@@ -1489,7 +1489,7 @@ pub fn live_merchant_shop_page(
             div data-inventory-pane="player" {
             div class="sidebar-section" {
                 (encumbrance_inventory_rail(html! {
-                (trade_inventory_table("merchant-player-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, true, matches!(shop, MerchantShop::Weapons | MerchantShop::Armor), html! {
+                (trade_inventory_table("merchant-player-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, true, true, matches!(shop, MerchantShop::Weapons | MerchantShop::Armor), html! {
                     @for item in inventory.iter().filter(|item| items.iter().find(|definition| definition.id == item.item_id).is_some_and(|definition| shop.shows_inventory(definition.kind))) {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
                         @let is_currency = definition.is_some_and(|definition| definition.kind == crate::spacetimedb::ItemKind::Currency);
@@ -1525,7 +1525,7 @@ pub fn live_merchant_shop_page(
             @if !matches!(shop, MerchantShop::Herbalist) { div data-inventory-pane="party" hidden {
             div class="sidebar-section" {
                 (encumbrance_inventory_rail(html! {
-                (trade_inventory_table("merchant-party-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, false, html! {
+                (trade_inventory_table("merchant-party-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, true, false, false, html! {
                     @for item in pooled.iter().filter(|item| items.iter().find(|definition| definition.id == item.item_id).is_some_and(|definition| shop.shows_inventory(definition.kind))) {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
                         @let is_currency = definition.is_some_and(|definition| definition.kind == crate::spacetimedb::ItemKind::Currency);
@@ -1592,7 +1592,7 @@ pub fn party_pool_page(
                         strong { (stake) " gold" }
                     }
                     p class="small-copy text-muted" { "Withdrawals use your stake. Personal gold automatically covers an indivisible item's shortfall." }
-                    (trade_inventory_table("party-pool-left", InventoryColumnSet::All, false, false, html! {
+                    (trade_inventory_table("party-pool-left", InventoryColumnSet::All, true, false, false, html! {
                         @for item in pooled {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
                             @let value = definition.and_then(|definition| definition.base_value).unwrap_or(0) as u64;
@@ -1622,7 +1622,7 @@ pub fn party_pool_page(
             (sidebar_section(&format!("{}'s inventory", character.name), html! {
                 (encumbrance_inventory_rail(html! {
                     p class="small-copy text-muted" { "Add items at their objective gold value." }
-                    (trade_inventory_table("party-pool-right", InventoryColumnSet::All, true, false, html! {
+                    (trade_inventory_table("party-pool-right", InventoryColumnSet::All, true, true, false, html! {
                         @for item in inventory {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
                             @let equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
@@ -1802,12 +1802,14 @@ fn weight_display(weight: f32) -> String {
 fn trade_inventory_table(
     namespace: &str,
     optional_columns: InventoryColumnSet,
+    show_quantities: bool,
     show_equipped: bool,
     show_condition: bool,
     rows: Markup,
 ) -> Markup {
     InventoryBrowser {
         namespace,
+        show_quantities,
         show_equipped,
         show_condition,
         optional_columns,
@@ -1867,10 +1869,10 @@ fn merchant_sell_repair_controls(
     repair: Option<Markup>,
 ) -> Markup {
     html! { div class="inventory-row-actions smith-player-actions" {
+        @if let Some(repair) = repair { (repair) }
         @if can_sell {
             button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-sell=(id) data-item-name=(item_id) data-merchant-sell-price=(price) data-transfer-mode="one" data-count=(quantity) data-target=(target) data-label-one=(format!("Sell one {item_id}")) data-label-target=(format!("Sell surplus {item_id}")) data-label-all=(format!("Sell all {item_id}")) aria-label=(format!("Sell one {item_id}")) title=(format!("Sell one {item_id}")) { (transfer_glyph(1)) }
         }
-        @if let Some(repair) = repair { (repair) }
     } }
 }
 
@@ -4001,9 +4003,15 @@ mod tests {
 
     #[test]
     fn smith_player_inventory_uses_the_compact_seven_column_table() {
-        let rendered =
-            trade_inventory_table("test", InventoryColumnSet::Weapons, true, true, html! {})
-                .into_string();
+        let rendered = trade_inventory_table(
+            "test",
+            InventoryColumnSet::Weapons,
+            true,
+            true,
+            true,
+            html! {},
+        )
+        .into_string();
         assert!(rendered.contains("smith-player-inventory-table"));
         assert!(rendered.contains("inventory-column-type"));
         assert!(rendered.contains("aria-label=\"Item type\""));
@@ -4214,12 +4222,19 @@ mod tests {
     }
 
     #[test]
-    fn merchant_stock_table_keeps_quantity_weight_and_gold_columns() {
-        let rendered =
-            trade_inventory_table("test", InventoryColumnSet::Basic, false, false, html! {})
-                .into_string();
+    fn merchant_stock_table_hides_quantity_and_target_columns() {
+        let rendered = trade_inventory_table(
+            "merchant-left",
+            InventoryColumnSet::Basic,
+            false,
+            false,
+            false,
+            html! {},
+        )
+        .into_string();
         assert!(rendered.contains("<colgroup>"));
-        assert!(rendered.contains("inventory-column-count"));
+        assert!(!rendered.contains("inventory-column-count"));
+        assert!(!rendered.contains("inventory-column-target"));
         assert!(rendered.contains("inventory-column-type"));
         assert!(rendered.contains("inventory-column-weight"));
         assert!(rendered.contains("inventory-column-gold"));
@@ -4233,6 +4248,7 @@ mod tests {
         let rendered = trade_inventory_table(
             "test",
             InventoryColumnSet::Basic,
+            true,
             false,
             false,
             html! {
@@ -4788,7 +4804,7 @@ mod tests {
         assert!(css.contains("66%, 74%"));
         assert!(!css.contains("left: -7rem;"));
         assert!(css.contains(".smith-wares-scroll .trade-inventory-table"));
-        assert!(css.contains("overflow-x: hidden;"));
+        assert!(css.contains("overflow-x: clip;"));
         assert!(css.contains("col.inventory-column-item { width: auto; }"));
         assert!(css.contains(".smith-player-inventory-table"));
         assert!(css.contains("width: 3.65rem;"));
@@ -4796,19 +4812,19 @@ mod tests {
         assert!(css.contains("width: calc(100% + 1.65rem);"));
         assert!(css.contains("right: -1.65rem;"));
         assert!(utilities.contains(".inventory-row-actions.smith-player-actions"));
-        assert!(utilities.contains(".smith-wares-scroll .inventory-row-actions"));
-        assert!(!utilities.contains(".smith-wares-scroll .inventory-footer-actions"));
+        assert!(!utilities.contains(".smith-wares-scroll .inventory-row-actions"));
+        assert!(utilities.contains(".inventory-actions-cell"));
         assert!(
-            utilities.contains(".inventory-actions-header:has(.inventory-footer-actions-grouped)")
+            utilities.contains(".left-sidebar .inventory-actions-cell > .inventory-row-actions")
         );
-        assert!(utilities.contains("position:sticky;"));
-        assert!(css.contains(".inventory-browser-table-scroll"));
-        assert!(css.contains("overflow-x:auto;"));
+        assert!(
+            utilities.contains(".right-sidebar .inventory-actions-cell > .inventory-row-actions")
+        );
+        assert!(css.contains(".inventory-browser-table-frame"));
+        assert!(css.contains("width:max-content;"));
         assert!(utilities.contains(".inventory-footer-repair .repair-all-button"));
         assert!(utilities.contains("grid-template-columns:repeat(2,1.35rem)"));
-        assert!(utilities.contains(
-            ".right-sidebar .inventory-row-actions.smith-player-actions { left:-3.15rem; }"
-        ));
+        assert!(utilities.contains(".inventory-actions-header > .inventory-footer-actions"));
         assert!(
             utilities
                 .contains(".smith-player-actions .row-repair-form { position:static; order:0;")

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1026,7 +1026,7 @@ pub fn party_discard_page(
             (sidebar_section("Discard", html! {
                 p class="text-muted small-copy" data-discard-empty { "Stage carried items here before discarding them." }
                 div data-discard-table hidden {
-                    (trade_inventory_table("discard-left", InventoryColumnSet::All, false, None, html! {}))
+                    (trade_inventory_table("discard-left", InventoryColumnSet::All, false, false, html! {}))
                 }
             }))
         }
@@ -1342,7 +1342,7 @@ fn party_trade_inventory_rail(
                 @if inventory.is_empty() {
                     p class="text-muted small-copy" { "No items carried." }
                 } @else {
-                    (trade_inventory_table(if direction == "left" { "party-transfer-right" } else { "party-transfer-left" }, InventoryColumnSet::All, true, None, html! {
+                    (trade_inventory_table(if direction == "left" { "party-transfer-right" } else { "party-transfer-left" }, InventoryColumnSet::All, true, false, html! {
                         @for item in inventory {
                             @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1380,7 +1380,7 @@ fn discard_inventory_rail(
                 @if inventory.is_empty() {
                     p class="text-muted small-copy" { "No items carried." }
                 } @else {
-                    (trade_inventory_table("discard-right", InventoryColumnSet::All, true, None, html! {
+                    (trade_inventory_table("discard-right", InventoryColumnSet::All, true, false, html! {
                         @for item in inventory {
                             @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1444,12 +1444,18 @@ pub fn live_merchant_shop_page(
     let player_footer = if matches!(shop, MerchantShop::Herbalist) {
         html! {}
     } else {
-        inventory_footer_controls("sell", "Sell surplus", "Sell everything")
+        inventory_footer_controls_with_leading(
+            matches!(shop, MerchantShop::Weapons | MerchantShop::Armor)
+                .then(|| repair_all_control(settlement, service_id)),
+            "sell",
+            "Sell surplus",
+            "Sell everything",
+        )
     };
     let content = html! {
         aside class="left-sidebar smith-wares-column" { (sidebar_section(if matches!(shop, MerchantShop::Herbalist) { "Prepared medicines and ingredients" } else { "Merchant stock" }, html! {
             div class="smith-wares-scroll" {
-            (trade_inventory_table("merchant-left", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, None, html! {
+            (trade_inventory_table("merchant-left", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, false, html! {
                 @for item in items.iter().filter(|item| shop.shows_inventory(item.kind)) {
                     @let is_currency = item.kind == crate::spacetimedb::ItemKind::Currency;
                     @let medication_recipe = adventuresim_core::disease::medication_recipe_for_item(&item.id);
@@ -1483,7 +1489,7 @@ pub fn live_merchant_shop_page(
             div data-inventory-pane="player" {
             div class="sidebar-section" {
                 (encumbrance_inventory_rail(html! {
-                (trade_inventory_table("merchant-player-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, true, matches!(shop, MerchantShop::Weapons | MerchantShop::Armor).then(|| repair_all_header(settlement, service_id)), html! {
+                (trade_inventory_table("merchant-player-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, true, matches!(shop, MerchantShop::Weapons | MerchantShop::Armor), html! {
                     @for item in inventory.iter().filter(|item| items.iter().find(|definition| definition.id == item.item_id).is_some_and(|definition| shop.shows_inventory(definition.kind))) {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
                         @let is_currency = definition.is_some_and(|definition| definition.kind == crate::spacetimedb::ItemKind::Currency);
@@ -1519,7 +1525,7 @@ pub fn live_merchant_shop_page(
             @if !matches!(shop, MerchantShop::Herbalist) { div data-inventory-pane="party" hidden {
             div class="sidebar-section" {
                 (encumbrance_inventory_rail(html! {
-                (trade_inventory_table("merchant-party-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, None, html! {
+                (trade_inventory_table("merchant-party-right", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, false, html! {
                     @for item in pooled.iter().filter(|item| items.iter().find(|definition| definition.id == item.item_id).is_some_and(|definition| shop.shows_inventory(definition.kind))) {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
                         @let is_currency = definition.is_some_and(|definition| definition.kind == crate::spacetimedb::ItemKind::Currency);
@@ -1586,7 +1592,7 @@ pub fn party_pool_page(
                         strong { (stake) " gold" }
                     }
                     p class="small-copy text-muted" { "Withdrawals use your stake. Personal gold automatically covers an indivisible item's shortfall." }
-                    (trade_inventory_table("party-pool-left", InventoryColumnSet::All, false, None, html! {
+                    (trade_inventory_table("party-pool-left", InventoryColumnSet::All, false, false, html! {
                         @for item in pooled {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
                             @let value = definition.and_then(|definition| definition.base_value).unwrap_or(0) as u64;
@@ -1616,7 +1622,7 @@ pub fn party_pool_page(
             (sidebar_section(&format!("{}'s inventory", character.name), html! {
                 (encumbrance_inventory_rail(html! {
                     p class="small-copy text-muted" { "Add items at their objective gold value." }
-                    (trade_inventory_table("party-pool-right", InventoryColumnSet::All, true, None, html! {
+                    (trade_inventory_table("party-pool-right", InventoryColumnSet::All, true, false, html! {
                         @for item in inventory {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
                             @let equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
@@ -1797,13 +1803,13 @@ fn trade_inventory_table(
     namespace: &str,
     optional_columns: InventoryColumnSet,
     show_equipped: bool,
-    condition_header: Option<Markup>,
+    show_condition: bool,
     rows: Markup,
 ) -> Markup {
     InventoryBrowser {
         namespace,
         show_equipped,
-        condition_header,
+        show_condition,
         optional_columns,
         rows,
     }
@@ -1916,10 +1922,9 @@ fn completed_repair_condition_bar(
     condition_bar(Some(&repaired), None)
 }
 
-fn repair_all_header(settlement: &Settlement, service_id: &str) -> Markup {
+fn repair_all_control(settlement: &Settlement, service_id: &str) -> Markup {
     html! {
-        span class="sr-only" { "Durability" }
-        form class="repair-all-form" action=(format!("/settlements/{}/{}/repair-all", settlement.id, service_id)) method="post" {
+        form class="repair-all-form inventory-footer-repair" action=(format!("/settlements/{}/{}/repair-all", settlement.id, service_id)) method="post" {
             button type="submit" class="repair-all-button" title="Entrust all eligible items for repair" aria-label="Repair all eligible items" {
                 span class="repair-action-icon" aria-hidden="true" {}
             }
@@ -2047,7 +2052,18 @@ pub(crate) fn inventory_footer_controls(
     target_label: &str,
     all_label: &str,
 ) -> Markup {
-    html! { div class="inventory-footer-actions" {
+    inventory_footer_controls_with_leading(None, action, target_label, all_label)
+}
+
+fn inventory_footer_controls_with_leading(
+    leading: Option<Markup>,
+    action: &str,
+    target_label: &str,
+    all_label: &str,
+) -> Markup {
+    let grouped = leading.is_some();
+    html! { div class=(if grouped { "inventory-footer-actions inventory-footer-actions-grouped" } else { "inventory-footer-actions" }) {
+        @if let Some(leading) = leading { (leading) }
         button type="button" class="trade-transfer inventory-footer-transfer" data-dynamic-transfer data-default-transfer-mode="target" data-inventory-bulk=(action) data-transfer-mode="target" data-label-target=(target_label) data-label-all=(all_label) aria-label=(target_label) title=(target_label) { (transfer_glyph(2)) }
     } }
 }
@@ -3985,21 +4001,31 @@ mod tests {
 
     #[test]
     fn smith_player_inventory_uses_the_compact_seven_column_table() {
-        let rendered = trade_inventory_table(
-            "test",
-            InventoryColumnSet::Weapons,
-            true,
-            Some(repair_all_header(&settlement(), "weapons")),
-            html! {},
-        )
-        .into_string();
+        let rendered =
+            trade_inventory_table("test", InventoryColumnSet::Weapons, true, true, html! {})
+                .into_string();
         assert!(rendered.contains("smith-player-inventory-table"));
         assert!(rendered.contains("inventory-column-type"));
         assert!(rendered.contains("aria-label=\"Item type\""));
         assert!(rendered.contains("inventory-column-durability"));
-        assert!(rendered.contains("Repair all eligible items"));
-        assert!(rendered.contains("class=\"sr-only\">Durability</span>"));
+        assert!(rendered.contains("hammer-nails.svg"));
+        assert!(!rendered.contains("Repair all eligible items"));
         assert!(!rendered.contains("durability-header-label"));
+    }
+
+    #[test]
+    fn repair_all_precedes_the_sell_bulk_control() {
+        let rendered = inventory_footer_controls_with_leading(
+            Some(repair_all_control(&settlement(), "weapons")),
+            "sell",
+            "Sell surplus",
+            "Sell everything",
+        )
+        .into_string();
+        let repair = rendered.find("inventory-footer-repair").unwrap();
+        let sell = rendered.find("data-inventory-bulk=\"sell\"").unwrap();
+        assert!(rendered.contains("inventory-footer-actions-grouped"));
+        assert!(repair < sell);
     }
 
     #[test]
@@ -4190,7 +4216,7 @@ mod tests {
     #[test]
     fn merchant_stock_table_keeps_quantity_weight_and_gold_columns() {
         let rendered =
-            trade_inventory_table("test", InventoryColumnSet::Basic, false, None, html! {})
+            trade_inventory_table("test", InventoryColumnSet::Basic, false, false, html! {})
                 .into_string();
         assert!(rendered.contains("<colgroup>"));
         assert!(rendered.contains("inventory-column-count"));
@@ -4208,7 +4234,7 @@ mod tests {
             "test",
             InventoryColumnSet::Basic,
             false,
-            None,
+            false,
             html! {
                 tr class="trade-inventory-row" {
                     td class="inventory-item-type" { (item_type_icon("arming_sword")) }
@@ -4771,7 +4797,14 @@ mod tests {
         assert!(css.contains("right: -1.65rem;"));
         assert!(utilities.contains(".inventory-row-actions.smith-player-actions"));
         assert!(utilities.contains(".smith-wares-scroll .inventory-row-actions"));
-        assert!(utilities.contains(".smith-wares-scroll .inventory-footer-actions"));
+        assert!(!utilities.contains(".smith-wares-scroll .inventory-footer-actions"));
+        assert!(
+            utilities.contains(".inventory-actions-header:has(.inventory-footer-actions-grouped)")
+        );
+        assert!(utilities.contains("position:sticky;"));
+        assert!(css.contains(".inventory-browser-table-scroll"));
+        assert!(css.contains("overflow-x:auto;"));
+        assert!(utilities.contains(".inventory-footer-repair .repair-all-button"));
         assert!(utilities.contains("grid-template-columns:repeat(2,1.35rem)"));
         assert!(utilities.contains(
             ".right-sidebar .inventory-row-actions.smith-player-actions { left:-3.15rem; }"

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1459,7 +1459,7 @@ pub fn live_merchant_shop_page(
                     );
                     @let sell_price = (item.base_value.unwrap_or(1) as f32 / 1.25).floor().max(1.0) as u32;
                     @let target = target_quantity(personal_targets, &item.id);
-                    tr class="trade-inventory-row trade-row-merchant" data-merchant-item=(&item.id) data-merchant-sell-price=(sell_price) data-herbalist-medication-name=[medication_recipe.map(|recipe| recipe.name)] { td class="inventory-item-type" { (item_type_icon(&item.id)) } td class="inventory-item-name" { @if let Some(recipe) = medication_recipe { (recipe.name) } @else { (item_name_with_quality(&item.id, Some(item))) } @if !is_currency { (merchant_buy_controls(&item.id, buy_price, target, 999)) } } td class="inventory-count" { "999" } td class="inventory-weight" { (weight_display(item.weight)) } td class="inventory-gold" { (buy_price) } }
+                    tr class="trade-inventory-row trade-row-merchant" data-merchant-item=(&item.id) data-merchant-sell-price=(sell_price) data-herbalist-medication-name=[medication_recipe.map(|recipe| recipe.name)] { td class="inventory-item-type" { (item_type_icon(&item.id)) } td class="inventory-item-name" { (item_name_with_display(medication_recipe.map_or(item.id.as_str(), |recipe| recipe.name), Some(item))) @if !is_currency { (merchant_buy_controls(&item.id, buy_price, target, 999)) } } td class="inventory-count" { "999" } td class="inventory-weight" { (weight_display(item.weight)) } td class="inventory-gold" { (buy_price) } }
                 }
             }))
             (inventory_footer_controls("buy", "Buy to targets", "Buy everything"))
@@ -1727,6 +1727,13 @@ pub(super) fn item_name_with_quality(
     item_id: &str,
     definition: Option<&crate::spacetimedb::ItemDefinition>,
 ) -> Markup {
+    item_name_with_display(item_id, definition)
+}
+
+fn item_name_with_display(
+    display_name: &str,
+    definition: Option<&crate::spacetimedb::ItemDefinition>,
+) -> Markup {
     let quality = definition
         .filter(|item| {
             matches!(
@@ -1758,7 +1765,7 @@ pub(super) fn item_name_with_quality(
     });
     html! {
         span class=(quality.map_or_else(|| "inventory-item-label".to_string(), |quality| format!("inventory-item-label item-quality-{quality}"))) title=[label]
-            data-item-name=(item_id)
+            data-item-name=(display_name)
             data-item-kind=[definition.map(|item| format!("{:?}", item.kind).to_ascii_lowercase())]
             data-stat-accuracy=[definition.map(|item| weight_display(item.accuracy))]
             data-stat-reach=[definition.map(|item| weight_display(item.reach))]
@@ -1773,7 +1780,7 @@ pub(super) fn item_name_with_quality(
             data-detail-slot=[definition.map(|item| format!("{:?}", item.slot))]
             data-detail-balance=[definition.map(|item| weight_display(item.balance))]
             data-detail-mode=[definition.map(|item| match (item.melee, item.ranged, item.precise) { (true, true, true) => "Melee, ranged, precise", (true, true, false) => "Melee and ranged", (true, false, true) => "Melee, precise", (false, true, true) => "Ranged, precise", (true, false, false) => "Melee", (false, true, false) => "Ranged", (false, false, true) => "Precise", _ => "—" }.to_string())] {
-            (item_id)
+            (display_name)
         }
     }
 }
@@ -1878,7 +1885,7 @@ fn condition_bar(
         "Damaged beyond this smith's skill".to_string()
     };
     html! {
-        span class="condition-bar" title=(&label) aria-label=(&label) {
+        span class="condition-bar" data-sort-value=(weight_display(green)) title=(&label) aria-label=(&label) {
             span class="condition-green" style=(format!("width:{}%", green * 100.0)) {}
             @for (index, amount) in bins.iter().enumerate() {
                 @let repairable = repair_skill.is_some_and(|skill| index < skill.min(5) as usize);
@@ -3655,6 +3662,15 @@ mod tests {
         assert!(MerchantShop::Herbalist.stocks(ItemKind::Ingredient));
         assert!(MerchantShop::Herbalist.stocks(ItemKind::Medication));
         assert_eq!(adventuresim_core::disease::MEDICATION_RECIPES.len(), 8);
+        let definition = crate::spacetimedb::ItemDefinition {
+            id: "black_death_tonic".into(),
+            kind: ItemKind::Medication,
+            ..Default::default()
+        };
+        let rendered = item_name_with_display("Black Death tonic", Some(&definition)).into_string();
+        assert!(rendered.contains("data-item-name=\"Black Death tonic\""));
+        assert!(rendered.contains("data-item-kind=\"medication\""));
+        assert!(rendered.contains(">Black Death tonic</span>"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -4863,6 +4863,8 @@ mod tests {
         assert!(!css.contains("left: -7rem;"));
         assert!(css.contains(".smith-wares-scroll .trade-inventory-table"));
         assert!(css.contains("--inventory-merchant-action-overhang"));
+        assert!(css.contains("--inventory-merchant-scrollbar-reserve: 8px;"));
+        assert!(css.contains("padding-left: var(--inventory-merchant-scrollbar-reserve);"));
         assert!(css.contains("padding-right: var(--inventory-merchant-action-overhang);"));
         assert!(css.contains("direction: rtl;"));
         assert!(css.contains(".smith-wares-scroll > * { direction: ltr; }"));
@@ -4876,6 +4878,7 @@ mod tests {
         assert!(css.contains("padding-right: var(--repair-custody-action-overhang);"));
         assert!(css.contains("scrollbar-gutter: stable;"));
         assert!(utilities.contains(".inventory-row-actions.smith-player-actions"));
+        assert!(utilities.contains("--inventory-action-bridge:.3rem"));
         assert!(!utilities.contains(".smith-wares-scroll .inventory-row-actions"));
         assert!(utilities.contains(".inventory-actions-cell"));
         assert!(

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -4820,6 +4820,9 @@ mod tests {
         assert!(
             utilities.contains(".right-sidebar .inventory-actions-cell > .inventory-row-actions")
         );
+        assert!(utilities.contains("background:var(--inventory-row-background"));
+        assert!(utilities.contains("left:100%; padding-left:var(--inventory-action-bridge);"));
+        assert!(utilities.contains("right:100%; padding-right:var(--inventory-action-bridge);"));
         assert!(css.contains(".inventory-browser-table-frame"));
         assert!(css.contains("width:max-content;"));
         assert!(utilities.contains(".inventory-footer-repair .repair-all-button"));

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -4872,6 +4872,7 @@ mod tests {
             ".trade-inventory-row:not(:last-child) .inventory-row-actions { bottom:-1px; }"
         ));
         assert!(utilities.contains(".inventory-row-actions .trade-transfer:disabled"));
+        assert!(utilities.contains("opacity:.42; transform:none;"));
         assert!(utilities.contains("left:100%; padding-left:var(--inventory-action-bridge);"));
         assert!(utilities.contains("right:100%; padding-right:var(--inventory-action-bridge);"));
         assert!(css.contains(".inventory-browser-table-frame"));

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -4851,8 +4851,9 @@ mod tests {
         assert!(!css.contains("left: -7rem;"));
         assert!(css.contains(".smith-wares-scroll .trade-inventory-table"));
         assert!(css.contains("--inventory-merchant-action-overhang"));
-        assert!(css.contains("+ 8px)"));
         assert!(css.contains("padding-right: var(--inventory-merchant-action-overhang);"));
+        assert!(css.contains("direction: rtl;"));
+        assert!(css.contains(".smith-wares-scroll > * { direction: ltr; }"));
         assert!(css.contains("scrollbar-gutter: stable;"));
         assert!(css.contains("overflow-x: clip;"));
         assert!(css.contains("col.inventory-column-item { width: auto; }"));

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -2025,19 +2025,28 @@ fn repair_custody_panel(
                 @if matching.is_empty() { p class="text-muted small-copy" { "No items entrusted." } }
                 div class="repair-custody-list" {
                     table class="trade-inventory-table repair-custody-table" {
+                        colgroup {
+                            col class="inventory-column-type";
+                            col class="inventory-column-item";
+                            col class="inventory-column-durability";
+                            col class="repair-column-eta";
+                            col class="inventory-column-gold";
+                            col class="inventory-column-actions";
+                        }
                         thead { tr {
                             (item_type_header())
-                            th scope="col" class="inventory-column-item" {
-                                span class="repair-custody-item-heading" { span { "Item" }
-                                    form class="repair-retrieve-all-form" data-repair-retrieve-form data-bulk-action=(format!("/settlements/{}/{}/repairs/retrieve", settlement.id, service_id)) action=(format!("/settlements/{}/{}/repairs/retrieve", settlement.id, service_id)) method="post" {
-                                        input type="hidden" name="limit" value="2";
-                                        button type="submit" class="trade-transfer trade-transfer-right repair-retrieve-all" data-dynamic-transfer data-default-transfer-mode="target" data-transfer-mode="target" data-label-target="Retrieve up to two completed repairs" data-label-all="Retrieve all completed repairs" title="Retrieve up to two completed repairs" aria-label="Retrieve up to two completed repairs" { (transfer_glyph(2)) }
-                                    }
-                                }
-                            }
+                            th scope="col" class="inventory-column-item" { "Item" }
                             th scope="col" class="inventory-column-durability" { "Durability" }
                             th scope="col" class="repair-column-eta" { "ETA" }
                             th scope="col" class="inventory-column-gold" title="Full repair cost (Currency)" { (currency_header("Full repair cost in Currency")) }
+                            th class="inventory-actions-header" aria-label="Repair retrieval actions" {
+                                div class="inventory-footer-actions repair-custody-header-actions" {
+                                    form class="repair-retrieve-all-form" data-repair-retrieve-form data-bulk-action=(format!("/settlements/{}/{}/repairs/retrieve", settlement.id, service_id)) action=(format!("/settlements/{}/{}/repairs/retrieve", settlement.id, service_id)) method="post" {
+                                        input type="hidden" name="limit" value="2";
+                                        button type="submit" class="trade-transfer trade-transfer-right inventory-footer-transfer repair-retrieve-all" data-dynamic-transfer data-default-transfer-mode="target" data-transfer-mode="target" data-label-target="Retrieve up to two completed repairs" data-label-all="Retrieve all completed repairs" title="Retrieve up to two completed repairs" aria-label="Retrieve up to two completed repairs" { (transfer_glyph(2)) }
+                                    }
+                                }
+                            }
                         } }
                         tbody {
                         @for order in matching {
@@ -2047,7 +2056,14 @@ fn repair_custody_panel(
                             @let remaining = order.ready_at_minutes.saturating_sub(now);
                             tr class="trade-inventory-row trade-row-merchant repair-order-row" {
                                 td class="inventory-item-type" { (item_type_icon(&order.item_id)) }
-                                td class="inventory-item-name" { (item_name_with_quality(&order.item_id, definition))
+                                td class="inventory-item-name" { (item_name_with_quality(&order.item_id, definition)) }
+                                td class="inventory-durability" {
+                                    @if ready { (completed_repair_condition_bar(condition, order.smith_skill)) }
+                                    @else { (condition_bar(condition, Some(order.smith_skill))) }
+                                }
+                                td class="repair-column-eta" { @if ready { "Ready" } @else { (format!("{}h {}m", remaining / 60, remaining % 60)) } }
+                                td class="inventory-gold" title="Quoted full-job cost, paid on retrieval" { (order.quoted_cost) }
+                                td class="inventory-actions-cell" aria-label="Item actions" {
                                     span class="inventory-row-actions repair-retrieve-actions" {
                                         form data-repair-retrieve-form data-single-action=(format!("/settlements/{}/{}/repairs/{}/retrieve", settlement.id, service_id, order.id)) data-bulk-action=(format!("/settlements/{}/{}/repairs/retrieve", settlement.id, service_id)) action=(format!("/settlements/{}/{}/repairs/{}/retrieve", settlement.id, service_id, order.id)) method="post" {
                                             input type="hidden" name="item_id" value=(&order.item_id);
@@ -2056,12 +2072,6 @@ fn repair_custody_panel(
                                         }
                                     }
                                 }
-                                td class="inventory-durability" {
-                                    @if ready { (completed_repair_condition_bar(condition, order.smith_skill)) }
-                                    @else { (condition_bar(condition, Some(order.smith_skill))) }
-                                }
-                                td class="repair-column-eta" { @if ready { "Ready" } @else { (format!("{}h {}m", remaining / 60, remaining % 60)) } }
-                                td class="inventory-gold" title="Quoted full-job cost, paid on retrieval" { (order.quoted_cost) }
                             }
                         }
                         }
@@ -4406,7 +4416,9 @@ mod tests {
         for tier in 1..=5 {
             assert!(weapons.contains(&format!("skill-rank-segment-{tier}")));
         }
-        assert!(weapons.contains("repair-custody-item-heading"));
+        assert!(weapons.contains("repair-custody-header-actions"));
+        assert!(weapons.contains("inventory-actions-header"));
+        assert!(weapons.contains("inventory-actions-cell"));
         assert!(weapons.contains("Durability"));
         assert!(weapons.contains("ETA"));
         assert!(weapons.contains("Full repair cost"));
@@ -4859,9 +4871,10 @@ mod tests {
         assert!(css.contains("col.inventory-column-item { width: auto; }"));
         assert!(css.contains(".smith-player-inventory-table"));
         assert!(css.contains("width: 3.65rem;"));
-        assert!(css.contains(".repair-custody-item-heading"));
-        assert!(css.contains("width: calc(100% + 1.65rem);"));
-        assert!(css.contains("right: -1.65rem;"));
+        assert!(css.contains("--repair-custody-action-overhang"));
+        assert!(css.contains("width: calc(100% + var(--repair-custody-action-overhang));"));
+        assert!(css.contains("padding-right: var(--repair-custody-action-overhang);"));
+        assert!(css.contains("scrollbar-gutter: stable;"));
         assert!(utilities.contains(".inventory-row-actions.smith-player-actions"));
         assert!(!utilities.contains(".smith-wares-scroll .inventory-row-actions"));
         assert!(utilities.contains(".inventory-actions-cell"));
@@ -4885,6 +4898,8 @@ mod tests {
         assert!(utilities.contains(".inventory-footer-repair .repair-all-button"));
         assert!(utilities.contains("grid-template-columns:repeat(2,1.35rem)"));
         assert!(utilities.contains(".inventory-actions-header > .inventory-footer-actions"));
+        assert!(utilities.contains("thead:hover .inventory-footer-actions"));
+        assert!(utilities.contains("background:var(--panel-bg)"));
         assert!(
             utilities
                 .contains(".smith-player-actions .row-repair-form { position:static; order:0;")

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -326,6 +326,15 @@
   overflow: hidden;
 }
 
+/* Inventory rails grow with their currently visible columns. The center track
+   yields space while row and bulk actions project into its portrait gutter. */
+.main-grid:has(.inventory-browser) {
+  grid-template-columns:
+    var(--inventory-left-width, 20%)
+    minmax(0, 1fr)
+    var(--inventory-right-width, 20%);
+}
+
 body:has(.settlement-top-bar) .main-grid {
   height: calc(100vh - var(--settlement-header-height));
 }
@@ -477,6 +486,9 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
   .main-grid {
     grid-template-columns: 1fr;
     grid-template-rows: auto 1fr;
+  }
+  .main-grid:has(.inventory-browser) {
+    grid-template-columns: 1fr;
   }
   body:has(.settlement-top-bar) .main-grid {
     height: auto;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -701,30 +701,15 @@
 .repair-custody-skill .skill-rank-bar { flex: 1; }
 .repair-custody-panel h3 { margin: 0; padding: 0.55rem var(--padding); font-size: var(--font-size-sm); }
 .repair-retrieve-all-form { display: contents; }
-.repair-custody-item-heading {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.2rem;
-  white-space: nowrap;
-}
-.repair-custody-table thead .repair-retrieve-all {
-  position: absolute;
-  top: 50%;
-  right: -1.65rem;
-  width: 1.35rem;
-  height: 1.35rem;
-  opacity: 0.8;
-  transform: translateY(-50%);
-}
 .repair-custody-scroll {
+  --repair-custody-action-overhang: calc(1.35rem + var(--building-frame-corner-size, 0rem) + .3rem);
   box-sizing: border-box;
-  width: calc(100% + 1.65rem);
+  width: calc(100% + var(--repair-custody-action-overhang));
   min-height: 0;
-  padding-right: 1.65rem;
+  padding-right: var(--repair-custody-action-overhang);
   overflow-x: hidden;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   display: flex;
   flex-direction: column;
 }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -474,23 +474,90 @@
   box-shadow: 0 0 0 1px #fff, 0 0 0 2px #000;
   transform: translateX(-50%);
 }
-.inventory-browser-toolbar { display:flex; align-items:center; gap:.35rem; padding:.35rem; border-bottom:1px solid var(--border-light); }
-.inventory-browser-search { flex:1; }
-.inventory-browser-search input { box-sizing:border-box; width:100%; min-width:0; padding:.28rem .4rem; }
+.inventory-browser { box-sizing:border-box; width:100%; max-width:100%; min-width:0; container-type:inline-size; }
+.inventory-browser-table-scroll {
+  box-sizing:border-box;
+  width:100%;
+  max-width:100%;
+  overflow-x:auto;
+  overflow-y:hidden;
+  overscroll-behavior-inline:contain;
+  scrollbar-gutter:stable;
+}
+.inventory-browser-table-scroll:focus-visible { outline:1px solid var(--accent); outline-offset:-1px; }
+.inventory-browser-table-scroll > .trade-inventory-table { width:max-content; min-width:100%; }
+.inventory-browser-table-scroll [data-inventory-column] { min-width:4.75rem; }
+.inventory-browser-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.5rem;
+  border-block: 1px solid color-mix(in srgb, var(--border-light) 72%, transparent);
+  background: color-mix(in srgb, var(--building-interactive) 72%, var(--panel-bg));
+}
+.inventory-browser-search { position: relative; flex: 1; min-width: 0; }
+.inventory-browser-search::before {
+  position: absolute;
+  top: 50%;
+  left: 0.45rem;
+  width: 0.85rem;
+  height: 0.85rem;
+  background: currentColor;
+  content: "";
+  opacity: 0.68;
+  transform: translateY(-50%);
+  -webkit-mask: url('/static/icons/game/eye-target.svg') center / contain no-repeat;
+  mask: url('/static/icons/game/eye-target.svg') center / contain no-repeat;
+}
+.inventory-browser-search input {
+  box-sizing: border-box;
+  width: 100%;
+  min-width: 0;
+  height: 2rem;
+  padding: 0.3rem 0.55rem 0.3rem 1.65rem;
+  border: 1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
+  border-radius: 0.2rem;
+  background: color-mix(in srgb, var(--panel-bg) 84%, black);
+  color: var(--text-primary);
+}
+.inventory-browser-search input:focus {
+  border-color: var(--accent);
+  outline: 1px solid color-mix(in srgb, var(--accent) 50%, transparent);
+}
 .inventory-column-picker { position:relative; }
-.inventory-column-picker summary { display:grid; place-items:center; width:1.8rem; height:1.8rem; cursor:pointer; list-style:none; }
+.inventory-column-picker summary {
+  display:grid;
+  place-items:center;
+  box-sizing:border-box;
+  width:2rem;
+  height:2rem;
+  border:1px solid color-mix(in srgb, var(--border-color) 80%, transparent);
+  border-radius:.2rem;
+  background:color-mix(in srgb, var(--panel-bg) 84%, black);
+  color:var(--text-muted);
+  cursor:pointer;
+  list-style:none;
+}
+.inventory-column-picker[open] summary,
+.inventory-column-picker summary:hover { color:var(--text-primary); border-color:var(--accent); }
 .inventory-column-picker summary::-webkit-details-marker { display:none; }
-.inventory-column-picker fieldset { position:absolute; z-index:60; top:100%; right:0; width:max-content; min-width:10rem; padding:.55rem; border:1px solid var(--border-light); background:var(--panel-bg); box-shadow:0 .25rem .75rem #0006; }
+.inventory-column-picker fieldset { position:absolute; z-index:60; top:calc(100% + .25rem); right:0; width:max-content; min-width:11rem; padding:.55rem; border:1px solid var(--border-light); border-radius:.2rem; background:var(--panel-bg); box-shadow:0 .35rem 1rem #0009; }
 .inventory-column-picker label { display:block; padding:.18rem; white-space:nowrap; }
-.trade-inventory-table th > button { width:100%; border:0; padding:0; background:transparent; color:inherit; font:inherit; cursor:pointer; }
-.inventory-sort-indicator { font-size:.65em; }
-.inventory-column-target, .inventory-target { min-width:2rem; text-align:center; }
-.inventory-detail-row td { padding:.4rem .65rem !important; background:color-mix(in srgb, var(--panel-bg) 82%, var(--accent)); }
-.inventory-detail-row dl { display:flex; flex-wrap:wrap; gap:.35rem 1rem; margin:0; }
-.inventory-detail-row dl div { display:flex; gap:.3rem; }
-.inventory-detail-row dt { color:var(--color-text-muted); }
-.inventory-detail-row dd { margin:0; }
-.trade-inventory-row[aria-expanded="true"] { background:color-mix(in srgb, var(--accent) 10%, var(--panel-bg)); }
+.trade-inventory-table th > button { position:relative; display:flex; align-items:center; justify-content:center; gap:.1rem; box-sizing:border-box; width:100%; height:100%; min-width:0; border:0; padding:0 .15rem; overflow:hidden; background:transparent; color:inherit; font:inherit; cursor:pointer; }
+.trade-inventory-table th > button:hover { color:var(--text-primary); }
+.inventory-sort-indicator { position:absolute; right:.05rem; bottom:.05rem; font-size:.48rem; line-height:1; }
+.inventory-column-target, .inventory-target { width:2.25rem; min-width:2.25rem; text-align:center; }
+.inventory-detail-row td { box-sizing:border-box; width:100cqi; max-width:100cqi; padding:.55rem .6rem .65rem !important; overflow:hidden; border-left:2px solid color-mix(in srgb, var(--accent) 72%, transparent); background:color-mix(in srgb, var(--panel-bg) 88%, var(--accent)); }
+.inventory-detail-row dl { display:grid; grid-template-columns:repeat(2, minmax(0, 1fr)); width:100%; min-width:0; gap:.4rem; margin:0; }
+.inventory-detail-stat { display:grid; grid-template-columns:1.5rem minmax(0, 1fr); grid-template-rows:auto auto; align-items:center; column-gap:.4rem; min-width:0; padding:.35rem .45rem; border:1px solid color-mix(in srgb, var(--border-light) 70%, transparent); border-radius:.2rem; background:color-mix(in srgb, var(--building-interactive) 70%, transparent); }
+.inventory-detail-icon { grid-row:1 / 3; width:1.25rem; height:1.25rem; background:var(--accent); filter:drop-shadow(0 1px 1px #0008); -webkit-mask:var(--inventory-detail-icon) center / contain no-repeat; mask:var(--inventory-detail-icon) center / contain no-repeat; }
+.inventory-detail-row dt { overflow:hidden; color:var(--text-muted); font-size:.64rem; letter-spacing:.035em; line-height:1.05; text-overflow:ellipsis; text-transform:uppercase; white-space:nowrap; }
+.inventory-detail-row dd { min-width:0; margin:0; overflow:hidden; color:var(--text-primary); font-size:.88rem; font-variant-numeric:tabular-nums; line-height:1.15; text-overflow:ellipsis; white-space:nowrap; }
+.inventory-detail-empty { color:var(--text-muted); font-size:var(--font-size-xs); font-style:italic; }
+.trade-inventory-row[aria-expanded="true"] { background:color-mix(in srgb, var(--accent) 14%, var(--panel-bg)); box-shadow:inset 2px 0 color-mix(in srgb, var(--accent) 72%, transparent); }
+@container (max-width:14rem) {
+  .inventory-detail-row dl { grid-template-columns:1fr; }
+}
 [data-inventory-column] { white-space:nowrap; text-align:center; }
 
 .condition-bar {
@@ -584,8 +651,9 @@
   overflow-y: auto;
 }
 .smith-wares-scroll .trade-inventory-table {
-  width: 100%;
-  table-layout: fixed;
+  width: max-content;
+  min-width: 100%;
+  table-layout: auto;
 }
 .smith-wares-scroll .trade-inventory-table col.inventory-column-item { width: auto; }
 .smith-wares-scroll .trade-inventory-table col.inventory-column-type { width: 1.35rem; }
@@ -677,11 +745,13 @@
 .trade-inventory-table th.inventory-column-item { padding-left: 0.35rem; text-align: left; }
 
 .inventory-column-count,
+.inventory-column-target,
 .inventory-column-type,
 .inventory-column-equipped,
 .inventory-column-weight,
 .inventory-column-gold,
 .inventory-count,
+.inventory-target,
 .inventory-item-type,
 .inventory-equipped,
 .inventory-weight,
@@ -702,16 +772,19 @@
   table-layout: fixed;
 }
 .smith-player-inventory-table col.inventory-column-count { width: 1.6rem; }
-.smith-player-inventory-table col.inventory-column-equipped { width: 1.35rem; }
+.smith-player-inventory-table col.inventory-column-target { width: 2.25rem; }
+.smith-player-inventory-table col.inventory-column-equipped { width: 1.75rem; }
 .smith-player-inventory-table col.inventory-column-durability { width: 3.65rem; }
 .smith-player-inventory-table col.inventory-column-weight { width: 1.9rem; }
 .smith-player-inventory-table col.inventory-column-gold { width: 1.65rem; }
 .smith-player-inventory-table .inventory-column-count,
+.smith-player-inventory-table .inventory-column-target,
 .smith-player-inventory-table .inventory-column-equipped,
 .smith-player-inventory-table .inventory-column-durability,
 .smith-player-inventory-table .inventory-column-weight,
 .smith-player-inventory-table .inventory-column-gold,
 .smith-player-inventory-table .inventory-count,
+.smith-player-inventory-table .inventory-target,
 .smith-player-inventory-table .inventory-equipped,
 .smith-player-inventory-table .inventory-durability,
 .smith-player-inventory-table .inventory-weight,
@@ -736,10 +809,12 @@
 }
 
 .inventory-column-count,
+.inventory-column-target,
 .inventory-column-equipped,
 .inventory-column-weight,
 .inventory-column-gold,
 .inventory-count,
+.inventory-target,
 .inventory-equipped,
 .inventory-weight,
 .inventory-gold {
@@ -747,9 +822,11 @@
 }
 
 .inventory-column-count,
+.inventory-column-target,
 .inventory-column-weight,
 .inventory-column-gold,
 .inventory-count,
+.inventory-target,
 .inventory-weight,
 .inventory-gold {
   min-width: 3ch;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -230,7 +230,10 @@
 
 .trade-transfer:not(:disabled) { cursor: pointer; }
 
-.party-trade-changed { background: color-mix(in srgb, var(--accent) 12%, var(--panel-bg)); }
+.trade-inventory-row.party-trade-changed {
+  --inventory-row-background: color-mix(in srgb, var(--accent) 12%, var(--panel-bg));
+  background: var(--inventory-row-background);
+}
 .trade-delta { margin-left: .25rem; font-weight: 700; }
 .trade-delta.negative { color: var(--danger); }
 .trade-delta.positive { color: var(--success); }
@@ -550,7 +553,7 @@
 .inventory-detail-row dt { overflow:hidden; color:var(--text-muted); font-size:.64rem; letter-spacing:.035em; line-height:1.05; text-overflow:ellipsis; text-transform:uppercase; white-space:nowrap; }
 .inventory-detail-row dd { min-width:0; margin:0; overflow:hidden; color:var(--text-primary); font-size:.88rem; font-variant-numeric:tabular-nums; line-height:1.15; text-overflow:ellipsis; white-space:nowrap; }
 .inventory-detail-empty { color:var(--text-muted); font-size:var(--font-size-xs); font-style:italic; }
-.trade-inventory-row[aria-expanded="true"] { background:color-mix(in srgb, var(--accent) 14%, var(--panel-bg)); box-shadow:inset 2px 0 color-mix(in srgb, var(--accent) 72%, transparent); }
+.trade-inventory-row[aria-expanded="true"] { --inventory-row-background:color-mix(in srgb, var(--accent) 14%, var(--panel-bg)); background:var(--inventory-row-background); box-shadow:inset 2px 0 color-mix(in srgb, var(--accent) 72%, transparent); }
 @container (max-width:14rem) {
   .inventory-detail-row dl { grid-template-columns:1fr; }
 }
@@ -831,9 +834,10 @@
 }
 
 .trade-inventory-row {
+  --inventory-row-background: var(--building-interactive);
   position: relative;
   border-bottom: 1px solid var(--border-light);
-  background: var(--building-interactive);
+  background: var(--inventory-row-background);
 }
 
 .trade-row:hover,
@@ -842,7 +846,8 @@
 .trade-row:focus-within,
 .inventory-trade-row:focus-within,
 .trade-inventory-row:focus-within {
-  background: var(--building-interactive-hover);
+  --inventory-row-background: var(--building-interactive-hover);
+  background: var(--inventory-row-background);
 }
 
 body:has(.settlement-top-bar) .main-grid .btn:not(.btn-danger),

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -645,9 +645,13 @@
   flex-direction: column;
 }
 .smith-wares-scroll {
+  --inventory-merchant-action-overhang: calc(1.35rem + var(--building-frame-corner-size, 0rem) + .3rem + 8px);
   min-height: 0;
+  margin-right: calc(-1 * var(--inventory-merchant-action-overhang));
+  padding-right: var(--inventory-merchant-action-overhang);
   overflow-x: clip;
   overflow-y: auto;
+  scrollbar-gutter: stable;
 }
 .smith-wares-scroll .trade-inventory-table {
   width: max-content;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -367,7 +367,7 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: clip;
   scrollbar-gutter: stable;
 }
 
@@ -474,19 +474,15 @@
   box-shadow: 0 0 0 1px #fff, 0 0 0 2px #000;
   transform: translateX(-50%);
 }
-.inventory-browser { box-sizing:border-box; width:100%; max-width:100%; min-width:0; container-type:inline-size; }
-.inventory-browser-table-scroll {
+.inventory-browser { box-sizing:border-box; width:max-content; min-width:16rem; container-type:inline-size; }
+.inventory-browser-table-frame {
   box-sizing:border-box;
-  width:100%;
-  max-width:100%;
-  overflow-x:auto;
-  overflow-y:hidden;
-  overscroll-behavior-inline:contain;
-  scrollbar-gutter:stable;
+  width:max-content;
+  min-width:100%;
+  overflow:visible;
 }
-.inventory-browser-table-scroll:focus-visible { outline:1px solid var(--accent); outline-offset:-1px; }
-.inventory-browser-table-scroll > .trade-inventory-table { width:max-content; min-width:100%; }
-.inventory-browser-table-scroll [data-inventory-column] { min-width:4.75rem; }
+.inventory-browser-table-frame > .trade-inventory-table { width:max-content; min-width:100%; }
+.inventory-browser-table-frame [data-inventory-column] { min-width:4.75rem; }
 .inventory-browser-toolbar {
   display: flex;
   align-items: center;
@@ -647,7 +643,7 @@
 }
 .smith-wares-scroll {
   min-height: 0;
-  overflow-x: hidden;
+  overflow-x: clip;
   overflow-y: auto;
 }
 .smith-wares-scroll .trade-inventory-table {
@@ -766,10 +762,12 @@
 .inventory-item-type { width: 1.45rem; padding-inline: 0.18rem !important; text-align: center; }
 .inventory-item-type .game-icon { width: 0.95rem; height: 0.95rem; }
 
-/* Seven smith-inventory columns must fit the 20vw rail at normal desktop widths. */
+/* Smith inventories retain compact fixed-purpose columns while the rail grows
+   to accommodate them and any enabled optional statistics. */
 .smith-player-inventory-table {
-  width: 100%;
-  table-layout: fixed;
+  width: max-content;
+  min-width: 100%;
+  table-layout: auto;
 }
 .smith-player-inventory-table col.inventory-column-count { width: 1.6rem; }
 .smith-player-inventory-table col.inventory-column-target { width: 2.25rem; }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -474,6 +474,24 @@
   box-shadow: 0 0 0 1px #fff, 0 0 0 2px #000;
   transform: translateX(-50%);
 }
+.inventory-browser-toolbar { display:flex; align-items:center; gap:.35rem; padding:.35rem; border-bottom:1px solid var(--border-light); }
+.inventory-browser-search { flex:1; }
+.inventory-browser-search input { box-sizing:border-box; width:100%; min-width:0; padding:.28rem .4rem; }
+.inventory-column-picker { position:relative; }
+.inventory-column-picker summary { display:grid; place-items:center; width:1.8rem; height:1.8rem; cursor:pointer; list-style:none; }
+.inventory-column-picker summary::-webkit-details-marker { display:none; }
+.inventory-column-picker fieldset { position:absolute; z-index:60; top:100%; right:0; width:max-content; min-width:10rem; padding:.55rem; border:1px solid var(--border-light); background:var(--panel-bg); box-shadow:0 .25rem .75rem #0006; }
+.inventory-column-picker label { display:block; padding:.18rem; white-space:nowrap; }
+.trade-inventory-table th > button { width:100%; border:0; padding:0; background:transparent; color:inherit; font:inherit; cursor:pointer; }
+.inventory-sort-indicator { font-size:.65em; }
+.inventory-column-target, .inventory-target { min-width:2rem; text-align:center; }
+.inventory-detail-row td { padding:.4rem .65rem !important; background:color-mix(in srgb, var(--panel-bg) 82%, var(--accent)); }
+.inventory-detail-row dl { display:flex; flex-wrap:wrap; gap:.35rem 1rem; margin:0; }
+.inventory-detail-row dl div { display:flex; gap:.3rem; }
+.inventory-detail-row dt { color:var(--color-text-muted); }
+.inventory-detail-row dd { margin:0; }
+.trade-inventory-row[aria-expanded="true"] { background:color-mix(in srgb, var(--accent) 10%, var(--panel-bg)); }
+[data-inventory-column] { white-space:nowrap; text-align:center; }
 
 .condition-bar {
   display: inline-flex;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -645,14 +645,16 @@
   flex-direction: column;
 }
 .smith-wares-scroll {
-  --inventory-merchant-action-overhang: calc(1.35rem + var(--building-frame-corner-size, 0rem) + .3rem + 8px);
+  --inventory-merchant-action-overhang: calc(1.35rem + var(--building-frame-corner-size, 0rem) + .3rem);
   min-height: 0;
   margin-right: calc(-1 * var(--inventory-merchant-action-overhang));
   padding-right: var(--inventory-merchant-action-overhang);
+  direction: rtl;
   overflow-x: clip;
   overflow-y: auto;
   scrollbar-gutter: stable;
 }
+.smith-wares-scroll > * { direction: ltr; }
 .smith-wares-scroll .trade-inventory-table {
   width: max-content;
   min-width: 100%;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -646,8 +646,11 @@
 }
 .smith-wares-scroll {
   --inventory-merchant-action-overhang: calc(1.35rem + var(--building-frame-corner-size, 0rem) + .3rem);
+  --inventory-merchant-scrollbar-reserve: 8px;
   min-height: 0;
+  margin-left: calc(-1 * var(--inventory-merchant-scrollbar-reserve));
   margin-right: calc(-1 * var(--inventory-merchant-action-overhang));
+  padding-left: var(--inventory-merchant-scrollbar-reserve);
   padding-right: var(--inventory-merchant-action-overhang);
   direction: rtl;
   overflow-x: clip;

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -70,7 +70,7 @@
 .inventory-actions-header { width:0; min-width:0; padding:0 !important; }
 .inventory-actions-cell { position:static; overflow:visible; }
 .inventory-actions-header { position:relative; overflow:visible; }
-.inventory-row-actions { --inventory-action-bridge:calc(var(--building-frame-corner-size, 0rem) + .3rem); position:absolute; z-index:40; top:0; bottom:0; box-sizing:border-box; display:grid; align-items:center; grid-template-columns:1.35rem; gap:2px; width:calc(1.35rem + var(--inventory-action-bridge)); border-bottom:1px solid var(--border-light); background:var(--inventory-row-background, var(--building-interactive-hover)); opacity:0; transition:opacity .12s; }
+.inventory-row-actions { --inventory-action-bridge:.3rem; position:absolute; z-index:40; top:0; bottom:0; box-sizing:border-box; display:grid; align-items:center; grid-template-columns:1.35rem; gap:2px; width:calc(1.35rem + var(--inventory-action-bridge)); border-bottom:1px solid var(--border-light); background:var(--inventory-row-background, var(--building-interactive-hover)); opacity:0; transition:opacity .12s; }
 .left-sidebar .inventory-actions-cell > .inventory-row-actions { left:100%; padding-left:var(--inventory-action-bridge); }
 .right-sidebar .inventory-actions-cell > .inventory-row-actions { right:100%; padding-right:var(--inventory-action-bridge); }
 .inventory-row-actions.smith-player-actions { grid-template-columns:repeat(2,1.35rem); width:calc(2.85rem + var(--inventory-action-bridge)); }

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -93,9 +93,10 @@
 .inventory-transfer-glyph i:first-child { margin-left:0; }
 .trade-transfer-left .inventory-transfer-glyph { transform:rotate(180deg); }
 .inventory-actions-header { z-index:40; }
-.inventory-footer-actions { position:absolute; top:50%; display:flex; align-items:center; gap:2px; width:max-content; padding:0; transform:translateY(-50%); }
-.left-sidebar .inventory-actions-header > .inventory-footer-actions { left:.3rem; }
-.right-sidebar .inventory-actions-header > .inventory-footer-actions { right:.3rem; }
+.inventory-footer-actions { position:absolute; top:50%; box-sizing:border-box; display:flex; align-items:center; gap:2px; width:max-content; height:100%; min-height:1.8rem; border-bottom:1px solid var(--border-light); background:var(--panel-bg); opacity:0; transform:translateY(-50%); transition:opacity .12s; }
+.left-sidebar .inventory-actions-header > .inventory-footer-actions { left:0; padding-left:.3rem; }
+.right-sidebar .inventory-actions-header > .inventory-footer-actions { right:0; padding-right:.3rem; }
+.trade-inventory-table thead:hover .inventory-footer-actions, .inventory-footer-actions:hover, .inventory-footer-actions:focus-within { opacity:1; }
 .inventory-footer-transfer { position:static; width:1.35rem; height:1.35rem; opacity:.8; transform:none; }
 .inventory-footer-repair { display:block; width:1.35rem; height:1.35rem; }
 .inventory-footer-repair .repair-all-button { width:1.35rem; height:1.35rem; opacity:.8; }

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -89,16 +89,22 @@
 .inventory-transfer-glyph i { display:block; width:.48rem; height:.48rem; border-top:2px solid currentColor; border-right:2px solid currentColor; transform:rotate(45deg); margin-left:-.16rem; }
 .inventory-transfer-glyph i:first-child { margin-left:0; }
 .trade-transfer-left .inventory-transfer-glyph { transform:rotate(180deg); }
-.trade-inventory-table thead tr { position:relative; }
-.inventory-footer-actions { position:absolute; z-index:30; top:50%; display:grid; grid-template-columns:1.35rem; gap:2px; width:1.35rem; padding:0; transform:translateY(-50%); }
-.left-sidebar .inventory-footer-actions { right:-1.65rem; }
-.right-sidebar .inventory-footer-actions { left:-1.65rem; }
-.smith-wares-scroll .inventory-footer-actions {
-  right:5.35rem;
-  padding-left:.25rem;
-  background:linear-gradient(90deg, transparent, var(--panel-bg) .25rem);
+.inventory-actions-header {
+  position:sticky;
+  z-index:35;
+  right:0;
+  box-sizing:border-box;
+  width:1.85rem;
+  min-width:1.85rem;
+  padding:0 .2rem !important;
+  background:var(--panel-bg);
+  box-shadow:-.3rem 0 .35rem color-mix(in srgb, var(--panel-bg) 75%, transparent);
 }
+.inventory-actions-header:has(.inventory-footer-actions-grouped) { width:3.35rem; min-width:3.35rem; }
+.inventory-footer-actions { position:static; display:flex; align-items:center; justify-content:flex-end; gap:2px; width:max-content; margin-left:auto; padding:0; transform:none; }
 .inventory-footer-transfer { position:static; width:1.35rem; height:1.35rem; opacity:.8; transform:none; }
+.inventory-footer-repair { display:block; width:1.35rem; height:1.35rem; }
+.inventory-footer-repair .repair-all-button { width:1.35rem; height:1.35rem; opacity:.8; }
 .right-sidebar .inventory-footer-transfer .inventory-transfer-glyph { transform:rotate(180deg); }
 
 .party-portrait-overlay > .party-aggregate-checks {

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -65,18 +65,17 @@
 .inventory-owner-panel [data-inventory-pane] .sidebar-header { display:none; }
 .left-sidebar:has(.trade-inventory-table) .sidebar-section,
 .right-sidebar:has(.trade-inventory-table) .sidebar-section { position:relative; }
-.inventory-row-actions { position:absolute; z-index:30; top:50%; display:grid; grid-template-columns:1.35rem; gap:2px; width:1.35rem; opacity:0; transform:translateY(-50%); transition:opacity .12s; }
-.left-sidebar .inventory-row-actions { right:-1.65rem; }
-.right-sidebar .inventory-row-actions { left:-1.65rem; }
-.smith-wares-scroll .inventory-row-actions {
-  right:5.35rem;
-  padding-left:.25rem;
-  background:linear-gradient(90deg, transparent, var(--panel-bg) .25rem);
-}
+.inventory-column-actions,
+.inventory-actions-cell,
+.inventory-actions-header { width:0; min-width:0; padding:0 !important; }
+.inventory-actions-cell,
+.inventory-actions-header { position:relative; overflow:visible; }
+.inventory-row-actions { position:absolute; z-index:40; top:50%; display:grid; grid-template-columns:1.35rem; gap:2px; width:1.35rem; opacity:0; transform:translateY(-50%); transition:opacity .12s; }
+.left-sidebar .inventory-actions-cell > .inventory-row-actions { left:.3rem; }
+.right-sidebar .inventory-actions-cell > .inventory-row-actions { right:.3rem; }
 .inventory-row-actions.smith-player-actions { grid-template-columns:repeat(2,1.35rem); width:2.85rem; }
-.right-sidebar .inventory-row-actions.smith-player-actions { left:-3.15rem; }
 .smith-player-actions .row-repair-form { position:static; order:0; width:1.35rem; height:1.35rem; opacity:1; transform:none; }
-.trade-inventory-row:hover .inventory-row-actions, .inventory-row-actions:focus-within { opacity:1; }
+.trade-inventory-row:hover .inventory-row-actions, .trade-inventory-row:focus-within .inventory-row-actions, .inventory-row-actions:focus-within { opacity:1; }
 .inventory-row-actions .trade-transfer { position:static; width:1.35rem; height:1.35rem; opacity:1; transform:none; }
 .inventory-row-actions .trade-transfer::before, .inventory-footer-transfer::before { display:none; }
 .trade-inventory-row:hover .inventory-row-actions .trade-transfer, .trade-inventory-row:focus-within .inventory-row-actions .trade-transfer { opacity:1; transform:none; }
@@ -89,19 +88,10 @@
 .inventory-transfer-glyph i { display:block; width:.48rem; height:.48rem; border-top:2px solid currentColor; border-right:2px solid currentColor; transform:rotate(45deg); margin-left:-.16rem; }
 .inventory-transfer-glyph i:first-child { margin-left:0; }
 .trade-transfer-left .inventory-transfer-glyph { transform:rotate(180deg); }
-.inventory-actions-header {
-  position:sticky;
-  z-index:35;
-  right:0;
-  box-sizing:border-box;
-  width:1.85rem;
-  min-width:1.85rem;
-  padding:0 .2rem !important;
-  background:var(--panel-bg);
-  box-shadow:-.3rem 0 .35rem color-mix(in srgb, var(--panel-bg) 75%, transparent);
-}
-.inventory-actions-header:has(.inventory-footer-actions-grouped) { width:3.35rem; min-width:3.35rem; }
-.inventory-footer-actions { position:static; display:flex; align-items:center; justify-content:flex-end; gap:2px; width:max-content; margin-left:auto; padding:0; transform:none; }
+.inventory-actions-header { z-index:40; }
+.inventory-footer-actions { position:absolute; top:50%; display:flex; align-items:center; gap:2px; width:max-content; padding:0; transform:translateY(-50%); }
+.left-sidebar .inventory-actions-header > .inventory-footer-actions { left:.3rem; }
+.right-sidebar .inventory-actions-header > .inventory-footer-actions { right:.3rem; }
 .inventory-footer-transfer { position:static; width:1.35rem; height:1.35rem; opacity:.8; transform:none; }
 .inventory-footer-repair { display:block; width:1.35rem; height:1.35rem; }
 .inventory-footer-repair .repair-all-button { width:1.35rem; height:1.35rem; opacity:.8; }

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -70,16 +70,19 @@
 .inventory-actions-header { width:0; min-width:0; padding:0 !important; }
 .inventory-actions-cell { position:static; overflow:visible; }
 .inventory-actions-header { position:relative; overflow:visible; }
-.inventory-row-actions { --inventory-action-bridge:calc(var(--building-frame-corner-size, 0rem) + .3rem); position:absolute; z-index:40; top:50%; box-sizing:border-box; display:grid; align-items:center; grid-template-columns:1.35rem; gap:2px; width:calc(1.35rem + var(--inventory-action-bridge)); height:2.45rem; border-bottom:1px solid var(--border-light); background:var(--inventory-row-background, var(--building-interactive-hover)); opacity:0; transform:translateY(-50%); transition:opacity .12s; }
+.inventory-row-actions { --inventory-action-bridge:calc(var(--building-frame-corner-size, 0rem) + .3rem); position:absolute; z-index:40; top:0; bottom:0; box-sizing:border-box; display:grid; align-items:center; grid-template-columns:1.35rem; gap:2px; width:calc(1.35rem + var(--inventory-action-bridge)); border-bottom:1px solid var(--border-light); background:var(--inventory-row-background, var(--building-interactive-hover)); opacity:0; transition:opacity .12s; }
 .left-sidebar .inventory-actions-cell > .inventory-row-actions { left:100%; padding-left:var(--inventory-action-bridge); }
 .right-sidebar .inventory-actions-cell > .inventory-row-actions { right:100%; padding-right:var(--inventory-action-bridge); }
 .inventory-row-actions.smith-player-actions { grid-template-columns:repeat(2,1.35rem); width:calc(2.85rem + var(--inventory-action-bridge)); }
+.trade-inventory-row:not(:last-child) .inventory-row-actions { bottom:-1px; }
 .trade-inventory-row:last-child .inventory-row-actions { border-bottom:0; }
 .smith-player-actions .row-repair-form { position:static; order:0; width:1.35rem; height:1.35rem; opacity:1; transform:none; }
 .trade-inventory-row:hover .inventory-row-actions, .trade-inventory-row:focus-within .inventory-row-actions, .inventory-row-actions:focus-within { opacity:1; }
 .inventory-row-actions .trade-transfer { position:static; width:1.35rem; height:1.35rem; opacity:1; transform:none; }
+.inventory-row-actions button:not(:disabled) { color:var(--text-primary); }
+.inventory-row-actions .trade-transfer:disabled { color:var(--text-muted); opacity:.42; }
 .inventory-row-actions .trade-transfer::before, .inventory-footer-transfer::before { display:none; }
-.trade-inventory-row:hover .inventory-row-actions .trade-transfer, .trade-inventory-row:focus-within .inventory-row-actions .trade-transfer { opacity:1; transform:none; }
+.trade-inventory-row:hover .inventory-row-actions .trade-transfer:not(:disabled), .trade-inventory-row:focus-within .inventory-row-actions .trade-transfer:not(:disabled) { opacity:1; transform:none; }
 .inventory-target-control { display:inline-flex; align-items:center; justify-content:center; white-space:nowrap; }
 .inventory-target-denominator { display:inline-grid; grid-template-rows:.7rem 1.1rem .7rem; justify-items:center; align-items:center; min-width:1.4rem; }
 .inventory-target-step { opacity:0; border:0; background:transparent; color:var(--color-accent); line-height:.65rem; padding:0 .25rem; cursor:pointer; transition:opacity .12s; }

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -80,7 +80,7 @@
 .trade-inventory-row:hover .inventory-row-actions, .trade-inventory-row:focus-within .inventory-row-actions, .inventory-row-actions:focus-within { opacity:1; }
 .inventory-row-actions .trade-transfer { position:static; width:1.35rem; height:1.35rem; opacity:1; transform:none; }
 .inventory-row-actions button:not(:disabled) { color:var(--text-primary); }
-.inventory-row-actions .trade-transfer:disabled { color:var(--text-muted); opacity:.42; }
+.inventory-row-actions .trade-transfer:disabled { color:var(--text-muted); opacity:.42; transform:none; }
 .inventory-row-actions .trade-transfer::before, .inventory-footer-transfer::before { display:none; }
 .trade-inventory-row:hover .inventory-row-actions .trade-transfer:not(:disabled), .trade-inventory-row:focus-within .inventory-row-actions .trade-transfer:not(:disabled) { opacity:1; transform:none; }
 .inventory-target-control { display:inline-flex; align-items:center; justify-content:center; white-space:nowrap; }

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -68,12 +68,13 @@
 .inventory-column-actions,
 .inventory-actions-cell,
 .inventory-actions-header { width:0; min-width:0; padding:0 !important; }
-.inventory-actions-cell,
+.inventory-actions-cell { position:static; overflow:visible; }
 .inventory-actions-header { position:relative; overflow:visible; }
-.inventory-row-actions { position:absolute; z-index:40; top:50%; display:grid; grid-template-columns:1.35rem; gap:2px; width:1.35rem; opacity:0; transform:translateY(-50%); transition:opacity .12s; }
-.left-sidebar .inventory-actions-cell > .inventory-row-actions { left:.3rem; }
-.right-sidebar .inventory-actions-cell > .inventory-row-actions { right:.3rem; }
-.inventory-row-actions.smith-player-actions { grid-template-columns:repeat(2,1.35rem); width:2.85rem; }
+.inventory-row-actions { --inventory-action-bridge:calc(var(--building-frame-corner-size, 0rem) + .3rem); position:absolute; z-index:40; top:50%; box-sizing:border-box; display:grid; align-items:center; grid-template-columns:1.35rem; gap:2px; width:calc(1.35rem + var(--inventory-action-bridge)); height:2.45rem; border-bottom:1px solid var(--border-light); background:var(--inventory-row-background, var(--building-interactive-hover)); opacity:0; transform:translateY(-50%); transition:opacity .12s; }
+.left-sidebar .inventory-actions-cell > .inventory-row-actions { left:100%; padding-left:var(--inventory-action-bridge); }
+.right-sidebar .inventory-actions-cell > .inventory-row-actions { right:100%; padding-right:var(--inventory-action-bridge); }
+.inventory-row-actions.smith-player-actions { grid-template-columns:repeat(2,1.35rem); width:calc(2.85rem + var(--inventory-action-bridge)); }
+.trade-inventory-row:last-child .inventory-row-actions { border-bottom:0; }
 .smith-player-actions .row-repair-form { position:static; order:0; width:1.35rem; height:1.35rem; opacity:1; transform:none; }
 .trade-inventory-row:hover .inventory-row-actions, .trade-inventory-row:focus-within .inventory-row-actions, .inventory-row-actions:focus-within { opacity:1; }
 .inventory-row-actions .trade-transfer { position:static; width:1.35rem; height:1.35rem; opacity:1; transform:none; }

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -54,14 +54,24 @@
     const number = Number(trimmed.replace(/[^0-9+.-]/g, ""));
     return Number.isFinite(number) ? number : trimmed;
   };
+  function normalizeSortValue(value, type = "number") {
+    if (type === "text") return String(value || "").trim();
+    return textNumber(value);
+  }
   function rowValue(row, key) {
     const label = row.querySelector?.("[data-item-name]");
     if (key === "name") return label?.dataset.itemName || label?.textContent.trim() || "";
     if (key === "type") return label?.dataset.itemKind || "";
-    if (OPTIONAL_COLUMNS[key]) return textNumber(label?.dataset[`stat${OPTIONAL_COLUMNS[key][1][0].toUpperCase()}${OPTIONAL_COLUMNS[key][1].slice(1)}`]);
+    if (OPTIONAL_COLUMNS[key]) {
+      const value = label?.dataset[`stat${OPTIONAL_COLUMNS[key][1][0].toUpperCase()}${OPTIONAL_COLUMNS[key][1].slice(1)}`];
+      return normalizeSortValue(value, key === "damage" ? "text" : "number");
+    }
     const selectors = { quantity: ".inventory-count", target: ".inventory-target-value", equipped: ".inventory-equipped input", durability: ".inventory-durability", weight: ".inventory-weight", value: ".inventory-gold" };
     if (key === "equipped") return row.querySelector(selectors[key])?.checked ? 1 : 0;
-    return textNumber(row.querySelector(selectors[key])?.textContent);
+    const cell = row.querySelector(selectors[key]);
+    if (key === "target") return normalizeSortValue(cell?.textContent || row.querySelector(".inventory-target")?.textContent);
+    if (key === "durability") return normalizeSortValue(cell?.querySelector("[data-sort-value]")?.dataset.sortValue || cell?.dataset.sortValue || cell?.textContent);
+    return normalizeSortValue(cell?.dataset.sortValue || cell?.textContent);
   }
 
   function ensureQuantityTargetSplit(row) {
@@ -80,6 +90,32 @@
       target.textContent = targetValue == null ? "—" : targetValue;
     }
     count.after(target);
+  }
+
+  function normalizeDestinationRow(row, browser) {
+    ensureQuantityTargetSplit(row);
+    const target = row.querySelector(":scope > .inventory-target");
+    let cursor = target;
+    const wantsEquipped = Boolean(browser.querySelector("thead .inventory-column-equipped"));
+    let equipped = row.querySelector(":scope > .inventory-equipped");
+    if (!wantsEquipped && equipped) { equipped.remove(); equipped = null; }
+    if (wantsEquipped && !equipped) {
+      equipped = document.createElement("td"); equipped.className = "inventory-equipped";
+      equipped.innerHTML = '<input type="checkbox" disabled aria-label="Generated item is not equipped">';
+      cursor.after(equipped);
+    }
+    if (equipped && (row.dataset.generatedOfferRow === "true" || row.dataset.generatedMerchantRow === "true")) {
+      const toggle = equipped.querySelector("input");
+      if (toggle) { toggle.disabled = true; delete toggle.dataset.equipmentToggle; toggle.setAttribute("aria-label", "Equipment can be changed after applying the transfer"); }
+    }
+    if (equipped) cursor = equipped;
+    const wantsDurability = Boolean(browser.querySelector("thead .inventory-column-durability"));
+    let durability = row.querySelector(":scope > .inventory-durability");
+    if (!wantsDurability && durability) { durability.remove(); durability = null; }
+    if (wantsDurability && !durability) {
+      durability = document.createElement("td"); durability.className = "inventory-durability"; durability.textContent = "—";
+      cursor.after(durability);
+    }
   }
 
   function optionalCell(row, column) {
@@ -108,15 +144,15 @@
     const body = browser.querySelector("tbody");
     if (!body) return;
     const rows = [...body.querySelectorAll(":scope > tr.trade-inventory-row:not(.inventory-detail-row)")];
-    rows.forEach(ensureQuantityTargetSplit);
+    rows.forEach((row) => normalizeDestinationRow(row, browser));
     rows.forEach((row) => {
       row.tabIndex = 0;
       if (!row.hasAttribute("aria-expanded")) row.setAttribute("aria-expanded", "false");
       const name = String(rowValue(row, "name")).toLocaleLowerCase();
       row.hidden = !name.includes(state.query.toLocaleLowerCase());
       Object.keys(OPTIONAL_COLUMNS).forEach((column) => optionalCell(row, column).hidden = !state.columns.includes(column));
-      const details = row.nextElementSibling?.classList.contains("inventory-detail-row") ? row.nextElementSibling : null;
-      if (details) details.hidden = row.hidden || row.getAttribute("aria-expanded") !== "true";
+      if (row._inventoryDetail) { row._inventoryDetail.remove(); row._inventoryDetail = null; }
+      if (row.getAttribute("aria-expanded") === "true") createDetail(row, browser);
     });
     browser.querySelectorAll("thead [data-inventory-column]").forEach((header) => { header.hidden = !state.columns.includes(header.dataset.inventoryColumn); });
     rows.map((row, index) => ({ row, index })).sort((a, b) => compareValues(rowValue(a.row, state.sort), rowValue(b.row, state.sort), state.direction) || a.index - b.index).forEach(({ row }) => {
@@ -127,13 +163,12 @@
     browser.querySelectorAll("[data-inventory-sort]").forEach((button) => {
       const active = button.dataset.inventorySort === state.sort;
       button.closest("th").setAttribute("aria-sort", active ? (state.direction === "asc" ? "ascending" : "descending") : "none");
-      button.querySelector(".inventory-sort-indicator").textContent = active ? (state.direction === "asc" ? "▲" : "▼") : "";
+      const indicator = button.querySelector(".inventory-sort-indicator");
+      if (indicator) indicator.textContent = active ? (state.direction === "asc" ? "▲" : "▼") : "";
     });
   }
 
-  function toggleExpanded(row, browser) {
-    const open = row.getAttribute("aria-expanded") === "true";
-    row.setAttribute("aria-expanded", String(!open));
+  function createDetail(row, browser) {
     if (!row._inventoryDetail) {
       const detail = document.createElement("tr");
       detail.className = "inventory-detail-row";
@@ -154,7 +189,14 @@
       } else cell.textContent = "No additional details.";
       detail.append(cell); row._inventoryDetail = detail; row.after(detail);
     }
-    row._inventoryDetail.hidden = open;
+    row._inventoryDetail.hidden = row.hidden;
+  }
+
+  function toggleExpanded(row, browser) {
+    const open = row.getAttribute("aria-expanded") === "true";
+    row.setAttribute("aria-expanded", String(!open));
+    if (!open) createDetail(row, browser);
+    else if (row._inventoryDetail) row._inventoryDetail.hidden = true;
   }
 
   function mount(browser) {
@@ -198,7 +240,15 @@
   }
 
   function mountAll(root = document) { root.querySelectorAll?.("[data-inventory-browser]").forEach(mount); }
-  const api = { parsePanelState, serializePanelState, compareValues, rowValue, mountAll };
+  function refresh(scope = document) {
+    const browsers = scope.matches?.("[data-inventory-browser]") ? [scope] : [...(scope.querySelectorAll?.("[data-inventory-browser]") || [])];
+    const closest = scope.closest?.("[data-inventory-browser]"); if (closest && !browsers.includes(closest)) browsers.push(closest);
+    browsers.forEach((browser) => {
+      if (!browser.dataset.inventoryMounted) mount(browser);
+      else apply(browser, browser._inventoryState || parsePanelState(global.location.search, browser.dataset.inventoryBrowser, browser.dataset.optionalColumns.split(",").filter(Boolean)));
+    });
+  }
+  const api = { parsePanelState, serializePanelState, compareValues, normalizeSortValue, rowValue, mountAll, refresh };
   global.strategicInventoryBrowser = api;
   if (typeof module !== "undefined") module.exports = api;
   if (global.document) { global.addEventListener("DOMContentLoaded", () => mountAll()); global.addEventListener("popstate", () => mountAll()); }

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -174,8 +174,10 @@
     if (!aside || !grid) return;
     const styles = global.getComputedStyle(aside);
     const frameWidth = (Number.parseFloat(styles.paddingLeft) || 0) + (Number.parseFloat(styles.paddingRight) || 0);
-    const tableWidth = browser.querySelector(".trade-inventory-table")?.scrollWidth || 0;
-    const contentWidth = Math.ceil(Math.max(browser.scrollWidth, tableWidth));
+    const table = browser.querySelector(".trade-inventory-table");
+    const tableWidth = table?.getBoundingClientRect?.().width || table?.clientWidth || 0;
+    const browserWidth = browser.getBoundingClientRect?.().width || browser.clientWidth || 0;
+    const contentWidth = Math.ceil(Math.max(browserWidth, tableWidth));
     const side = aside.classList.contains("left-sidebar") ? "left" : "right";
     grid.style.setProperty(`--inventory-${side}-width`, `${contentWidth + frameWidth}px`);
   }

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -9,6 +9,21 @@
     flexibility: ["Flexibility", "flexibility"],
     "range-of-motion": ["Range of motion", "rangeOfMotion"],
   };
+  const DETAIL_ICONS = {
+    Slot: "knapsack",
+    Balance: "scales",
+    Mode: "crossed-swords",
+    Precision: "bullseye",
+    "Reach m": "spear-hook",
+    Penetration: "piercing-sword",
+    "Damage types": "saber-slash",
+    Block: "shield",
+    Coverage: "armor-vest",
+    "Resistance J": "bordered-shield",
+    "Padding J": "layered-armor",
+    Flexibility: "dodge",
+    "Range of motion": "acrobatic",
+  };
   const VALID_SORTS = new Set(["type", "name", "quantity", "target", "equipped", "durability", "weight", "value", ...Object.keys(OPTIONAL_COLUMNS)]);
 
   const prefix = (namespace) => `inv.${namespace}.`;
@@ -181,12 +196,20 @@
         const list = document.createElement("dl");
         entries.forEach(([name, value]) => {
           const group = document.createElement("div");
+          group.className = "inventory-detail-stat";
+          const icon = document.createElement("span");
+          icon.className = "inventory-detail-icon";
+          icon.setAttribute("aria-hidden", "true");
+          icon.style.setProperty("--inventory-detail-icon", `url('/static/icons/game/${DETAIL_ICONS[name] || "help"}.svg')`);
           const term = document.createElement("dt"); term.textContent = name;
-          const description = document.createElement("dd"); description.textContent = value;
-          group.append(term, description); list.append(group);
+          const description = document.createElement("dd"); description.textContent = value; description.title = value;
+          group.append(icon, term, description); list.append(group);
         });
         cell.append(list);
-      } else cell.textContent = "No additional details.";
+      } else {
+        cell.className = "inventory-detail-empty";
+        cell.textContent = "No additional details.";
+      }
       detail.append(cell); row._inventoryDetail = detail; row.after(detail);
     }
     row._inventoryDetail.hidden = row.hidden;
@@ -221,7 +244,8 @@
       input.addEventListener("change", () => { state.columns = [...options.querySelectorAll("input:checked")].map((entry) => entry.value); updateHistory(browser, state); apply(browser, state); });
       options.append(label);
       const th = document.createElement("th"); th.scope = "col"; th.dataset.inventoryColumn = column; th.innerHTML = `<button type="button" data-inventory-sort="${column}" aria-label="Sort by ${OPTIONAL_COLUMNS[column][0]}">${OPTIONAL_COLUMNS[column][0]} <span class="inventory-sort-indicator" aria-hidden="true"></span></button>`;
-      browser.querySelector("thead tr").append(th);
+      const headerRow = browser.querySelector("thead tr");
+      headerRow.insertBefore(th, headerRow.querySelector(".inventory-actions-header"));
     });
     search.addEventListener("input", () => { state.query = search.value; updateHistory(browser, state, browser._searchEditing === true); browser._searchEditing = true; apply(browser, state); });
     search.addEventListener("blur", () => { browser._searchEditing = false; });

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -108,16 +108,26 @@
   }
 
   function normalizeDestinationRow(row, browser) {
-    ensureQuantityTargetSplit(row);
+    const wantsQuantities = Boolean(browser.querySelector("thead .inventory-column-count"));
+    if (wantsQuantities) {
+      const count = row.querySelector(":scope > .inventory-count");
+      if (count) count.hidden = false;
+      ensureQuantityTargetSplit(row);
+    }
+    else {
+      const count = row.querySelector(":scope > .inventory-count");
+      if (count) count.hidden = true;
+      row.querySelector(":scope > .inventory-target")?.remove();
+    }
     const target = row.querySelector(":scope > .inventory-target");
-    let cursor = target;
+    let cursor = target || row.querySelector(":scope > .inventory-item-name");
     const wantsEquipped = Boolean(browser.querySelector("thead .inventory-column-equipped"));
     let equipped = row.querySelector(":scope > .inventory-equipped");
     if (!wantsEquipped && equipped) { equipped.remove(); equipped = null; }
     if (wantsEquipped && !equipped) {
       equipped = document.createElement("td"); equipped.className = "inventory-equipped";
       equipped.innerHTML = '<input type="checkbox" disabled aria-label="Generated item is not equipped">';
-      cursor.after(equipped);
+      cursor?.after(equipped);
     }
     if (equipped && (row.dataset.generatedOfferRow === "true" || row.dataset.generatedMerchantRow === "true")) {
       const toggle = equipped.querySelector("input");
@@ -129,7 +139,7 @@
     if (!wantsDurability && durability) { durability.remove(); durability = null; }
     if (wantsDurability && !durability) {
       durability = document.createElement("td"); durability.className = "inventory-durability"; durability.textContent = "—";
-      cursor.after(durability);
+      cursor?.after(durability);
     }
   }
 
@@ -145,7 +155,9 @@
     const weaponColumn = ["accuracy", "reach", "penetration", "damage", "block"].includes(column);
     const applicable = weaponColumn ? ["weapon", "shield"].includes(kind) : kind === "armor";
     cell.textContent = applicable ? (label?.dataset[property] || "—") : "—";
-    row.append(cell);
+    const actionCell = row.querySelector(":scope > .inventory-actions-cell");
+    if (actionCell && actionCell === row.lastElementChild) row.insertBefore(cell, actionCell);
+    else row.append(cell);
     return cell;
   }
 
@@ -153,6 +165,19 @@
     const query = serializePanelState(global.location.search, browser.dataset.inventoryBrowser, state);
     const url = `${global.location.pathname}${query}${global.location.hash}`;
     global.history[replace ? "replaceState" : "pushState"]({}, "", url);
+  }
+
+  function syncPanelWidth(browser) {
+    if (!global.getComputedStyle || browser.closest("[hidden]")) return;
+    const aside = browser.closest(".left-sidebar, .right-sidebar");
+    const grid = aside?.closest(".main-grid");
+    if (!aside || !grid) return;
+    const styles = global.getComputedStyle(aside);
+    const frameWidth = (Number.parseFloat(styles.paddingLeft) || 0) + (Number.parseFloat(styles.paddingRight) || 0);
+    const tableWidth = browser.querySelector(".trade-inventory-table")?.scrollWidth || 0;
+    const contentWidth = Math.ceil(Math.max(browser.scrollWidth, tableWidth));
+    const side = aside.classList.contains("left-sidebar") ? "left" : "right";
+    grid.style.setProperty(`--inventory-${side}-width`, `${contentWidth + frameWidth}px`);
   }
 
   function apply(browser, state) {
@@ -181,6 +206,7 @@
       const indicator = button.querySelector(".inventory-sort-indicator");
       if (indicator) indicator.textContent = active ? (state.direction === "asc" ? "▲" : "▼") : "";
     });
+    syncPanelWidth(browser);
   }
 
   function createDetail(row, browser) {
@@ -245,7 +271,9 @@
       options.append(label);
       const th = document.createElement("th"); th.scope = "col"; th.dataset.inventoryColumn = column; th.innerHTML = `<button type="button" data-inventory-sort="${column}" aria-label="Sort by ${OPTIONAL_COLUMNS[column][0]}">${OPTIONAL_COLUMNS[column][0]} <span class="inventory-sort-indicator" aria-hidden="true"></span></button>`;
       const headerRow = browser.querySelector("thead tr");
-      headerRow.insertBefore(th, headerRow.querySelector(".inventory-actions-header"));
+      const actionHeader = headerRow.querySelector(":scope > .inventory-actions-header");
+      if (actionHeader && actionHeader === headerRow.lastElementChild) headerRow.insertBefore(th, actionHeader);
+      else headerRow.append(th);
     });
     search.addEventListener("input", () => { state.query = search.value; updateHistory(browser, state, browser._searchEditing === true); browser._searchEditing = true; apply(browser, state); });
     search.addEventListener("blur", () => { browser._searchEditing = false; });
@@ -272,7 +300,7 @@
       else apply(browser, browser._inventoryState || parsePanelState(global.location.search, browser.dataset.inventoryBrowser, browser.dataset.optionalColumns.split(",").filter(Boolean)));
     });
   }
-  const api = { parsePanelState, serializePanelState, compareValues, normalizeSortValue, rowValue, mountAll, refresh };
+  const api = { parsePanelState, serializePanelState, compareValues, normalizeSortValue, rowValue, mountAll, refresh, syncPanelWidth };
   global.strategicInventoryBrowser = api;
   if (typeof module !== "undefined") module.exports = api;
   if (global.document) { global.addEventListener("DOMContentLoaded", () => mountAll()); global.addEventListener("popstate", () => mountAll()); }

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -1,0 +1,205 @@
+(function inventoryBrowserModule(global) {
+  "use strict";
+
+  const OPTIONAL_COLUMNS = {
+    accuracy: ["Precision", "accuracy"], reach: ["Reach m", "reach"],
+    penetration: ["Penetration", "penetration"], damage: ["Damage types", "damage"],
+    block: ["Block", "block"], coverage: ["Coverage", "coverage"],
+    resistance: ["Resistance J", "resistance"], padding: ["Padding J", "padding"],
+    flexibility: ["Flexibility", "flexibility"],
+    "range-of-motion": ["Range of motion", "rangeOfMotion"],
+  };
+  const VALID_SORTS = new Set(["type", "name", "quantity", "target", "equipped", "durability", "weight", "value", ...Object.keys(OPTIONAL_COLUMNS)]);
+
+  const prefix = (namespace) => `inv.${namespace}.`;
+  function parsePanelState(search, namespace, available = []) {
+    const params = new URLSearchParams(search);
+    const p = prefix(namespace);
+    const sort = params.get(`${p}sort`);
+    const direction = params.get(`${p}dir`);
+    const allowed = new Set(available);
+    return {
+      query: params.get(`${p}q`) || "",
+      sort: VALID_SORTS.has(sort) ? sort : "name",
+      direction: direction === "desc" ? "desc" : "asc",
+      columns: (params.get(`${p}cols`) || "").split(",").filter((column) => allowed.has(column)),
+    };
+  }
+
+  function serializePanelState(search, namespace, state) {
+    const params = new URLSearchParams(search);
+    const p = prefix(namespace);
+    [["q", state.query], ["sort", state.sort], ["dir", state.direction], ["cols", state.columns.join(",")]].forEach(([key, value]) => {
+      if (value && !(key === "sort" && value === "name") && !(key === "dir" && value === "asc")) params.set(`${p}${key}`, value);
+      else params.delete(`${p}${key}`);
+    });
+    const encoded = params.toString();
+    return encoded ? `?${encoded}` : "";
+  }
+
+  function compareValues(left, right, direction = "asc") {
+    const blankLeft = left === "" || left == null || Number.isNaN(left);
+    const blankRight = right === "" || right == null || Number.isNaN(right);
+    if (blankLeft !== blankRight) return blankLeft ? 1 : -1;
+    if (blankLeft) return 0;
+    const result = typeof left === "number" && typeof right === "number"
+      ? left - right
+      : String(left).localeCompare(String(right), undefined, { sensitivity: "base", numeric: true });
+    return direction === "desc" ? -result : result;
+  }
+
+  const textNumber = (text) => {
+    const trimmed = String(text || "").trim();
+    if (!trimmed || trimmed === "—") return "";
+    const number = Number(trimmed.replace(/[^0-9+.-]/g, ""));
+    return Number.isFinite(number) ? number : trimmed;
+  };
+  function rowValue(row, key) {
+    const label = row.querySelector?.("[data-item-name]");
+    if (key === "name") return label?.dataset.itemName || label?.textContent.trim() || "";
+    if (key === "type") return label?.dataset.itemKind || "";
+    if (OPTIONAL_COLUMNS[key]) return textNumber(label?.dataset[`stat${OPTIONAL_COLUMNS[key][1][0].toUpperCase()}${OPTIONAL_COLUMNS[key][1].slice(1)}`]);
+    const selectors = { quantity: ".inventory-count", target: ".inventory-target-value", equipped: ".inventory-equipped input", durability: ".inventory-durability", weight: ".inventory-weight", value: ".inventory-gold" };
+    if (key === "equipped") return row.querySelector(selectors[key])?.checked ? 1 : 0;
+    return textNumber(row.querySelector(selectors[key])?.textContent);
+  }
+
+  function ensureQuantityTargetSplit(row) {
+    const count = row.querySelector(":scope > .inventory-count");
+    if (!count || row.querySelector(":scope > .inventory-target")) return;
+    const control = count.querySelector("[data-target-control]");
+    const target = document.createElement("td");
+    target.className = "inventory-target";
+    if (control) {
+      target.append(control);
+      const quantity = control.dataset.quantity || row.dataset.inventoryQuantity || "0";
+      row.dataset.inventoryQuantity = quantity;
+      count.textContent = quantity;
+    } else {
+      const targetValue = row.dataset.target || row.querySelector("[data-target]")?.dataset.target;
+      target.textContent = targetValue == null ? "—" : targetValue;
+    }
+    count.after(target);
+  }
+
+  function optionalCell(row, column) {
+    let cell = row.querySelector(`[data-inventory-column="${column}"]`);
+    if (cell) return cell;
+    cell = document.createElement("td");
+    cell.dataset.inventoryColumn = column;
+    const dataKey = OPTIONAL_COLUMNS[column][1];
+    const property = `stat${dataKey[0].toUpperCase()}${dataKey.slice(1)}`;
+    const label = row.querySelector("[data-item-name]");
+    const kind = label?.dataset.itemKind;
+    const weaponColumn = ["accuracy", "reach", "penetration", "damage", "block"].includes(column);
+    const applicable = weaponColumn ? ["weapon", "shield"].includes(kind) : kind === "armor";
+    cell.textContent = applicable ? (label?.dataset[property] || "—") : "—";
+    row.append(cell);
+    return cell;
+  }
+
+  function updateHistory(browser, state, replace = false) {
+    const query = serializePanelState(global.location.search, browser.dataset.inventoryBrowser, state);
+    const url = `${global.location.pathname}${query}${global.location.hash}`;
+    global.history[replace ? "replaceState" : "pushState"]({}, "", url);
+  }
+
+  function apply(browser, state) {
+    const body = browser.querySelector("tbody");
+    if (!body) return;
+    const rows = [...body.querySelectorAll(":scope > tr.trade-inventory-row:not(.inventory-detail-row)")];
+    rows.forEach(ensureQuantityTargetSplit);
+    rows.forEach((row) => {
+      row.tabIndex = 0;
+      if (!row.hasAttribute("aria-expanded")) row.setAttribute("aria-expanded", "false");
+      const name = String(rowValue(row, "name")).toLocaleLowerCase();
+      row.hidden = !name.includes(state.query.toLocaleLowerCase());
+      Object.keys(OPTIONAL_COLUMNS).forEach((column) => optionalCell(row, column).hidden = !state.columns.includes(column));
+      const details = row.nextElementSibling?.classList.contains("inventory-detail-row") ? row.nextElementSibling : null;
+      if (details) details.hidden = row.hidden || row.getAttribute("aria-expanded") !== "true";
+    });
+    browser.querySelectorAll("thead [data-inventory-column]").forEach((header) => { header.hidden = !state.columns.includes(header.dataset.inventoryColumn); });
+    rows.map((row, index) => ({ row, index })).sort((a, b) => compareValues(rowValue(a.row, state.sort), rowValue(b.row, state.sort), state.direction) || a.index - b.index).forEach(({ row }) => {
+      body.append(row);
+      const detail = row._inventoryDetail;
+      if (detail) body.append(detail);
+    });
+    browser.querySelectorAll("[data-inventory-sort]").forEach((button) => {
+      const active = button.dataset.inventorySort === state.sort;
+      button.closest("th").setAttribute("aria-sort", active ? (state.direction === "asc" ? "ascending" : "descending") : "none");
+      button.querySelector(".inventory-sort-indicator").textContent = active ? (state.direction === "asc" ? "▲" : "▼") : "";
+    });
+  }
+
+  function toggleExpanded(row, browser) {
+    const open = row.getAttribute("aria-expanded") === "true";
+    row.setAttribute("aria-expanded", String(!open));
+    if (!row._inventoryDetail) {
+      const detail = document.createElement("tr");
+      detail.className = "inventory-detail-row";
+      const cell = document.createElement("td");
+      cell.colSpan = 20;
+      const label = row.querySelector("[data-item-name]");
+      const visible = new Set(parsePanelState(global.location.search, browser.dataset.inventoryBrowser, browser.dataset.optionalColumns.split(",").filter(Boolean)).columns);
+      const entries = [["Slot", label?.dataset.detailSlot], ["Balance", label?.dataset.detailBalance], ["Mode", label?.dataset.detailMode], ...Object.entries(OPTIONAL_COLUMNS).filter(([key]) => !visible.has(key)).map(([key, [name, dataKey]]) => [name, label?.dataset[`stat${dataKey[0].toUpperCase()}${dataKey.slice(1)}`]])].filter(([, value]) => value && value !== "0" && value !== "—");
+      if (entries.length) {
+        const list = document.createElement("dl");
+        entries.forEach(([name, value]) => {
+          const group = document.createElement("div");
+          const term = document.createElement("dt"); term.textContent = name;
+          const description = document.createElement("dd"); description.textContent = value;
+          group.append(term, description); list.append(group);
+        });
+        cell.append(list);
+      } else cell.textContent = "No additional details.";
+      detail.append(cell); row._inventoryDetail = detail; row.after(detail);
+    }
+    row._inventoryDetail.hidden = open;
+  }
+
+  function mount(browser) {
+    if (browser.dataset.inventoryMounted) { // live refresh may preserve the wrapper but replace rows
+      const refreshed = parsePanelState(global.location.search, browser.dataset.inventoryBrowser, browser.dataset.optionalColumns.split(",").filter(Boolean));
+      Object.assign(browser._inventoryState, refreshed);
+      const search = browser.querySelector("[data-inventory-search]"); if (search) search.value = refreshed.query;
+      browser.querySelectorAll("[data-inventory-column-options] input").forEach((input) => { input.checked = refreshed.columns.includes(input.value); });
+      apply(browser, browser._inventoryState);
+      return;
+    }
+    browser.dataset.inventoryMounted = "true";
+    const available = browser.dataset.optionalColumns.split(",").filter(Boolean);
+    let state = parsePanelState(global.location.search, browser.dataset.inventoryBrowser, available);
+    browser._inventoryState = state;
+    const search = browser.querySelector("[data-inventory-search]"); search.value = state.query;
+    const options = browser.querySelector("[data-inventory-column-options]");
+    available.forEach((column) => {
+      const label = document.createElement("label");
+      label.innerHTML = `<input type="checkbox" value="${column}"> ${OPTIONAL_COLUMNS[column][0]}`;
+      const input = label.querySelector("input"); input.checked = state.columns.includes(column);
+      input.addEventListener("change", () => { state.columns = [...options.querySelectorAll("input:checked")].map((entry) => entry.value); updateHistory(browser, state); apply(browser, state); });
+      options.append(label);
+      const th = document.createElement("th"); th.scope = "col"; th.dataset.inventoryColumn = column; th.innerHTML = `<button type="button" data-inventory-sort="${column}" aria-label="Sort by ${OPTIONAL_COLUMNS[column][0]}">${OPTIONAL_COLUMNS[column][0]} <span class="inventory-sort-indicator" aria-hidden="true"></span></button>`;
+      browser.querySelector("thead tr").append(th);
+    });
+    search.addEventListener("input", () => { state.query = search.value; updateHistory(browser, state, browser._searchEditing === true); browser._searchEditing = true; apply(browser, state); });
+    search.addEventListener("blur", () => { browser._searchEditing = false; });
+    browser.addEventListener("click", (event) => {
+      const sort = event.target.closest("[data-inventory-sort]");
+      if (sort) { const key = sort.dataset.inventorySort; state.direction = state.sort === key && state.direction === "asc" ? "desc" : "asc"; state.sort = key; updateHistory(browser, state); apply(browser, state); return; }
+      const row = event.target.closest("tr.trade-inventory-row");
+      if (row && !event.target.closest("button,input,a,select,textarea,label,form,details,summary")) toggleExpanded(row, browser);
+    });
+    browser.addEventListener("keydown", (event) => {
+      if ((event.key === "Enter" || event.key === " ") && event.target.matches("tr.trade-inventory-row")) {
+        event.preventDefault(); toggleExpanded(event.target, browser);
+      }
+    });
+    apply(browser, state);
+  }
+
+  function mountAll(root = document) { root.querySelectorAll?.("[data-inventory-browser]").forEach(mount); }
+  const api = { parsePanelState, serializePanelState, compareValues, rowValue, mountAll };
+  global.strategicInventoryBrowser = api;
+  if (typeof module !== "undefined") module.exports = api;
+  if (global.document) { global.addEventListener("DOMContentLoaded", () => mountAll()); global.addEventListener("popstate", () => mountAll()); }
+})(typeof window === "undefined" ? globalThis : window);

--- a/crates/strategic-web/static/live-regions.js
+++ b/crates/strategic-web/static/live-regions.js
@@ -75,6 +75,7 @@
 
     // Match the post-mount table structure before comparing it with the live DOM.
     window.strategicTradeUi?.mountInventoryBulkControls?.(nextDocument);
+    window.strategicInventoryBrowser?.mountAll?.(nextDocument);
     const inventoryTab = selectedInventoryTab();
     const leftSidebarScroll = scrollOffsets(".left-sidebar");
     const rightSidebarScroll = scrollOffsets(".right-sidebar");

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -1,4 +1,5 @@
 const strategicTradeUi = window.strategicTradeUi ||= { state: {} };
+const refreshInventoryPanel = (element) => { if (element) window.strategicInventoryBrowser?.refresh?.(element); };
 
 function changeTradeDraftCount(row, change) {
   const count = row.querySelector(".inventory-count");
@@ -136,6 +137,7 @@ function ensureMerchantPlayerRow(itemId, sourceRow) {
   name.append(cancel);
   applyDynamicTransferModifiers();
   playerSidebar.querySelector(".trade-inventory-table tbody").append(row);
+  refreshInventoryPanel(playerSidebar);
   return row;
 }
 
@@ -181,6 +183,7 @@ function resetTradeDraft(form) {
   form.querySelectorAll("input:not([name='return_to']):not([name='inventory_scope'])").forEach((input) => input.remove());
   form.hidden = true;
   form.querySelector("[type='submit']").disabled = true;
+  window.strategicInventoryBrowser?.refresh?.(document);
 }
 
 function updateDiscardForm() {
@@ -235,7 +238,7 @@ function ensureDiscardRow(sourceRow, inventoryId) {
   delete count.dataset.tradeDraftChange;
   document.querySelector("[data-discard-table] tbody").append(row);
   applyDynamicTransferModifiers();
-  window.strategicInventoryBrowser?.mountAll?.();
+  refreshInventoryPanel(row);
   return row;
 }
 
@@ -357,6 +360,8 @@ document.addEventListener("click", (event) => {
       draft.set(id, quantity - amount);
       stagedRow.querySelector(".inventory-count").textContent = String(quantity - amount);
     }
+    refreshInventoryPanel(sourceRow || document.querySelector("[data-discard-table]"));
+    refreshInventoryPanel(document.querySelector("[data-discard-table]"));
     updateDiscardForm();
     return;
   }
@@ -372,7 +377,10 @@ document.addEventListener("click", (event) => {
     const amount = mode === "one" ? 1 : available - quantity;
     draft.set(id, quantity + amount);
     setTradeDraftCount(sourceRow, -(quantity + amount));
-    ensureDiscardRow(sourceRow, id).querySelector(".inventory-count").textContent = String(quantity + amount);
+    const stagedRow = ensureDiscardRow(sourceRow, id);
+    stagedRow.querySelector(".inventory-count").textContent = String(quantity + amount);
+    refreshInventoryPanel(sourceRow);
+    refreshInventoryPanel(stagedRow);
     updateDiscardForm();
     return;
   }
@@ -390,8 +398,11 @@ document.addEventListener("click", (event) => {
     if (!amount) return;
     if (amount >= quantity) buys.delete(itemId); else buys.set(itemId, quantity - amount);
     changeTradeDraftCount(playerRow, -amount);
-    changeTradeDraftCount(merchantRow(itemId, document.querySelector(".left-sidebar")), amount);
+    const stockRow = merchantRow(itemId, document.querySelector(".left-sidebar"));
+    changeTradeDraftCount(stockRow, amount);
     if (playerRow.dataset.generatedMerchantRow === "true" && Number(playerRow.querySelector(".inventory-count").dataset.tradeDraftChange || 0) === 0) playerRow.remove();
+    refreshInventoryPanel(stockRow);
+    refreshInventoryPanel(document.querySelector('[data-inventory-pane]:not([hidden])'));
     updateMerchantGoldDraft();
     updateMerchantOfferForm();
     return;
@@ -405,7 +416,9 @@ document.addEventListener("click", (event) => {
     if (pendingPurchase > 0) {
       if (pendingPurchase === 1) buys.delete(itemId); else buys.set(itemId, pendingPurchase - 1);
       changeTradeDraftCount(sourceRow, -1);
-      changeTradeDraftCount(merchantRow(itemId, document.querySelector(".left-sidebar")), 1);
+      const stockRow = merchantRow(itemId, document.querySelector(".left-sidebar"));
+      changeTradeDraftCount(stockRow, 1);
+      refreshInventoryPanel(sourceRow); refreshInventoryPanel(stockRow);
       updateMerchantGoldDraft();
       updateMerchantOfferForm();
       return;
@@ -422,6 +435,7 @@ document.addEventListener("click", (event) => {
     changeTradeDraftCount(sourceRow, -amount);
     const stockRow = merchantRow(itemId, document.querySelector(".left-sidebar"));
     if (stockRow) changeTradeDraftCount(stockRow, amount);
+    refreshInventoryPanel(sourceRow); refreshInventoryPanel(stockRow);
     updateMerchantGoldDraft();
     updateMerchantOfferForm();
     return;
@@ -443,7 +457,10 @@ document.addEventListener("click", (event) => {
     (strategicTradeUi.state.merchantBuyPrices ||= new Map()).set(item, Number(merchantButton.dataset.merchantBuyPrice));
     const sourceRow = merchantButton.closest("tr");
     changeTradeDraftCount(sourceRow, -amount);
-    changeTradeDraftCount(ensureMerchantPlayerRow(item, sourceRow), amount);
+    const playerRow = ensureMerchantPlayerRow(item, sourceRow);
+    changeTradeDraftCount(playerRow, amount);
+    refreshInventoryPanel(playerRow);
+    refreshInventoryPanel(sourceRow);
     updateMerchantGoldDraft();
     updateMerchantOfferForm();
     return;
@@ -474,6 +491,8 @@ document.addEventListener("click", (event) => {
     targetSidebar.querySelector(".trade-inventory-table tbody").append(targetRow);
   }
   setTradeDraftCount(targetRow, entry.quantity);
+  refreshInventoryPanel(targetRow);
+  refreshInventoryPanel(button.closest("tr"));
   const form = document.querySelector("#party-offer");
   form.querySelectorAll("input").forEach((input) => input.remove());
   const fields = { from_character_ids: [], to_character_ids: [], inventory_item_ids: [], quantities: [] };

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -303,10 +303,12 @@ function updateMerchantGoldDraft() {
 }
 
 document.addEventListener("click", (event) => {
-  if (event.isTrusted && event.target.closest("[data-dynamic-transfer]")) {
+  const dynamicTransfer = event.target.closest?.("[data-dynamic-transfer]");
+  const clickTarget = dynamicTransfer || event.target;
+  if (event.isTrusted && dynamicTransfer) {
     applyDynamicTransferModifiers(event);
   }
-  const tab = event.target.closest("[data-inventory-tab]");
+  const tab = clickTarget.closest("[data-inventory-tab]");
   if (tab) {
     const root = tab.closest("[data-inventory-tabs]");
     root.querySelectorAll("[data-inventory-tab]").forEach((entry) => entry.classList.toggle("active", entry === tab));
@@ -317,20 +319,20 @@ document.addEventListener("click", (event) => {
     refreshInventoryPanel(root.querySelector('[data-inventory-pane]:not([hidden])'));
     return;
   }
-  const targetStep = event.target.closest("[data-target-step]");
+  const targetStep = clickTarget.closest("[data-target-step]");
   if (targetStep) {
     event.preventDefault();
     changeInventoryTarget(targetStep.closest("[data-target-control]"), Number(targetStep.dataset.targetStep));
     return;
   }
-  const bulk = event.target.closest("[data-inventory-bulk]");
+  const bulk = clickTarget.closest("[data-inventory-bulk]");
   if (bulk) {
     const panel = bulk.closest("aside, section, .sidebar-section") || document;
     const selector = bulk.dataset.inventoryBulk === "buy" ? "[data-merchant-buy]" : bulk.dataset.inventoryBulk === "loot" ? "[data-loot-stage]" : ["deposit", "withdraw"].includes(bulk.dataset.inventoryBulk) ? `[data-pool-stage][data-pool-direction="${bulk.dataset.inventoryBulk}"]` : bulk.dataset.inventoryBulk.startsWith("party-") ? ".party-draft-transfer" : "[data-merchant-sell]";
     panel.querySelectorAll(`${selector}[data-transfer-mode="${bulk.dataset.transferMode}"]`).forEach((button) => button.click());
     return;
   }
-  const cancelLoot = event.target.closest("[data-cancel-loot]");
+  const cancelLoot = clickTarget.closest("[data-cancel-loot]");
   if (cancelLoot) {
     strategicTradeUi.state.lootTransferDraft = new Map();
     document.querySelectorAll("[data-loot-row]").forEach((row) => setTradeDraftCount(row, 0));
@@ -340,7 +342,7 @@ document.addEventListener("click", (event) => {
     document.dispatchEvent(new Event("strategic-live-refresh-requested"));
     return;
   }
-  const lootStage = event.target.closest("[data-loot-stage]");
+  const lootStage = clickTarget.closest("[data-loot-stage]");
   if (lootStage) {
     const row = lootStage.closest("tr");
     const draft = strategicTradeUi.state.lootTransferDraft ||= new Map();
@@ -360,9 +362,9 @@ document.addEventListener("click", (event) => {
     form.hidden = false; form.querySelector('[type="submit"]').disabled = false;
     return;
   }
-  const cancelPool = event.target.closest("[data-cancel-pool]");
+  const cancelPool = clickTarget.closest("[data-cancel-pool]");
   if (cancelPool) { strategicTradeUi.state.poolTransferDraft = new Map(); document.querySelectorAll("[data-pool-stage]").forEach((button) => setTradeDraftCount(button.closest("tr"), 0)); const form=cancelPool.closest("form"); form.querySelectorAll("input").forEach((input)=>input.remove()); form.hidden=true; document.dispatchEvent(new Event("strategic-live-refresh-requested")); return; }
-  const poolStage = event.target.closest("[data-pool-stage]");
+  const poolStage = clickTarget.closest("[data-pool-stage]");
   if (poolStage) {
     const form = document.querySelector("#pool-transfer-offer");
     if (form.dataset.direction && form.dataset.direction !== poolStage.dataset.poolDirection) { strategicTradeUi.state.poolTransferDraft = new Map(); document.querySelectorAll("[data-pool-stage]").forEach((button) => setTradeDraftCount(button.closest("tr"), 0)); }
@@ -376,13 +378,13 @@ document.addEventListener("click", (event) => {
     for (const [name, values] of Object.entries({item_id:[...draft.keys()],quantity:[...draft.values()]})) { const input=document.createElement("input");input.type="hidden";input.name=name;input.value=values.join(",");form.append(input); }
     form.hidden=false;form.querySelector('[type="submit"]').disabled=false;return;
   }
-  const cancelTrade = event.target.closest("[data-cancel-trade]");
+  const cancelTrade = clickTarget.closest("[data-cancel-trade]");
   if (cancelTrade) {
     resetTradeDraft(cancelTrade.closest("form"));
     document.dispatchEvent(new Event("strategic-live-refresh-requested"));
     return;
   }
-  const unstageDiscard = event.target.closest("[data-unstage-discard]");
+  const unstageDiscard = clickTarget.closest("[data-unstage-discard]");
   if (unstageDiscard) {
     const id = unstageDiscard.dataset.unstageDiscard;
     const draft = strategicTradeUi.state.inventoryDiscardDraft ||= new Map();
@@ -405,7 +407,7 @@ document.addEventListener("click", (event) => {
     updateDiscardForm();
     return;
   }
-  const discardItem = event.target.closest("[data-discard-item]");
+  const discardItem = clickTarget.closest("[data-discard-item]");
   if (discardItem) {
     const id = discardItem.dataset.discardItem;
     const sourceRow = discardItem.closest("tr");
@@ -424,7 +426,7 @@ document.addEventListener("click", (event) => {
     updateDiscardForm();
     return;
   }
-  const cancelBuy = event.target.closest("[data-merchant-cancel-buy]");
+  const cancelBuy = clickTarget.closest("[data-merchant-cancel-buy]");
   if (cancelBuy) {
     const itemId = cancelBuy.dataset.merchantCancelBuy;
     const buys = strategicTradeUi.state.merchantDraft ||= new Map();
@@ -447,7 +449,7 @@ document.addEventListener("click", (event) => {
     updateMerchantOfferForm();
     return;
   }
-  const merchantSell = event.target.closest("[data-merchant-sell]");
+  const merchantSell = clickTarget.closest("[data-merchant-sell]");
   if (merchantSell) {
     const itemId = merchantSell.dataset.itemName;
     const buys = strategicTradeUi.state.merchantDraft ||= new Map();
@@ -480,7 +482,7 @@ document.addEventListener("click", (event) => {
     updateMerchantOfferForm();
     return;
   }
-  const merchantButton = event.target.closest("[data-merchant-buy]");
+  const merchantButton = clickTarget.closest("[data-merchant-buy]");
   if (merchantButton) {
     const draft = strategicTradeUi.state.merchantDraft ||= new Map();
     const item = merchantButton.dataset.merchantBuy;
@@ -505,7 +507,7 @@ document.addEventListener("click", (event) => {
     updateMerchantOfferForm();
     return;
   }
-  const button = event.target.closest(".party-draft-transfer");
+  const button = clickTarget.closest(".party-draft-transfer");
   if (!button) return;
   const key = button.dataset.item;
   const draft = strategicTradeUi.state.partyTradeDraft ||= new Map();

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -1,5 +1,18 @@
 const strategicTradeUi = window.strategicTradeUi ||= { state: {} };
-const refreshInventoryPanel = (element) => { if (element) window.strategicInventoryBrowser?.refresh?.(element); };
+const refreshInventoryPanel = (element) => {
+  if (!element) return;
+  if (element === document) {
+    const grid = document.querySelector(".main-grid");
+    ["left", "right"].forEach((side) => {
+      const sidebar = grid?.querySelector(`.${side}-sidebar`);
+      const hasVisibleBrowser = [...(sidebar?.querySelectorAll("[data-inventory-browser]") || [])]
+        .some((browser) => !browser.closest("[hidden]"));
+      if (!hasVisibleBrowser) grid?.style.removeProperty(`--inventory-${side}-width`);
+    });
+  }
+  window.strategicInventoryBrowser?.refresh?.(element);
+  mountInventoryBulkControls(element);
+};
 
 function changeTradeDraftCount(row, change) {
   const count = row.querySelector(".inventory-count");
@@ -9,18 +22,36 @@ function changeTradeDraftCount(row, change) {
 
 function mountInventoryBulkControls(root = document) {
   if (!root?.querySelectorAll) root = document;
+  const browsers = root.matches?.("[data-inventory-browser]") ? [root] : [...root.querySelectorAll("[data-inventory-browser]")];
+  const closestBrowser = root.closest?.("[data-inventory-browser]");
+  if (closestBrowser && !browsers.includes(closestBrowser)) browsers.push(closestBrowser);
+
+  browsers.forEach((browser) => {
+    const placeAtStart = Boolean(browser.closest(".right-sidebar"));
+    const headerRow = browser.querySelector(".trade-inventory-table thead tr");
+    const headerCell = headerRow?.querySelector(":scope > .inventory-actions-header");
+    const actionColumn = browser.querySelector(".trade-inventory-table colgroup .inventory-column-actions");
+    if (headerCell) headerRow[placeAtStart ? "prepend" : "append"](headerCell);
+    if (actionColumn) actionColumn.parentElement[placeAtStart ? "prepend" : "append"](actionColumn);
+
+    browser.querySelectorAll("tbody > tr.trade-inventory-row:not(.inventory-detail-row)").forEach((row) => {
+      let cell = row.querySelector(":scope > .inventory-actions-cell");
+      if (!cell) {
+        cell = document.createElement("td");
+        cell.className = "inventory-actions-cell";
+        cell.setAttribute("aria-label", "Item actions");
+      }
+      const actions = row.querySelector(".inventory-row-actions");
+      if (actions && actions.parentElement !== cell) cell.append(actions);
+      row[placeAtStart ? "prepend" : "append"](cell);
+    });
+  });
+
   root.querySelectorAll(".inventory-footer-actions").forEach((actions) => {
     if (actions.closest(".inventory-actions-header")) return;
-    const section = actions.closest(".sidebar-section");
-    const headerRow = section?.querySelector(".trade-inventory-table thead tr");
-    if (headerRow) {
-      const cell = document.createElement("th");
-      cell.scope = "col";
-      cell.className = "inventory-actions-header";
-      cell.setAttribute("aria-label", "Inventory actions");
-      cell.append(actions);
-      headerRow.append(cell);
-    }
+    const inventoryRegion = actions.closest(".encumbrance-inventory-rail, .smith-wares-scroll, .sidebar-section");
+    const headerCell = inventoryRegion?.querySelector("[data-inventory-browser] .inventory-actions-header");
+    if (headerCell) headerCell.append(actions);
   });
   applyDynamicTransferModifiers();
 }
@@ -128,7 +159,7 @@ function ensureMerchantPlayerRow(itemId, sourceRow) {
   (row.querySelector(".inventory-target") || count).after(equipped);
   row.querySelector(".inventory-gold").textContent = sourceRow.dataset.merchantSellPrice;
   row.dataset.generatedMerchantRow = "true";
-  const name = row.querySelector(".inventory-item-name");
+  const actions = row.querySelector(".inventory-row-actions");
   const cancel = document.createElement("button");
   cancel.type = "button";
   cancel.className = "trade-transfer trade-transfer-left";
@@ -142,7 +173,7 @@ function ensureMerchantPlayerRow(itemId, sourceRow) {
   cancel.setAttribute("aria-label", cancel.dataset.labelOne);
   cancel.title = cancel.dataset.labelOne;
   cancel.innerHTML = '<span class="inventory-transfer-glyph arrows-1" aria-hidden="true"><i></i></span>';
-  name.append(cancel);
+  actions.append(cancel);
   applyDynamicTransferModifiers();
   playerSidebar.querySelector(".trade-inventory-table tbody").append(row);
   refreshInventoryPanel(playerSidebar);
@@ -283,6 +314,7 @@ document.addEventListener("click", (event) => {
     const scope = document.querySelector("#merchant-offer [name='inventory_scope']");
     if (scope) scope.value = tab.dataset.inventoryTab;
     resetTradeDraft(document.querySelector("#merchant-offer"));
+    refreshInventoryPanel(root.querySelector('[data-inventory-pane]:not([hidden])'));
     return;
   }
   const targetStep = event.target.closest("[data-target-step]");
@@ -534,4 +566,4 @@ if (document.readyState === "loading") {
 } else {
   mountInventoryBulkControls();
 }
-document.addEventListener("strategic-live-regions-refreshed", () => mountInventoryBulkControls());
+document.addEventListener("strategic-live-regions-refreshed", () => refreshInventoryPanel(document));

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -116,7 +116,7 @@ function ensureMerchantPlayerRow(itemId, sourceRow) {
   const equipped = document.createElement("td");
   equipped.className = "inventory-equipped";
   equipped.innerHTML = '<input type="checkbox" disabled>';
-  count.after(equipped);
+  (row.querySelector(".inventory-target") || count).after(equipped);
   row.querySelector(".inventory-gold").textContent = sourceRow.dataset.merchantSellPrice;
   row.dataset.generatedMerchantRow = "true";
   const name = row.querySelector(".inventory-item-name");
@@ -233,8 +233,9 @@ function ensureDiscardRow(sourceRow, inventoryId) {
   count.textContent = "0";
   delete count.dataset.base;
   delete count.dataset.tradeDraftChange;
-  document.querySelector("[data-discard-list]").append(row);
+  document.querySelector("[data-discard-table] tbody").append(row);
   applyDynamicTransferModifiers();
+  window.strategicInventoryBrowser?.mountAll?.();
   return row;
 }
 

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -10,9 +10,17 @@ function changeTradeDraftCount(row, change) {
 function mountInventoryBulkControls(root = document) {
   if (!root?.querySelectorAll) root = document;
   root.querySelectorAll(".inventory-footer-actions").forEach((actions) => {
+    if (actions.closest(".inventory-actions-header")) return;
     const section = actions.closest(".sidebar-section");
     const headerRow = section?.querySelector(".trade-inventory-table thead tr");
-    if (headerRow) headerRow.append(actions);
+    if (headerRow) {
+      const cell = document.createElement("th");
+      cell.scope = "col";
+      cell.className = "inventory-actions-header";
+      cell.setAttribute("aria-label", "Inventory actions");
+      cell.append(actions);
+      headerRow.append(cell);
+    }
   });
   applyDynamicTransferModifiers();
 }

--- a/crates/strategic-web/tests/inventory-browser.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.test.cjs
@@ -1,5 +1,7 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const {
   parsePanelState,
   serializePanelState,
@@ -37,6 +39,13 @@ test("advertised sort types retain text damage and numeric target or durability 
 
 test("destination refresh is exposed for generated row insertion", () => {
   assert.equal(typeof refresh, "function");
+});
+
+test("bulk controls mount inside a semantic header cell", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../static/party-trade.js"), "utf8");
+  assert.match(source, /createElement\("th"\)/);
+  assert.match(source, /cell\.append\(actions\)/);
+  assert.doesNotMatch(source, /headerRow\.append\(actions\)/);
 });
 
 test("serialization preserves unrelated params and round trips bookmarks", () => {

--- a/crates/strategic-web/tests/inventory-browser.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.test.cjs
@@ -9,6 +9,7 @@ const {
   normalizeSortValue,
   rowValue,
   refresh,
+  syncPanelWidth,
 } = require("../static/inventory-browser.js");
 
 test("panel state is independently namespaced", () => {
@@ -39,13 +40,27 @@ test("advertised sort types retain text damage and numeric target or durability 
 
 test("destination refresh is exposed for generated row insertion", () => {
   assert.equal(typeof refresh, "function");
+  assert.equal(typeof syncPanelWidth, "function");
 });
 
 test("bulk controls mount inside a semantic header cell", () => {
   const source = fs.readFileSync(path.join(__dirname, "../static/party-trade.js"), "utf8");
-  assert.match(source, /createElement\("th"\)/);
-  assert.match(source, /cell\.append\(actions\)/);
+  assert.match(source, /querySelector\("\[data-inventory-browser\] \.inventory-actions-header"\)/);
+  assert.match(source, /headerCell\.append\(actions\)/);
   assert.doesNotMatch(source, /headerRow\.append\(actions\)/);
+});
+
+test("row controls mount in center-facing action cells", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../static/party-trade.js"), "utf8");
+  assert.match(source, /createElement\("td"\)/);
+  assert.match(source, /cell\.className = "inventory-actions-cell"/);
+  assert.match(source, /row\[placeAtStart \? "prepend" : "append"\]\(cell\)/);
+});
+
+test("live sidebar replacement remeasures connected inventory rails", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../static/party-trade.js"), "utf8");
+  assert.match(source, /"strategic-live-regions-refreshed", \(\) => refreshInventoryPanel\(document\)/);
+  assert.match(source, /if \(!hasVisibleBrowser\) grid\?\.style\.removeProperty/);
 });
 
 test("serialization preserves unrelated params and round trips bookmarks", () => {

--- a/crates/strategic-web/tests/inventory-browser.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.test.cjs
@@ -1,0 +1,36 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  parsePanelState,
+  serializePanelState,
+  compareValues,
+} = require("../static/inventory-browser.js");
+
+test("panel state is independently namespaced", () => {
+  const search = "?inv.left.q=sword&inv.left.sort=weight&inv.left.dir=desc&inv.left.cols=reach,damage&inv.right.q=mail";
+  assert.deepEqual(parsePanelState(search, "left", ["reach", "damage"]), {
+    query: "sword", sort: "weight", direction: "desc", columns: ["reach", "damage"],
+  });
+  assert.equal(parsePanelState(search, "right", []).query, "mail");
+});
+
+test("serialization preserves unrelated params and round trips bookmarks", () => {
+  const state = { query: "axe", sort: "value", direction: "desc", columns: ["block"] };
+  const search = serializePanelState("?tab=party", "merchant-left", state);
+  assert.match(search, /tab=party/);
+  assert.deepEqual(parsePanelState(search, "merchant-left", ["block"]), state);
+});
+
+test("invalid and stale parameters are safely ignored", () => {
+  assert.deepEqual(parsePanelState("?inv.x.sort=wat&inv.x.dir=sideways&inv.x.cols=reach,obsolete", "x", ["reach"]), {
+    query: "", sort: "name", direction: "asc", columns: ["reach"],
+  });
+});
+
+test("numeric and text sorting is directional and keeps blanks stable at the end", () => {
+  assert.ok(compareValues(2, 10, "asc") < 0);
+  assert.ok(compareValues("Sword 2", "sword 10", "asc") < 0);
+  assert.ok(compareValues(2, 10, "desc") > 0);
+  assert.ok(compareValues("", 2, "desc") > 0);
+  assert.equal(compareValues("", "", "asc"), 0);
+});

--- a/crates/strategic-web/tests/inventory-browser.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.test.cjs
@@ -43,6 +43,13 @@ test("destination refresh is exposed for generated row insertion", () => {
   assert.equal(typeof syncPanelWidth, "function");
 });
 
+test("rail measurement excludes projected action overflow", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../static/inventory-browser.js"), "utf8");
+  assert.match(source, /table\?\.getBoundingClientRect\?\.\(\)\.width/);
+  assert.match(source, /browser\.getBoundingClientRect\?\.\(\)\.width/);
+  assert.doesNotMatch(source, /Math\.max\(browser\.scrollWidth, tableWidth\)/);
+});
+
 test("bulk controls mount inside a semantic header cell", () => {
   const source = fs.readFileSync(path.join(__dirname, "../static/party-trade.js"), "utf8");
   assert.match(source, /querySelector\("\[data-inventory-browser\] \.inventory-actions-header"\)/);

--- a/crates/strategic-web/tests/inventory-browser.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.test.cjs
@@ -4,6 +4,9 @@ const {
   parsePanelState,
   serializePanelState,
   compareValues,
+  normalizeSortValue,
+  rowValue,
+  refresh,
 } = require("../static/inventory-browser.js");
 
 test("panel state is independently namespaced", () => {
@@ -12,6 +15,28 @@ test("panel state is independently namespaced", () => {
     query: "sword", sort: "weight", direction: "desc", columns: ["reach", "damage"],
   });
   assert.equal(parsePanelState(search, "right", []).query, "mail");
+});
+
+test("advertised sort types retain text damage and numeric target or durability values", () => {
+  assert.equal(normalizeSortValue("Slash, Pierce", "text"), "Slash, Pierce");
+  assert.equal(normalizeSortValue("12", "number"), 12);
+  assert.equal(normalizeSortValue("0.76", "number"), 0.76);
+  assert.equal(normalizeSortValue("—", "number"), "");
+  const label = { dataset: { itemName: "Sword", statDamage: "Slash, Pierce" }, textContent: "Sword" };
+  const durabilityBar = { dataset: { sortValue: "0.76" } };
+  const durabilityCell = { dataset: {}, textContent: "Damaged", querySelector: () => durabilityBar };
+  const row = { querySelector: (selector) => ({
+    "[data-item-name]": label,
+    ".inventory-target": { textContent: "12" },
+    ".inventory-durability": durabilityCell,
+  })[selector] || null };
+  assert.equal(rowValue(row, "damage"), "Slash, Pierce");
+  assert.equal(rowValue(row, "target"), 12);
+  assert.equal(rowValue(row, "durability"), 0.76);
+});
+
+test("destination refresh is exposed for generated row insertion", () => {
+  assert.equal(typeof refresh, "function");
 });
 
 test("serialization preserves unrelated params and round trips bookmarks", () => {

--- a/crates/strategic-web/tests/inventory-browser.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.test.cjs
@@ -64,6 +64,14 @@ test("row controls mount in center-facing action cells", () => {
   assert.match(source, /row\[placeAtStart \? "prepend" : "append"\]\(cell\)/);
 });
 
+test("dynamic transfer routing survives glyph replacement", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../static/party-trade.js"), "utf8");
+  assert.match(source, /const dynamicTransfer = event\.target\.closest\?\.\("\[data-dynamic-transfer\]"\)/);
+  assert.match(source, /const clickTarget = dynamicTransfer \|\| event\.target/);
+  assert.match(source, /const merchantButton = clickTarget\.closest\("\[data-merchant-buy\]"\)/);
+  assert.doesNotMatch(source, /const merchantButton = event\.target\.closest/);
+});
+
 test("live sidebar replacement remeasures connected inventory rails", () => {
   const source = fs.readFileSync(path.join(__dirname, "../static/party-trade.js"), "utf8");
   assert.match(source, /"strategic-live-regions-refreshed", \(\) => refreshInventoryPanel\(document\)/);

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (796)
+## Files (803)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -571,11 +571,14 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/src/spacetimedb/types.rs` — Strategic web SpacetimeDB integration module.
 - `crates/strategic-web/src/templates/character.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/components.rs` — Strategic web server-rendered template.
+- `crates/strategic-web/src/templates/inventory_browser.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/layout.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/mission.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/mod.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/quest.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/recruitment.rs` — Strategic web server-rendered template.
+- `crates/strategic-web/src/templates/settlement.rs` — Strategic web server-rendered template.
+- `crates/strategic-web/src/templates/settlement.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/settlement.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/static/background-fetch.js` — Repository support file.
 - `crates/strategic-web/static/building-state.js` — Repository support file.
@@ -584,6 +587,8 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/static/css/components.css` — Browser UI styling.
 - `crates/strategic-web/static/css/layout.css` — Browser UI styling.
 - `crates/strategic-web/static/css/reset.css` — Browser UI styling.
+- `crates/strategic-web/static/css/strategic.css` — Browser UI styling.
+- `crates/strategic-web/static/css/strategic.css` — Browser UI styling.
 - `crates/strategic-web/static/css/strategic.css` — Browser UI styling.
 - `crates/strategic-web/static/css/utilities.css` — Browser UI styling.
 - `crates/strategic-web/static/equipment-toggle.js` — Repository support file.
@@ -725,6 +730,7 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/static/icons/stats/attributes/immunity.png` — Binary game or UI asset.
 - `crates/strategic-web/static/icons/stats/attributes/strength-arm.png` — Binary game or UI asset.
 - `crates/strategic-web/static/icons/stats/attributes/strength-leg.png` — Binary game or UI asset.
+- `crates/strategic-web/static/inventory-browser.js` — Repository support file.
 - `crates/strategic-web/static/live-regions.js` — Repository support file.
 - `crates/strategic-web/static/live-state.js` — Repository support file.
 - `crates/strategic-web/static/local-chat.js` — Repository support file.
@@ -739,6 +745,7 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/static/travel-planner.js` — Repository support file.
 - `crates/strategic-web/tests/environment.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/icon-rendering.test.cjs` — Repository support file.
+- `crates/strategic-web/tests/inventory-browser.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/local-chat.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/service-quests.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/training-schedule.test.cjs` — Repository support file.

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (803)
+## Files (799)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -578,8 +578,6 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/src/templates/quest.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/recruitment.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/src/templates/settlement.rs` — Strategic web server-rendered template.
-- `crates/strategic-web/src/templates/settlement.rs` — Strategic web server-rendered template.
-- `crates/strategic-web/src/templates/settlement.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/static/background-fetch.js` — Repository support file.
 - `crates/strategic-web/static/building-state.js` — Repository support file.
 - `crates/strategic-web/static/chat-resize.js` — Repository support file.
@@ -587,8 +585,6 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/static/css/components.css` — Browser UI styling.
 - `crates/strategic-web/static/css/layout.css` — Browser UI styling.
 - `crates/strategic-web/static/css/reset.css` — Browser UI styling.
-- `crates/strategic-web/static/css/strategic.css` — Browser UI styling.
-- `crates/strategic-web/static/css/strategic.css` — Browser UI styling.
 - `crates/strategic-web/static/css/strategic.css` — Browser UI styling.
 - `crates/strategic-web/static/css/utilities.css` — Browser UI styling.
 - `crates/strategic-web/static/equipment-toggle.js` — Repository support file.

--- a/wiki/shared/Inventory.md
+++ b/wiki/shared/Inventory.md
@@ -54,6 +54,14 @@ panel-namespaced URL query parameters. This keeps the left and right views
 independent, makes useful layouts bookmarkable, and lets browser Back and
 Forward restore prior layouts. Expanded rows are intentionally transient.
 
+Inventory rails grow to the width required by their currently visible columns
+instead of adding a horizontal table scrollbar. Per-item actions appear only
+while their row is hovered or focused and project from the center-facing edge
+of each rail over the portrait area. Bulk actions use the same center-facing
+gutter and align vertically with the column headers. Merchant-stock rails omit
+the quantity and target columns because merchant availability is not presented
+as a player-managed stack or restocking target.
+
 Weaponsmith inventories contain weapons, shields, and currency and offer
 precision, reach, penetration, damage-type, and block columns. Armourers show
 armor and currency and offer coverage, resistance, padding, flexibility, and

--- a/wiki/shared/Inventory.md
+++ b/wiki/shared/Inventory.md
@@ -33,10 +33,29 @@ define how communal consumables should be charged.
 # Inventory icons
 
 Inventory tables include a narrow **Type** column before the item name. Its
-header is the compact letter `T` with the accessible label “Item type”. Every
+header uses a compact backpack symbol with the accessible label “Item type”. Every
 seeded item uses a specific, monochrome Game Icons illustration selected by its
 stable item ID (for example, swords, maces, polearms, shields, and armour pieces
 remain visually distinct). Unknown or modded IDs use a visible question-mark
 fallback; they never generate an unvalidated or broken asset URL. Icons expose
 tooltips/accessibility labels and inherit the active theme colour through CSS
 masks.
+
+## Inventory browser controls
+
+Two-sided inventory views use the same browser controls for each panel. A
+panel has its own name search, sortable headers, expanded item details, and a
+gear menu for optional columns. Quantity (`#`) is the displayed quantity after
+the current staged draft; target (`#?`) is the independently editable desired
+quantity used by shift-transfer and bulk actions.
+
+Search, sorting, direction, and visible optional columns are stored in
+panel-namespaced URL query parameters. This keeps the left and right views
+independent, makes useful layouts bookmarkable, and lets browser Back and
+Forward restore prior layouts. Expanded rows are intentionally transient.
+
+Weaponsmith inventories contain weapons, shields, and currency and offer
+precision, reach, penetration, damage-type, and block columns. Armourers show
+armor and currency and offer coverage, resistance, padding, flexibility, and
+range-of-motion columns. General inventory views offer the union; merchants
+whose goods do not use combat statistics retain only the basic columns.


### PR DESCRIPTION
## Summary

- consolidate all live dual-panel inventory screens behind a reusable inventory browser component
- add independent per-panel name search, sortable headers, expandable icon-based item details, and gear-controlled optional columns
- persist each panel's search, sort, and visible-column state in URL query parameters for navigation and bookmarks
- split the former dual-purpose quantity display into `#` and `#?`
- filter specialist merchant inventories appropriately while retaining currency and exposing context-relevant columns
- hide quantity and target columns on merchant-owned inventories
- size each desktop inventory rail to its visible columns instead of adding table-level horizontal scrolling
- place per-row trade/repair actions on the center-facing edge, extend each row background behind them, and align bulk actions with the column headers
- retain unavailable equipped-item and full-durability action slots as muted disabled icons while available actions remain bright
- preserve live trade behavior and rail measurement when rows or whole sidebars are replaced dynamically

## User impact

Inventory browsing is faster and configurable across transfers, discarding, merchant trade, party-pool browsing, and quest loot. Each side can keep a different layout, including NPC-specific configurations, and those settings survive reloads and browser history. Expanded item statistics use the repository's Game Icons and compact cards. Optional columns now expand their owning rail, while hover actions remain aligned with the affected row in the portrait gutter.

## Validation

- `cargo test -p strategic-web` - 98 passed
- `cargo fmt --all -- --check`
- `node --test crates/strategic-web/tests/inventory-browser.test.cjs` - 11 passed
- JavaScript syntax checks for `inventory-browser.js` and `party-trade.js`
- `python scripts/update_project_map.py --check`
- `git diff --check`
- independent correctness and maintainability reviews, including final remediation review

## Manual demo

Verified in an isolated local stack at the Ironforge weaponsmith:

- merchant inventories omit `#` and `#?`, while player/party inventories retain them
- enabling all weapon stat columns expands only the configured right rail and produces no table scrollbar
- measured rail variables match their rendered tables (`325px` merchant, `769px` player in the all-columns scenario)
- merchant buy and player repair/sell controls use symmetric panel-edge offsets and continuous row-colored action strips
- merchant rows and their action strips expand fully into the portrait gutter without being clipped by the stock viewport
- merchant stock keeps left-to-right table content while placing its native scrollbar on the outer left edge
- the merchant scrollbar reserves the outer panel gutter without covering item content, and row transfer arrows share the bulk-action horizontal anchor on both panels
- Playwright-verified merchant buys and player sales both stage visible quantity and gold deltas; Cancel restores the draft
- equipped sell/transfer and unavailable repair actions remain visible but muted, with accessible explanations
- Buy to Targets, Repair All, and Sell Surplus align with the header row; Repair All precedes Sell Surplus
- bulk trade/repair controls and smith-custody retrieval stay hidden at rest, then reveal with a continuous header background on header hover or keyboard focus
- the smith-custody list reserves a stable scrollbar gutter so row retrieval actions remain unobstructed when the list scrolls
- independent left/right optional columns, search terms, sorting, expansion, and URL state remain functional
- buying an item absent from the player inventory creates a normalized provisional destination row; cancel removes it cleanly

No SpacetimeDB schema or generated-binding change is required; item stat fields are serde-defaulted against existing authoritative data. Expanded-row state is intentionally session-local rather than URL-persisted.
