### PR TITLE
Add strategic-only development stack

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -87,6 +87,31 @@ just build-wasm
 
 Now when you click a location in the browser, a tactical server will automatically spawn.
 
+## Strategic-Only Development
+
+For strategic-layer work, start SpacetimeDB and the server-rendered browser UI
+without building the tactical WASM client or tactical server binaries and
+without running the tactical dispatcher:
+
+```bash
+just dev-strategic
+```
+
+This preserves the canonical local database just like `just dev`. It also
+stops a canonical dispatcher left by an earlier full-stack run. Tactical
+missions can still enter the pending state, but they will not start until the
+full stack is running again.
+
+For a disposable, worktree-safe strategic-only database, use:
+
+```bash
+just web-isolated-strategic renderer-demo 23100
+```
+
+The isolated lifecycle retains the same guarded reset, ownership checks, and
+cleanup as `web-isolated`, but it neither reserves the tactical port nor starts
+a dispatcher.
+
 For native tactical testing from WSL on Windows, the equivalent of running
 `just dev`, `just tactical`, and `just client 0` in separate Linux terminals is:
 
@@ -129,7 +154,9 @@ package `gcc-mingw-w64-x86-64` must already be installed.
 ```bash
 # Development
 just dev              # Start the complete browser stack
+just dev-strategic    # Start only SpacetimeDB and the strategic browser UI
 just web-isolated     # Reset and start an explicitly isolated local profile
+just web-isolated-strategic # Reset and start an isolated strategic-only profile
 just web-secure       # Start strategic-web at https://localhost:8443
 just secure-web-trust # Trust Caddy's local development CA (normally once)
 just web-damaged      # Refuses canonical reset; seed damage in an isolated profile

--- a/justfile
+++ b/justfile
@@ -70,6 +70,10 @@ dev:
 dev-full:
     @just web
 
+# Start only the persistent strategic layer and its browser UI.
+dev-strategic:
+    @just web-strategic
+
 # Start the local browser stack.
 web: preflight spacetime-start publish _seed-world build-wasm build-tactical
     @just _spawner-start
@@ -85,10 +89,29 @@ web: preflight spacetime-start publish _seed-world build-wasm build-tactical
      TACTICAL_STATIC_DIR={{strategic_static}} \
      cargo run -p strategic-web
 
+# Start the strategic browser stack without building or running tactical services.
+web-strategic: preflight spacetime-start publish _seed-world verify-db-client
+    @just _spawner-stop
+    @echo ""
+    @echo "Starting strategic-web server (strategic-only mode)..."
+    @echo "Open: http://localhost:{{web_port}}"
+    @echo "Tactical server spawning is disabled."
+    @echo ""
+    @SPACETIMEDB_HOST={{spacetime_url}} \
+     SPACETIMEDB_DATABASE={{spacetime_module}} \
+     BIND_ADDRESS=127.0.0.1:{{web_port}} \
+     STATIC_DIR={{strategic_web_dir}}/static \
+     TACTICAL_STATIC_DIR={{strategic_static}} \
+     cargo run -p strategic-web
+
 # Start a disposable, worktree-safe stack. Every destructive target is derived
 # from the validated profile and loopback base port.
 web-isolated profile="renderer-demo" base_port="23100": preflight verify-db-client build-wasm build-tactical
     @{{python_bin}} scripts/dev_stack.py run-profile {{quote(profile)}} {{quote(base_port)}}
+
+# Start a disposable, worktree-safe strategic-only stack.
+web-isolated-strategic profile="renderer-demo" base_port="23100": preflight verify-db-client
+    @{{python_bin}} scripts/dev_stack.py run-profile --strategic-only {{quote(profile)}} {{quote(base_port)}}
 
 # Canonical database deletion is deliberately unavailable. Use web-isolated.
 web-reset:

--- a/scripts/dev_stack.py
+++ b/scripts/dev_stack.py
@@ -315,6 +315,13 @@ def ports_in_use(ports: list[int]) -> list[int]:
     return occupied
 
 
+def profile_ports(values: dict[str, object], with_tactical: bool) -> list[int]:
+    keys = ["spacetime_port", "web_port"]
+    if with_tactical:
+        keys.append("tactical_port")
+    return [int(values[key]) for key in keys]
+
+
 def listener_process_snapshot(port: int) -> dict[str, object] | None:
     if os.name == "nt":
         result = subprocess.run(
@@ -576,14 +583,19 @@ def wait_for_spacetime(process: subprocess.Popen[str], metadata_file: Path, log_
     raise RuntimeError(f"isolated SpacetimeDB did not become ready; see {log_file}")
 
 
-def run_profile(name: str, base_port: int, verify_http: bool = False) -> int:
+def run_profile(
+    name: str,
+    base_port: int,
+    verify_http: bool = False,
+    with_tactical: bool = True,
+) -> int:
     values = profile_values(name, base_port)
     state_root = runtime_root()
     profile_dir = ensure_secure_directory(Path(str(values["profile_dir"])), state_root)
     run_dir = ensure_secure_directory(profile_dir / "run", state_root)
     data_dir = ensure_secure_directory(profile_dir / "spacetimedb-data", state_root)
     with ProfileLock(profile_dir / "lifecycle.lock") as lifecycle:
-        ports = [int(values[key]) for key in ("spacetime_port", "web_port", "tactical_port")]
+        ports = profile_ports(values, with_tactical)
         occupied = ports_in_use(ports)
         if occupied:
             raise ValueError(f"isolated profile ports already occupied: {occupied}")
@@ -621,8 +633,15 @@ def run_profile(name: str, base_port: int, verify_http: bool = False) -> int:
             code = seed(server, str(values["database"]), include_damaged_demo=True)
             if code:
                 return code
-            spawner_config = spawner_identity(name, server, str(values["database"]), "127.0.0.1", int(values["tactical_port"]))
-            spawner = start_spawner(run_dir, spawner_config)
+            if with_tactical:
+                spawner_config = spawner_identity(
+                    name,
+                    server,
+                    str(values["database"]),
+                    "127.0.0.1",
+                    int(values["tactical_port"]),
+                )
+                spawner = start_spawner(run_dir, spawner_config)
             built = subprocess.run(["cargo", "build", "-p", "strategic-web"], cwd=ROOT)
             if built.returncode:
                 return built.returncode
@@ -633,7 +652,11 @@ def run_profile(name: str, base_port: int, verify_http: bool = False) -> int:
                 "STATIC_DIR": str(ROOT / "crates" / "strategic-web" / "static"),
                 "TACTICAL_STATIC_DIR": str(ROOT / "crates" / "adventuresim-stdb-module" / "static"),
             })
-            print(f"Starting isolated profile {name!r} at http://127.0.0.1:{values['web_port']}")
+            mode = "full-stack" if with_tactical else "strategic-only"
+            print(
+                f"Starting isolated {mode} profile {name!r} "
+                f"at http://127.0.0.1:{values['web_port']}"
+            )
             executable = ROOT / "target" / "debug" / ("strategic-web.exe" if os.name == "nt" else "strategic-web")
             web_config = {"role": "strategic-web", "profile": name, "executable": str(executable), "server": server}
             log = secure_log(run_dir / "web.log")
@@ -674,16 +697,18 @@ def canonical_spawner(action: str) -> int:
         state_root / worktree_fingerprint() / "canonical", state_root
     )
     run_dir = ensure_secure_directory(profile_dir / "run", state_root)
-    config = spawner_identity(
-        "canonical", "http://localhost:3000", "adventuresim-stdb-module", "127.0.0.1", 6001
-    )
     with ProfileLock(profile_dir / "lifecycle.lock"):
+        identity_file = run_dir / "spawner.identity.json"
+        if action == "stop":
+            stop_recorded(identity_file)
+            return 0
+        config = spawner_identity(
+            "canonical", "http://localhost:3000", "adventuresim-stdb-module", "127.0.0.1", 6001
+        )
         if action == "start":
             start_spawner(run_dir, config)
-        elif action == "stop":
-            stop_recorded(run_dir / "spawner.identity.json", config)
         else:
-            status = check_spawner_identity(run_dir / "spawner.identity.json", config)
+            status = check_spawner_identity(identity_file, config)
             if status == 1:
                 print("Tactical spawner: not running")
             return 0 if status in {0, 1} else status
@@ -704,9 +729,11 @@ def create_parser() -> argparse.ArgumentParser:
     seed_parser.add_argument("--database", required=True)
     sub.add_parser("verify-bindings")
     runner = sub.add_parser("run-profile")
+    runner.add_argument("--strategic-only", action="store_true")
     runner.add_argument("name")
     runner.add_argument("base_port", type=int)
     verifier = sub.add_parser("verify-profile")
+    verifier.add_argument("--strategic-only", action="store_true")
     verifier.add_argument("name")
     verifier.add_argument("base_port", type=int)
     canonical = sub.add_parser("canonical-spawner")
@@ -727,9 +754,14 @@ def main() -> int:
         if args.command == "verify-bindings":
             return verify_bindings()
         if args.command == "run-profile":
-            return run_profile(args.name, args.base_port)
+            return run_profile(args.name, args.base_port, with_tactical=not args.strategic_only)
         if args.command == "verify-profile":
-            return run_profile(args.name, args.base_port, verify_http=True)
+            return run_profile(
+                args.name,
+                args.base_port,
+                verify_http=True,
+                with_tactical=not args.strategic_only,
+            )
         if args.command == "canonical-spawner":
             return canonical_spawner(args.action)
     except (ValueError, RuntimeError) as error:

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -41,6 +41,14 @@ class ProfileTests(unittest.TestCase):
             port = listener.getsockname()[1]
             self.assertEqual(dev_stack.ports_in_use([port]), [port])
 
+    def test_strategic_only_profile_does_not_reserve_tactical_port(self):
+        values = dev_stack.profile_values("demo", 23100)
+        self.assertEqual(dev_stack.profile_ports(values, with_tactical=False), [23100, 23101])
+        self.assertEqual(
+            dev_stack.profile_ports(values, with_tactical=True),
+            [23100, 23101, 23102],
+        )
+
     def test_symlink_profile_path_rejected(self):
         with tempfile.TemporaryDirectory() as state:
             root = Path(state)
@@ -172,6 +180,14 @@ class WorkflowTests(unittest.TestCase):
                     "--reset-profile", "demo", "--base-port", "23100",
                 ])
 
+    def test_profile_parser_supports_strategic_only_mode(self):
+        args = dev_stack.create_parser().parse_args([
+            "run-profile", "--strategic-only", "demo", "23100",
+        ])
+        self.assertTrue(args.strategic_only)
+        self.assertEqual(args.name, "demo")
+        self.assertEqual(args.base_port, 23100)
+
     def test_binding_diff_detects_changed_and_extra_files(self):
         with tempfile.TemporaryDirectory() as left, tempfile.TemporaryDirectory() as right:
             Path(left, "a.rs").write_text("fn a() {}\n")
@@ -203,6 +219,13 @@ class WorkflowTests(unittest.TestCase):
                 dev_stack.stop_recorded(metadata, {"role": "test"})
             self.assertTrue(metadata.exists())
 
+    def test_canonical_stop_does_not_require_tactical_binaries(self):
+        with tempfile.TemporaryDirectory() as temp, \
+             mock.patch.object(dev_stack, "runtime_root", return_value=Path(temp)), \
+             mock.patch.object(dev_stack, "spawner_identity") as spawner_identity:
+            self.assertEqual(dev_stack.canonical_spawner("stop"), 0)
+        spawner_identity.assert_not_called()
+
     def test_child_exit_rejected_during_readiness(self):
         with tempfile.TemporaryDirectory() as temp:
             metadata = Path(temp, "process.json")
@@ -216,10 +239,20 @@ class WorkflowTests(unittest.TestCase):
 
     def test_just_recipe_shell_quotes_untrusted_parameters(self):
         source = Path(dev_stack.ROOT, "justfile").read_text()
-        line = next(line for line in source.splitlines() if "run-profile" in line)
-        self.assertIn("{{quote(profile)}}", line)
-        self.assertIn("{{quote(base_port)}}", line)
-        self.assertNotIn("'{{profile}}'", line)
+        lines = [line for line in source.splitlines() if "run-profile" in line]
+        self.assertEqual(len(lines), 2)
+        for line in lines:
+            self.assertIn("{{quote(profile)}}", line)
+            self.assertIn("{{quote(base_port)}}", line)
+            self.assertNotIn("'{{profile}}'", line)
+
+    def test_strategic_only_recipes_skip_tactical_builds(self):
+        source = Path(dev_stack.ROOT, "justfile").read_text()
+        canonical = next(line for line in source.splitlines() if line.startswith("web-strategic:"))
+        isolated = next(line for line in source.splitlines() if line.startswith("web-isolated-strategic "))
+        for line in (canonical, isolated):
+            self.assertNotIn("build-wasm", line)
+            self.assertNotIn("build-tactical", line)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add `just dev-strategic` for the canonical strategic database and browser UI
- add `just web-isolated-strategic` for disposable, worktree-safe strategic testing
- skip tactical WASM and server builds, tactical port reservation, and dispatcher startup in strategic-only mode
- stop a previously recorded canonical dispatcher without requiring tactical binaries to exist
- document the new workflows and cover their lifecycle policy with tests

## Why

The existing development recipes always built and launched tactical components, even when testing behavior that exists only in the persistent strategic layer. That added unnecessary build time and processes to strategic UI and reducer work.

The full-stack recipes retain their existing behavior. Strategic-only missions can enter the pending state, but do not start until the tactical dispatcher is run again.

## Validation

- `python -B -m unittest scripts.tests.test_dev_stack -v` (26 tests)
- `cargo check -p strategic-web`
- `git diff --check`
- disposable `verify-profile --strategic-only strategic-test 24200`: guarded publish and seed succeeded, strategic web returned HTTP 200, all profile ports were cleaned up, and no tactical process or dispatcher identity was created

## Notes

`scripts/update_project_map.py --check` remains stale because the existing checkout contains unrelated untracked `reference/` and `target-personality-verify/` files. This PR adds no files and does not modify the generated project map.
