### PR TITLE
Add settlement currencies behind aggregate Coin inventory

### DIFF
--- a/crates/adventuresim-core/src/lib.rs
+++ b/crates/adventuresim-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod morale;
 pub mod provisioning;
 pub mod simulation_security;
 pub mod skill;
+pub mod strategic_currency;
 pub mod strategic_economy;
 pub mod strategic_schedule;
 pub mod strategic_time;

--- a/crates/adventuresim-core/src/strategic_currency.rs
+++ b/crates/adventuresim-core/src/strategic_currency.rs
@@ -1,0 +1,53 @@
+/// Equal-value historical denominations used by the northern-German 1544
+/// setting. Exchange-rate gameplay intentionally remains deferred.
+pub const CURRENCY_IDS: [&str; 6] = [
+    "rhenish_gulden",
+    "lubeck_mark",
+    "hamburg_mark",
+    "saxon_thaler",
+    "brandenburg_groschen",
+    "danish_mark",
+];
+
+pub fn is_currency_id(item_id: &str) -> bool {
+    CURRENCY_IDS.contains(&item_id)
+}
+
+pub fn currency_name(item_id: &str) -> Option<&'static str> {
+    Some(match item_id {
+        "rhenish_gulden" => "Rhenish gulden",
+        "lubeck_mark" => "Lübeck mark",
+        "hamburg_mark" => "Hamburg mark",
+        "saxon_thaler" => "Saxon thaler",
+        "brandenburg_groschen" => "Brandenburg groschen",
+        "danish_mark" => "Danish mark",
+        _ => return None,
+    })
+}
+
+/// Stable FNV-1a assignment. Unlike `DefaultHasher`, this mapping is stable
+/// across Rust and toolchain releases.
+pub fn assigned_currency_id(settlement_id: &str) -> &'static str {
+    let hash = settlement_id
+        .as_bytes()
+        .iter()
+        .fold(0xcbf29ce484222325_u64, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+        });
+    CURRENCY_IDS[hash as usize % CURRENCY_IDS.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_names_and_assignment_are_total_and_stable() {
+        assert!(CURRENCY_IDS.iter().all(|id| currency_name(id).is_some()));
+        assert_eq!(
+            assigned_currency_id("viabundus-123"),
+            assigned_currency_id("viabundus-123")
+        );
+        assert!(is_currency_id(assigned_currency_id("viabundus-123")));
+    }
+}

--- a/crates/adventuresim-stdb-client/src/settlement_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_type.rs
@@ -42,6 +42,7 @@ pub struct Settlement {
     pub industries: InferredIndustryProfile,
     pub scene_key: String,
     pub religion_id: String,
+    pub currency_id: String,
     pub source_node_id: Option<u64>,
     pub sources: String,
 }
@@ -75,6 +76,7 @@ pub struct SettlementCols {
     pub industries: __sdk::__query_builder::Col<Settlement, InferredIndustryProfile>,
     pub scene_key: __sdk::__query_builder::Col<Settlement, String>,
     pub religion_id: __sdk::__query_builder::Col<Settlement, String>,
+    pub currency_id: __sdk::__query_builder::Col<Settlement, String>,
     pub source_node_id: __sdk::__query_builder::Col<Settlement, Option<u64>>,
     pub sources: __sdk::__query_builder::Col<Settlement, String>,
 }
@@ -113,6 +115,7 @@ impl __sdk::__query_builder::HasCols for Settlement {
             industries: __sdk::__query_builder::Col::new(table_name, "industries"),
             scene_key: __sdk::__query_builder::Col::new(table_name, "scene_key"),
             religion_id: __sdk::__query_builder::Col::new(table_name, "religion_id"),
+            currency_id: __sdk::__query_builder::Col::new(table_name, "currency_id"),
             source_node_id: __sdk::__query_builder::Col::new(table_name, "source_node_id"),
             sources: __sdk::__query_builder::Col::new(table_name, "sources"),
         }

--- a/crates/adventuresim-stdb-module/README.md
+++ b/crates/adventuresim-stdb-module/README.md
@@ -77,7 +77,7 @@ The tactical server calls `commit_mission` when the mission ends:
 ```rust
 // Tactical server computes results in memory
 let xp_gained = enemies_killed * 25;
-let items = vec![("gold_coin", 10), ("health_potion", 2)];
+let items = vec![("lubeck_mark", 10), ("health_potion", 2)];
 let items_json = serde_json::to_string(&items)?;
 
 // Commit to SpacetimeDB

--- a/crates/adventuresim-stdb-module/src/character.rs
+++ b/crates/adventuresim-stdb-module/src/character.rs
@@ -610,7 +610,7 @@ fn insert_character_with_origin(
     crate::personality::initialize_personality(ctx, id, npc);
 
     // Starter items
-    crate::item::credit_personal_currency(ctx, character.id, &start_settlement.id, 100);
+    crate::item::credit_personal_currency(ctx, character.id, &start_settlement.id, 100)?;
     add_inventory_item(ctx, character.id, "torch", 1);
     add_inventory_item(ctx, character.id, "bandage", 3);
 

--- a/crates/adventuresim-stdb-module/src/character.rs
+++ b/crates/adventuresim-stdb-module/src/character.rs
@@ -530,7 +530,9 @@ fn insert_character_with_origin(
         name,
         xp: 0,
         level: 1,
-        gold: 100,
+        // Legacy scalar retained only for schema compatibility. Currency is
+        // authoritative in inventory.
+        gold: 0,
         current_settlement_id: Some(start_settlement.id.clone()),
         current_quest_location_id: None,
         party_id: None,
@@ -608,7 +610,7 @@ fn insert_character_with_origin(
     crate::personality::initialize_personality(ctx, id, npc);
 
     // Starter items
-    add_inventory_item(ctx, character.id, "gold_coin", 100);
+    crate::item::credit_personal_currency(ctx, character.id, &start_settlement.id, 100);
     add_inventory_item(ctx, character.id, "torch", 1);
     add_inventory_item(ctx, character.id, "bandage", 3);
 

--- a/crates/adventuresim-stdb-module/src/condition.rs
+++ b/crates/adventuresim-stdb-module/src/condition.rs
@@ -313,20 +313,20 @@ pub fn provision_character_for_travel(
     let cost = rations_to_buy
         .saturating_mul(ration.base_value.unwrap_or(0))
         .saturating_add(waterskins_to_buy.saturating_mul(waterskin.base_value.unwrap_or(0)));
-    let mut character = ctx
+    let character = ctx
         .db
         .character()
         .id()
         .find(character_id)
         .ok_or("Character not found")?;
-    if character.gold < cost {
+    let available = crate::item::personal_currency_total(ctx, character_id);
+    if available < u64::from(cost) {
         return Err(format!(
-            "{} needs {cost} gold for food and water provisions but has only {}",
-            character.name, character.gold
+            "{} needs {cost} coin for food and water provisions but has only {available}",
+            character.name
         ));
     }
-    character.gold -= cost;
-    ctx.db.character().id().update(character);
+    crate::item::consume_personal_currency(ctx, character_id, u64::from(cost))?;
     crate::add_inventory_item(ctx, character_id, TRAVEL_RATION_ID, rations_to_buy);
     crate::add_inventory_item(ctx, character_id, WATERSKIN_ID, waterskins_to_buy);
 

--- a/crates/adventuresim-stdb-module/src/item.rs
+++ b/crates/adventuresim-stdb-module/src/item.rs
@@ -2,6 +2,30 @@ use crate::{character::character_equip, repair::item_condition};
 use spacetimedb::{ReducerContext, SpacetimeType, Table, reducer, table};
 use strum::{EnumCount, VariantArray};
 
+/// Equal-value historical denominations used by the northern-German 1544
+/// setting.  Their exchange behavior is deliberately identical until the
+/// Mercantile system is introduced.
+pub const CURRENCY_IDS: [&str; 6] = [
+    "rhenish_gulden",
+    "lubeck_mark",
+    "hamburg_mark",
+    "saxon_thaler",
+    "brandenburg_groschen",
+    "danish_mark",
+];
+
+pub fn settlement_currency_id(settlement_id: &str) -> &'static str {
+    // Repository-owned FNV-1a: unlike DefaultHasher this mapping is stable
+    // across Rust/toolchain releases and reproducible by import tooling.
+    let hash = settlement_id
+        .as_bytes()
+        .iter()
+        .fold(0xcbf29ce484222325_u64, |hash, byte| {
+            (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+        });
+    CURRENCY_IDS[hash as usize % CURRENCY_IDS.len()]
+}
+
 /// [`Item`] that is in the inventory
 #[derive(Clone, Debug)]
 #[table(
@@ -803,13 +827,15 @@ fn init_items(ctx: &ReducerContext) -> Result<(), String> {
 
     define_item(ctx, "torch", 0.5);
     define_item(ctx, "arrow", 0.05);
-    ctx.db.item().insert(Item {
-        id: "gold_coin".into(),
-        weight: 0.01,
-        base_value: Some(1),
-        kind: ItemKind::Currency,
-        ..Item::default()
-    });
+    for id in CURRENCY_IDS {
+        ctx.db.item().insert(Item {
+            id: id.into(),
+            weight: 0.01,
+            base_value: Some(1),
+            kind: ItemKind::Currency,
+            ..Item::default()
+        });
+    }
     define_item(ctx, "bandage", 0.05);
     for (id, weight) in [
         ("honey", 0.25),
@@ -1106,6 +1132,98 @@ pub fn add_inventory_item(
     first
 }
 
+pub fn is_currency(ctx: &ReducerContext, item_id: &str) -> bool {
+    ctx.db
+        .item()
+        .id()
+        .find(item_id.to_owned())
+        .is_some_and(|item| item.kind == ItemKind::Currency)
+}
+
+pub fn personal_currency_total(ctx: &ReducerContext, character_id: u64) -> u64 {
+    ctx.db
+        .inventory_item()
+        .character_id()
+        .filter(character_id)
+        .filter(|stack| is_currency(ctx, &stack.item_id))
+        .map(|stack| u64::from(stack.quantity))
+        .sum()
+}
+
+fn currency_withdrawal_plan(
+    mut stacks: Vec<(String, u64, u32)>,
+    amount: u64,
+) -> Option<Vec<(u64, u32)>> {
+    if stacks
+        .iter()
+        .map(|(_, _, quantity)| u64::from(*quantity))
+        .sum::<u64>()
+        < amount
+    {
+        return None;
+    }
+    stacks.sort_by(|a, b| (&a.0, a.1).cmp(&(&b.0, b.1)));
+    let mut remaining = amount;
+    let mut plan = Vec::new();
+    for (_, id, quantity) in stacks {
+        if remaining == 0 {
+            break;
+        }
+        let taken = remaining.min(u64::from(quantity)) as u32;
+        remaining -= u64::from(taken);
+        plan.push((id, taken));
+    }
+    Some(plan)
+}
+
+/// Atomically consumes equal-value currency in a stable denomination/stack
+/// order.  The preflight makes an insufficient payment a no-op.
+pub fn consume_personal_currency(
+    ctx: &ReducerContext,
+    character_id: u64,
+    amount: u64,
+) -> Result<(), String> {
+    let stacks: Vec<_> = ctx
+        .db
+        .inventory_item()
+        .character_id()
+        .filter(character_id)
+        .filter(|stack| is_currency(ctx, &stack.item_id))
+        .collect();
+    let plan = currency_withdrawal_plan(
+        stacks
+            .iter()
+            .map(|stack| (stack.item_id.clone(), stack.id, stack.quantity))
+            .collect(),
+        amount,
+    )
+    .ok_or_else(|| "Not enough coin to cover this payment".to_string())?;
+    for (id, taken) in plan {
+        let mut stack = stacks.iter().find(|stack| stack.id == id).cloned().unwrap();
+        stack.quantity -= taken;
+        if stack.quantity == 0 {
+            ctx.db.inventory_item().id().delete(stack.id);
+        } else {
+            ctx.db.inventory_item().id().update(stack);
+        }
+    }
+    Ok(())
+}
+
+pub fn credit_personal_currency(
+    ctx: &ReducerContext,
+    character_id: u64,
+    settlement_id: &str,
+    amount: u32,
+) {
+    add_inventory_item(
+        ctx,
+        character_id,
+        settlement_currency_id(settlement_id),
+        amount,
+    );
+}
+
 #[reducer]
 pub fn change_inventory_item(
     ctx: &ReducerContext,
@@ -1201,6 +1319,34 @@ pub fn change_inventory_item(
 mod tests {
     use super::*;
     use std::collections::HashSet;
+
+    #[test]
+    fn settlement_currency_assignment_is_stable_and_uses_the_fixed_catalog() {
+        let first = settlement_currency_id("viabundus-12345");
+        assert_eq!(first, settlement_currency_id("viabundus-12345"));
+        assert!(CURRENCY_IDS.contains(&first));
+        assert_eq!(
+            CURRENCY_IDS.len(),
+            CURRENCY_IDS.iter().copied().collect::<HashSet<_>>().len()
+        );
+        assert!(
+            (0..128)
+                .map(|id| settlement_currency_id(&format!("demo-{id}")))
+                .collect::<HashSet<_>>()
+                .len()
+                > 1
+        );
+    }
+
+    #[test]
+    fn mixed_currency_withdrawal_plan_is_deterministic_and_atomic() {
+        let stacks = vec![("lubeck_mark".into(), 4, 3), ("danish_mark".into(), 9, 2)];
+        assert_eq!(
+            currency_withdrawal_plan(stacks.clone(), 4),
+            Some(vec![(9, 2), (4, 2)])
+        );
+        assert_eq!(currency_withdrawal_plan(stacks, 6), None);
+    }
 
     #[test]
     fn historical_equipment_catalog_is_well_formed() {

--- a/crates/adventuresim-stdb-module/src/item.rs
+++ b/crates/adventuresim-stdb-module/src/item.rs
@@ -1,29 +1,27 @@
-use crate::{character::character_equip, repair::item_condition};
+use crate::{character::character_equip, repair::item_condition, strategic::settlement};
 use spacetimedb::{ReducerContext, SpacetimeType, Table, reducer, table};
 use strum::{EnumCount, VariantArray};
 
-/// Equal-value historical denominations used by the northern-German 1544
-/// setting.  Their exchange behavior is deliberately identical until the
-/// Mercantile system is introduced.
-pub const CURRENCY_IDS: [&str; 6] = [
-    "rhenish_gulden",
-    "lubeck_mark",
-    "hamburg_mark",
-    "saxon_thaler",
-    "brandenburg_groschen",
-    "danish_mark",
-];
+pub use adventuresim_core::strategic_currency::CURRENCY_IDS;
 
 pub fn settlement_currency_id(settlement_id: &str) -> &'static str {
-    // Repository-owned FNV-1a: unlike DefaultHasher this mapping is stable
-    // across Rust/toolchain releases and reproducible by import tooling.
-    let hash = settlement_id
-        .as_bytes()
-        .iter()
-        .fold(0xcbf29ce484222325_u64, |hash, byte| {
-            (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
-        });
-    CURRENCY_IDS[hash as usize % CURRENCY_IDS.len()]
+    adventuresim_core::strategic_currency::assigned_currency_id(settlement_id)
+}
+
+pub fn currency_id_for_settlement(
+    ctx: &ReducerContext,
+    settlement_id: &str,
+) -> Result<String, String> {
+    match ctx.db.settlement().id().find(settlement_id.to_string()) {
+        Some(settlement) if CURRENCY_IDS.contains(&settlement.currency_id.as_str()) => {
+            Ok(settlement.currency_id)
+        }
+        Some(settlement) => Err(format!(
+            "Settlement {} has invalid currency {}",
+            settlement.id, settlement.currency_id
+        )),
+        None => Ok(settlement_currency_id(settlement_id).to_string()),
+    }
 }
 
 /// [`Item`] that is in the inventory
@@ -1215,13 +1213,28 @@ pub fn credit_personal_currency(
     character_id: u64,
     settlement_id: &str,
     amount: u32,
-) {
-    add_inventory_item(
-        ctx,
-        character_id,
-        settlement_currency_id(settlement_id),
-        amount,
-    );
+) -> Result<(), String> {
+    if amount == 0 {
+        return Ok(());
+    }
+    let currency_id = currency_id_for_settlement(ctx, settlement_id)?;
+    if let Some(mut stack) = ctx
+        .db
+        .inventory_item()
+        .character_and_item_id()
+        .filter((character_id, &currency_id))
+        .next()
+    {
+        stack.quantity = merged_currency_quantity(stack.quantity, amount);
+        ctx.db.inventory_item().id().update(stack);
+    } else {
+        add_inventory_item(ctx, character_id, &currency_id, amount);
+    }
+    Ok(())
+}
+
+fn merged_currency_quantity(existing: u32, credit: u32) -> u32 {
+    existing.saturating_add(credit)
 }
 
 #[reducer]
@@ -1346,6 +1359,12 @@ mod tests {
             Some(vec![(9, 2), (4, 2)])
         );
         assert_eq!(currency_withdrawal_plan(stacks, 6), None);
+    }
+
+    #[test]
+    fn repeated_same_denomination_credits_merge_safely() {
+        assert_eq!(merged_currency_quantity(40, 2), 42);
+        assert_eq!(merged_currency_quantity(u32::MAX, 1), u32::MAX);
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/repair.rs
+++ b/crates/adventuresim-stdb-module/src/repair.rs
@@ -558,19 +558,13 @@ pub fn retrieve_repaired_items(
     if ids.is_empty() {
         return Err("No completed matching repairs are ready to retrieve".into());
     }
-    let available_gold: u64 = ctx
-        .db
-        .inventory_item()
-        .character_and_item_id()
-        .filter((character_id, &"gold_coin".to_string()))
-        .map(|stack| u64::from(stack.quantity))
-        .sum();
+    let available_gold = crate::item::personal_currency_total(ctx, character_id);
     let affordable = adventuresim_core::durability::affordable_repair_prefix(
         available_gold,
         &ids.iter().map(|(_, _, cost)| *cost).collect::<Vec<_>>(),
     );
     if affordable == 0 {
-        return Err("Not enough personal gold to retrieve the next completed repair".into());
+        return Err("Not enough personal coin to retrieve the next completed repair".into());
     }
     for (_, order_id, _) in ids.into_iter().take(affordable) {
         retrieve(ctx, character_id, order_id)?;

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -3322,7 +3322,10 @@ pub(crate) fn record_battle_result(
         let gold = 1 + (ctx.random::<u64>() % u64::from(maximum_gold)) as u32;
         if gold > 0 {
             *combined
-                .entry(crate::item::settlement_currency_id(&quest.settlement_id).into())
+                .entry(crate::item::currency_id_for_settlement(
+                    ctx,
+                    &quest.settlement_id,
+                )?)
                 .or_default() += gold;
         }
     }
@@ -3585,13 +3588,10 @@ pub(crate) fn credit_party_currency(
     party_id: &str,
     settlement_id: &str,
     amount: u32,
-) {
-    add_to_party_inventory(
-        ctx,
-        party_id,
-        crate::item::settlement_currency_id(settlement_id),
-        amount,
-    );
+) -> Result<(), String> {
+    let currency_id = crate::item::currency_id_for_settlement(ctx, settlement_id)?;
+    add_to_party_inventory(ctx, party_id, &currency_id, amount);
+    Ok(())
 }
 
 fn transfer_personal_currency_to_party(
@@ -3800,7 +3800,7 @@ pub fn liquidate_party_inventory(
             ctx.db.party_inventory_item().id().update(entry);
         }
     }
-    credit_party_currency(ctx, &party_id, &settlement_id, proceeds as u32);
+    credit_party_currency(ctx, &party_id, &settlement_id, proceeds as u32)?;
     Ok(())
 }
 
@@ -4144,14 +4144,14 @@ pub fn finalize_merchant_trade(
     let net = proceeds as i64 - cost as i64;
     if party_scope && net > 0 {
         let party_id = party_id.as_ref().unwrap();
-        credit_party_currency(ctx, party_id, &settlement_id, net as u32);
+        credit_party_currency(ctx, party_id, &settlement_id, net as u32)?;
     } else if party_scope && net < 0 {
         let party_id = party_id.as_ref().unwrap();
         consume_party_currency(ctx, party_id, (-net) as u64)?;
     } else if net < 0 {
         consume_personal_gold(ctx, character_id, (-net) as u64)?;
     } else if net > 0 {
-        crate::item::credit_personal_currency(ctx, character_id, &settlement_id, net as u32);
+        crate::item::credit_personal_currency(ctx, character_id, &settlement_id, net as u32)?;
     }
     Ok(())
 }
@@ -5534,7 +5534,7 @@ pub fn turn_in_quest(
 
     let reward = quest.gold_reward.max(0) as u64;
     if reward > 0 {
-        credit_party_currency(ctx, &party_id, &quest.settlement_id, reward as u32);
+        credit_party_currency(ctx, &party_id, &quest.settlement_id, reward as u32)?;
         let recipients = living_party_member_ids(ctx, &party_id);
         let recipient_count = recipients.len().max(1) as u64;
         let share = reward / recipient_count;

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -520,6 +520,8 @@ pub struct Settlement {
     pub scene_key: String,
     /// The single faith represented by this settlement's church and priest.
     pub religion_id: String,
+    /// Stable local denomination assigned from the settlement ID.
+    pub currency_id: String,
     /// Viabundus node that supplies this settlement, if it was imported from
     /// the historical world dataset. Demo settlements deliberately leave this
     /// empty.
@@ -934,6 +936,7 @@ pub fn import_settlements(
                 settlement.id
             ));
         }
+        let currency_id = crate::item::settlement_currency_id(&settlement.id).to_string();
         let row = Settlement {
             id: settlement.id,
             name: settlement.name,
@@ -955,6 +958,7 @@ pub fn import_settlements(
             geology,
             scene_key: settlement.scene_key,
             religion_id: settlement.religious_status.church().religion_id().into(),
+            currency_id,
             religious_status: settlement.religious_status,
             drought,
             hydrology: settlement.hydrology,
@@ -3317,7 +3321,9 @@ pub(crate) fn record_battle_result(
         let maximum_gold = quest.difficulty.max(1) as u32 * 10;
         let gold = 1 + (ctx.random::<u64>() % u64::from(maximum_gold)) as u32;
         if gold > 0 {
-            *combined.entry("gold_coin".into()).or_default() += gold;
+            *combined
+                .entry(crate::item::settlement_currency_id(&quest.settlement_id).into())
+                .or_default() += gold;
         }
     }
     for (item_id, quantity) in combined {
@@ -3521,28 +3527,137 @@ pub fn deposit_party_inventory_item(
 pub(crate) fn consume_personal_gold(
     ctx: &ReducerContext,
     character_id: u64,
-    mut amount: u64,
+    amount: u64,
 ) -> Result<(), String> {
-    let stacks: Vec<_> = ctx
+    crate::item::consume_personal_currency(ctx, character_id, amount)
+}
+
+pub(crate) fn party_currency_total(ctx: &ReducerContext, party_id: &str) -> u64 {
+    ctx.db
+        .party_inventory_item()
+        .party_id()
+        .filter(party_id)
+        .filter(|stack| crate::item::is_currency(ctx, &stack.item_id))
+        .map(|stack| u64::from(stack.quantity))
+        .sum()
+}
+
+pub(crate) fn consume_party_currency(
+    ctx: &ReducerContext,
+    party_id: &str,
+    amount: u64,
+) -> Result<(), String> {
+    let mut stacks: Vec<_> = ctx
+        .db
+        .party_inventory_item()
+        .party_id()
+        .filter(party_id)
+        .filter(|stack| crate::item::is_currency(ctx, &stack.item_id))
+        .collect();
+    if stacks
+        .iter()
+        .map(|stack| u64::from(stack.quantity))
+        .sum::<u64>()
+        < amount
+    {
+        return Err("Not enough party coin to cover this payment".into());
+    }
+    stacks.sort_by(|a, b| (&a.item_id, a.id).cmp(&(&b.item_id, b.id)));
+    let mut remaining = amount;
+    for mut stack in stacks {
+        let taken = remaining.min(u64::from(stack.quantity)) as u32;
+        stack.quantity -= taken;
+        remaining -= u64::from(taken);
+        if stack.quantity == 0 {
+            ctx.db.party_inventory_item().id().delete(stack.id);
+        } else {
+            ctx.db.party_inventory_item().id().update(stack);
+        }
+        if remaining == 0 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn credit_party_currency(
+    ctx: &ReducerContext,
+    party_id: &str,
+    settlement_id: &str,
+    amount: u32,
+) {
+    add_to_party_inventory(
+        ctx,
+        party_id,
+        crate::item::settlement_currency_id(settlement_id),
+        amount,
+    );
+}
+
+fn transfer_personal_currency_to_party(
+    ctx: &ReducerContext,
+    character_id: u64,
+    party_id: &str,
+    amount: u64,
+) -> Result<(), String> {
+    let mut stacks: Vec<_> = ctx
         .db
         .inventory_item()
-        .character_and_item_id()
-        .filter((character_id, &"gold_coin".to_string()))
+        .character_id()
+        .filter(character_id)
+        .filter(|stack| crate::item::is_currency(ctx, &stack.item_id))
         .collect();
-    let available: u64 = stacks.iter().map(|stack| u64::from(stack.quantity)).sum();
-    if available < amount {
-        return Err("Not enough personal gold to cover this withdrawal".into());
+    if stacks.iter().map(|s| u64::from(s.quantity)).sum::<u64>() < amount {
+        return Err("Not enough personal coin".into());
     }
+    stacks.sort_by(|a, b| (&a.item_id, a.id).cmp(&(&b.item_id, b.id)));
+    let mut remaining = amount;
     for mut stack in stacks {
-        let taken = amount.min(u64::from(stack.quantity)) as u32;
+        let taken = remaining.min(u64::from(stack.quantity)) as u32;
+        add_to_party_inventory(ctx, party_id, &stack.item_id, taken);
         stack.quantity -= taken;
-        amount -= u64::from(taken);
+        remaining -= u64::from(taken);
         if stack.quantity == 0 {
             ctx.db.inventory_item().id().delete(stack.id);
         } else {
             ctx.db.inventory_item().id().update(stack);
         }
-        if amount == 0 {
+        if remaining == 0 {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn transfer_party_currency_to_personal(
+    ctx: &ReducerContext,
+    party_id: &str,
+    character_id: u64,
+    amount: u64,
+) -> Result<(), String> {
+    let mut stacks: Vec<_> = ctx
+        .db
+        .party_inventory_item()
+        .party_id()
+        .filter(party_id)
+        .filter(|stack| crate::item::is_currency(ctx, &stack.item_id))
+        .collect();
+    if stacks.iter().map(|s| u64::from(s.quantity)).sum::<u64>() < amount {
+        return Err("The party has insufficient coin".into());
+    }
+    stacks.sort_by(|a, b| (&a.item_id, a.id).cmp(&(&b.item_id, b.id)));
+    let mut remaining = amount;
+    for mut stack in stacks {
+        let taken = remaining.min(u64::from(stack.quantity)) as u32;
+        crate::add_inventory_item(ctx, character_id, &stack.item_id, taken);
+        stack.quantity -= taken;
+        remaining -= u64::from(taken);
+        if stack.quantity == 0 {
+            ctx.db.party_inventory_item().id().delete(stack.id);
+        } else {
+            ctx.db.party_inventory_item().id().update(stack);
+        }
+        if remaining == 0 {
             break;
         }
     }
@@ -3583,8 +3698,7 @@ pub fn withdraw_party_inventory_item(
     let stake_value = stake.as_ref().map_or(0, |stake| stake.value);
     if cost > stake_value {
         let top_up = cost - stake_value;
-        consume_personal_gold(ctx, character_id, top_up)?;
-        add_to_party_inventory(ctx, &party_id, "gold_coin", top_up as u32);
+        transfer_personal_currency_to_party(ctx, character_id, &party_id, top_up)?;
     }
     if let Some(ref mut stake) = stake {
         stake.value = stake.value.saturating_sub(cost);
@@ -3665,7 +3779,7 @@ pub fn liquidate_party_inventory(
         if quantity == 0
             || entry.party_id != party_id
             || entry.quantity < quantity
-            || entry.item_id == "gold_coin"
+            || crate::item::is_currency(ctx, &entry.item_id)
         {
             return Err("Invalid party asset liquidation".into());
         }
@@ -3686,7 +3800,7 @@ pub fn liquidate_party_inventory(
             ctx.db.party_inventory_item().id().update(entry);
         }
     }
-    add_to_party_inventory(ctx, &party_id, "gold_coin", proceeds as u32);
+    credit_party_currency(ctx, &party_id, &settlement_id, proceeds as u32);
     Ok(())
 }
 
@@ -3955,25 +4069,13 @@ pub fn finalize_merchant_trade(
                 * quantity,
         );
     }
-    let coins: u64 = if party_scope {
-        let party_id = party_id.as_ref().ok_or("Character has no party")?;
-        ctx.db
-            .party_inventory_item()
-            .party_id()
-            .filter(party_id)
-            .filter(|v| v.item_id == "gold_coin")
-            .map(|v| u64::from(v.quantity))
-            .sum()
+    let coins = if party_scope {
+        party_currency_total(ctx, party_id.as_ref().ok_or("Character has no party")?)
     } else {
-        ctx.db
-            .inventory_item()
-            .character_and_item_id()
-            .filter((character_id, &"gold_coin".to_string()))
-            .map(|coin| u64::from(coin.quantity))
-            .sum()
+        crate::item::personal_currency_total(ctx, character_id)
     };
     if coins.saturating_add(u64::from(proceeds)) < u64::from(cost) {
-        return Err("Not enough gold".into());
+        return Err("Not enough coin".into());
     }
     for (inventory_id, quantity) in sell_inventory_ids.iter().zip(&sell_quantities) {
         if party_scope {
@@ -4042,45 +4144,14 @@ pub fn finalize_merchant_trade(
     let net = proceeds as i64 - cost as i64;
     if party_scope && net > 0 {
         let party_id = party_id.as_ref().unwrap();
-        let mut coin = ctx
-            .db
-            .party_inventory_item()
-            .party_id()
-            .filter(party_id)
-            .find(|v| v.item_id == "gold_coin");
-        if let Some(ref mut coin) = coin {
-            coin.quantity = coin.quantity.saturating_add(net as u32);
-            ctx.db.party_inventory_item().id().update(coin.clone());
-        } else {
-            add_to_party_inventory(ctx, party_id, "gold_coin", net as u32);
-        }
+        credit_party_currency(ctx, party_id, &settlement_id, net as u32);
     } else if party_scope && net < 0 {
         let party_id = party_id.as_ref().unwrap();
-        let mut remaining = (-net) as u64;
-        for mut coin in ctx
-            .db
-            .party_inventory_item()
-            .party_id()
-            .filter(party_id)
-            .filter(|row| row.item_id == "gold_coin")
-            .collect::<Vec<_>>()
-        {
-            let taken = remaining.min(u64::from(coin.quantity)) as u32;
-            coin.quantity -= taken;
-            remaining -= u64::from(taken);
-            if coin.quantity == 0 {
-                ctx.db.party_inventory_item().id().delete(coin.id);
-            } else {
-                ctx.db.party_inventory_item().id().update(coin);
-            }
-            if remaining == 0 {
-                break;
-            }
-        }
+        consume_party_currency(ctx, party_id, (-net) as u64)?;
     } else if net < 0 {
         consume_personal_gold(ctx, character_id, (-net) as u64)?;
     } else if net > 0 {
-        crate::add_inventory_item(ctx, character_id, "gold_coin", net as u32);
+        crate::item::credit_personal_currency(ctx, character_id, &settlement_id, net as u32);
     }
     Ok(())
 }
@@ -4238,16 +4309,7 @@ fn settle_temporary_member_stake(
     if stake_value == 0 {
         return Ok(());
     }
-    let gold = ctx
-        .db
-        .party_inventory_item()
-        .party_id()
-        .filter(party_id)
-        .find(|item| item.item_id == "gold_coin")
-        .ok_or("The party has no liquid gold to settle this companion's stake")?;
-    let quantity =
-        u32::try_from(stake_value).map_err(|_| "Companion stake is too large to settle")?;
-    withdraw_party_inventory_item(ctx, member_character_id, gold.id, quantity)
+    transfer_party_currency_to_personal(ctx, party_id, member_character_id, stake_value)
 }
 
 #[reducer]
@@ -4285,7 +4347,7 @@ pub fn disband_party(ctx: &ReducerContext, leader_id: u64, party_id: String) -> 
         .map_or(0, |state| state.reserve_value);
     if pooled_items
         .iter()
-        .any(|entry| entry.item_id != "gold_coin")
+        .any(|entry| !crate::item::is_currency(ctx, &entry.item_id))
         || pooled_items
             .iter()
             .map(|entry| u64::from(entry.quantity))
@@ -4295,7 +4357,7 @@ pub fn disband_party(ctx: &ReducerContext, leader_id: u64, party_id: String) -> 
         return Err("Liquidate and distribute the party inventory before disbanding".into());
     }
     if reserve > 0 {
-        crate::add_inventory_item(ctx, party.leader_id, "gold_coin", reserve as u32);
+        transfer_party_currency_to_personal(ctx, &party_id, party.leader_id, reserve)?;
     }
     for entry in pooled_items {
         ctx.db.party_inventory_item().id().delete(entry.id);
@@ -5472,7 +5534,7 @@ pub fn turn_in_quest(
 
     let reward = quest.gold_reward.max(0) as u64;
     if reward > 0 {
-        add_to_party_inventory(ctx, &party_id, "gold_coin", reward as u32);
+        credit_party_currency(ctx, &party_id, &quest.settlement_id, reward as u32);
         let recipients = living_party_member_ids(ctx, &party_id);
         let recipient_count = recipients.len().max(1) as u64;
         let share = reward / recipient_count;
@@ -5797,6 +5859,7 @@ pub fn seed_world(ctx: &ReducerContext) -> Result<(), String> {
                 ]).unwrap(),
                 scene_key: scene.into(),
                 religion_id: religious_status.church().religion_id().into(),
+                currency_id: crate::item::settlement_currency_id(id).into(),
                 source_node_id: None,
                 sources: "- **Adventure Simulator demo data:** Hand-authored settlement and deterministic placeholder environment; no external world-data source was imported.".into(),
             });

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -514,9 +514,12 @@ fn apply_activity_outcomes(
         },
     );
     if outcome.gold_earned > 0 {
-        let mut character = character;
-        character.gold = character.gold.saturating_add(outcome.gold_earned);
-        ctx.db.character().id().update(character);
+        crate::item::credit_personal_currency(
+            ctx,
+            character_id,
+            &settlement.id,
+            outcome.gold_earned,
+        );
     }
     initialize_notoriety(ctx, character_id);
     let notoriety_gain = outcome.notoriety_gained;
@@ -661,17 +664,8 @@ fn rest_for_minutes(
     let cost =
         (requested_minutes.div_ceil(MINUTES_PER_DAY) as u32).saturating_mul(INN_GOLD_PER_DAY);
     if at_inn {
-        let mut character = ctx
-            .db
-            .character()
-            .id()
-            .find(character_id)
-            .ok_or_else(|| "Character not found".to_string())?;
-        if character.gold < cost {
-            return Err("Not enough gold to pay for the inn stay".into());
-        }
-        character.gold -= cost;
-        ctx.db.character().id().update(character);
+        crate::item::consume_personal_currency(ctx, character_id, u64::from(cost))
+            .map_err(|_| "Not enough coin to pay for the inn stay".to_string())?;
     }
 
     let (elapsed, terminal) =

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -519,7 +519,7 @@ fn apply_activity_outcomes(
             character_id,
             &settlement.id,
             outcome.gold_earned,
-        );
+        )?;
     }
     initialize_notoriety(ctx, character_id);
     let notoriety_gain = outcome.notoriety_gained;

--- a/crates/adventuresim-strategic-sim/src/live_core.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core.rs
@@ -17,6 +17,18 @@ use std::{
     sync::mpsc,
     time::Duration,
 };
+
+fn is_currency_id(item_id: &str) -> bool {
+    matches!(
+        item_id,
+        "rhenish_gulden"
+            | "lubeck_mark"
+            | "hamburg_mark"
+            | "saxon_thaler"
+            | "brandenburg_groschen"
+            | "danish_mark"
+    )
+}
 use url::Url;
 
 use adventuresim_stdb_client::{
@@ -631,7 +643,7 @@ impl LiveRunner {
             .db
             .inventory_item()
             .iter()
-            .filter(|row| row.character_id == character_id && row.item_id == "gold_coin")
+            .filter(|row| row.character_id == character_id && is_currency_id(&row.item_id))
             .map(|row| u64::from(row.quantity))
             .sum()
     }
@@ -1079,7 +1091,7 @@ impl LiveRunner {
             .db
             .inventory_item()
             .iter()
-            .filter(|row| row.character_id == character_id && row.item_id == "gold_coin")
+            .filter(|row| row.character_id == character_id && is_currency_id(&row.item_id))
             .map(|row| u64::from(row.quantity))
             .sum();
 
@@ -1201,7 +1213,7 @@ impl LiveRunner {
             .db
             .inventory_item()
             .iter()
-            .filter(|row| row.character_id == character_id && row.item_id == "gold_coin")
+            .filter(|row| row.character_id == character_id && is_currency_id(&row.item_id))
             .map(|row| u64::from(row.quantity))
             .sum();
         let affordable: Vec<_> = orders
@@ -1638,7 +1650,7 @@ impl LiveRunner {
             .db
             .party_inventory_item()
             .iter()
-            .filter(|row| row.party_id == party.id && row.item_id != "gold_coin")
+            .filter(|row| row.party_id == party.id && !is_currency_id(&row.item_id))
             .collect();
         if !sale.is_empty() {
             let before_coins: u64 = self
@@ -1646,7 +1658,7 @@ impl LiveRunner {
                 .db
                 .party_inventory_item()
                 .iter()
-                .filter(|row| row.party_id == party.id && row.item_id == "gold_coin")
+                .filter(|row| row.party_id == party.id && is_currency_id(&row.item_id))
                 .map(|row| u64::from(row.quantity))
                 .sum();
             let ids = sale.iter().map(|row| row.id).collect();
@@ -1667,7 +1679,7 @@ impl LiveRunner {
                 .db
                 .party_inventory_item()
                 .iter()
-                .filter(|row| row.party_id == party.id && row.item_id == "gold_coin")
+                .filter(|row| row.party_id == party.id && is_currency_id(&row.item_id))
                 .map(|row| u64::from(row.quantity))
                 .sum();
             self.metrics.sale_proceeds += after_coins.saturating_sub(before_coins);
@@ -1792,21 +1804,35 @@ impl LiveRunner {
         let Some((improvement, cost, candidate)) = candidates.into_iter().next() else {
             return Ok(());
         };
-        let treasury = self
+        let mut treasury: Vec<_> = self
             .connection
             .db
             .party_inventory_item()
             .iter()
-            .find(|row| row.party_id == party_id && row.item_id == "gold_coin")
-            .ok_or("earned party treasury is missing")?;
-        if treasury.quantity < cost {
+            .filter(|row| row.party_id == party_id && is_currency_id(&row.item_id))
+            .collect();
+        treasury.sort_by_key(|row| (row.item_id.clone(), row.id));
+        if treasury
+            .iter()
+            .map(|row| u64::from(row.quantity))
+            .sum::<u64>()
+            < u64::from(cost)
+        {
             return Ok(());
         }
-        let result = reducer_call!(self, "withdraw_earned_upgrade_gold", |cb| self
-            .connection
-            .reducers
-            .withdraw_party_inventory_item_then(character_id, treasury.id, cost, cb));
-        self.call(result)?;
+        let mut remaining = cost;
+        for stack in treasury {
+            let quantity = remaining.min(stack.quantity);
+            let result = reducer_call!(self, "withdraw_earned_upgrade_coin", |cb| self
+                .connection
+                .reducers
+                .withdraw_party_inventory_item_then(character_id, stack.id, quantity, cb));
+            self.call(result)?;
+            remaining -= quantity;
+            if remaining == 0 {
+                break;
+            }
+        }
         self.metrics.earned_gold_withdrawn += u64::from(cost);
         let result = reducer_call!(self, "finalize_merchant_trade", |cb| self
             .connection
@@ -2295,12 +2321,12 @@ pub fn run_core_loop(config: CoreLoopConfig) -> Result<CoreLoopReport, String> {
                 .find(|row| row.character_id == *character_id)
                 .ok_or("missing final clock")?
                 .minutes;
-            let personal_gold_coin = runner
+            let personal_gold_coin: u64 = runner
                 .connection
                 .db
                 .inventory_item()
                 .iter()
-                .filter(|row| row.character_id == *character_id && row.item_id == "gold_coin")
+                .filter(|row| row.character_id == *character_id && is_currency_id(&row.item_id))
                 .map(|row| u64::from(row.quantity))
                 .sum();
             let worst_equipment_condition = equipped_ids
@@ -2339,7 +2365,7 @@ pub fn run_core_loop(config: CoreLoopConfig) -> Result<CoreLoopReport, String> {
                 .db
                 .party_inventory_item()
                 .iter()
-                .filter(|row| row.party_id == party_id && row.item_id == "gold_coin")
+                .filter(|row| row.party_id == party_id && is_currency_id(&row.item_id))
                 .map(|row| u64::from(row.quantity))
                 .sum();
             let party_stake = runner
@@ -2352,7 +2378,7 @@ pub fn run_core_loop(config: CoreLoopConfig) -> Result<CoreLoopReport, String> {
             Ok(FinalAgentState {
                 agent_id: agent as u32,
                 character_id: *character_id,
-                gold: character.gold,
+                gold: personal_gold_coin.min(u64::from(u32::MAX)) as u32,
                 equipment_item_ids,
                 capability_summary: format!(
                     "melee={};ranged={};heavy={};athletics={:.2};endurance={:.2}",

--- a/crates/adventuresim-strategic-sim/src/live_core.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core.rs
@@ -18,17 +18,7 @@ use std::{
     time::Duration,
 };
 
-fn is_currency_id(item_id: &str) -> bool {
-    matches!(
-        item_id,
-        "rhenish_gulden"
-            | "lubeck_mark"
-            | "hamburg_mark"
-            | "saxon_thaler"
-            | "brandenburg_groschen"
-            | "danish_mark"
-    )
-}
+use adventuresim_core::strategic_currency::is_currency_id;
 use url::Url;
 
 use adventuresim_stdb_client::{

--- a/crates/strategic-web/package-lock.json
+++ b/crates/strategic-web/package-lock.json
@@ -1,0 +1,198 @@
+{
+  "name": "strategic-web",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "linkedom": "0.18.12"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.12",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.12.tgz",
+      "integrity": "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==",
+      "dev": true,
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.0.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true
+    }
+  }
+}

--- a/crates/strategic-web/package.json
+++ b/crates/strategic-web/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "scripts": {
+    "test": "cd ../.. && node --test crates/strategic-web/tests/*.test.cjs"
+  },
+  "devDependencies": {
+    "linkedom": "0.18.12"
+  }
+}

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -3117,17 +3117,7 @@ fn rest_summary(
     let currency_total = |inventory: &[InventoryItem]| -> u32 {
         inventory
             .iter()
-            .filter(|item| {
-                matches!(
-                    item.item_id.as_str(),
-                    "rhenish_gulden"
-                        | "lubeck_mark"
-                        | "hamburg_mark"
-                        | "saxon_thaler"
-                        | "brandenburg_groschen"
-                        | "danish_mark"
-                )
-            })
+            .filter(|item| adventuresim_core::strategic_currency::is_currency_id(&item.item_id))
             .map(|item| item.qty)
             .sum()
     };

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -1293,7 +1293,7 @@ async fn service_quest_offers(
                     state,
                     waiting: "Hello again, I eagerly await the results of your efforts.",
                     turn_in_response: format!(
-                        "Excellent work. Here is the promised {} gold. You've earned it.",
+                        "Excellent work. Here is the promised {} coin. You've earned it.",
                         quest.gold_reward
                     ),
                     can_accept,
@@ -1360,7 +1360,7 @@ fn service_quest_details(
         ),
     };
     format!(
-        "Yes, {situation}. I believe there are about {low} or {high} {}, give or take. I'd offer {} gold to anyone who clears them out. Are you",
+        "Yes, {situation}. I believe there are about {low} or {high} {}, give or take. I'd offer {} coin to anyone who clears them out. Are you",
         quest.enemy_type, quest.gold_reward,
     )
 }
@@ -3042,8 +3042,12 @@ async fn rest(
     let after_notoriety =
         query_single::<CharacterNotoriety>(&state, "character_notoriety", character_id).await;
     let summary = rest_summary(
-        before_character.as_ref().map(|(character, _)| character),
-        active_character.as_ref().map(|(character, _)| character),
+        before_character
+            .as_ref()
+            .map_or(&[], |(_, inventory)| inventory.as_slice()),
+        active_character
+            .as_ref()
+            .map_or(&[], |(_, inventory)| inventory.as_slice()),
         before_limbs.as_ref(),
         after_limbs.as_ref(),
         before_skills.as_ref(),
@@ -3096,8 +3100,8 @@ async fn query_single<T: serde::de::DeserializeOwned>(
 }
 
 fn rest_summary(
-    before_character: Option<&Character>,
-    after_character: Option<&Character>,
+    before_inventory: &[InventoryItem],
+    after_inventory: &[InventoryItem],
     before_limbs: Option<&CharacterLimbs>,
     after_limbs: Option<&CharacterLimbs>,
     before_skills: Option<&CharacterSkills>,
@@ -3110,12 +3114,27 @@ fn rest_summary(
     let minutes = before_time.zip(after_time).map_or(0, |(before, after)| {
         after.minutes.saturating_sub(before.minutes)
     });
-    let gold_spent = before_character
-        .zip(after_character)
-        .map_or(0, |(before, after)| before.gold.saturating_sub(after.gold));
-    let gold_earned = before_character
-        .zip(after_character)
-        .map_or(0, |(before, after)| after.gold.saturating_sub(before.gold));
+    let currency_total = |inventory: &[InventoryItem]| -> u32 {
+        inventory
+            .iter()
+            .filter(|item| {
+                matches!(
+                    item.item_id.as_str(),
+                    "rhenish_gulden"
+                        | "lubeck_mark"
+                        | "hamburg_mark"
+                        | "saxon_thaler"
+                        | "brandenburg_groschen"
+                        | "danish_mark"
+                )
+            })
+            .map(|item| item.qty)
+            .sum()
+    };
+    let before_currency = currency_total(before_inventory);
+    let after_currency = currency_total(after_inventory);
+    let gold_spent = before_currency.saturating_sub(after_currency);
+    let gold_earned = after_currency.saturating_sub(before_currency);
     let notoriety_gained = after_notoriety.map_or(0.0, |after| {
         after.value - before_notoriety.map_or(0.0, |before| before.value)
     });

--- a/crates/strategic-web/src/routes/travel.rs
+++ b/crates/strategic-web/src/routes/travel.rs
@@ -407,6 +407,7 @@ mod tests {
             .unwrap(),
             scene_key: String::new(),
             religion_id: String::new(),
+            currency_id: "rhenish_gulden".into(),
             source_node_id: Some(node),
         }
     }

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -129,6 +129,7 @@ pub struct Settlement {
     pub industries: adventuresim_world_schema::InferredIndustryProfile,
     pub scene_key: String,
     pub religion_id: String,
+    pub currency_id: String,
     pub source_node_id: Option<u64>,
 }
 

--- a/crates/strategic-web/src/templates/character.rs
+++ b/crates/strategic-web/src/templates/character.rs
@@ -2,10 +2,7 @@
 
 use maud::{Markup, html};
 
-use super::{
-    entry_layout, gold_display, input_field, item_type_header, item_type_icon, panel,
-    sidebar_section,
-};
+use super::{entry_layout, input_field, item_type_header, item_type_icon, panel, sidebar_section};
 use crate::spacetimedb::Character;
 
 /// List all characters and select the adventurer who enters the strategic layer.
@@ -37,7 +34,6 @@ pub fn characters_list_page(characters: &[Character], current_character_id: Opti
                                         @if character.alive { "Alive" } @else { span class="badge badge-danger" { "Dead" } }
                                     }
                                 }
-                                div class="stat-item" { span class="stat-label" { "Gold" } span class="stat-value" { (gold_display(character.gold)) } }
                             }
                             @if is_current {
                                 p class="text-accent small-copy" {
@@ -105,7 +101,7 @@ pub fn character_new_page(_logged_in_as: Option<&str>) -> Markup {
                 (panel("", html! {
                     p style="font-size:var(--font-size-sm)" {
                         "Choose a name for your adventurer. You'll start with "
-                        "100 gold and some basic supplies."
+                        "100 coin and some basic supplies."
                     }
                 }))
             }))

--- a/crates/strategic-web/src/templates/components.rs
+++ b/crates/strategic-web/src/templates/components.rs
@@ -27,7 +27,13 @@ pub fn item_icon_name(item_id: &str) -> &'static str {
     match item_id {
         "torch" => "torch",
         "arrow" => "plain-arrow",
-        "gold_coin" => "coins",
+        "rhenish_gulden"
+        | "lubeck_mark"
+        | "hamburg_mark"
+        | "saxon_thaler"
+        | "brandenburg_groschen"
+        | "danish_mark"
+        | "coin" => "coins",
         "bandage" => "bandage-roll",
         "travel_ration" => "bread",
         "waterskin" => "waterskin",
@@ -203,16 +209,6 @@ pub fn input_field(
     }
 }
 
-/// Gold amount display
-pub fn gold_display(amount: impl std::fmt::Display) -> Markup {
-    html! {
-        span class="gold-amount" {
-            (amount)
-            (game_icon("Gold", "coins"))
-        }
-    }
-}
-
 #[cfg(test)]
 mod icon_tests {
     use super::*;
@@ -287,7 +283,12 @@ mod icon_tests {
         let mappings = [
             ("torch", "torch"),
             ("arrow", "plain-arrow"),
-            ("gold_coin", "coins"),
+            ("rhenish_gulden", "coins"),
+            ("lubeck_mark", "coins"),
+            ("hamburg_mark", "coins"),
+            ("saxon_thaler", "coins"),
+            ("brandenburg_groschen", "coins"),
+            ("danish_mark", "coins"),
             ("bandage", "bandage-roll"),
             ("travel_ration", "bread"),
             ("waterskin", "waterskin"),

--- a/crates/strategic-web/src/templates/components.rs
+++ b/crates/strategic-web/src/templates/components.rs
@@ -24,16 +24,12 @@ pub fn decorative_game_icon(icon: &str) -> Markup {
 /// Exact icon name for a seeded item. Unknown/modded items get a real fallback
 /// asset rather than a URL derived from untrusted data.
 pub fn item_icon_name(item_id: &str) -> &'static str {
+    if adventuresim_core::strategic_currency::is_currency_id(item_id) || item_id == "coin" {
+        return "coins";
+    }
     match item_id {
         "torch" => "torch",
         "arrow" => "plain-arrow",
-        "rhenish_gulden"
-        | "lubeck_mark"
-        | "hamburg_mark"
-        | "saxon_thaler"
-        | "brandenburg_groschen"
-        | "danish_mark"
-        | "coin" => "coins",
         "bandage" => "bandage-roll",
         "travel_ration" => "bread",
         "waterskin" => "waterskin",

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -91,7 +91,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=left-rail-scrollbars-3";
-                link rel="stylesheet" href="/static/css/components.css?v=game-icons-2";
+                link rel="stylesheet" href="/static/css/components.css?v=coin-currencies-1";
                 link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-15-religion-5";
                 link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-15";
 
@@ -104,8 +104,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/live-regions.js?v=floating-time-editor-1" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
-                    script src="/static/inventory-browser.js?v=inventory-browser-8" defer {}
-                    script src="/static/party-trade.js?v=inventory-browser-8" {}
+                    script src="/static/inventory-browser.js?v=coin-currencies-1" defer {}
+                    script src="/static/party-trade.js?v=coin-currencies-1" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -91,7 +91,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=left-rail-scrollbars-3";
-                link rel="stylesheet" href="/static/css/components.css?v=coin-currencies-1";
+                link rel="stylesheet" href="/static/css/components.css?v=coin-currencies-2";
                 link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-15-religion-5";
                 link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-15";
 
@@ -104,12 +104,12 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/live-regions.js?v=floating-time-editor-1" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
-                    script src="/static/inventory-browser.js?v=coin-currencies-1" defer {}
-                    script src="/static/party-trade.js?v=coin-currencies-1" {}
+                    script src="/static/inventory-browser.js?v=coin-currencies-2" defer {}
+                    script src="/static/party-trade.js?v=coin-currencies-2" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}
-                    script src="/static/service-quests.js?v=map-markers-3" defer {}
+                    script src="/static/service-quests.js?v=coin-currencies-2" defer {}
                     script src="/static/chat-resize.js?v=floating-chat-3" defer {}
                     script src="/static/local-chat.js?v=herbalist-private-1" defer {}
                     script src="/static/strategic-condition.js?v=strategic-condition-3" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -91,7 +91,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=left-rail-scrollbars-3";
-                link rel="stylesheet" href="/static/css/components.css?v=coin-currencies-2";
+                link rel="stylesheet" href="/static/css/components.css?v=coin-currencies-3";
                 link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-15-religion-5";
                 link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-15";
 
@@ -104,7 +104,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/live-regions.js?v=floating-time-editor-1" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
-                    script src="/static/inventory-browser.js?v=coin-currencies-2" defer {}
+                    script src="/static/inventory-browser.js?v=coin-currencies-3" defer {}
                     script src="/static/party-trade.js?v=coin-currencies-2" {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -218,7 +218,7 @@ pub fn quest_location_page(
             (sidebar_section("Party inventory", html! {
                 div class="party-stake-summary" {
                     span { "Your available stake" }
-                    strong { (stake) " gold" }
+                    strong { (stake) " coin" }
                 }
                 @if pooled.is_empty() {
                     (empty_state("The party chest is empty.", None, None))

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1626,7 +1626,7 @@ pub fn party_pool_page(
                                 td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                                 td class="inventory-item-name" {
                                     (item_name_with_quality(&item.item_id, definition))
-                                    span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="withdraw" data-transfer-mode="one" data-count=(item.quantity) data-current=(current) data-target=(target) data-label-one=(format!("Withdraw one {}", item.item_id)) data-label-target=(format!("Withdraw {} to target", item.item_id)) data-label-all=(format!("Withdraw all {}", item.item_id)) title=(if value > stake { format!("Withdraw one {}; {} personal gold required", item.item_id, value - stake) } else { format!("Withdraw one {} using your stake", item.item_id) }) aria-label=(format!("Withdraw one {}", item.item_id)) { (transfer_glyph(1)) } }
+                                span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="withdraw" data-transfer-mode="one" data-count=(item.quantity) data-current=(current) data-target=(target) data-label-one=(format!("Withdraw one {}", item.item_id)) data-label-target=(format!("Withdraw {} to target", item.item_id)) data-label-all=(format!("Withdraw all {}", item.item_id)) title=(if value > stake { format!("Withdraw one {}; {} personal coin required", item.item_id, value - stake) } else { format!("Withdraw one {} using your stake", item.item_id) }) aria-label=(format!("Withdraw one {}", item.item_id)) { (transfer_glyph(1)) } }
                                 }
                                 td class="inventory-count" { (quantity_target_control(item.quantity, target_quantity(party_targets, &item.item_id), &item.item_id, true)) }
                                 td class="inventory-weight" { (item_weight(definition)) }
@@ -1761,15 +1761,7 @@ pub(super) fn item_name_with_quality(
     item_id: &str,
     definition: Option<&crate::spacetimedb::ItemDefinition>,
 ) -> Markup {
-    let currency_name = match item_id {
-        "rhenish_gulden" => Some("Rhenish gulden"),
-        "lubeck_mark" => Some("Lübeck mark"),
-        "hamburg_mark" => Some("Hamburg mark"),
-        "saxon_thaler" => Some("Saxon thaler"),
-        "brandenburg_groschen" => Some("Brandenburg groschen"),
-        "danish_mark" => Some("Danish mark"),
-        _ => None,
-    };
+    let currency_name = adventuresim_core::strategic_currency::currency_name(item_id);
     if let Some(currency_name) = currency_name {
         html! {
             span class="inventory-item-label" data-item-name="Coin"

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -819,11 +819,11 @@ fn travel_provision_forecast(forecast: Option<&TravelProvisionForecast>) -> Mark
                         (&traveler.name) ": "
                         (traveler.rations_to_buy) " ration" @if traveler.rations_to_buy != 1 { "s" }
                         " · " (traveler.waterskins_to_buy) " waterskin" @if traveler.waterskins_to_buy != 1 { "s" }
-                        " · " (traveler.cost) " gold"
+                        " · " (traveler.cost) " coin"
                     }
                 }
                 p class="text-muted small-copy" {
-                    "Party total: " (forecast.total_cost) " gold · includes 30% reserve"
+                    "Party total: " (forecast.total_cost) " coin · includes 30% reserve"
                 }
             } @else {
                 p class="text-muted small-copy" { "Provision costs are temporarily unavailable." }
@@ -1480,7 +1480,7 @@ pub fn live_merchant_shop_page(
         aside class="left-sidebar smith-wares-column" { (sidebar_section(if matches!(shop, MerchantShop::Herbalist) { "Prepared medicines and ingredients" } else { "Merchant stock" }, html! {
             div class="smith-wares-scroll" {
             (trade_inventory_table("merchant-left", if matches!(shop, MerchantShop::Weapons) { InventoryColumnSet::Weapons } else if matches!(shop, MerchantShop::Armor) { InventoryColumnSet::Armor } else { InventoryColumnSet::Basic }, false, false, false, html! {
-                @for item in items.iter().filter(|item| shop.shows_inventory(item.kind)) {
+                @for item in items.iter().filter(|item| shop.stocks(item.kind)) {
                     @let is_currency = item.kind == crate::spacetimedb::ItemKind::Currency;
                     @let medication_recipe = adventuresim_core::disease::medication_recipe_for_item(&item.id);
                     @let buy_price = medication_recipe.map_or_else(
@@ -1613,9 +1613,9 @@ pub fn party_pool_page(
                 (encumbrance_inventory_rail(html! {
                     div class="party-stake-summary" {
                         span { "Your available stake" }
-                        strong { (stake) " gold" }
+                        strong { (stake) " coin" }
                     }
-                    p class="small-copy text-muted" { "Withdrawals use your stake. Personal gold automatically covers an indivisible item's shortfall." }
+                    p class="small-copy text-muted" { "Withdrawals use your stake. Personal coin automatically covers an indivisible item's shortfall." }
                     (trade_inventory_table("party-pool-left", InventoryColumnSet::All, true, false, false, html! {
                         @for item in pooled {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1645,7 +1645,7 @@ pub fn party_pool_page(
         aside class="right-sidebar" {
             (sidebar_section(&format!("{}'s inventory", character.name), html! {
                 (encumbrance_inventory_rail(html! {
-                    p class="small-copy text-muted" { "Add items at their objective gold value." }
+                    p class="small-copy text-muted" { "Add items at their objective coin value." }
                     (trade_inventory_table("party-pool-right", InventoryColumnSet::All, true, true, false, html! {
                         @for item in inventory {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1761,7 +1761,23 @@ pub(super) fn item_name_with_quality(
     item_id: &str,
     definition: Option<&crate::spacetimedb::ItemDefinition>,
 ) -> Markup {
-    item_name_with_display(item_id, definition)
+    let currency_name = match item_id {
+        "rhenish_gulden" => Some("Rhenish gulden"),
+        "lubeck_mark" => Some("Lübeck mark"),
+        "hamburg_mark" => Some("Hamburg mark"),
+        "saxon_thaler" => Some("Saxon thaler"),
+        "brandenburg_groschen" => Some("Brandenburg groschen"),
+        "danish_mark" => Some("Danish mark"),
+        _ => None,
+    };
+    if let Some(currency_name) = currency_name {
+        html! {
+            span class="inventory-item-label" data-item-name="Coin"
+                data-item-kind="currency" data-currency-name=(currency_name) { "Coin" }
+        }
+    } else {
+        item_name_with_display(item_id, definition)
+    }
 }
 
 fn item_name_with_display(
@@ -2270,9 +2286,9 @@ fn skills_table(
                                 "Meditation gives modest morale independently of party Religion knowledge and does not train Religion or create Fervor."
                             },
                         ))
-                        (schedule_special_row("Labor", "hammer-sickle", "labor_minutes", schedule.downtime.labor_minutes, true, ActivityEffectRates::linear(preview.labor_gold_per_hour, 0.0, 0.0, LABOR_FATIGUE_PER_HOUR / FATIGUE_RESERVOIR_PER_PREVIEW_POINT), None, "Earn gold during settlement downtime from Strength and Endurance checks; trains Will at 25% speed and generates fatigue."))
-                        (schedule_special_row("Thievery", "lockpicks", "thievery_minutes", schedule.downtime.thievery_minutes, true, ActivityEffectRates::linear(preview.thievery_gold_per_hour, preview.thievery_virtue_per_hour, 0.0, 0.0), None, "Settlement downtime can earn gold and risk discovery while training Stealth at 25% speed."))
-                        (schedule_special_row("Raiding", "mounted-knight", "raiding_minutes", schedule.downtime.raiding_minutes, true, ActivityEffectRates::linear(preview.raiding_gold_per_hour, preview.raiding_virtue_per_hour, 0.0, 0.0), None, "Settlement downtime can earn gold and risk retaliation while feeding the equipment-derived Combat training distribution at 25% speed."))
+                        (schedule_special_row("Labor", "hammer-sickle", "labor_minutes", schedule.downtime.labor_minutes, true, ActivityEffectRates::linear(preview.labor_gold_per_hour, 0.0, 0.0, LABOR_FATIGUE_PER_HOUR / FATIGUE_RESERVOIR_PER_PREVIEW_POINT), None, "Earn coin during settlement downtime from Strength and Endurance checks; trains Will at 25% speed and generates fatigue."))
+                        (schedule_special_row("Thievery", "lockpicks", "thievery_minutes", schedule.downtime.thievery_minutes, true, ActivityEffectRates::linear(preview.thievery_gold_per_hour, preview.thievery_virtue_per_hour, 0.0, 0.0), None, "Settlement downtime can earn coin and risk discovery while training Stealth at 25% speed."))
+                        (schedule_special_row("Raiding", "mounted-knight", "raiding_minutes", schedule.downtime.raiding_minutes, true, ActivityEffectRates::linear(preview.raiding_gold_per_hour, preview.raiding_virtue_per_hour, 0.0, 0.0), None, "Settlement downtime can earn coin and risk retaliation while feeding the equipment-derived Combat training distribution at 25% speed."))
                         @let leisure = leisure_preview(&schedule.downtime, preview.current_fatigue);
                         (schedule_special_row("Leisure", "bed", "leisure_minutes", 0, false, ActivityEffectRates::default(), Some(leisure), "Unallocated downtime first offsets baseline and activity fatigue; only surplus recovery improves morale."))
                     }
@@ -3924,7 +3940,7 @@ fn rest_service_menu(
     section class="rest-service-menu" aria-label=(format!("{} rest service", location)) {
         div class="rest-service-heading" { strong { "Rest" } }
         @if kind == "inn" {
-            p class="rest-service-copy" { "A bed costs 1 gold per day. Injuries are tended before any downtime." }
+            p class="rest-service-copy" { "A bed costs 1 coin per day. Injuries are tended before any downtime." }
         } @else {
             p class="rest-service-copy" { "Sanctuary is freely offered to those down on their luck. Injuries are tended before any downtime." }
         }
@@ -3957,8 +3973,8 @@ fn rest_service_menu(
                         a href=(format!("/settlements/{settlement_id}/{}", if kind == "inn" { "inn" } else { "religion" })) class="rest-summary-close" aria-label="Close rest summary" { "×" }
                     }
                     p { (format_rest_duration(summary.minutes)) " passed." }
-                    @if summary.gold_spent > 0 { p { (summary.gold_spent) " gold paid." } }
-                    @if summary.gold_earned > 0 { p { (summary.gold_earned) " gold earned from activities." } }
+                    @if summary.gold_spent > 0 { p { (summary.gold_spent) " coin paid." } }
+                    @if summary.gold_earned > 0 { p { (summary.gold_earned) " coin earned from activities." } }
                     @if summary.notoriety_gained > 0.0 { p class="schedule-effect-negative" { (format!("-{:.1}", summary.notoriety_gained)) " Virtue from activities." } }
                     @if summary.healed.is_empty() { p { "No injuries needed tending." } } @else {
                         p { "Healed:" }
@@ -4345,6 +4361,7 @@ mod tests {
             .unwrap(),
             scene_key: "hills".into(),
             religion_id: "western_church".into(),
+            currency_id: "lubeck_mark".into(),
             source_node_id: Some(1),
         }
     }
@@ -4365,6 +4382,21 @@ mod tests {
         assert!(rendered.contains("tabindex=\"0\""));
         assert!(rendered.contains("All damage requires Smithing"));
         assert!(rendered.contains("disabled"));
+    }
+
+    #[test]
+    fn collapsed_currency_label_hides_the_historical_denomination() {
+        let definition = crate::spacetimedb::ItemDefinition {
+            id: "lubeck_mark".into(),
+            kind: crate::spacetimedb::ItemKind::Currency,
+            base_value: Some(1),
+            weight: 0.01,
+            ..Default::default()
+        };
+        let rendered = item_name_with_quality(&definition.id, Some(&definition)).into_string();
+        assert!(rendered.contains(">Coin<"));
+        assert!(rendered.contains("data-currency-name=\"Lübeck mark\""));
+        assert!(!rendered.contains(">Lübeck mark<"));
     }
 
     #[test]

--- a/crates/strategic-web/static/css/components.css
+++ b/crates/strategic-web/static/css/components.css
@@ -344,7 +344,7 @@
   background: transparent;
   color: currentColor;
   cursor: pointer;
-  margin-right: 0.3rem;
+  margin-left: 0.3rem;
   padding: 0.1rem 0.25rem;
   transform: rotate(0deg);
   transition: transform 120ms ease;

--- a/crates/strategic-web/static/css/components.css
+++ b/crates/strategic-web/static/css/components.css
@@ -339,6 +339,24 @@
 
 .gold-amount .game-icon { margin-left: 0.18em; }
 
+.currency-disclosure {
+  border: 0;
+  background: transparent;
+  color: currentColor;
+  cursor: pointer;
+  margin-right: 0.3rem;
+  padding: 0.1rem 0.25rem;
+  transform: rotate(0deg);
+  transition: transform 120ms ease;
+}
+.currency-disclosure[aria-expanded="true"] { transform: rotate(90deg); }
+.currency-disclosure:focus-visible { outline: 2px solid var(--accent-color, currentColor); outline-offset: 2px; }
+.currency-component-row .inventory-item-name { padding-left: 1.4rem; }
+.currency-component-row .inventory-row-actions,
+.currency-component-row .inventory-actions-cell,
+.currency-component-row button,
+.currency-component-row input { visibility: hidden; }
+
 .xp-amount {
   color: var(--xp-color);
   font-weight: 600;

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -187,35 +187,76 @@
     return Number.isFinite(value) ? value : 0;
   }
 
+  function currencyRowQuantity(row) {
+    const count = row.querySelector(".inventory-count");
+    const base = Number(row.dataset.inventoryQuantity
+      ?? count?.dataset.base
+      ?? row.querySelector("[data-target-control]")?.dataset.quantity
+      ?? row.querySelector("[data-count]")?.dataset.count
+      ?? currencyNumber(count));
+    const change = Number(count?.dataset.tradeDraftChange || 0);
+    return Math.max(0, (Number.isFinite(base) ? base : 0) + (Number.isFinite(change) ? change : 0));
+  }
+
+  function currencyRowTarget(row) {
+    return Math.max(0, Number(row.dataset.target
+      ?? row.querySelector("[data-target-value]")?.textContent
+      ?? row.querySelector("[data-target]")?.dataset.target
+      ?? 0) || 0);
+  }
+
   function groupCurrencyRows(browser) {
     const body = browser.querySelector("tbody");
-    if (!body || body.querySelector(":scope > .currency-parent-row")) return;
+    if (!body) return;
+    const previousParent = body.querySelector(":scope > .currency-parent-row");
+    const wasExpanded = previousParent?.getAttribute("aria-expanded") === "true";
+    const parentDraftChange = Number(previousParent?.querySelector(".inventory-count")?.dataset.tradeDraftChange || 0);
+    previousParent?.remove();
     const components = [...body.querySelectorAll(":scope > tr.trade-inventory-row")]
-      .filter((row) => row.querySelector('[data-item-kind="currency"]'));
+      .filter((row) => !row.classList.contains("currency-parent-row") && row.querySelector('[data-item-kind="currency"]'));
     if (!components.length) return;
     const first = components[0];
     const parent = first.cloneNode(true);
     parent.classList.add("currency-parent-row");
+    parent.classList.remove("currency-component-row");
     parent.dataset.itemKey = "coin";
     parent.dataset.merchantItem = "coin";
     const labels = parent.querySelectorAll("[data-item-name]");
     labels.forEach((label) => { label.dataset.itemName = "Coin"; label.textContent = "Coin"; delete label.dataset.currencyName; });
-    const total = components.reduce((sum, row) => sum + currencyNumber(row.querySelector(".inventory-count")), 0);
-    const weight = components.reduce((sum, row) => {
-      const quantity = currencyNumber(row.querySelector(".inventory-count"));
+    const componentTotal = components.reduce((sum, row) => sum + currencyRowQuantity(row), 0);
+    const total = Math.max(0, componentTotal + (Number.isFinite(parentDraftChange) ? parentDraftChange : 0));
+    const target = components.reduce((sum, row) => sum + currencyRowTarget(row), 0);
+    const componentWeight = components.reduce((sum, row) => {
+      const quantity = currencyRowQuantity(row);
       return sum + quantity * currencyNumber(row.querySelector(".inventory-weight"));
     }, 0);
+    const unitWeight = currencyNumber(first.querySelector(".inventory-weight"));
+    const weight = Math.max(0, componentWeight + parentDraftChange * unitWeight);
+    parent.querySelector("[data-target-control]")?.remove();
     const count = parent.querySelector(".inventory-count");
-    if (count) count.textContent = String(total);
-    parent.dataset.inventoryQuantity = String(total);
+    if (count) {
+      count.textContent = String(total);
+      count.dataset.base = String(componentTotal);
+      if (parentDraftChange) count.dataset.tradeDraftChange = String(parentDraftChange);
+      else delete count.dataset.tradeDraftChange;
+    }
+    parent.dataset.inventoryQuantity = String(componentTotal);
+    parent.dataset.target = String(target);
+    const targetCell = parent.querySelector(":scope > .inventory-target");
+    if (targetCell) targetCell.textContent = String(target);
     const weightCell = parent.querySelector(".inventory-weight");
     if (weightCell) { weightCell.textContent = weight.toFixed(2).replace(/\.00$/, ""); weightCell.dataset.sortValue = String(weight); }
     const valueCell = parent.querySelector(".inventory-gold");
     if (valueCell) { valueCell.textContent = String(total); valueCell.dataset.sortValue = String(total); }
     parent.querySelectorAll("button,input,select").forEach((control) => {
       if (control.matches("button.trade-transfer")) {
-        ["data-item", "data-from", "data-to", "data-discard-item", "data-pool-stage", "data-loot-stage", "data-merchant-sell"].forEach((attribute) => control.removeAttribute(attribute));
+        ["data-item", "data-item-name", "data-key", "data-from", "data-to", "data-discard-item", "data-pool-stage", "data-loot-stage", "data-merchant-sell"].forEach((attribute) => control.removeAttribute(attribute));
         control.dataset.coinAction = "true";
+        control.dataset.count = String(total);
+        control.dataset.target = String(target);
+        control.dataset.labelOne = "Transfer one Coin";
+        control.dataset.labelTarget = "Transfer Coin to target";
+        control.dataset.labelAll = "Transfer all Coin";
         control.setAttribute("aria-label", "Transfer Coin");
         control.title = "Transfer Coin";
       } else if (!control.matches('[data-coin-toggle]')) control.remove();
@@ -227,13 +268,22 @@
       toggle.setAttribute("aria-label", "Show currency denominations"); toggle.setAttribute("aria-expanded", "false");
       toggle.textContent = "›"; nameCell.prepend(toggle);
     }
+    parent.querySelectorAll(".game-icon").forEach((icon) => {
+      icon.setAttribute("aria-label", "Item type: Coin");
+      icon.setAttribute("title", "Item type: Coin");
+    });
     components.forEach((row) => {
       row.classList.add("currency-component-row"); row.hidden = true; row.tabIndex = -1;
       const label = row.querySelector("[data-currency-name]");
       if (label) { label.textContent = label.dataset.currencyName; label.dataset.itemName = label.dataset.currencyName; }
+      const componentCount = row.querySelector(".inventory-count");
+      if (componentCount) componentCount.textContent = String(currencyRowQuantity(row));
     });
     first.before(parent);
     parent._currencyComponents = components;
+    parent.setAttribute("aria-expanded", String(Boolean(wasExpanded)));
+    parent.querySelector("[data-coin-toggle]")?.setAttribute("aria-expanded", String(Boolean(wasExpanded)));
+    components.forEach((component) => { component.hidden = !wasExpanded; });
   }
 
   function apply(browser, state) {
@@ -347,8 +397,25 @@
         const row = coinAction.closest(".currency-parent-row");
         const buttons = row?._currencyComponents?.map((component) => component.querySelector("button.trade-transfer:not([disabled])")).filter(Boolean) || [];
         const mode = coinAction.dataset.transferMode || "one";
-        if (mode === "one") buttons[0]?.click();
-        else buttons.forEach((button) => { button.dataset.transferMode = mode; button.click(); });
+        if (mode === "one") buttons.find((button) => currencyRowQuantity(button.closest("tr")) > 0)?.click();
+        else if (mode === "all") buttons.forEach((button) => { button.dataset.transferMode = "all"; button.click(); });
+        else {
+          let remaining = Math.max(0, currencyRowQuantity(row) - Number(coinAction.dataset.target || 0));
+          buttons.forEach((button) => {
+            if (remaining === 0) return;
+            const component = button.closest("tr");
+            const quantity = currencyRowQuantity(component);
+            const transfer = Math.min(quantity, remaining);
+            const originalTarget = button.dataset.target;
+            button.dataset.target = String(quantity - transfer);
+            button.dataset.transferMode = "target";
+            button.click();
+            if (originalTarget == null) delete button.dataset.target;
+            else button.dataset.target = originalTarget;
+            remaining -= transfer;
+          });
+        }
+        groupCurrencyRows(browser);
         return;
       }
       const coinToggle = event.target.closest("[data-coin-toggle]");
@@ -375,7 +442,7 @@
       else apply(browser, browser._inventoryState || parsePanelState(global.location.search, browser.dataset.inventoryBrowser, browser.dataset.optionalColumns.split(",").filter(Boolean)));
     });
   }
-  const api = { parsePanelState, serializePanelState, compareValues, normalizeSortValue, rowValue, mountAll, refresh, syncPanelWidth };
+  const api = { parsePanelState, serializePanelState, compareValues, normalizeSortValue, rowValue, groupCurrencyRows, mountAll, refresh, syncPanelWidth };
   global.strategicInventoryBrowser = api;
   if (typeof module !== "undefined") module.exports = api;
   if (global.document) { global.addEventListener("DOMContentLoaded", () => mountAll()); global.addEventListener("popstate", () => mountAll()); }

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -266,7 +266,10 @@
       const toggle = document.createElement("button");
       toggle.type = "button"; toggle.className = "currency-disclosure"; toggle.dataset.coinToggle = "true";
       toggle.setAttribute("aria-label", "Show currency denominations"); toggle.setAttribute("aria-expanded", "false");
-      toggle.textContent = "›"; nameCell.prepend(toggle);
+      toggle.textContent = "›";
+      const coinLabel = nameCell.querySelector("[data-item-name]");
+      if (coinLabel) coinLabel.after(toggle);
+      else nameCell.append(toggle);
     }
     parent.querySelectorAll(".game-icon").forEach((icon) => {
       icon.setAttribute("aria-label", "Item type: Coin");
@@ -302,7 +305,10 @@
       if (row.getAttribute("aria-expanded") === "true" && !row._currencyComponents) createDetail(row, browser);
     });
     browser.querySelectorAll("thead [data-inventory-column]").forEach((header) => { header.hidden = !state.columns.includes(header.dataset.inventoryColumn); });
-    rows.map((row, index) => ({ row, index })).sort((a, b) => compareValues(rowValue(a.row, state.sort), rowValue(b.row, state.sort), state.direction) || a.index - b.index).forEach(({ row }) => {
+    rows.map((row, index) => ({ row, index })).sort((a, b) => {
+      const coinPriority = Number(!a.row.classList.contains("currency-parent-row")) - Number(!b.row.classList.contains("currency-parent-row"));
+      return coinPriority || compareValues(rowValue(a.row, state.sort), rowValue(b.row, state.sort), state.direction) || a.index - b.index;
+    }).forEach(({ row }) => {
       body.append(row);
       if (row._currencyComponents) row._currencyComponents.forEach((component) => body.append(component));
       const detail = row._inventoryDetail;

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -299,7 +299,7 @@
       row.hidden = !name.includes(state.query.toLocaleLowerCase());
       Object.keys(OPTIONAL_COLUMNS).forEach((column) => optionalCell(row, column).hidden = !state.columns.includes(column));
       if (row._inventoryDetail) { row._inventoryDetail.remove(); row._inventoryDetail = null; }
-      if (row.getAttribute("aria-expanded") === "true") createDetail(row, browser);
+      if (row.getAttribute("aria-expanded") === "true" && !row._currencyComponents) createDetail(row, browser);
     });
     browser.querySelectorAll("thead [data-inventory-column]").forEach((header) => { header.hidden = !state.columns.includes(header.dataset.inventoryColumn); });
     rows.map((row, index) => ({ row, index })).sort((a, b) => compareValues(rowValue(a.row, state.sort), rowValue(b.row, state.sort), state.direction) || a.index - b.index).forEach(({ row }) => {

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -182,10 +182,65 @@
     grid.style.setProperty(`--inventory-${side}-width`, `${contentWidth + frameWidth}px`);
   }
 
+  function currencyNumber(cell) {
+    const value = Number(String(cell?.dataset.sortValue || cell?.textContent || "0").replace(/[^0-9+.-]/g, ""));
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  function groupCurrencyRows(browser) {
+    const body = browser.querySelector("tbody");
+    if (!body || body.querySelector(":scope > .currency-parent-row")) return;
+    const components = [...body.querySelectorAll(":scope > tr.trade-inventory-row")]
+      .filter((row) => row.querySelector('[data-item-kind="currency"]'));
+    if (!components.length) return;
+    const first = components[0];
+    const parent = first.cloneNode(true);
+    parent.classList.add("currency-parent-row");
+    parent.dataset.itemKey = "coin";
+    parent.dataset.merchantItem = "coin";
+    const labels = parent.querySelectorAll("[data-item-name]");
+    labels.forEach((label) => { label.dataset.itemName = "Coin"; label.textContent = "Coin"; delete label.dataset.currencyName; });
+    const total = components.reduce((sum, row) => sum + currencyNumber(row.querySelector(".inventory-count")), 0);
+    const weight = components.reduce((sum, row) => {
+      const quantity = currencyNumber(row.querySelector(".inventory-count"));
+      return sum + quantity * currencyNumber(row.querySelector(".inventory-weight"));
+    }, 0);
+    const count = parent.querySelector(".inventory-count");
+    if (count) count.textContent = String(total);
+    parent.dataset.inventoryQuantity = String(total);
+    const weightCell = parent.querySelector(".inventory-weight");
+    if (weightCell) { weightCell.textContent = weight.toFixed(2).replace(/\.00$/, ""); weightCell.dataset.sortValue = String(weight); }
+    const valueCell = parent.querySelector(".inventory-gold");
+    if (valueCell) { valueCell.textContent = String(total); valueCell.dataset.sortValue = String(total); }
+    parent.querySelectorAll("button,input,select").forEach((control) => {
+      if (control.matches("button.trade-transfer")) {
+        ["data-item", "data-from", "data-to", "data-discard-item", "data-pool-stage", "data-loot-stage", "data-merchant-sell"].forEach((attribute) => control.removeAttribute(attribute));
+        control.dataset.coinAction = "true";
+        control.setAttribute("aria-label", "Transfer Coin");
+        control.title = "Transfer Coin";
+      } else if (!control.matches('[data-coin-toggle]')) control.remove();
+    });
+    const nameCell = parent.querySelector(".inventory-item-name");
+    if (nameCell) {
+      const toggle = document.createElement("button");
+      toggle.type = "button"; toggle.className = "currency-disclosure"; toggle.dataset.coinToggle = "true";
+      toggle.setAttribute("aria-label", "Show currency denominations"); toggle.setAttribute("aria-expanded", "false");
+      toggle.textContent = "›"; nameCell.prepend(toggle);
+    }
+    components.forEach((row) => {
+      row.classList.add("currency-component-row"); row.hidden = true; row.tabIndex = -1;
+      const label = row.querySelector("[data-currency-name]");
+      if (label) { label.textContent = label.dataset.currencyName; label.dataset.itemName = label.dataset.currencyName; }
+    });
+    first.before(parent);
+    parent._currencyComponents = components;
+  }
+
   function apply(browser, state) {
+    groupCurrencyRows(browser);
     const body = browser.querySelector("tbody");
     if (!body) return;
-    const rows = [...body.querySelectorAll(":scope > tr.trade-inventory-row:not(.inventory-detail-row)")];
+    const rows = [...body.querySelectorAll(":scope > tr.trade-inventory-row:not(.inventory-detail-row):not(.currency-component-row)")];
     rows.forEach((row) => normalizeDestinationRow(row, browser));
     rows.forEach((row) => {
       row.tabIndex = 0;
@@ -199,6 +254,7 @@
     browser.querySelectorAll("thead [data-inventory-column]").forEach((header) => { header.hidden = !state.columns.includes(header.dataset.inventoryColumn); });
     rows.map((row, index) => ({ row, index })).sort((a, b) => compareValues(rowValue(a.row, state.sort), rowValue(b.row, state.sort), state.direction) || a.index - b.index).forEach(({ row }) => {
       body.append(row);
+      if (row._currencyComponents) row._currencyComponents.forEach((component) => body.append(component));
       const detail = row._inventoryDetail;
       if (detail) body.append(detail);
     });
@@ -246,6 +302,11 @@
   function toggleExpanded(row, browser) {
     const open = row.getAttribute("aria-expanded") === "true";
     row.setAttribute("aria-expanded", String(!open));
+    if (row._currencyComponents) {
+      row.querySelector("[data-coin-toggle]")?.setAttribute("aria-expanded", String(!open));
+      row._currencyComponents.forEach((component) => { component.hidden = open || row.hidden; });
+      return;
+    }
     if (!open) createDetail(row, browser);
     else if (row._inventoryDetail) row._inventoryDetail.hidden = true;
   }
@@ -280,6 +341,18 @@
     search.addEventListener("input", () => { state.query = search.value; updateHistory(browser, state, browser._searchEditing === true); browser._searchEditing = true; apply(browser, state); });
     search.addEventListener("blur", () => { browser._searchEditing = false; });
     browser.addEventListener("click", (event) => {
+      const coinAction = event.target.closest("[data-coin-action]");
+      if (coinAction) {
+        event.preventDefault(); event.stopImmediatePropagation();
+        const row = coinAction.closest(".currency-parent-row");
+        const buttons = row?._currencyComponents?.map((component) => component.querySelector("button.trade-transfer:not([disabled])")).filter(Boolean) || [];
+        const mode = coinAction.dataset.transferMode || "one";
+        if (mode === "one") buttons[0]?.click();
+        else buttons.forEach((button) => { button.dataset.transferMode = mode; button.click(); });
+        return;
+      }
+      const coinToggle = event.target.closest("[data-coin-toggle]");
+      if (coinToggle) { event.preventDefault(); toggleExpanded(coinToggle.closest(".currency-parent-row"), browser); return; }
       const sort = event.target.closest("[data-inventory-sort]");
       if (sort) { const key = sort.dataset.inventorySort; state.direction = state.sort === key && state.direction === "asc" ? "desc" : "asc"; state.sort = key; updateHistory(browser, state); apply(browser, state); return; }
       const row = event.target.closest("tr.trade-inventory-row");

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -298,7 +298,7 @@ function updateMerchantGoldDraft() {
     if (quantity > 0) goldChange -= buyPrices.get(itemId) * quantity;
     if (quantity < 0) goldChange += saleDetails.get([...sales.keys()].find((inventoryId) => saleDetails.get(inventoryId).itemId === itemId)).price * -quantity;
   });
-  const goldRow = merchantRow("gold_coin", document.querySelector(".right-sidebar"));
+  const goldRow = merchantRow("coin", document.querySelector(".right-sidebar"));
   if (goldRow) setTradeDraftCount(goldRow, goldChange);
 }
 

--- a/crates/strategic-web/static/service-quests.js
+++ b/crates/strategic-web/static/service-quests.js
@@ -178,7 +178,7 @@
     line("npc", quest.npc_name, quest.turn_in_response);
     window.strategicChat?.appendInfo(
       chat,
-      `${result.reward} gold has been added to your party inventory.`,
+      `${result.reward} coin has been added to your party inventory.`,
     );
     setMapQuestActive(false);
     const tab = services.querySelector(`[data-service-id="${CSS.escape(quest.service_id)}"]`);
@@ -259,7 +259,7 @@
     greeting.append(link("Feeling ill", requestHerbalistExamination));
     const examFee = Number(chat.dataset.herbalistExamFee);
     greeting.append(document.createTextNode(
-      `? Or are you looking to purchase some ingredients? An examination costs ${examFee} gold.`,
+      `? Or are you looking to purchase some ingredients? An examination costs ${examFee} coin.`,
     ));
     if (quest?.state === "available" || quest?.state === "recruiting") {
       greeting.append(document.createTextNode(" I could also use your help concerning "));

--- a/crates/strategic-web/tests/currency-backend-source.test.cjs
+++ b/crates/strategic-web/tests/currency-backend-source.test.cjs
@@ -1,0 +1,17 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+
+const source = fs.readFileSync("crates/adventuresim-stdb-module/src/item.rs", "utf8");
+
+test("currency issuance validates and uses the persisted settlement denomination", () => {
+  assert.match(source, /currency_id_for_settlement[\s\S]*ctx\.db\.settlement\(\)\.id\(\)\.find/);
+  assert.match(source, /CURRENCY_IDS\.contains\(&settlement\.currency_id\.as_str\(\)\)/);
+  assert.match(source, /let currency_id = currency_id_for_settlement\(ctx, settlement_id\)\?/);
+});
+
+test("repeated personal currency credits merge their existing denomination stack", () => {
+  assert.match(source, /character_and_item_id\(\)[\s\S]*filter\(\(character_id, &currency_id\)\)/);
+  assert.match(source, /stack\.quantity = merged_currency_quantity\(stack\.quantity, amount\)/);
+  assert.match(source, /inventory_item\(\)\.id\(\)\.update\(stack\)/);
+});

--- a/crates/strategic-web/tests/inventory-browser.dom.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.dom.test.cjs
@@ -58,6 +58,7 @@ test("mixed currency DOM stays one aggregate through normalization, staging, and
   parents = browser.querySelectorAll(".currency-parent-row");
   assert.equal(parents.length, 1);
   assert.equal(parents[0].querySelector(".inventory-count").textContent, "4");
+  assert.equal(browser.querySelectorAll(".inventory-detail-row").length, 0);
 
   browser.querySelector("tbody").insertAdjacentHTML("beforeend", currencyRow("saxon_thaler", "Saxon thaler", 4));
   inventory.refresh(browser);

--- a/crates/strategic-web/tests/inventory-browser.dom.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.dom.test.cjs
@@ -1,0 +1,99 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { parseHTML } = require("linkedom");
+
+function currencyRow(id, name, quantity, target = 0) {
+  return `<tr class="trade-inventory-row" data-inventory-quantity="${quantity}" data-item-key="${id}">
+    <td class="inventory-item-type"><span class="game-icon" role="img" aria-label="Item type: ${name}" title="Item type: ${name}"></span></td>
+    <td class="inventory-item-name"><span data-item-name="Coin" data-item-kind="currency" data-currency-name="${name}">Coin</span>
+      <span class="inventory-row-actions"><button type="button" class="trade-transfer" data-dynamic-transfer data-item-name="${name}" data-transfer-mode="one" data-count="${quantity}" data-target="${target}" data-label-one="Transfer one ${name}" data-label-target="Transfer ${name} to target" data-label-all="Transfer all ${name}" aria-label="Transfer one ${name}" title="Transfer one ${name}">→</button></span>
+    </td>
+    <td class="inventory-count"><span data-target-control data-quantity="${quantity}"><span data-target-value>${target}</span></span></td>
+    <td class="inventory-weight">0.01</td><td class="inventory-gold">1</td>
+  </tr>`;
+}
+
+function fixture() {
+  const { window, document } = parseHTML(`<html><body>
+    <div data-inventory-browser="test" data-optional-columns="">
+      <input data-inventory-search><div data-inventory-column-options></div>
+      <table class="trade-inventory-table"><thead><tr><th>Name</th><th class="inventory-column-count">#</th></tr></thead><tbody>
+        ${currencyRow("lubeck_mark", "Lübeck mark", 3, 1)}
+        ${currencyRow("danish_mark", "Danish mark", 2, 0)}
+      </tbody></table>
+    </div></body></html>`);
+  window.location = { search: "", pathname: "/", hash: "" };
+  window.history = { pushState() {}, replaceState() {} };
+  window.getComputedStyle = () => ({ paddingLeft: "0", paddingRight: "0" });
+  global.window = window;
+  global.document = document;
+  return { window, document, browser: document.querySelector("[data-inventory-browser]") };
+}
+
+test("mixed currency DOM stays one aggregate through normalization, staging, and live insertion", () => {
+  const { document, browser } = fixture();
+  delete require.cache[require.resolve("../static/inventory-browser.js")];
+  const inventory = require("../static/inventory-browser.js");
+  inventory.mountAll(document);
+
+  let parents = browser.querySelectorAll(".currency-parent-row");
+  assert.equal(parents.length, 1);
+  assert.equal(parents[0].querySelector(".inventory-count").textContent, "5");
+  assert.equal(parents[0].dataset.inventoryQuantity, "5");
+  assert.equal(parents[0].querySelector(".inventory-weight").textContent, "0.05");
+  assert.equal(parents[0].querySelector(".game-icon").getAttribute("aria-label"), "Item type: Coin");
+  assert.equal(parents[0].querySelector(".trade-transfer").dataset.labelAll, "Transfer all Coin");
+  assert.doesNotMatch(parents[0].outerHTML, /Lübeck|Danish/);
+
+  parents[0].querySelector("[data-coin-toggle]").click();
+  const children = [...browser.querySelectorAll(".currency-component-row")];
+  assert.deepEqual(children.map((row) => row.querySelector(".inventory-count").textContent), ["3", "2"]);
+  assert.deepEqual(children.map((row) => row.querySelector("[data-item-name]").textContent), ["Lübeck mark", "Danish mark"]);
+
+  const firstCount = children[0].querySelector(".inventory-count");
+  firstCount.dataset.base = "3";
+  firstCount.dataset.tradeDraftChange = "-1";
+  firstCount.innerHTML = "3 <span>-1</span>";
+  inventory.refresh(browser);
+  parents = browser.querySelectorAll(".currency-parent-row");
+  assert.equal(parents.length, 1);
+  assert.equal(parents[0].querySelector(".inventory-count").textContent, "4");
+
+  browser.querySelector("tbody").insertAdjacentHTML("beforeend", currencyRow("saxon_thaler", "Saxon thaler", 4));
+  inventory.refresh(browser);
+  parents = browser.querySelectorAll(".currency-parent-row");
+  assert.equal(parents.length, 1);
+  assert.equal(parents[0].querySelector(".inventory-count").textContent, "8");
+});
+
+test("aggregate Coin one, all, and target actions route coherently to component rows", () => {
+  const { document, browser } = fixture();
+  delete require.cache[require.resolve("../static/inventory-browser.js")];
+  const inventory = require("../static/inventory-browser.js");
+  inventory.mountAll(document);
+  const calls = [];
+  browser.querySelectorAll(".currency-component-row .trade-transfer").forEach((button) => {
+    button.addEventListener("click", () => calls.push({
+      name: button.closest("tr").querySelector("[data-item-name]").textContent,
+      mode: button.dataset.transferMode,
+      target: button.dataset.target,
+    }));
+  });
+
+  browser.querySelector(".currency-parent-row .trade-transfer").click();
+  assert.deepEqual(calls.map((call) => call.name), ["Lübeck mark"]);
+
+  calls.length = 0;
+  let action = browser.querySelector(".currency-parent-row .trade-transfer");
+  action.dataset.transferMode = "all";
+  action.click();
+  assert.equal(calls.length, 2);
+  assert.ok(calls.every((call) => call.mode === "all"));
+
+  calls.length = 0;
+  action = browser.querySelector(".currency-parent-row .trade-transfer");
+  action.dataset.transferMode = "target";
+  action.click();
+  assert.equal(calls.length, 2);
+  assert.ok(calls.every((call) => call.mode === "target"));
+});

--- a/crates/strategic-web/tests/inventory-browser.dom.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.dom.test.cjs
@@ -13,11 +13,21 @@ function currencyRow(id, name, quantity, target = 0) {
   </tr>`;
 }
 
+function ordinaryRow(id, name, quantity) {
+  return `<tr class="trade-inventory-row" data-inventory-quantity="${quantity}" data-item-key="${id}">
+    <td class="inventory-item-type"></td>
+    <td class="inventory-item-name"><span data-item-name="${name}" data-item-kind="supply">${name}</span></td>
+    <td class="inventory-count">${quantity}</td>
+    <td class="inventory-weight">1</td><td class="inventory-gold">999</td>
+  </tr>`;
+}
+
 function fixture() {
   const { window, document } = parseHTML(`<html><body>
     <div data-inventory-browser="test" data-optional-columns="">
       <input data-inventory-search><div data-inventory-column-options></div>
       <table class="trade-inventory-table"><thead><tr><th>Name</th><th class="inventory-column-count">#</th></tr></thead><tbody>
+        ${ordinaryRow("apple", "Apple", 999)}
         ${currencyRow("lubeck_mark", "Lübeck mark", 3, 1)}
         ${currencyRow("danish_mark", "Danish mark", 2, 0)}
       </tbody></table>
@@ -43,7 +53,15 @@ test("mixed currency DOM stays one aggregate through normalization, staging, and
   assert.equal(parents[0].querySelector(".inventory-weight").textContent, "0.05");
   assert.equal(parents[0].querySelector(".game-icon").getAttribute("aria-label"), "Item type: Coin");
   assert.equal(parents[0].querySelector(".trade-transfer").dataset.labelAll, "Transfer all Coin");
+  assert.equal(parents[0].querySelector("[data-item-name]").nextElementSibling, parents[0].querySelector("[data-coin-toggle]"));
   assert.doesNotMatch(parents[0].outerHTML, /Lübeck|Danish/);
+  assert.equal(browser.querySelector("tbody > tr:not(.currency-component-row)"), parents[0]);
+
+  browser._inventoryState.sort = "quantity";
+  browser._inventoryState.direction = "desc";
+  inventory.refresh(browser);
+  parents = browser.querySelectorAll(".currency-parent-row");
+  assert.equal(browser.querySelector("tbody > tr:not(.currency-component-row)"), parents[0]);
 
   parents[0].querySelector("[data-coin-toggle]").click();
   const children = [...browser.querySelectorAll(".currency-component-row")];

--- a/crates/strategic-web/tests/inventory-browser.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.test.cjs
@@ -43,6 +43,17 @@ test("destination refresh is exposed for generated row insertion", () => {
   assert.equal(typeof syncPanelWidth, "function");
 });
 
+test("currency rows use one aggregate parent and dedicated denomination components", () => {
+  const source = fs.readFileSync(path.join(__dirname, "../static/inventory-browser.js"), "utf8");
+  assert.match(source, /groupCurrencyRows\(browser\)/);
+  assert.match(source, /currency-parent-row/);
+  assert.match(source, /currency-component-row/);
+  assert.match(source, /data-coin-toggle/);
+  assert.match(source, /row\._currencyComponents/);
+  assert.match(source, /not\(\.currency-component-row\)/);
+  assert.doesNotMatch(source, /No additional details[\s\S]*currency-component-row/);
+});
+
 test("rail measurement excludes projected action overflow", () => {
   const source = fs.readFileSync(path.join(__dirname, "../static/inventory-browser.js"), "utf8");
   assert.match(source, /table\?\.getBoundingClientRect\?\.\(\)\.width/);

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (815)
+## Files (820)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -53,6 +53,7 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-core/src/provisioning.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/simulation_security.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/skill.rs` — Rust source module for this component.
+- `crates/adventuresim-core/src/strategic_currency.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/strategic_economy.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/strategic_schedule.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/strategic_time.rs` — Rust source module for this component.
@@ -553,6 +554,8 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/Cargo.toml` — Cargo package/workspace manifest.
 - `crates/strategic-web/Dockerfile` — Container build definition.
 - `crates/strategic-web/README.md` — Component overview and usage notes.
+- `crates/strategic-web/package-lock.json` — Repository support file.
+- `crates/strategic-web/package.json` — Repository support file.
 - `crates/strategic-web/src/config.rs` — Rust source module for this component.
 - `crates/strategic-web/src/live.rs` — Rust source module for this component.
 - `crates/strategic-web/src/main.rs` — Rust source module for this component.
@@ -754,8 +757,10 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/static/strategic-time.js` — Repository support file.
 - `crates/strategic-web/static/training-schedule.js` — Repository support file.
 - `crates/strategic-web/static/travel-planner.js` — Repository support file.
+- `crates/strategic-web/tests/currency-backend-source.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/environment.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/icon-rendering.test.cjs` — Repository support file.
+- `crates/strategic-web/tests/inventory-browser.dom.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/inventory-browser.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/local-chat.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/rest-duration.test.cjs` — Repository support file.

--- a/wiki/shared/Inventory.md
+++ b/wiki/shared/Inventory.md
@@ -12,7 +12,13 @@ Durable equipment is never stacked: every weapon, shield, and armor piece is a d
 ### Looting and Selling
 A party can configure a weight limit using a slider, which shows them what the total party [travel](../strategic/Travel.md) speed would be at a given limit presuming that the load is optimally distributed (such that all characters can maintain the same pace). When a tactical simulation ends, the party sees a screen that displays all of the loot available to collect. They _could_ loot each individual item and decide whose inventories they are going into, _or_ they could just press the "autoloot" button which will loot items in order of their value to weight ratio until the weight limit is reached. Like with resupplying, you can anticipate this behavior because any items to be looted will have a gold highlight which matches the gold loot button. When in a town, the loot button becomes a sell button, and any items not in any of your equipment sets will be sold.
 
-For the current implementation, battle loot first enters a shared party inventory. Every item has an objective hardcoded gold value. New battle loot credits each battle participant an equal stake by value, with an indivisible remainder retained by the party and eventually awarded to the captain when the party closes. A character may deposit personal items for an equivalent increase in their own stake, or withdraw items against that stake. If an indivisible item is worth more than the character's remaining stake, personal gold may cover the difference and enters the party inventory. The two-sided party-inventory view keeps the shared chest on the left and the active character's inventory on the right. At settlement merchants, party-owned items can be liquidated into party gold without changing the existing stakes. A dead character's stake currently expires; inheritance is a future system.
+For the current implementation, battle loot first enters a shared party inventory. Every item has an objective hardcoded coin value. New battle loot credits each battle participant an equal stake by value, with an indivisible remainder retained by the party and eventually awarded to the captain when the party closes. A character may deposit personal items for an equivalent increase in their own stake, or withdraw items against that stake. If an indivisible item is worth more than the character's remaining stake, personal coin may cover the difference and enters the party inventory without changing denomination. The two-sided party-inventory view keeps the shared chest on the left and the active character's inventory on the right. At settlement merchants, party-owned items can be liquidated into locally denominated party coin without changing the existing stakes. A dead character's stake currently expires; inheritance is a future system.
+
+Currency stacks are grouped into a single **Coin** row throughout inventory UI.
+The collapsed row supports the normal transfer, trade, and discard interactions;
+expanding its chevron reveals the historical denominations without treating
+them as independent rows for search, sorting, or bulk operations. Currency is
+excluded from ordinary sale and liquidation.
 
 Some items might also automatically be flagged as "keep" (perhaps a checkbox next to them in the inventory menu), such as goblin ears if you're on a quest to kill goblins and this is the required trophy to turn in for the reward.
 
@@ -23,8 +29,8 @@ Any items which _are_ in your equipment sets, but not in the currently configure
 The trade/loot page can also have a red button+highlight for rations. When pressed, you will purchase however many rations would be required for the currently planned journey. It may also have a slider to increase/decrease the number of expected days in case you want some safety margin or to eat something at your destination (warning: orc and goblin meat is nasty and unsanitary).
 
 The current implementation defines personal `travel_ration` and `waterskin`
-items. A ration weighs 1 kg, costs 3 gold through automatic provisioning, and
-supplies 6,000 kcal. A waterskin weighs 0.5 kg empty, costs 2 gold, and adds 4
+items. A ration weighs 1 kg, costs 3 coin through automatic provisioning, and
+supplies 6,000 kcal. A waterskin weighs 0.5 kg empty, costs 2 coin, and adds 4
 litres of aggregate carried-water capacity. Water volume is tracked per
 character rather than per individual container; carried water adds one kilogram
 per litre to that character's encumbrance. Party-pool provisions are not

--- a/wiki/strategic/Trade.md
+++ b/wiki/strategic/Trade.md
@@ -26,7 +26,7 @@ is transient and has no effect on sorting, filtering, or bulk actions.
 The General Market, Weaponsmith, Armourer, and Tailor use the same live trade
 interface and transaction reducer. The specialist storefronts filter their
 unlimited displayed stock by item category, while all use the same pricing and
-buy/sell behavior. Drafting a trade immediately displays the item and gold
+buy/sell behavior. Drafting a trade immediately displays the item and coin
 quantity changes on both sides; inventory changes only persist after choosing
 **Offer**.
 Trades are bound to the settlement where the character is currently located;

--- a/wiki/strategic/Trade.md
+++ b/wiki/strategic/Trade.md
@@ -6,12 +6,22 @@ consume these signals, but rules v6 does not create prices, inventory, or
 shipping flows.
 
 For the current strategic prototype, every settlement exposes the same unlimited
-merchant catalogue, including imported Viabundus settlements. Items have a base gold value; merchant buy and sell prices are
+merchant catalogue, including imported Viabundus settlements. Items have a base coin value; merchant buy and sell prices are
 derived from it with shared hidden profit-margin and sales-tax multipliers.
 Both the merchant and player inventory tables display each item's per-unit
-weight and relevant gold value.
-Gold is represented by the `gold_coin` inventory item, in the `Currency`
-category, rather than a separate character resource.
+weight and relevant coin value.
+Coin is authoritative inventory rather than a separate character resource.
+Every settlement reproducibly selects one denomination from a fixed 1544-flavoured
+set: Rhenish gulden, Lübeck mark, Hamburg mark, Saxon thaler, Brandenburg
+groschen, and Danish mark. Starter funds and newly issued payments use the
+issuing settlement's denomination; quest and battle rewards use the quest's
+issuing settlement. All denominations currently have equal value and are
+accepted everywhere.
+
+Inventory presents every character or party's currency as one ordinary,
+collapsed **Coin** row. Its quantity, value, and weight aggregate the underlying
+stacks. An accessible disclosure reveals read-only denomination rows; expansion
+is transient and has no effect on sorting, filtering, or bulk actions.
 
 The General Market, Weaponsmith, Armourer, and Tailor use the same live trade
 interface and transaction reducer. The specialist storefronts filter their
@@ -36,8 +46,8 @@ separate actions that never enter the sale draft. A smith repairs only condition
 their independently seeded skill (minimum 3), but may accept an item with additional harder damage
 and leave that residual condition untouched. Custody and the quoted ETA persist across travel and
 have no collection deadline. The smith quotes the full job when accepting it: the item's base value
-multiplied by the share of damage that smith can repair, rounded up to at least one gold. The quote
-is stable while the item is in custody and is paid from personal gold when completed work is
+multiplied by the share of damage that smith can repair, rounded up to at least one coin. The quote
+is stable while the item is in custody and is paid from personal coin when completed work is
 retrieved. The custody table shows durability, ETA, and this full-job cost. A row arrow retrieves
 that exact quoted order by default; Shift changes it to retrieve up to two matching ready orders,
 and Control changes it to retrieve all matching ready orders. The header arrow defaults to two and


### PR DESCRIPTION
## Summary

- replace the player-facing gold abstraction with an aggregate **Coin** inventory row
- assign each settlement a deterministic historical currency and issue that currency for settlement-sourced rewards
- accept every historical currency at equal value while preserving denominations behind an expandable row
- centralize the currency catalog, merge repeated denomination credits, and update strategic docs/copy
- add DOM regression coverage for aggregation, disclosure privacy, live refresh, and aggregate actions

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p adventuresim-core -p adventuresim-stdb-module -p strategic-web -p adventuresim-strategic-sim`
- `npm test` (57/57)
- `just verify-db-client`
- `python scripts/update_project_map.py --check`
- `git diff --check`

## Live demo

Ran the isolated strategic profile at `http://127.0.0.1:23501`. Riverdale persisted `lubeck_mark`; a character carrying 100 Rhenish gulden bought a 2-coin bandage there. The collapsed aggregate showed only Coin, expansion revealed Rhenish gulden, and the confirmed trade persisted both balances at 98.