### PR TITLE
Overhaul strategic web UI

### DIFF
--- a/crates/strategic-web/src/routes/characters.rs
+++ b/crates/strategic-web/src/routes/characters.rs
@@ -3,7 +3,7 @@
 use axum::{
     Form, Router,
     extract::{Path, State},
-    response::{Html, IntoResponse, Redirect, Response},
+    response::{Html, IntoResponse, Response},
     routing::{get, post},
 };
 use serde::Deserialize;
@@ -12,7 +12,9 @@ use serde_json::json;
 use super::AppState;
 use crate::session::{Session, clear_character_cookie, set_character_cookie};
 use crate::spacetimedb::Character;
-use crate::templates::character::{character_new_page, characters_list_page};
+use crate::templates::character::{
+    character_new_page, character_new_page_with_error, characters_list_page,
+};
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -65,7 +67,17 @@ async fn create_character(
         .await
     {
         tracing::error!("Failed to create character {id}: {error}");
-        return Redirect::to("/characters/new").into_response();
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Html(
+                character_new_page_with_error(
+                    Some(form.name.trim()),
+                    Some("That adventurer could not be created. Check the name and try again."),
+                )
+                .into_string(),
+            ),
+        )
+            .into_response();
     }
 
     // Auto-select the newly created character

--- a/crates/strategic-web/src/routes/quests.rs
+++ b/crates/strategic-web/src/routes/quests.rs
@@ -343,7 +343,7 @@ async fn quest_location_base(
     State(state): State<AppState>,
     Path(id): Path<String>,
     session: Session,
-) -> Html<String> {
+) -> Response {
     render_quest_location(state, id, session, QuestLocationTab::Base).await
 }
 
@@ -352,7 +352,7 @@ async fn quest_location_map(
     Path(id): Path<String>,
     Query(query): Query<QuestMapQuery>,
     session: Session,
-) -> Html<String> {
+) -> Response {
     render_quest_location(state, id, session, QuestLocationTab::Map(query.destination)).await
 }
 
@@ -360,7 +360,7 @@ async fn quest_location_loot(
     State(state): State<AppState>,
     Path(id): Path<String>,
     session: Session,
-) -> Html<String> {
+) -> Response {
     render_quest_location(state, id, session, QuestLocationTab::Loot).await
 }
 
@@ -447,7 +447,7 @@ async fn render_quest_location(
     id: String,
     session: Session,
     tab: QuestLocationTab,
-) -> Html<String> {
+) -> Response {
     let matching_quests: Vec<Quest> = state
         .db
         .query(&format!(
@@ -457,7 +457,20 @@ async fn render_quest_location(
         .await
         .unwrap_or_default();
     let Some(quest) = matching_quests.first() else {
-        return Html("<h1>Quest location not found</h1>".to_string());
+        return (
+            StatusCode::NOT_FOUND,
+            Html(
+                crate::templates::strategic_notice_page(
+                    "Quest location not found",
+                    "The requested destination is no longer available.",
+                    "/characters",
+                    "Return to character select",
+                    None,
+                )
+                .into_string(),
+            ),
+        )
+            .into_response();
     };
     let character = match session.character_id_u64() {
         Some(character_id) => {
@@ -490,7 +503,21 @@ async fn render_quest_location(
         .as_ref()
         .is_some_and(|c| c.current_quest_location_id.as_deref() == Some(&quest.id));
     if !is_at_location {
-        return Html("<h1>Your party is not at this quest location</h1>".to_string());
+        let return_href = character
+            .as_ref()
+            .and_then(|character| character.current_settlement_id.as_deref())
+            .map(|settlement_id| format!("/locations/settlement/{settlement_id}"))
+            .unwrap_or_else(|| "/characters".to_string());
+        return (
+            StatusCode::FORBIDDEN,
+            Html(crate::templates::strategic_notice_page(
+                "Your party is elsewhere",
+                "Travel to this quest destination before opening its encounter, map, or loot views.",
+                &return_href,
+                "Return to your location",
+                character.as_ref().map(|character| character.name.as_str()),
+            ).into_string()),
+        ).into_response();
     }
     let settlements: Vec<Settlement> = state
         .db
@@ -717,7 +744,7 @@ async fn render_quest_location(
             logged_in_as,
         ),
     };
-    Html(page.into_string())
+    Html(page.into_string()).into_response()
 }
 
 async fn party_is_ready(state: &AppState, members: &[Character]) -> bool {

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -277,20 +277,60 @@ async fn alchemy(
     Path(id): Path<String>,
     Query(query): Query<AlchemyQuery>,
     session: Session,
-) -> Html<String> {
+) -> Response {
     let Some((character, inventory)) =
         get_active_character(&state, session.character_id_u64()).await
     else {
-        return Html("<h1>Choose a character first</h1>".into());
+        return (
+            StatusCode::UNAUTHORIZED,
+            Html(
+                crate::templates::strategic_notice_page(
+                    "Choose an adventurer",
+                    "Select an adventurer before opening the alchemy workbench.",
+                    "/characters",
+                    "Choose an adventurer",
+                    None,
+                )
+                .into_string(),
+            ),
+        )
+            .into_response();
     };
     if character.current_settlement_id.as_deref() != Some(&id) {
-        return Html("<h1>Your character is not at this settlement</h1>".into());
+        let return_href = character
+            .current_settlement_id
+            .as_deref()
+            .map(|settlement_id| format!("/locations/settlement/{settlement_id}"))
+            .unwrap_or_else(|| "/characters".to_string());
+        return (
+            StatusCode::FORBIDDEN,
+            Html(
+                crate::templates::strategic_notice_page(
+                    "Alchemy is out of reach",
+                    "Your adventurer must be at this settlement to use its workbench.",
+                    &return_href,
+                    "Return to your location",
+                    Some(&character.name),
+                )
+                .into_string(),
+            ),
+        )
+            .into_response();
     }
     let medicine = get_character_capability(&state, character.id)
         .await
         .map_or(0.0, |capability| capability.medicine);
     if medicine < adventuresim_core::disease::MEDICINE_VITALS_THRESHOLD {
-        return Html("<h1>Medicine 2 is required to prepare medication</h1>".into());
+        return (
+            StatusCode::FORBIDDEN,
+            Html(crate::templates::strategic_notice_page(
+                "More Medicine training required",
+                "Alchemy requires Medicine 2. Visit the herbalist for prepared treatments and ingredients.",
+                &format!("/settlements/{id}/herbalist"),
+                "Return to the herbalist",
+                Some(&character.name),
+            ).into_string()),
+        ).into_response();
     }
     let settlement: Option<Settlement> = state
         .db
@@ -301,7 +341,20 @@ async fn alchemy(
         .await
         .unwrap_or_default();
     let Some(settlement) = settlement else {
-        return Html("<h1>Settlement not found</h1>".into());
+        return (
+            StatusCode::NOT_FOUND,
+            Html(
+                crate::templates::strategic_notice_page(
+                    "Settlement not found",
+                    "The requested settlement could not be found.",
+                    "/characters",
+                    "Return to character select",
+                    Some(&character.name),
+                )
+                .into_string(),
+            ),
+        )
+            .into_response();
     };
     let selected = query
         .recipe
@@ -337,6 +390,7 @@ async fn alchemy(
         )
         .into_string(),
     )
+    .into_response()
 }
 
 async fn craft_medication(

--- a/crates/strategic-web/src/templates/character.rs
+++ b/crates/strategic-web/src/templates/character.rs
@@ -41,7 +41,7 @@ pub fn characters_list_page(characters: &[Character], current_character_id: Opti
                                 }
                             }
                             form action=(format!("/characters/{}/select", character.id)) method="post" class="mt-1" {
-                                button type="submit" class="btn btn-primary btn-block" {
+                                button type="submit" class="btn btn-primary btn-block character-select-action" {
                                     @if !character.alive { "View " (&character.name) }
                                     @else if is_current { "Continue" }
                                     @else { "Play as " (&character.name) }
@@ -95,6 +95,10 @@ mod tests {
 
 /// Character creation form.
 pub fn character_new_page(_logged_in_as: Option<&str>) -> Markup {
+    character_new_page_with_error(None, None)
+}
+
+pub fn character_new_page_with_error(name: Option<&str>, error: Option<&str>) -> Markup {
     let content = html! {
         aside class="left-sidebar" {
             (sidebar_section("Tips", html! {
@@ -111,7 +115,10 @@ pub fn character_new_page(_logged_in_as: Option<&str>) -> Markup {
             h2 class="page-title" { "Create Character" }
             (panel("Character Details", html! {
                 form # "character-form" action="/characters" method="post" {
-                    (input_field("name", "Character Name", "text", true, None))
+                    (input_field("name", "Character Name", "text", true, name))
+                    @if let Some(error) = error {
+                        p class="form-error" role="alert" { (error) }
+                    }
                     div class="form-actions" {
                         button type="submit" class="btn btn-primary" { "Create Character" }
                         a href="/characters" class="btn btn-secondary" { "Cancel" }

--- a/crates/strategic-web/src/templates/components.rs
+++ b/crates/strategic-web/src/templates/components.rs
@@ -98,7 +98,11 @@ pub fn item_type_icon(item_id: &str) -> Markup {
 }
 
 pub fn item_type_header() -> Markup {
-    html! { th scope="col" class="inventory-column-type" title="Item type" aria-label="Item type" { "T" } }
+    html! {
+        th scope="col" class="inventory-column-type" title="Item type" aria-label="Item type" {
+            (decorative_game_icon("knapsack"))
+        }
+    }
 }
 
 pub fn stat_game_icon_name(icon: &str) -> &'static str {

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -22,7 +22,7 @@ pub fn mission_layout(title: &str, content: Markup, logged_in_as: Option<&str>) 
     let header = html! {
         header class="top-bar entry-top-bar" {
             div class="top-bar-left" { h1 class="logo" { "Adventure Simulator" } }
-            div class="entry-message" { "Preparing tactical mission" }
+            div class="entry-message" { "Tactical mission" }
             div class="top-bar-right" {
                 @if let Some(name) = logged_in_as {
                     span class="player-name" { strong { (name) } }
@@ -31,6 +31,48 @@ pub fn mission_layout(title: &str, content: Markup, logged_in_as: Option<&str>) 
         }
     };
     page_shell(title, header, content, ScriptProfile::Live)
+}
+
+/// A complete strategic shell for guard and error states reached from ordinary
+/// navigation. Keeping these responses inside the application prevents a bad
+/// URL or stale action from dropping the player into raw browser text.
+pub fn strategic_notice_page(
+    title: &str,
+    message: &str,
+    return_href: &str,
+    return_label: &str,
+    logged_in_as: Option<&str>,
+) -> Markup {
+    let content = html! {
+        aside class="left-sidebar notice-rail" aria-hidden="true" {}
+        main class="center-content strategic-notice-main" {
+            section class="strategic-notice" role="alert" aria-labelledby="strategic-notice-title" {
+                span class="strategic-notice-icon" aria-hidden="true" {}
+                h2 id="strategic-notice-title" { (title) }
+                p { (message) }
+                a href=(return_href) class="btn btn-primary" { (return_label) }
+            }
+        }
+        aside class="right-sidebar notice-rail" aria-hidden="true" {}
+    };
+    page_shell(
+        title,
+        entry_top_bar_with_session(logged_in_as),
+        content,
+        ScriptProfile::Live,
+    )
+}
+
+fn entry_top_bar_with_session(logged_in_as: Option<&str>) -> Markup {
+    html! {
+        header class="top-bar entry-top-bar" {
+            div class="top-bar-left" { h1 class="logo" { "Adventure Simulator" } }
+            div class="entry-message" { "The road ahead" }
+            div class="top-bar-right" {
+                @if let Some(name) = logged_in_as { span class="player-name" { strong { (name) } } }
+            }
+        }
+    }
 }
 
 /// Settlement-specific layout. Settlement services replace the global navigation
@@ -90,15 +132,15 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/base.css?v=environment-14";
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
-                link rel="stylesheet" href="/static/css/layout.css?v=left-rail-scrollbars-3-settlement-watchtowers-10";
+                link rel="stylesheet" href="/static/css/layout.css?v=strategic-ui-overhaul-1";
                 link rel="stylesheet" href="/static/css/components.css?v=coin-currencies-3";
-                link rel="stylesheet" href="/static/css/strategic.css?v=inventory-browser-15-religion-5-travel-polish-9";
-                link rel="stylesheet" href="/static/css/utilities.css?v=inventory-browser-15";
+                link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ui-overhaul-1";
+                link rel="stylesheet" href="/static/css/utilities.css?v=strategic-ui-overhaul-1";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
                 script src="/static/background-fetch.js?v=background-fetch-2" {}
-                script src="/static/medical-examination.js?v=one-shot-1" defer {}
+                script src="/static/medical-examination.js?v=strategic-dialogs-1" defer {}
                 @if scripts != ScriptProfile::Entry {
                     script src="/static/live-state.js?v=sse-3" defer {}
                     script src="/static/live-regions.js?v=floating-time-editor-1" defer {}
@@ -106,11 +148,11 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 @if scripts == ScriptProfile::Strategic {
                     script src="/static/numeric-editor.js?v=shared-numeric-editor-2" defer {}
                     script src="/static/inventory-browser.js?v=coin-currencies-3" defer {}
-                    script src="/static/party-trade.js?v=coin-currencies-2-travel-provisioning-3" defer {}
+                    script src="/static/party-trade.js?v=strategic-dialogs-1" defer {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}
-                    script src="/static/service-quests.js?v=coin-currencies-2-quest-description-tooltip-1" defer {}
+                    script src="/static/service-quests.js?v=strategic-ui-overhaul-1" defer {}
                     script src="/static/chat-resize.js?v=floating-chat-3" defer {}
                     script src="/static/local-chat.js?v=herbalist-private-1" defer {}
                     script src="/static/strategic-condition.js?v=strategic-condition-3" defer {}
@@ -204,6 +246,7 @@ fn settlement_top_bar(
                         class=(if active_service == path { "nav-tab active" } else { "nav-tab" })
                         style=(format!("--building-tint:{tint}"))
                         data-service-id=(path)
+                        data-service-label=(label)
                         aria-label=(label)
                         title=(label)
                         aria-current=(if active_service == path { "page" } else { "false" })
@@ -239,10 +282,13 @@ fn quest_location_top_bar(
     active_tab: &str,
     logged_in_as: Option<&str>,
 ) -> Markup {
+    let encounter_tint = "hsl(134 31% 20%)";
     let map_tint = "hsl(126 30% 22%)";
     let loot_tint = "hsl(105 27% 19%)";
     let active_tint = if active_tab == "loot" {
         loot_tint
+    } else if active_tab == "encounter" || active_tab == "camp" {
+        encounter_tint
     } else {
         map_tint
     };
@@ -251,11 +297,29 @@ fn quest_location_top_bar(
         header class="top-bar settlement-top-bar quest-location-top-bar" data-environment="wilderness" {
             div class="top-bar-left settlement-location" {
                 div class="settlement-identity" {
-                    a href=(format!("/locations/quest/{}", location_id)) class="settlement-name" { (location_name) }
+                    @if active_tab == "camp" {
+                        a href="/camp" class="settlement-name" aria-current="page" { (location_name) }
+                    } @else {
+                        a href=(format!("/locations/quest/{}", location_id)) class="settlement-name" { (location_name) }
+                    }
                     span class="settlement-time" data-player-time { "1st of First Seed · 08:00" }
                 }
             }
             nav class="top-bar-center settlement-services" aria-label="Location views" {
+                @if active_tab == "camp" {
+                    span class="nav-tab active quest-context-tab"
+                        style=(format!("--building-tint:{encounter_tint}"))
+                        aria-current="page" aria-label="Camp" title="Camp" {
+                        span class="service-tab-icon service-tab-icon-camp" aria-hidden="true" {}
+                    }
+                } @else {
+                a href=(format!("/locations/quest/{}", location_id))
+                    class=(if active_tab == "encounter" { "nav-tab active" } else { "nav-tab" })
+                    style=(format!("--building-tint:{encounter_tint}"))
+                    aria-current=(if active_tab == "encounter" { "page" } else { "false" })
+                    aria-label="Encounter" title="Encounter" {
+                    span class="service-tab-icon service-tab-icon-encounter" aria-hidden="true" {}
+                }
                 a href=(format!("/locations/quest/{}/map", location_id))
                     class=(if active_tab == "map" { "nav-tab active" } else { "nav-tab" })
                     style=(format!("--building-tint:{map_tint}"))
@@ -269,6 +333,7 @@ fn quest_location_top_bar(
                     aria-current=(if active_tab == "loot" { "page" } else { "false" })
                     aria-label="Loot" title="Loot" {
                     span class="service-tab-icon service-tab-icon-loot" aria-hidden="true" {}
+                }
                 }
             }
             div class="top-bar-right" {
@@ -391,8 +456,9 @@ pub fn sidebar_section(title: &str, content: Markup) -> Markup {
 #[cfg(test)]
 mod tests {
     use super::{
-        HorizonVariant, building_tier, building_tint, horizon_variant, quest_location_top_bar,
-        religion_icon_path, settlement_layout_with_session, settlement_top_bar,
+        HorizonVariant, building_tier, building_tint, entry_layout, horizon_variant,
+        quest_location_top_bar, religion_icon_path, settlement_layout_with_session,
+        settlement_top_bar,
     };
     use crate::spacetimedb::SettlementCategory;
     use maud::html;
@@ -598,5 +664,67 @@ mod tests {
         assert!(!routes.contains("/theme/{name}"));
         assert!(!layout.contains("details class=\"theme-switcher\""));
         assert!(layout.contains("/static/css/base.css"));
+    }
+
+    #[test]
+    fn location_navigation_reports_only_truthful_active_contexts() {
+        let overview = settlement_top_bar(
+            "Smallville",
+            "s",
+            &SettlementCategory::Village,
+            "",
+            None,
+            None,
+        )
+        .into_string();
+        assert!(!overview.contains("aria-current=\"page\""));
+
+        let encounter = quest_location_top_bar("Ruins", "q", "encounter", None).into_string();
+        assert!(encounter.contains("aria-label=\"Encounter\""));
+        assert!(encounter.contains("href=\"/locations/quest/q\" class=\"nav-tab active\""));
+
+        let camp = quest_location_top_bar("Camp", "party-7", "camp", None).into_string();
+        assert!(camp.contains("aria-label=\"Camp\""));
+        assert!(camp.contains("href=\"/camp\""));
+        assert!(!camp.contains("/locations/quest/party-7"));
+        assert!(!camp.contains("/locations/quest/party-7/map"));
+        assert!(!camp.contains("/locations/quest/party-7/loot"));
+    }
+
+    #[test]
+    fn strategic_notice_is_a_complete_accessible_page() {
+        let markup = super::strategic_notice_page(
+            "Not here",
+            "Travel first.",
+            "/characters",
+            "Return",
+            Some("Ada"),
+        )
+        .into_string();
+        assert!(markup.contains("<!DOCTYPE html>"));
+        assert!(markup.contains("role=\"alert\""));
+        assert!(markup.contains("href=\"/characters\""));
+        assert!(markup.contains("Ada"));
+    }
+
+    #[test]
+    fn narrow_entry_layout_stacks_every_rail_without_clipping_document_scroll() {
+        let markup = entry_layout(
+            "Create",
+            html! {
+                aside class="left-sidebar" { "Help" }
+                main class="center-content" { "Form" }
+                aside class="right-sidebar" { "Equipment" }
+            },
+        )
+        .into_string();
+        assert!(markup.contains("class=\"main-grid\""));
+        assert!(markup.contains("class=\"right-sidebar\""));
+        let css = include_str!("../../static/css/layout.css");
+        let mobile = &css[css.find("@media (max-width: 768px)").unwrap()..];
+        assert!(mobile.contains(".app {\n    height: auto;"));
+        assert!(mobile.contains("overflow: visible;"));
+        assert!(mobile.contains("grid-template-areas: \"main\" \"left\" \"right\""));
+        assert!(!mobile.contains("body:has(.settlement-top-bar) .main-grid"));
     }
 }

--- a/crates/strategic-web/src/templates/mission.rs
+++ b/crates/strategic-web/src/templates/mission.rs
@@ -11,18 +11,8 @@ pub fn mission_status_page(server: &TacticalServer, logged_in_as: Option<&str>) 
 
     let content = html! {
         aside class="left-sidebar" {
-            (sidebar_section("Mission Info", html! {
+            (sidebar_section("Mission", html! {
                 div class="flex flex-col gap-sm" {
-                    div {
-                        span class="detail-label" { "Mission ID" }
-                        p class="detail-value" style="font-size:var(--font-size-xs);word-break:break-all" {
-                            (server.mission_id)
-                        }
-                    }
-                    div {
-                        span class="detail-label" { "Scene" }
-                        p class="detail-value" { (server.scene_key) }
-                    }
                     div {
                         span class="detail-label" { "Status" }
                         div { (status_badge(status.label())) }
@@ -47,10 +37,19 @@ pub fn mission_status_page(server: &TacticalServer, logged_in_as: Option<&str>) 
         }
 
         aside class="right-sidebar" {
-            @if status == MissionStatus::Ready {
-                (sidebar_section("Connection", html! {
-                    (panel("", html! {
-                        div class="flex flex-col gap-sm" {
+            (sidebar_section("Details", html! {
+                details class="mission-diagnostics" {
+                    summary { "Technical details" }
+                    div class="flex flex-col gap-sm" {
+                        div {
+                            span class="detail-label" { "Mission ID" }
+                            p class="detail-value cert-digest" { (server.mission_id) }
+                        }
+                        div {
+                            span class="detail-label" { "Scene" }
+                            p class="detail-value" { (server.scene_key) }
+                        }
+                        @if status == MissionStatus::Ready {
                             div {
                                 span class="detail-label" { "Server" }
                                 p class="detail-value" style="font-size:var(--font-size-xs)" { (server.addr) }
@@ -62,18 +61,9 @@ pub fn mission_status_page(server: &TacticalServer, logged_in_as: Option<&str>) 
                                 }
                             }
                         }
-                    }))
-                }))
-            } @else {
-                (sidebar_section("Info", html! {
-                    (panel("", html! {
-                        p style="font-size:var(--font-size-sm)" {
-                            "Your tactical mission is being prepared. "
-                            "The page will update automatically."
-                        }
-                    }))
-                }))
-            }
+                    }
+                }
+            }))
         }
     };
 
@@ -85,9 +75,9 @@ fn pending_state(mission_id: &str) -> Markup {
         (panel("Waiting", html! {
             div {
                 div class="status-message" {
-                    div class="loading-spinner" { "Preparing server" }
-                    p class="status-detail mt-1" {
-                        "A tactical server is being prepared for your mission."
+                div class="loading-spinner" { "Allocating server" }
+                p class="status-detail mt-1" {
+                        "This page will update automatically when the mission is ready."
                     }
                 }
             }
@@ -182,5 +172,20 @@ pub fn mission_status_fragment(server: &TacticalServer) -> Markup {
                 MissionStatus::Pending => { (pending_state(&server.mission_id)) }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pending_state;
+
+    #[test]
+    fn pending_status_is_concise_and_diagnostics_are_collapsed() {
+        let pending = pending_state("mission-1").into_string();
+        assert!(pending.contains("Allocating server"));
+        assert_eq!(pending.matches("prepared").count(), 0);
+        let source = include_str!("mission.rs");
+        assert!(source.contains("details class=\"mission-diagnostics\""));
+        assert!(source.contains("Technical details"));
     }
 }

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -68,7 +68,7 @@ pub fn quest_location_base_page(
         &quest.title,
         &quest.title,
         &quest.id,
-        "",
+        "encounter",
         content,
         logged_in_as,
     )
@@ -158,7 +158,7 @@ fn quest_location_center(
                 false,
             ))
             div class="quest-visual-wrap" {
-                (visual_stage("map", &quest.title, "TODO: quest location image"))
+                (visual_stage("quest", &quest.title, &quest.location_description))
                 @if can_fight || !resolved {
                 div class="quest-combat-actions" aria-label="Quest actions" {
                     @if can_fight {
@@ -299,7 +299,8 @@ fn inventory_target(targets: &[InventoryQuantityTarget], item_id: &str) -> u32 {
 
 fn loot_stage_form(quest_id: &str) -> Markup {
     html! {
-        form method="post" action=(format!("/quests/{quest_id}/loot/store")) id="loot-transfer-offer" class="party-offer loot-transfer-offer" hidden {
+        form method="post" action=(format!("/quests/{quest_id}/loot/store")) id="loot-transfer-offer" class="party-offer loot-transfer-offer" hidden
+            role="dialog" aria-modal="true" aria-label="Confirm collected loot" tabindex="-1" {
             span class="loot-transfer-prompt" data-loot-transfer-prompt { "Apply staged loot to the party inventory?" }
             button type="button" class="party-offer-cancel" data-cancel-loot { "Cancel" }
             button type="submit" disabled { "Apply" }

--- a/crates/strategic-web/src/templates/recruitment.rs
+++ b/crates/strategic-web/src/templates/recruitment.rs
@@ -48,6 +48,7 @@ pub fn service_role_inspection(
 ) -> (String, String) {
     let left = html! {
         section class="role-inspection-panel role-inspection-content" data-service-role-inspection {
+            button type="button" class="btn btn-secondary btn-small service-role-back" data-close-service-role-inspection { "Back to service" }
             h3 class="sidebar-header" { (role_name) }
             div class="role-detail-list" {
                 @if requirements.is_empty() { div class="role-detail-row" { "No minimum recommendations" } }
@@ -57,6 +58,7 @@ pub fn service_role_inspection(
     };
     let right = html! {
         section class="role-inspection-panel role-inspection-content" data-service-role-inspection {
+            button type="button" class="btn btn-secondary btn-small service-role-back" data-close-service-role-inspection { "Back to service" }
             h3 class="sidebar-header" { (party_name) }
             p { "Led by " (leader_name) }
             p class=(format!("small-copy service-role-match service-role-match-{match_level}")) { (match_summary) }
@@ -177,7 +179,7 @@ pub fn recruitment_panel(
                                             aria-label=(format!("Edit {}", panel.role.name)) { "Edit" }
                                         form action=(format!("/party-recruitment/roles/{}/delete", panel.role.id)) method="post" class="saved-role-delete-form" {
                                             button type="submit" class="saved-role-action saved-role-delete"
-                                                aria-label=(format!("Delete {}", panel.role.name)) title=(format!("Delete {}", panel.role.name)) { "Ã—" }
+                                                aria-label=(format!("Delete {}", panel.role.name)) title=(format!("Delete {}", panel.role.name)) { "×" }
                                         }
                                     }
                                 }
@@ -243,7 +245,7 @@ pub fn recruitment_panel(
                             }
                         }
                         footer class="role-builder-footer" {
-                            span class="small-copy text-muted" data-role-builder-help { "Create one visually grouped portrait per slot." }
+                            span class="small-copy text-muted" data-role-builder-help { "Choose how many openings this role should advertise." }
                             button type="submit" class="btn btn-primary" data-role-builder-submit { "Add role" }
                         }
                     }

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -291,7 +291,10 @@ pub fn alchemy_page(
         }
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(character), &format!("/locations/settlement/{}", settlement.id), Some(character.id), true))
-            (visual_stage("npc", "Alchemy", "Medication preparation"))
+            (visual_stage("alchemy", "Alchemy", "A working table of herbs, vessels, and prepared medicines"))
+            a class="stage-context-link" href=(format!("/settlements/{}/herbalist", settlement.id)) {
+                "Return to the herbalist"
+            }
             (settlement_chat_area_with_info("Alchemy", Some(character), &[format!("Selected recipe: {}", selected.name)]))
             form method="post" action=(format!("/locations/settlement/{}/alchemy/craft", settlement.id)) class="alchemy-craft-form" {
                 input type="hidden" name="disease_id" value=(format!("{:?}", selected.disease_id).to_ascii_lowercase());
@@ -339,7 +342,7 @@ pub fn alchemy_page(
         &settlement.name,
         &settlement.id,
         &settlement.category,
-        "alchemy",
+        "herbalist",
         Some(&settlement.religion_id),
         content,
         Some(&character.name),
@@ -375,7 +378,7 @@ pub fn settlement_overview_page(
         }
         main class="center-content settlement-main settlement-overview" {
             (party_portrait_overlay(party_members, active_character, &format!("/locations/settlement/{}", settlement.id), None, false))
-            (visual_stage("map", &settlement.name, "TODO: settlement image"))
+            (visual_stage("settlement", &settlement.name, "Streets, landmarks, and the settlement approach"))
             (settlement_chat_area(&settlement.name, active_character))
         }
         aside class="right-sidebar" {
@@ -493,7 +496,7 @@ pub fn settlement_map_page(
         ))
         main class="center-content settlement-main settlement-overview" {
             (party_portrait_overlay(party_members, active_character, &format!("/locations/settlement/{}", settlement.id), None, false))
-            (visual_stage("map", &settlement.name, "TODO: settlement map"))
+            (visual_stage("route", &settlement.name, "Roads and known destinations from this settlement"))
             (settlement_chat_area(&settlement.name, active_character))
         }
         (map_destination_detail(
@@ -1161,7 +1164,7 @@ pub fn camp_page(
         }
         main class="center-content settlement-main settlement-overview" {
             (party_portrait_overlay(party_members, active_character, "/camp", None, false))
-            (visual_stage("camp", "Camp", "The party is resting beside the road."))
+            (visual_stage("camp", "Camp", "A sheltered fire beside the party's onward route"))
             (settlement_chat_area("Camp", active_character))
         }
         aside class="right-sidebar camp-journey-sidebar" {
@@ -1259,8 +1262,7 @@ fn format_journey_time(minutes: u64) -> String {
     }
 }
 
-/// Market interface. Inventory and prices are intentionally UI-only placeholders
-/// until settlement-owned inventory and trade reducers exist.
+/// Market interface shown while settlement stock is unavailable.
 pub fn merchants_page(
     settlement: &Settlement,
     active_character: Option<&Character>,
@@ -1273,7 +1275,7 @@ pub fn merchants_page(
         "merchants",
         "Market Square",
         "Market Steward",
-        "Merchant stock and prices will appear here once the trade backend is available.",
+        "The market steward has no listed stock at present.",
         active_character,
         inventory,
         &[],
@@ -1284,7 +1286,7 @@ pub fn merchants_page(
     )
 }
 
-/// Inn interface placeholder.
+/// Inn interface.
 pub fn inn_page(
     settlement: &Settlement,
     active_character: Option<&Character>,
@@ -1303,7 +1305,7 @@ pub fn inn_page(
         "inn",
         "The Inn",
         "Innkeeper",
-        "Rest duration, recovery, training, and strategic time advancement are not connected yet.",
+        "Rest, recover, and manage your downtime from the lodging menu.",
         active_character,
         inventory,
         items,
@@ -1320,7 +1322,7 @@ pub fn inn_page(
     )
 }
 
-/// Church placeholder.
+/// Church interface.
 pub fn religion_page(
     settlement: &Settlement,
     active_character: Option<&Character>,
@@ -1378,9 +1380,11 @@ pub fn party_inventory_page(
         }
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(selected.id), false))
-            (visual_stage("npc", &selected.name, &format!("TODO: {} portrait", selected.name.to_lowercase())))
+            (visual_stage("character", &selected.name, "Party member and trading companion"))
             (player_chat_area(selected, active_character))
-            form id="party-offer" class="party-offer" action=(format!("{}/party/{}/inventory/offer", location.base_path(), selected.id)) method="post" hidden {
+            form id="party-offer" class="party-offer" action=(format!("{}/party/{}/inventory/offer", location.base_path(), selected.id)) method="post" hidden
+                role="dialog" aria-modal="true" aria-label="Confirm party item offer" tabindex="-1" {
+                span class="party-offer-summary" { "Review and send the staged item offer." }
                 button type="button" class="party-offer-cancel" data-cancel-trade="party" { "Cancel" }
                 button type="submit" disabled { "Offer" }
             }
@@ -1413,11 +1417,12 @@ pub fn party_discard_page(
         }
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(active_character.id), false))
-            (visual_stage("npc", &active_character.name, &format!("TODO: {} portrait", active_character.name.to_lowercase())))
+            (visual_stage("character", &active_character.name, "Your carried equipment and supplies"))
             (settlement_chat_area(&active_character.name, Some(active_character)))
             form id="inventory-discard" class="party-offer"
                 action=(format!("{}/party/{}/inventory/discard", location.base_path(), active_character.id))
-                method="post" hidden {
+                method="post" hidden role="dialog" aria-modal="true" aria-label="Confirm discarded items" tabindex="-1" {
+                span class="party-offer-summary" data-discard-confirmation { "Discard the staged items?" }
                 button type="button" class="party-offer-cancel" data-cancel-trade="discard" { "Cancel" }
                 button type="submit" disabled { "Discard" }
             }
@@ -1471,7 +1476,7 @@ pub fn party_personal_page(
                 Some(active_character.id),
                 can_examine,
             ))
-            (visual_stage("npc", &active_character.name, &format!("TODO: {} portrait", active_character.name.to_lowercase())))
+            (visual_stage("character", &active_character.name, "Your identity, condition, and capabilities"))
             (settlement_chat_area(&active_character.name, Some(active_character)))
             (medical_examination_popup(medical, &location.base_path(), active_character.id, limbs))
         }
@@ -1554,7 +1559,7 @@ pub fn party_stats_page(
                 Some(selected.id),
                 can_examine,
             ))
-            (visual_stage("npc", &selected.name, &format!("TODO: {} portrait", selected.name.to_lowercase())))
+            (visual_stage("character", &selected.name, "Party member identity and capabilities"))
             (player_chat_area(selected, active_character))
             (medical_examination_popup(medical, &location.base_path(), selected.id, selected_limbs))
         }
@@ -1606,7 +1611,7 @@ fn service_page(
     service_id: &str,
     title: &str,
     npc_name: &str,
-    todo: &str,
+    service_summary: &str,
     active_character: Option<&Character>,
     inventory: &[InventoryItem],
     items: &[crate::spacetimedb::ItemDefinition],
@@ -1661,18 +1666,14 @@ fn service_page(
             } @else if let Some((stock_title, offers)) = trade_offers {
                 (merchant_offers_rail(stock_title, offers))
             } @else {
-                (sidebar_section("Settlement offerings", html! {
-                    div class="service-placeholder-list" {
-                        span { "Inventory / offers" }
-                        span class="badge badge-warning" { "TODO" }
-                    }
-                    p class="text-muted small-copy" { (todo) }
+                (sidebar_section("Service", html! {
+                    p class="small-copy" { (service_summary) }
                 }))
             }
         }
         main class="center-content settlement-main" {
             (party_portrait_overlay(party_members, active_character, &format!("/locations/settlement/{}", settlement.id), None, false))
-            (visual_stage("npc", npc_name, &format!("TODO: {} portrait", npc_name.to_lowercase())))
+            (visual_stage("service", npc_name, &format!("{title} host and service counter")))
             (settlement_service_chat_area(
                 title,
                 active_character,
@@ -1686,7 +1687,7 @@ fn service_page(
                     active_character,
                     inventory,
                     items,
-                    Some(("Sell", "TODO: selling requires merchant pricing and trade reducers")),
+                    None,
                     matches!(service_id, "weapons" | "armor" | "clothing"),
                 ))
             } @else if service_id == "smith" {
@@ -1694,14 +1695,14 @@ fn service_page(
                     active_character,
                     inventory,
                     items,
-                    Some(("Repair", "TODO: repairs require durability, pricing, and smithing reducers")),
+                    None,
                     true,
                 ))
             } @else if service_id == "religion" {
                 (inventory_rail(active_character, inventory, items, None, false))
             } @else {
                 (sidebar_section("Service", html! {
-                    p class="text-muted small-copy" { (todo) }
+                    p class="small-copy" { (service_summary) }
                 }))
             }
         }
@@ -1881,7 +1882,7 @@ pub fn live_merchant_shop_page(
             (repair_custody_panel(settlement, shop, repair_orders, conditions, items, now_minutes, smith_skill))
         }
         }
-        main class="center-content settlement-main" { (party_portrait_overlay(party_members, Some(character), &format!("/locations/settlement/{}", settlement.id), None, false)) (visual_stage("npc", title, &format!("TODO: {} portrait", title.to_lowercase()))) (settlement_service_chat_area(title, Some(character), &settlement.id, service_id)) form # "merchant-offer" class="party-offer" action=(if matches!(shop, MerchantShop::Herbalist) { format!("/settlements/{}/herbalist/purchase", settlement.id) } else { format!("/settlements/{}/merchants/offer", settlement.id) }) method="post" hidden { input type="hidden" name="return_to" value=(format!("/settlements/{}/{}", settlement.id, service_id)); input type="hidden" name="inventory_scope" value="player"; button type="button" class="party-offer-cancel" data-cancel-trade="merchant" { "Cancel" } button type="submit" disabled { "Offer" } } }
+        main class="center-content settlement-main" { (party_portrait_overlay(party_members, Some(character), &format!("/locations/settlement/{}", settlement.id), None, false)) (visual_stage("service", title, "Merchant counter and attending craftsperson")) (settlement_service_chat_area(title, Some(character), &settlement.id, service_id)) form # "merchant-offer" class="party-offer" action=(if matches!(shop, MerchantShop::Herbalist) { format!("/settlements/{}/herbalist/purchase", settlement.id) } else { format!("/settlements/{}/merchants/offer", settlement.id) }) method="post" hidden role="dialog" aria-modal="true" aria-label="Confirm merchant offer" tabindex="-1" { span class="party-offer-summary" { "Review and submit the staged trade." } input type="hidden" name="return_to" value=(format!("/settlements/{}/{}", settlement.id, service_id)); input type="hidden" name="inventory_scope" value="player"; button type="button" class="party-offer-cancel" data-cancel-trade="merchant" { "Cancel" } button type="submit" disabled { "Offer" } } }
         aside class="right-sidebar inventory-owner-panel" data-inventory-tabs {
             nav class="inventory-owner-tabs" aria-label="Trading inventory" {
                 button type="button" class="inventory-owner-tab active" data-inventory-tab="player" { "Player" }
@@ -2031,7 +2032,7 @@ pub fn party_pool_page(
         }
         main class="center-content settlement-main" {
             (party_portrait_overlay(party_members, Some(character), &location.base_path(), None, false))
-            (visual_stage("npc", "Party chest", "Shared party inventory chest"))
+            (visual_stage("chest", "Party chest", "Shared supplies and each member's stake"))
             (settlement_chat_area("Party inventory", Some(character)))
         }
         aside class="right-sidebar" {
@@ -2066,7 +2067,7 @@ pub fn party_pool_page(
                 }, inventory_footer_controls("deposit", "Deposit to party targets", "Deposit everything"), personal_encumbrance))
             }))
         }
-        form method="post" action=(format!("{}/party-inventory/deposit", location.base_path())) id="pool-transfer-offer" class="party-offer" hidden { button type="button" data-cancel-pool class="party-offer-cancel" { "Cancel" } button type="submit" disabled { "Offer" } }
+        form method="post" action=(format!("{}/party-inventory/deposit", location.base_path())) id="pool-transfer-offer" class="party-offer" hidden role="dialog" aria-modal="true" aria-label="Confirm party inventory transfer" tabindex="-1" { span class="party-offer-summary" { "Apply the staged party inventory transfer?" } button type="button" data-cancel-pool class="party-offer-cancel" { "Cancel" } button type="submit" disabled { "Offer" } }
     };
     location.render_layout("Party inventory", content, Some(&character.name))
 }
@@ -2972,20 +2973,22 @@ fn party_skill_row(
 fn skill_rank_bar(rank: f32, effective_rank: f32, title: &str) -> Markup {
     let rank = rank.clamp(0.0, 5.0);
     let effective_rank = effective_rank.clamp(0.0, rank);
-    let value_left = (effective_rank / 5.0 * 100.0).clamp(2.0, 98.0);
     html! {
-        div class="skill-rank-bar" title=(title) aria-label=(format!("{effective_rank:.1} out of 5")) {
-            @for tier in 1..=5 {
-                @let offset = (tier - 1) as f32;
-                @let current = (effective_rank - offset).clamp(0.0, 1.0) * 100.0;
-                @let trained = (rank - offset).clamp(0.0, 1.0) * 100.0;
-                @let damaged = (trained - current).max(0.0);
-                span class=(format!("skill-rank-segment skill-rank-segment-{tier}")) {
-                    span class="rank-current" style=(format!("width:{current:.1}%")) {}
-                    span class="rank-damage" style=(format!("left:{current:.1}%;width:{damaged:.1}%")) {}
+        div class="skill-rank-bar" title=(title) aria-label=(format!("{effective_rank:.1} out of 5"))
+            role="meter" aria-valuemin="0" aria-valuemax="5" aria-valuenow=(format!("{effective_rank:.1}")) {
+            span class="skill-rank-track" aria-hidden="true" {
+                @for tier in 1..=5 {
+                    @let offset = (tier - 1) as f32;
+                    @let current = (effective_rank - offset).clamp(0.0, 1.0) * 100.0;
+                    @let trained = (rank - offset).clamp(0.0, 1.0) * 100.0;
+                    @let damaged = (trained - current).max(0.0);
+                    span class=(format!("skill-rank-segment skill-rank-segment-{tier}")) {
+                        span class="rank-current" style=(format!("width:{current:.1}%")) {}
+                        span class="rank-damage" style=(format!("left:{current:.1}%;width:{damaged:.1}%")) {}
+                    }
                 }
             }
-            span class="skill-rank-value" style=(format!("left:{value_left:.1}%")) { (format!("{effective_rank:.1}")) }
+            span class="skill-rank-value" aria-hidden="true" { (format!("{effective_rank:.1}")) }
         }
     }
 }
@@ -3242,11 +3245,7 @@ pub(crate) fn character_stats_panel(
 }
 
 pub(crate) fn character_visual_preview(character: &Character) -> Markup {
-    visual_stage(
-        "npc",
-        &character.name,
-        &format!("TODO: {} portrait", character.name.to_lowercase()),
-    )
+    visual_stage("character", &character.name, "Adventurer profile")
 }
 
 fn religion_name(religion_id: Option<&str>) -> &'static str {
@@ -3976,10 +3975,13 @@ fn attribute_row(name: &str, icon: &str, value: f32, health: f32, show_label: bo
         div class=(if show_label { "party-attribute-row" } else { "party-attribute-row party-attribute-icon-only" }) {
             (stat_icon(name, "attributes", icon, show_label))
             @if show_label { span class="party-attribute-name" { (name) } }
-            div class="attribute-rank-bar" title=(format!("{effective_value:.1}")) {
+            div class="attribute-rank-bar" title=(format!("{effective_value:.1}"))
+                role="meter" aria-valuemin="0" aria-valuemax="5" aria-valuenow=(format!("{effective_value:.1}"))
+                aria-label=(format!("{name}: {effective_value:.1} out of 5")) {
                 span class="rank-current" style=(format!("width:{current_width:.1}%")) {}
                 span class="rank-damage" style=(format!("left:{current_width:.1}%;width:{damage_width:.1}%")) {}
             }
+            span class="attribute-rank-value" aria-hidden="true" { (format!("{effective_value:.1}")) }
         }
     }
 }
@@ -3998,18 +4000,35 @@ fn stat_icon(label: &str, category: &str, icon: &str, decorative: bool) -> Marku
     }
 }
 
-pub(crate) fn visual_stage(kind: &str, title: &str, placeholder: &str) -> Markup {
+pub(crate) fn visual_stage(kind: &str, title: &str, description: &str) -> Markup {
+    let (primary_icon, secondary_icon, scene_label) = match kind {
+        "settlement" => ("house", "sun", "At the settlement gates"),
+        "map" | "route" => ("treasure-map", "plain-arrow", "Roads and destinations"),
+        "camp" => ("campfire", "night-sleep", "Camp beside the road"),
+        "quest" => ("sword-clash", "torch", "Encounter ground"),
+        "alchemy" => ("medical-pack", "water-bottle", "The apothecary workbench"),
+        "service" => ("conversation", "shop", "At the counter"),
+        "chest" => ("open-chest", "coins", "Shared party stores"),
+        _ => ("person", "shield", "Adventurer profile"),
+    };
     html! {
         figure class=(format!("service-visual service-visual-{}", kind)) {
-            div class="service-visual-placeholder" role="img" aria-label=(placeholder) {
-                @if kind == "map" {
-                    span class="visual-symbol" { (decorative_game_icon("treasure-map")) }
-                    span class="visual-label" { "Map placeholder" }
-                } @else {
-                    span class="visual-symbol" { (title.chars().next().unwrap_or('?')) }
-                    span class="visual-label" { "Portrait placeholder" }
+            div class="service-visual-scene" role="img" aria-label=(format!("{title}. {description}")) {
+                span class="visual-scene-sky" aria-hidden="true" {}
+                span class="visual-scene-horizon" aria-hidden="true" {}
+                span class="visual-scene-route" aria-hidden="true" {}
+                span class="visual-scene-emblem visual-scene-emblem-primary" aria-hidden="true" {
+                    (decorative_game_icon(primary_icon))
+                }
+                span class="visual-scene-emblem visual-scene-emblem-secondary" aria-hidden="true" {
+                    (decorative_game_icon(secondary_icon))
+                }
+                span class="visual-scene-caption" {
+                    strong { (title) }
+                    span { (scene_label) }
                 }
             }
+            figcaption { (description) }
         }
     }
 }
@@ -4076,7 +4095,9 @@ pub(crate) fn party_portrait_overlay(
                                     button type="submit" class="party-portrait-action party-medical-examine"
                                         title=(format!("Examine {} (15 minutes)", member.name))
                                         aria-label=(format!("Examine {} (15 minutes)", member.name)) {
-                                        span aria-hidden="true" { "⚕" }
+                                        span class="party-action-icon"
+                                            style="--party-action-icon: url('/static/icons/game/scalpel.svg')"
+                                            aria-hidden="true" {}
                                     }
                                 }
                             }
@@ -4170,17 +4191,18 @@ fn chat_area(
                 span aria-hidden="true" {}
             }
             div class="settlement-chat-filters" role="group" aria-label="Visible chat channels" {
-                @for (channel, label) in [
-                    ("local", "Local"),
-                    ("party", "Party"),
-                    ("settlement", "Settlement"),
-                    ("dm", "DMs"),
-                    ("guild", "Guild"),
-                    ("info", "Info"),
+                @for (channel, label, abbreviation) in [
+                    ("local", "Local", "L"),
+                    ("party", "Party", "P"),
+                    ("settlement", "Settlement", "S"),
+                    ("dm", "DMs", "D"),
+                    ("guild", "Guild", "G"),
+                    ("info", "Info", "I"),
                 ] {
                     label class=(format!("chat-channel-filter chat-channel-filter-{channel}")) title=(label) {
                         input type="checkbox" checked data-chat-filter=(channel)
                             aria-label=(label) title=(label);
+                        span aria-hidden="true" { (abbreviation) }
                     }
                 }
             }
@@ -4202,35 +4224,20 @@ fn chat_area(
                     placeholder=(format!("Message {location} (Local)"));
                 button type="button" class="btn btn-primary btn-icon" disabled[local_context.is_none()]
                     aria-label="Send message" {
-                    "➤"
+                    (decorative_game_icon("plain-arrow"))
                 }
             }
         }
     }
 }
 
-fn merchant_offers_rail(title: &str, placeholder_offers: &[&str]) -> Markup {
+fn merchant_offers_rail(title: &str, unavailable_offers: &[&str]) -> Markup {
     html! {
         (sidebar_section(title, html! {
-            p class="text-muted small-copy" { "TODO: merchant inventory and prices are not available yet." }
-            table class="trade-inventory-table" {
-                (trade_inventory_table_header(false, None))
-                tbody {
-                @for offer in placeholder_offers {
-                    tr class="trade-inventory-row trade-row-merchant"
-                        title="TODO: buying requires merchant inventory, pricing, and trade reducers" {
-                        td class="inventory-item-type" { (game_icon("Item type: placeholder", "help")) }
-                        td class="inventory-item-name" {
-                            (offer)
-                            button type="button" class="trade-transfer trade-transfer-right" disabled
-                                aria-label=(format!("Buy {}", offer))
-                                title="TODO: buying requires merchant inventory, pricing, and trade reducers" { "▶" }
-                        }
-                        td class="inventory-count" { "1" }
-                        td class="inventory-weight" { "—" }
-                        td class="inventory-gold" { "—" }
-                    }
-                }
+            p class="small-copy" { "No stock is listed at present." }
+            ul class="service-offering-list" aria-label="Expected offerings" {
+                @for offer in unavailable_offers {
+                    li { (decorative_game_icon("shop")) span { (offer) } }
                 }
             }
         }))
@@ -4242,7 +4249,7 @@ fn inventory_rail(
     inventory: &[InventoryItem],
     items: &[crate::spacetimedb::ItemDefinition],
     trade_action: Option<(&str, &str)>,
-    show_repair: bool,
+    _show_repair: bool,
 ) -> Markup {
     let title = active_character
         .map(|character| format!("{}'s inventory", character.name))
@@ -4266,13 +4273,6 @@ fn inventory_rail(
                                 button type="button" class="trade-transfer trade-transfer-left" disabled
                                     aria-label=(format!("{} {}", action, item.item_id))
                                     title=(tooltip) { "◀" }
-                                }
-                                @if show_repair {
-                                span class="repair-placeholder"
-                                    style="--repair-icon: url('/static/icons/game/hammer-nails.svg')"
-                                    role="img"
-                                    aria-label=(format!("Repair {}", item.item_id))
-                                    title="TODO: repairs require durability, pricing, and repair reducers" {}
                                 }
                             }
                             td class="inventory-count" { (item.qty) }
@@ -4955,6 +4955,10 @@ mod tests {
         for tier in 1..=5 {
             assert!(meter.contains(&format!("skill-rank-segment-{tier}")));
         }
+        assert!(meter.contains("role=\"meter\""));
+        assert!(meter.contains("aria-valuenow=\"2.8\""));
+        assert!(meter.contains("class=\"skill-rank-value\""));
+        assert!(!meter.contains("tabindex"));
         let allocation = schedule_allocation_cell("smithing_minutes", 75, true).into_string();
         assert!(allocation.contains("data-schedule-input"));
         assert!(allocation.contains("data-schedule-display"));
@@ -5823,7 +5827,8 @@ mod tests {
 
         assert!(fallback < enhanced);
         assert!(css.contains("background: color-mix(in srgb, var(--header-bg) 86%, transparent);"));
-        assert!(!css.contains(".chat-channel-filter input::after"));
+        assert!(css.contains(".chat-channel-filter input::after"));
+        assert!(css.contains("text-decoration: line-through"));
         assert!(css.contains("outline: 2px solid var(--text-primary);"));
         assert!(css.contains("0 0 0 2px var(--panel-bg)"));
         assert!(css.contains(
@@ -6069,6 +6074,9 @@ mod tests {
         let lifecycle = include_str!("../../static/medical-examination.js");
         assert!(lifecycle.contains("pagehide"));
         assert!(lifecycle.contains("navigator.sendBeacon"));
+        assert!(lifecycle.contains("event.key !== \"Escape\""));
+        assert!(lifecycle.contains("restoreFocus"));
+        assert!(lifecycle.contains(".party-offer[role='dialog']"));
     }
 
     #[test]
@@ -6137,5 +6145,52 @@ mod tests {
             1,
             "one physical camp marker"
         );
+    }
+
+    #[test]
+    fn intentional_stages_have_distinct_semantics_and_no_prototype_copy() {
+        for (kind, label) in [
+            ("settlement", "At the settlement gates"),
+            ("route", "Roads and destinations"),
+            ("camp", "Camp beside the road"),
+            ("character", "Adventurer profile"),
+            ("service", "At the counter"),
+            ("quest", "Encounter ground"),
+            ("alchemy", "The apothecary workbench"),
+            ("chest", "Shared party stores"),
+        ] {
+            let markup = visual_stage(kind, "A Place", "An intentional scene").into_string();
+            assert!(markup.contains(label));
+            assert!(markup.contains("role=\"img\""));
+            assert!(!markup.contains("placeholder"));
+            assert!(!markup.contains("TODO"));
+        }
+    }
+
+    #[test]
+    fn responsive_and_hidden_control_rules_keep_content_available() {
+        let layout = include_str!("../../static/css/layout.css");
+        let strategic = include_str!("../../static/css/strategic.css");
+        let utilities = include_str!("../../static/css/utilities.css");
+        assert!(layout.contains("grid-template-areas: \"main\" \"left\" \"right\""));
+        assert!(layout.contains(".right-sidebar {\n    display: block;"));
+        assert!(strategic.contains("@media (hover: none), (pointer: coarse)"));
+        assert!(utilities.contains(".inventory-count:focus-within"));
+        assert!(utilities.contains("@media (hover:none), (pointer:coarse)"));
+        assert!(utilities.contains("width: 2.75rem"));
+        assert!(utilities.contains("height: 2.75rem"));
+        assert!(utilities.contains("grid-template-columns: 2.75rem 1.4rem 2.75rem"));
+        for scene in [
+            "settlement",
+            "route",
+            "camp",
+            "quest",
+            "character",
+            "service",
+            "alchemy",
+            "chest",
+        ] {
+            assert!(strategic.contains(&format!(".service-visual-{scene}")));
+        }
     }
 }

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -4001,15 +4001,15 @@ fn stat_icon(label: &str, category: &str, icon: &str, decorative: bool) -> Marku
 }
 
 pub(crate) fn visual_stage(kind: &str, title: &str, description: &str) -> Markup {
-    let (primary_icon, secondary_icon, scene_label) = match kind {
-        "settlement" => ("house", "sun", "At the settlement gates"),
-        "map" | "route" => ("treasure-map", "plain-arrow", "Roads and destinations"),
-        "camp" => ("campfire", "night-sleep", "Camp beside the road"),
-        "quest" => ("sword-clash", "torch", "Encounter ground"),
-        "alchemy" => ("medical-pack", "water-bottle", "The apothecary workbench"),
-        "service" => ("conversation", "shop", "At the counter"),
-        "chest" => ("open-chest", "coins", "Shared party stores"),
-        _ => ("person", "shield", "Adventurer profile"),
+    let scene_label = match kind {
+        "settlement" => "At the settlement gates",
+        "map" | "route" => "Roads and destinations",
+        "camp" => "Camp beside the road",
+        "quest" => "Encounter ground",
+        "alchemy" => "The apothecary workbench",
+        "service" => "At the counter",
+        "chest" => "Shared party stores",
+        _ => "Adventurer profile",
     };
     html! {
         figure class=(format!("service-visual service-visual-{}", kind)) {
@@ -4017,12 +4017,6 @@ pub(crate) fn visual_stage(kind: &str, title: &str, description: &str) -> Markup
                 span class="visual-scene-sky" aria-hidden="true" {}
                 span class="visual-scene-horizon" aria-hidden="true" {}
                 span class="visual-scene-route" aria-hidden="true" {}
-                span class="visual-scene-emblem visual-scene-emblem-primary" aria-hidden="true" {
-                    (decorative_game_icon(primary_icon))
-                }
-                span class="visual-scene-emblem visual-scene-emblem-secondary" aria-hidden="true" {
-                    (decorative_game_icon(secondary_icon))
-                }
                 span class="visual-scene-caption" {
                     strong { (title) }
                     span { (scene_label) }
@@ -6164,6 +6158,8 @@ mod tests {
             assert!(markup.contains("role=\"img\""));
             assert!(!markup.contains("placeholder"));
             assert!(!markup.contains("TODO"));
+            assert!(!markup.contains("visual-scene-emblem"));
+            assert!(!markup.contains("/static/icons/game/"));
         }
     }
 

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -455,6 +455,8 @@
 
 .service-tab-icon-map { --service-tab-icon: url("/static/icons/settlement-services/travel.png"); }
 .service-tab-icon-loot { --service-tab-icon: url("/static/icons/game/open-chest.svg"); }
+.service-tab-icon-encounter { --service-tab-icon: url("/static/icons/game/sword-clash.svg"); }
+.service-tab-icon-camp { --service-tab-icon: url("/static/icons/game/campfire.svg"); }
 
 .settlement-services .nav-tab:hover .service-tab-icon,
 .settlement-services .nav-tab.active .service-tab-icon { background-color: var(--text-primary); }
@@ -703,32 +705,43 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
 }
 
 @media (max-width: 768px) {
-  body:has(.settlement-top-bar) .app {
-    height: 100vh;
-    min-height: 0;
+  .app {
+    height: auto;
+    min-height: 100dvh;
+    overflow: visible;
   }
   .main-grid {
     grid-template-columns: 1fr;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto auto auto;
+    grid-template-areas: "main" "left" "right";
   }
   .main-grid:has(.inventory-browser) {
     grid-template-columns: 1fr;
   }
-  body:has(.settlement-top-bar) .main-grid {
+  .main-grid {
     height: auto;
     min-height: 0;
     flex: 1;
+    overflow: visible;
   }
   .left-sidebar {
+    grid-area: left;
     border-right: none;
     border-bottom: 1px solid var(--border-color);
     height: auto;
-    max-height: 35vh;
-    overflow-y: auto;
+    max-height: none;
+    overflow: visible;
   }
   .right-sidebar {
-    display: none;
+    display: block;
+    grid-area: right;
+    height: auto;
+    min-height: 10rem;
+    overflow: visible;
+    border-top: 1px solid var(--border-color);
+    border-left: 0;
   }
+  .center-content { grid-area: main; min-height: 32rem; }
   .top-bar {
     padding: 0 0.75rem;
   }
@@ -767,14 +780,16 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     overflow-x: auto;
     overflow-y: hidden;
     justify-content: flex-start;
-    scrollbar-width: none;
+    padding-bottom: 0.35rem;
+    scrollbar-width: thin;
+    mask-image: linear-gradient(to right, transparent, #000 0.75rem, #000 calc(100% - 0.75rem), transparent);
   }
   .settlement-top-bar[data-environment="settlement"] .settlement-services .nav-tab {
     width: 4.5rem;
     height: 6.25rem;
     flex-basis: 4.5rem;
   }
-  .settlement-services::-webkit-scrollbar { display: none; }
+  .settlement-services::-webkit-scrollbar { height: 0.35rem; }
   .entry-message {
     display: none;
   }
@@ -788,4 +803,7 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     padding: 0.25rem 0.4rem;
     letter-spacing: 0;
   }
+  .center-content { min-height: 27rem; }
+  .left-sidebar,
+  .right-sidebar { padding: 0.85rem; }
 }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -1478,19 +1478,6 @@ body:has(.settlement-top-bar) .main-grid .settlement-card:hover {
   border-block: 0;
   transform: perspective(15rem) rotateX(34deg) rotate(7deg);
 }
-.visual-scene-emblem {
-  position: absolute;
-  z-index: 2;
-  display: grid;
-  place-items: center;
-  border: 1px solid rgb(239 218 170 / 45%);
-  border-radius: 50%;
-  background: rgb(12 18 16 / 76%);
-  box-shadow: 0 0.5rem 1.4rem #0009, inset 0 0 0 0.3rem rgb(255 255 255 / 4%);
-}
-.visual-scene-emblem .game-icon { width: 55%; height: 55%; }
-.visual-scene-emblem-primary { top: 21%; left: 50%; width: 8rem; height: 8rem; transform: translateX(-50%); }
-.visual-scene-emblem-secondary { top: 43%; left: calc(50% + 4rem); width: 3.1rem; height: 3.1rem; color: var(--accent-gold-light); }
 .visual-scene-caption {
   position: absolute;
   z-index: 3;
@@ -1511,16 +1498,11 @@ body:has(.settlement-top-bar) .main-grid .settlement-card:hover {
 .service-visual-character .service-visual-scene { background: radial-gradient(circle at 50% 37%, #374a48, #172120 62%, #101513); }
 .service-visual-character .visual-scene-horizon { inset: 42% 28% -10%; border-radius: 48% 48% 0 0; clip-path: none; background: #111918; }
 .service-visual-character .visual-scene-route { display: none; }
-.service-visual-character .visual-scene-emblem-primary { top: 15%; width: 9rem; height: 9rem; border-radius: 45% 45% 38% 38%; }
-
 .service-visual-settlement .service-visual-scene { background: linear-gradient(#4d6570 0 40%, #28372d 40%); }
 .service-visual-settlement .visual-scene-horizon {
   inset: 25% -2% 10%;
   clip-path: polygon(0 66%, 8% 66%, 8% 38%, 18% 38%, 18% 61%, 28% 61%, 28% 22%, 42% 22%, 42% 55%, 51% 55%, 51% 31%, 64% 31%, 64% 62%, 78% 62%, 78% 42%, 91% 42%, 91% 66%, 100% 66%, 100% 100%, 0 100%);
 }
-.service-visual-settlement .visual-scene-emblem-primary { top: 27%; left: 27%; width: 6rem; height: 6rem; transform: none; }
-.service-visual-settlement .visual-scene-emblem-secondary { top: 13%; right: 18%; left: auto; border: 0; background: rgb(237 196 98 / 24%); }
-
 .service-visual-route .service-visual-scene {
   background: repeating-linear-gradient(8deg, rgb(76 55 29 / 8%) 0 1px, transparent 1px 1.7rem), #b8a276;
   color: #302313;
@@ -1528,35 +1510,24 @@ body:has(.settlement-top-bar) .main-grid .settlement-card:hover {
 .service-visual-route .visual-scene-sky { display: none; }
 .service-visual-route .visual-scene-horizon { inset: 10%; clip-path: none; border: 2px solid rgb(55 39 20 / 35%); background: transparent; }
 .service-visual-route .visual-scene-route { inset: 5% 36% -20%; border-color: rgb(78 48 24 / 62%); border-width: 0.3rem; border-radius: 48%; transform: rotate(28deg); }
-.service-visual-route .visual-scene-emblem-primary { top: 16%; left: 22%; border-color: rgb(55 39 20 / 40%); background: rgb(216 199 157 / 82%); }
-.service-visual-route .visual-scene-emblem-secondary { top: auto; right: 17%; bottom: 23%; left: auto; background: #40301f; }
-
 .service-visual-service .service-visual-scene,
 .service-visual-alchemy .service-visual-scene { background: linear-gradient(165deg, #35291f, #17130f 70%); }
 .service-visual-service .visual-scene-horizon,
 .service-visual-alchemy .visual-scene-horizon { inset: 55% 0 0; clip-path: none; border-top: 0.75rem solid #100d0a; background: #241a12; }
 .service-visual-service .visual-scene-route,
 .service-visual-alchemy .visual-scene-route { display: none; }
-.service-visual-service .visual-scene-emblem-primary { top: 18%; left: 35%; }
-.service-visual-alchemy .visual-scene-emblem-primary { top: 14%; border-radius: 18%; }
-.service-visual-alchemy .visual-scene-emblem-secondary { top: 48%; left: calc(50% + 2.8rem); }
-
 .service-visual-camp .service-visual-scene { background: radial-gradient(circle at 50% 59%, #d58a38 0 2%, #59432b 9%, #25312d 25%, #111b21 58%); }
 .service-visual-camp .visual-scene-horizon { inset: 42% 8% 4%; clip-path: polygon(0 70%, 20% 48%, 32% 70%, 50% 25%, 68% 70%, 82% 50%, 100% 70%, 100% 100%, 0 100%); }
 .service-visual-camp .visual-scene-route { display: none; }
-.service-visual-camp .visual-scene-emblem-primary { top: 37%; width: 6rem; height: 6rem; border: 0; background: transparent; color: #f1a14b; box-shadow: none; }
 
 .service-visual-quest .service-visual-scene { background: radial-gradient(circle at 50% 42%, #67362e, #17231d 58%, #101513); }
 .service-visual-quest .visual-scene-horizon { inset: 28% 7% 8%; clip-path: polygon(0 72%, 16% 44%, 28% 58%, 42% 20%, 58% 55%, 74% 31%, 100% 69%, 100% 100%, 0 100%); }
 .service-visual-quest .visual-scene-route { border-color: rgb(124 43 35 / 48%); transform: perspective(15rem) rotateX(34deg) rotate(-4deg); }
-.service-visual-quest .visual-scene-emblem-primary { border-radius: 0.4rem; transform: translateX(-50%) rotate(4deg); }
 
 .service-visual-chest .service-visual-scene { background: repeating-linear-gradient(90deg, #4b301c 0 4.8rem, #2d1d12 4.8rem 5rem); }
 .service-visual-chest .visual-scene-sky,
 .service-visual-chest .visual-scene-route { display: none; }
 .service-visual-chest .visual-scene-horizon { inset: 60% 0 0; clip-path: none; border-top: 0.7rem solid #21140c; background: #382315; }
-.service-visual-chest .visual-scene-emblem-primary { top: 19%; width: 10rem; height: 7rem; border-radius: 0.45rem; background: #2d1b0e; color: #d6a64f; }
-.service-visual-chest .visual-scene-emblem-secondary { top: 48%; left: calc(50% + 4.5rem); }
 .service-offering-list { display: grid; gap: 0.45rem; margin: 0.7rem 0 0; padding: 0; list-style: none; }
 .service-offering-list li { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); }
 .stage-context-link { position: absolute; z-index: 5; top: 0.75rem; right: 0.75rem; padding: 0.35rem 0.55rem; border: 1px solid var(--border-accent); background: rgb(7 11 10 / 78%); color: var(--text-primary); }
@@ -3602,8 +3573,6 @@ body.chat-resizing {
 @media (max-width: 480px) {
   .settlement-main { min-height: 27rem; }
   .service-visual-scene { min-height: 14rem; }
-  .visual-scene-emblem-primary { width: 6rem; height: 6rem; }
-  .visual-scene-emblem-secondary { left: calc(50% + 3rem); }
   .visual-scene-caption { align-items: flex-start; flex-direction: column; gap: 0.15rem; }
   .settlement-chat { --chat-panel-height: 9.5rem; min-height: 9.5rem; }
 }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -1250,9 +1250,21 @@ body:has(.settlement-top-bar) .main-grid .settlement-card:hover {
 
 .rest-duration-control { display: grid; gap: 0.4rem; margin-bottom: 0.55rem; }
 .rest-duration-units { display: flex; overflow: hidden; border: 1px solid var(--border-light); border-radius: var(--radius); }
-.rest-duration-unit { flex: 1; padding: 0.38rem; color: var(--text-muted); cursor: pointer; font-size: var(--font-size-xs); text-align: center; }
+.rest-duration-unit { position: relative; flex: 1; padding: 0.38rem; color: var(--text-muted); cursor: pointer; font-size: var(--font-size-xs); text-align: center; }
 .rest-duration-unit + .rest-duration-unit { border-left: 1px solid var(--border-light); }
-.rest-duration-unit input { position: absolute; opacity: 0; pointer-events: none; }
+.rest-duration-unit input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.rest-duration-unit:focus-within { outline: 2px solid var(--accent); outline-offset: -2px; }
 .rest-duration-unit.active { background: var(--building-interactive-hover); color: var(--text-primary); }
 
 .rest-wake-time {
@@ -1438,46 +1450,116 @@ body:has(.settlement-top-bar) .main-grid .settlement-card:hover {
   box-shadow: var(--shadow-sm);
 }
 
-.service-visual-placeholder {
-  display: flex;
+.service-visual-scene {
+  position: relative;
   flex: 1;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 0.75rem;
-  min-height: 0;
-  color: var(--accent-dark);
+  min-height: 12rem;
+  overflow: hidden;
+  isolation: isolate;
+  color: #e9dfc8;
   background:
-    linear-gradient(135deg, transparent 49.5%, color-mix(in srgb, var(--accent) 10%, transparent) 50%, transparent 50.5%),
-    linear-gradient(45deg, transparent 49.5%, color-mix(in srgb, var(--accent) 10%, transparent) 50%, transparent 50.5%),
-    var(--bg-secondary);
-  background-size: 42px 42px;
+    radial-gradient(circle at 68% 18%, rgb(235 196 116 / 28%) 0 4%, transparent 13%),
+    linear-gradient(#293a43 0 48%, #18261f 48% 100%);
 }
 
-.service-visual-map .service-visual-placeholder {
-  background-color: color-mix(in srgb, var(--accent) 8%, var(--bg-secondary));
+.visual-scene-sky,
+.visual-scene-horizon,
+.visual-scene-route { position: absolute; pointer-events: none; }
+.visual-scene-sky { inset: 0 0 45%; background: linear-gradient(165deg, transparent 35%, rgb(255 235 180 / 8%)); }
+.visual-scene-horizon {
+  inset: 34% -5% 16%;
+  background: color-mix(in srgb, var(--active-building-tint) 74%, #0d1714);
+  clip-path: polygon(0 68%, 10% 42%, 21% 61%, 34% 26%, 48% 56%, 61% 31%, 75% 60%, 88% 36%, 100% 64%, 100% 100%, 0 100%);
 }
-
-.visual-symbol {
+.visual-scene-route {
+  z-index: 1;
+  inset: 52% 32% -25%;
+  border: 0.45rem solid rgb(209 178 121 / 36%);
+  border-block: 0;
+  transform: perspective(15rem) rotateX(34deg) rotate(7deg);
+}
+.visual-scene-emblem {
+  position: absolute;
+  z-index: 2;
   display: grid;
   place-items: center;
-  width: 7rem;
-  height: 7rem;
-  border: 2px solid var(--border-accent);
+  border: 1px solid rgb(239 218 170 / 45%);
   border-radius: 50%;
-  color: var(--accent-dark);
-  font-family: var(--font-display), serif;
-  font-size: 3.5rem;
-  line-height: 1;
+  background: rgb(12 18 16 / 76%);
+  box-shadow: 0 0.5rem 1.4rem #0009, inset 0 0 0 0.3rem rgb(255 255 255 / 4%);
 }
+.visual-scene-emblem .game-icon { width: 55%; height: 55%; }
+.visual-scene-emblem-primary { top: 21%; left: 50%; width: 8rem; height: 8rem; transform: translateX(-50%); }
+.visual-scene-emblem-secondary { top: 43%; left: calc(50% + 4rem); width: 3.1rem; height: 3.1rem; color: var(--accent-gold-light); }
+.visual-scene-caption {
+  position: absolute;
+  z-index: 3;
+  right: 1rem;
+  bottom: 1rem;
+  left: 1rem;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgb(239 218 170 / 25%);
+  background: rgb(7 11 10 / 78%);
+  box-shadow: 0 0.3rem 1rem #0008;
+}
+.visual-scene-caption strong { font-family: var(--font-display), serif; font-size: var(--font-size-lg); }
+.visual-scene-caption span { color: #c9bfa9; font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.08em; }
+.service-visual-character .service-visual-scene { background: radial-gradient(circle at 50% 37%, #374a48, #172120 62%, #101513); }
+.service-visual-character .visual-scene-horizon { inset: 42% 28% -10%; border-radius: 48% 48% 0 0; clip-path: none; background: #111918; }
+.service-visual-character .visual-scene-route { display: none; }
+.service-visual-character .visual-scene-emblem-primary { top: 15%; width: 9rem; height: 9rem; border-radius: 45% 45% 38% 38%; }
 
-.visual-label {
-  color: var(--text-muted);
-  font-family: var(--font-display), serif;
-  font-size: var(--font-size-sm);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.service-visual-settlement .service-visual-scene { background: linear-gradient(#4d6570 0 40%, #28372d 40%); }
+.service-visual-settlement .visual-scene-horizon {
+  inset: 25% -2% 10%;
+  clip-path: polygon(0 66%, 8% 66%, 8% 38%, 18% 38%, 18% 61%, 28% 61%, 28% 22%, 42% 22%, 42% 55%, 51% 55%, 51% 31%, 64% 31%, 64% 62%, 78% 62%, 78% 42%, 91% 42%, 91% 66%, 100% 66%, 100% 100%, 0 100%);
 }
+.service-visual-settlement .visual-scene-emblem-primary { top: 27%; left: 27%; width: 6rem; height: 6rem; transform: none; }
+.service-visual-settlement .visual-scene-emblem-secondary { top: 13%; right: 18%; left: auto; border: 0; background: rgb(237 196 98 / 24%); }
+
+.service-visual-route .service-visual-scene {
+  background: repeating-linear-gradient(8deg, rgb(76 55 29 / 8%) 0 1px, transparent 1px 1.7rem), #b8a276;
+  color: #302313;
+}
+.service-visual-route .visual-scene-sky { display: none; }
+.service-visual-route .visual-scene-horizon { inset: 10%; clip-path: none; border: 2px solid rgb(55 39 20 / 35%); background: transparent; }
+.service-visual-route .visual-scene-route { inset: 5% 36% -20%; border-color: rgb(78 48 24 / 62%); border-width: 0.3rem; border-radius: 48%; transform: rotate(28deg); }
+.service-visual-route .visual-scene-emblem-primary { top: 16%; left: 22%; border-color: rgb(55 39 20 / 40%); background: rgb(216 199 157 / 82%); }
+.service-visual-route .visual-scene-emblem-secondary { top: auto; right: 17%; bottom: 23%; left: auto; background: #40301f; }
+
+.service-visual-service .service-visual-scene,
+.service-visual-alchemy .service-visual-scene { background: linear-gradient(165deg, #35291f, #17130f 70%); }
+.service-visual-service .visual-scene-horizon,
+.service-visual-alchemy .visual-scene-horizon { inset: 55% 0 0; clip-path: none; border-top: 0.75rem solid #100d0a; background: #241a12; }
+.service-visual-service .visual-scene-route,
+.service-visual-alchemy .visual-scene-route { display: none; }
+.service-visual-service .visual-scene-emblem-primary { top: 18%; left: 35%; }
+.service-visual-alchemy .visual-scene-emblem-primary { top: 14%; border-radius: 18%; }
+.service-visual-alchemy .visual-scene-emblem-secondary { top: 48%; left: calc(50% + 2.8rem); }
+
+.service-visual-camp .service-visual-scene { background: radial-gradient(circle at 50% 59%, #d58a38 0 2%, #59432b 9%, #25312d 25%, #111b21 58%); }
+.service-visual-camp .visual-scene-horizon { inset: 42% 8% 4%; clip-path: polygon(0 70%, 20% 48%, 32% 70%, 50% 25%, 68% 70%, 82% 50%, 100% 70%, 100% 100%, 0 100%); }
+.service-visual-camp .visual-scene-route { display: none; }
+.service-visual-camp .visual-scene-emblem-primary { top: 37%; width: 6rem; height: 6rem; border: 0; background: transparent; color: #f1a14b; box-shadow: none; }
+
+.service-visual-quest .service-visual-scene { background: radial-gradient(circle at 50% 42%, #67362e, #17231d 58%, #101513); }
+.service-visual-quest .visual-scene-horizon { inset: 28% 7% 8%; clip-path: polygon(0 72%, 16% 44%, 28% 58%, 42% 20%, 58% 55%, 74% 31%, 100% 69%, 100% 100%, 0 100%); }
+.service-visual-quest .visual-scene-route { border-color: rgb(124 43 35 / 48%); transform: perspective(15rem) rotateX(34deg) rotate(-4deg); }
+.service-visual-quest .visual-scene-emblem-primary { border-radius: 0.4rem; transform: translateX(-50%) rotate(4deg); }
+
+.service-visual-chest .service-visual-scene { background: repeating-linear-gradient(90deg, #4b301c 0 4.8rem, #2d1d12 4.8rem 5rem); }
+.service-visual-chest .visual-scene-sky,
+.service-visual-chest .visual-scene-route { display: none; }
+.service-visual-chest .visual-scene-horizon { inset: 60% 0 0; clip-path: none; border-top: 0.7rem solid #21140c; background: #382315; }
+.service-visual-chest .visual-scene-emblem-primary { top: 19%; width: 10rem; height: 7rem; border-radius: 0.45rem; background: #2d1b0e; color: #d6a64f; }
+.service-visual-chest .visual-scene-emblem-secondary { top: 48%; left: calc(50% + 4.5rem); }
+.service-offering-list { display: grid; gap: 0.45rem; margin: 0.7rem 0 0; padding: 0; list-style: none; }
+.service-offering-list li { display: flex; align-items: center; gap: 0.5rem; color: var(--text-muted); }
+.stage-context-link { position: absolute; z-index: 5; top: 0.75rem; right: 0.75rem; padding: 0.35rem 0.55rem; border: 1px solid var(--border-accent); background: rgb(7 11 10 / 78%); color: var(--text-primary); }
 
 .service-visual figcaption {
   padding: 0.65rem 0.85rem;
@@ -2942,6 +3024,15 @@ button.party-portrait-action {
 
 .skill-rank-bar {
   position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 2rem;
+  align-items: center;
+  gap: 0.3rem;
+  min-height: 1rem;
+  overflow: visible;
+}
+
+.skill-rank-track {
   display: flex;
   height: 0.45rem;
   gap: 0.12rem;
@@ -2994,7 +3085,7 @@ button.party-portrait-action {
 
 .party-attribute-row {
   display: grid;
-  grid-template-columns: 1.15rem minmax(0, 1fr) minmax(3rem, 2fr);
+  grid-template-columns: 1.15rem minmax(0, 1fr) minmax(3rem, 2fr) 2rem;
   align-items: center;
   gap: 0.35rem;
   min-width: 0;
@@ -3003,7 +3094,7 @@ button.party-portrait-action {
 }
 
 .party-attribute-icon-only {
-  grid-template-columns: 1.15rem minmax(0, 1fr);
+  grid-template-columns: 1.15rem minmax(0, 1fr) 2rem;
 }
 
 .party-attribute-row .stat-icon {
@@ -3016,6 +3107,9 @@ button.party-portrait-action {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.attribute-rank-value,
+.skill-rank-value { color: var(--text-primary); font-size: var(--font-size-xs); font-variant-numeric: tabular-nums; text-align: right; }
 
 .limb-attribute-pair {
   display: grid;
@@ -3210,9 +3304,11 @@ body.chat-resizing {
   --channel-color: #fff;
   display: inline-flex;
   align-items: center;
+  gap: 0.2rem;
   cursor: pointer;
   user-select: none;
 }
+.chat-channel-filter > span { color: var(--channel-color); font-size: 0.65rem; font-weight: 800; line-height: 1; }
 
 .chat-channel-filter input {
   display: grid;
@@ -3235,6 +3331,9 @@ body.chat-resizing {
   box-shadow: inset 0 0 0 1px #0004, 0 0 0 2px var(--panel-bg);
 }
 .chat-channel-filter input:not(:checked) { opacity: 0.45; }
+.chat-channel-filter input::after { content: ""; width: 0.34rem; height: 0.18rem; border: solid #111; border-width: 0 0 2px 2px; opacity: 0; transform: translateY(-0.05rem) rotate(-45deg); }
+.chat-channel-filter input:checked::after { opacity: 1; }
+.chat-channel-filter:has(input:not(:checked)) > span { text-decoration: line-through; opacity: 0.65; }
 
 .chat-channel-filter-local { --channel-color: #fff; }
 .chat-channel-filter-party { --channel-color: #4a9eff; }
@@ -3275,6 +3374,8 @@ body.chat-resizing {
   text-decoration: underline;
   text-underline-offset: 0.14em;
 }
+.chat-quest-link[data-used],
+.chat-quest-link[aria-disabled="true"] { color: var(--text-muted); text-decoration: none; cursor: default; opacity: 0.8; }
 
 .chat-timestamp {
   color: var(--text-secondary);
@@ -3408,28 +3509,103 @@ body.chat-resizing {
   grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
   gap: 0.75rem;
 }
-
-.skill-rank-value {
-  position: absolute;
-  z-index: 4;
-  bottom: calc(100% + 0.35rem);
-  padding: 0.1rem 0.3rem;
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius);
-  background: var(--bg-secondary);
-  color: var(--text-primary);
-  font-size: var(--font-size-xs);
-  font-variant-numeric: tabular-nums;
-  line-height: 1;
-  opacity: 0;
-  pointer-events: none;
-  transform: translateX(-50%);
-  transition: opacity var(--transition-fast);
-  white-space: nowrap;
+.character-select-grid .panel,
+.character-select-grid form { min-width: 0; }
+.character-select-action {
+  box-sizing: border-box;
+  max-width: 100%;
+  min-height: 2.25rem;
+  height: auto;
+  overflow-wrap: anywhere;
+  line-height: 1.25;
+  text-align: center;
+  white-space: normal;
 }
 
-.skill-rank-bar:hover .skill-rank-value {
-  opacity: 1;
+.strategic-notice-main { display: grid; min-height: 28rem; place-items: center; background: radial-gradient(circle at 50% 35%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 55%); }
+.strategic-notice { width: min(32rem, 100%); padding: 2rem; border: 1px solid var(--border-accent); background: var(--panel-bg); box-shadow: var(--shadow-lg); text-align: center; }
+.strategic-notice h2 { margin: 0.75rem 0 0.5rem; font-family: var(--font-display), serif; }
+.strategic-notice p { margin-bottom: 1.25rem; color: var(--text-secondary); }
+.strategic-notice-icon { display: inline-block; width: 3rem; height: 3rem; background: var(--accent); -webkit-mask: url('/static/icons/game/treasure-map.svg') center / contain no-repeat; mask: url('/static/icons/game/treasure-map.svg') center / contain no-repeat; }
+.form-error { margin: 0.6rem 0; padding: 0.55rem 0.7rem; border-left: 3px solid var(--danger); background: color-mix(in srgb, var(--danger) 12%, transparent); color: var(--text-primary); }
+.mission-diagnostics { font-size: var(--font-size-sm); }
+.mission-diagnostics summary { cursor: pointer; color: var(--text-secondary); }
+.mission-diagnostics[open] summary { margin-bottom: 0.75rem; }
+.party-offer-summary { flex: 1 1 auto; color: var(--text-secondary); }
+.role-inspection-back,
+.service-role-back { margin-bottom: 0.75rem; }
+
+@media (hover: none), (pointer: coarse) {
+  .inventory-row-actions,
+  .inventory-footer-actions,
+  .inventory-target-step:not([hidden]),
+  .party-portrait-actions,
+  .character-religion-action { opacity: 1; pointer-events: auto; transform: none; }
+  .party-portrait-actions { gap: 0.2rem; transform: translateX(-50%); }
+  .party-portrait-action,
+  button.party-portrait-action { width: 2.75rem; height: 2.75rem; min-width: 2.75rem; min-height: 2.75rem; }
+  .party-portrait-overlay { padding-bottom: 3.2rem; }
+}
+
+@media (max-width: 768px) {
+  .settlement-main { min-height: 32rem; }
+  .party-portrait-overlay {
+    right: 0.5rem;
+    left: 0.5rem;
+    max-width: none;
+    justify-content: flex-start;
+    gap: 0.65rem;
+    padding: 0.3rem 0.4rem 1.6rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+    transform: none;
+    scrollbar-width: thin;
+  }
+  .party-portrait-overlay > [data-party-portrait-members] { display: contents; }
+  .party-role-group { flex: 0 0 auto; }
+  .service-visual-scene { min-height: 18rem; }
+  .party-offer { width: min(32rem, calc(100vw - 1rem)); flex-wrap: wrap; }
+  .party-offer-summary { flex-basis: 100%; }
+  .left-sidebar:has(.inventory-browser),
+  .right-sidebar:has(.inventory-browser) {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    direction: ltr;
+    overflow-x: hidden;
+  }
+  :is(.left-sidebar, .right-sidebar):has(.inventory-browser) .sidebar-section,
+  .inventory-browser,
+  .inventory-browser-table-frame {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+  }
+  .inventory-browser-table-frame { overflow-x: auto; overflow-y: visible; }
+  .smith-wares-scroll,
+  .left-sidebar .encumbrance-inventory-scroll,
+  .right-sidebar .encumbrance-inventory-scroll {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 100%;
+    margin-inline: 0;
+    padding-inline: 0;
+    direction: ltr;
+    overflow-x: visible;
+    overflow-y: visible;
+    scrollbar-gutter: auto;
+  }
+}
+
+@media (max-width: 480px) {
+  .settlement-main { min-height: 27rem; }
+  .service-visual-scene { min-height: 14rem; }
+  .visual-scene-emblem-primary { width: 6rem; height: 6rem; }
+  .visual-scene-emblem-secondary { left: calc(50% + 3rem); }
+  .visual-scene-caption { align-items: flex-start; flex-direction: column; gap: 0.15rem; }
+  .settlement-chat { --chat-panel-height: 9.5rem; min-height: 9.5rem; }
 }
 
 .party-skill-allocation {

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -86,7 +86,8 @@
 .inventory-target-control { display:inline-flex; align-items:center; justify-content:center; white-space:nowrap; }
 .inventory-target-denominator { display:inline-grid; grid-template-rows:.7rem 1.1rem .7rem; justify-items:center; align-items:center; min-width:1.4rem; }
 .inventory-target-step { opacity:0; border:0; background:transparent; color:var(--color-accent); line-height:.65rem; padding:0 .25rem; cursor:pointer; transition:opacity .12s; }
-.inventory-count:hover .inventory-target-step:not([hidden]) { opacity:1; }
+.inventory-count:hover .inventory-target-step:not([hidden]),
+.inventory-count:focus-within .inventory-target-step:not([hidden]) { opacity:1; }
 .inventory-target-value { grid-row:2; }
 .inventory-transfer-glyph { display:inline-flex; align-items:center; }
 .inventory-transfer-glyph i { display:block; width:.48rem; height:.48rem; border-top:2px solid currentColor; border-right:2px solid currentColor; transform:rotate(45deg); margin-left:-.16rem; }
@@ -101,6 +102,54 @@
 .inventory-footer-repair { display:block; width:1.35rem; height:1.35rem; }
 .inventory-footer-repair .repair-all-button { width:1.35rem; height:1.35rem; opacity:.8; }
 .right-sidebar .inventory-footer-transfer .inventory-transfer-glyph { transform:rotate(180deg); }
+
+@media (hover:none), (pointer:coarse) {
+  .inventory-row-actions,
+  .inventory-footer-actions,
+  .inventory-target-step:not([hidden]) { opacity:1; }
+  .inventory-row-actions {
+    top: 50%;
+    bottom: auto;
+    grid-template-columns: 2.75rem;
+    width: calc(2.75rem + var(--inventory-action-bridge));
+    min-height: 2.75rem;
+    transform: translateY(-50%);
+  }
+  .inventory-row-actions.smith-player-actions {
+    grid-template-columns: repeat(2, 2.75rem);
+    width: calc(5.5rem + var(--inventory-action-bridge));
+  }
+  .inventory-row-actions .trade-transfer,
+  .smith-player-actions .row-repair-form,
+  .inventory-footer-transfer,
+  .inventory-footer-repair,
+  .inventory-footer-repair .repair-all-button {
+    width: 2.75rem;
+    height: 2.75rem;
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+  .inventory-footer-actions { min-height: 2.75rem; }
+  .inventory-target-denominator {
+    grid-template-columns: 2.75rem 1.4rem 2.75rem;
+    grid-template-rows: 2.75rem;
+  }
+  .inventory-target-step { width: 2.75rem; height: 2.75rem; padding: 0; }
+  .inventory-target-up { grid-column: 3; grid-row: 1; }
+  .inventory-target-down { grid-column: 1; grid-row: 1; }
+  .inventory-target-value { grid-column: 2; grid-row: 1; }
+}
+
+@media (max-width:480px) and (pointer:coarse) {
+  .inventory-column-actions,
+  .inventory-actions-cell,
+  .inventory-actions-header { width:2.75rem; min-width:2.75rem; }
+  .inventory-actions-cell > .inventory-row-actions {
+    position:static;
+    padding:0;
+    transform:none;
+  }
+}
 
 .party-portrait-overlay > .party-aggregate-checks {
   position:static;

--- a/crates/strategic-web/static/medical-examination.js
+++ b/crates/strategic-web/static/medical-examination.js
@@ -1,14 +1,78 @@
-(() => {
-  const examination = document.querySelector("[data-medical-examination]");
-  if (!examination) return;
+const wrappedDialogFocusIndex = (length, current, backwards) => {
+  if (length <= 0) return -1;
+  if (current < 0) return backwards ? length - 1 : 0;
+  if (backwards && current === 0) return length - 1;
+  if (!backwards && current === length - 1) return 0;
+  return current + (backwards ? -1 : 1);
+};
 
-  let resolved = false;
-  examination.querySelectorAll("form").forEach((form) => {
-    form.addEventListener("submit", () => {
-      resolved = true;
+if (typeof module !== "undefined") module.exports = { wrappedDialogFocusIndex };
+
+(() => {
+  if (typeof document === "undefined") return;
+  let lastFocused = null;
+  const focusableSelector = [
+    "a[href]", "button:not(:disabled)", "input:not(:disabled)",
+    "select:not(:disabled)", "textarea:not(:disabled)", "[tabindex]:not([tabindex='-1'])",
+  ].join(",");
+  const visibleFocusables = (dialog) => [...dialog.querySelectorAll(focusableSelector)]
+    .filter((element) => !element.hidden && !element.closest("[hidden]") && element.getAttribute("aria-hidden") !== "true");
+
+  const focusDialog = (dialog) => {
+    if (!dialog || dialog.hidden) return;
+    lastFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    requestAnimationFrame(() => {
+      const target = visibleFocusables(dialog)[0] || dialog;
+      target.focus?.();
     });
+  };
+
+  const restoreFocus = () => {
+    if (lastFocused?.isConnected) lastFocused.focus();
+    lastFocused = null;
+  };
+
+  document.querySelectorAll(".party-offer[role='dialog']").forEach((dialog) => {
+    new MutationObserver(() => {
+      if (dialog.hidden) restoreFocus();
+      else focusDialog(dialog);
+    }).observe(dialog, { attributes: true, attributeFilter: ["hidden"] });
   });
 
+  const examination = document.querySelector("[data-medical-examination]");
+  const restSummary = document.querySelector(".rest-summary-overlay[role='dialog']");
+  if (examination) focusDialog(examination);
+  else if (restSummary) focusDialog(restSummary);
+
+  document.addEventListener("keydown", (event) => {
+    const openConfirmation = [...document.querySelectorAll(".party-offer[role='dialog']")]
+      .find((dialog) => !dialog.hidden);
+    const activeDialog = openConfirmation || examination || restSummary;
+    if (!activeDialog) return;
+    if (event.key === "Tab") {
+      const focusables = visibleFocusables(activeDialog);
+      const current = focusables.indexOf(document.activeElement);
+      const next = wrappedDialogFocusIndex(focusables.length, current, event.shiftKey);
+      if (next >= 0 && (current < 0 || next !== current + (event.shiftKey ? -1 : 1))) {
+        event.preventDefault();
+        focusables[next].focus();
+      }
+      return;
+    }
+    if (event.key !== "Escape") return;
+    const close = activeDialog.querySelector(
+      ".party-offer-cancel, [data-cancel-loot], [data-cancel-pool], .medical-examination-close, .rest-summary-close",
+    );
+    if (!close) return;
+    event.preventDefault();
+    close.click();
+  });
+
+  if (!examination) return;
+  let resolved = false;
+  examination.querySelectorAll("form").forEach((form) => {
+    form.addEventListener("submit", () => { resolved = true; });
+  });
   window.addEventListener("pagehide", () => {
     if (!resolved && examination.dataset.dismissUrl) {
       navigator.sendBeacon(examination.dataset.dismissUrl, new Blob([], {

--- a/crates/strategic-web/static/party-recruitment.js
+++ b/crates/strategic-web/static/party-recruitment.js
@@ -68,6 +68,12 @@
         const detail = document.createElement("div");
         detail.dataset.roleInspectionPanel = "true";
         detail.className = "role-inspection-panel";
+        const back = document.createElement("button");
+        back.type = "button";
+        back.className = "btn btn-secondary btn-small role-inspection-back";
+        back.textContent = "Back to party";
+        back.addEventListener("click", clearRoleInspection);
+        detail.append(back);
         detail.append(template.content.cloneNode(true));
         sidebar.append(detail);
       });
@@ -117,7 +123,7 @@
       roleBuilder.elements.quantity.value = "1";
       if (builderHeading) builderHeading.textContent = "Recruit party roles";
       if (builderSubmit) builderSubmit.textContent = "Add role";
-      if (builderHelp) builderHelp.textContent = "Create one visually grouped portrait per slot.";
+      if (builderHelp) builderHelp.textContent = "Choose how many openings this role should advertise.";
     };
     const populateBuilder = (source) => {
       if (!roleBuilder) return;

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -245,6 +245,9 @@ function updateDiscardForm() {
     form.append(input);
   });
   const hasDraft = draft.size > 0;
+  const staged = [...draft.values()].reduce((total, quantity) => total + quantity, 0);
+  const confirmation = form.querySelector("[data-discard-confirmation]");
+  if (confirmation) confirmation.textContent = `Permanently discard ${staged} staged item${staged === 1 ? "" : "s"}?`;
   form.hidden = !hasDraft;
   form.querySelector("[type='submit']").disabled = !hasDraft;
   const table = document.querySelector("[data-discard-table]");

--- a/crates/strategic-web/static/service-quests.js
+++ b/crates/strategic-web/static/service-quests.js
@@ -1,4 +1,14 @@
+const serviceQuestTabState = (serviceQuests) => {
+  if (serviceQuests.some((quest) => quest.state === "ready")) return "quest ready to report";
+  if (serviceQuests.some((quest) => quest.state === "available")) return "quest available";
+  if (serviceQuests.some((quest) => quest.state === "recruiting")) return "recruitment available";
+  return null;
+};
+
+if (typeof module !== "undefined") module.exports = { serviceQuestTabState };
+
 (() => {
+  if (typeof document === "undefined") return;
   const services = document.querySelector("[data-settlement-id]");
   if (!services) return;
 
@@ -80,6 +90,8 @@
     const action = dialogueActions.get(anchor.dataset.questDialogueAction);
     if (!action) return;
     anchor.dataset.used = "true";
+    anchor.setAttribute("aria-disabled", "true");
+    anchor.removeAttribute("href");
     dialogueActions.delete(anchor.dataset.questDialogueAction);
     action();
   });
@@ -90,6 +102,10 @@
       element.classList.remove("service-role-inspection-hidden");
     });
   };
+
+  document.addEventListener("click", (event) => {
+    if (event.target.closest("[data-close-service-role-inspection]")) clearRoleInspection();
+  });
 
   const inspectRecruitingRole = (quest, role) => {
     clearRoleInspection();
@@ -405,6 +421,8 @@
           "service-turn-in-badge",
           "service-recruitment-badge",
         );
+        const tab = badge.closest("[data-service-id]");
+        if (tab) tab.setAttribute("aria-label", tab.dataset.serviceLabel || tab.title || "Service");
       });
       const serviceIds = new Set(quests.map((quest) => quest.service_id));
       serviceIds.forEach((serviceId) => {
@@ -429,6 +447,9 @@
               && !hasAvailableQuest
               && serviceQuests.some((quest) => quest.state === "recruiting"),
           );
+          const baseLabel = tab.dataset.serviceLabel || tab.title || "Service";
+          const stateLabel = serviceQuestTabState(serviceQuests);
+          tab.setAttribute("aria-label", stateLabel ? `${baseLabel}, ${stateLabel}` : baseLabel);
         }
       });
       if (!chat || chat.dataset.serviceQuestSettlement !== settlementId) return;

--- a/crates/strategic-web/tests/environment.test.cjs
+++ b/crates/strategic-web/tests/environment.test.cjs
@@ -138,6 +138,21 @@ test("skill schedule columns fit inside a framed left rail", () => {
   assert.match(strategicCss, /\.skill-schedule \.religion-expand-column \{ width: 1\.35rem; \}/);
 });
 
+test("character selection actions wrap long adventurer names inside their cards", () => {
+  assert.match(strategicCss, /\.character-select-action \{[\s\S]*max-width: 100%;[\s\S]*overflow-wrap: anywhere;[\s\S]*white-space: normal;/);
+});
+
+test("stacked inventory rails shed desktop overhang and scroll within the available width", () => {
+  assert.match(strategicCss, /@media \(max-width: 768px\)[\s\S]*:has\(\.inventory-browser\)[\s\S]*width: 100%;[\s\S]*direction: ltr;[\s\S]*overflow-x: hidden;/);
+  assert.match(strategicCss, /\.inventory-browser-table-frame \{ overflow-x: auto; overflow-y: visible; \}/);
+  assert.match(strategicCss, /\.smith-wares-scroll,[\s\S]*\.encumbrance-inventory-scroll[\s\S]*margin-inline: 0;[\s\S]*padding-inline: 0;/);
+});
+
+test("rest duration radios use a bounded accessible hiding technique", () => {
+  assert.match(strategicCss, /\.rest-duration-unit input \{[\s\S]*width: 1px;[\s\S]*height: 1px;[\s\S]*clip-path: inset\(50%\);/);
+  assert.match(strategicCss, /\.rest-duration-unit:focus-within \{ outline: 2px solid var\(--accent\)/);
+});
+
 test("building state is re-applied when live regions replace party links", () => {
   assert.match(buildingSource, /new MutationObserver/);
   assert.match(buildingSource, /mutation\.addedNodes/);

--- a/crates/strategic-web/tests/inventory-browser.test.cjs
+++ b/crates/strategic-web/tests/inventory-browser.test.cjs
@@ -11,6 +11,15 @@ const {
   refresh,
   syncPanelWidth,
 } = require("../static/inventory-browser.js");
+const { wrappedDialogFocusIndex } = require("../static/medical-examination.js");
+
+test("modal focus wraps forward and backward without leaving the dialog", () => {
+  assert.equal(wrappedDialogFocusIndex(3, 2, false), 0);
+  assert.equal(wrappedDialogFocusIndex(3, 0, true), 2);
+  assert.equal(wrappedDialogFocusIndex(3, -1, false), 0);
+  assert.equal(wrappedDialogFocusIndex(3, -1, true), 2);
+  assert.equal(wrappedDialogFocusIndex(0, -1, false), -1);
+});
 
 test("panel state is independently namespaced", () => {
   const search = "?inv.left.q=sword&inv.left.sort=weight&inv.left.dir=desc&inv.left.cols=reach,damage&inv.right.q=mail";

--- a/crates/strategic-web/tests/service-quests.test.cjs
+++ b/crates/strategic-web/tests/service-quests.test.cjs
@@ -7,6 +7,7 @@ const source = fs.readFileSync(
   path.join(__dirname, "..", "static", "service-quests.js"),
   "utf8",
 );
+const { serviceQuestTabState } = require(path.join(__dirname, "..", "static", "service-quests.js"));
 
 test("herbalist greeting offers a clickable examination without replacing quest dialogue", () => {
   assert.match(source, /Greetings, traveler, what brings you to my humble shop/);
@@ -49,4 +50,24 @@ test("active quest state drives the red Map tab marker", () => {
   assert.match(source, /marker\.description/);
   assert.match(source, /queueStrategicInitialLoad\(refreshMapQuestMarker\)/);
   assert.match(source, /strategic-live-update", refreshMapQuestMarker/);
+});
+
+test("service quest badges keep tab names accessible and used dialogue links inert", () => {
+  assert.match(source, /dataServiceLabel|dataset\.serviceLabel/);
+  assert.match(source, /stateLabel \? `\$\{baseLabel\}, \$\{stateLabel\}` : baseLabel/);
+  assert.match(source, /anchor\.setAttribute\("aria-disabled", "true"\)/);
+  assert.match(source, /anchor\.removeAttribute\("href"\)/);
+  assert.match(source, /data-close-service-role-inspection/);
+});
+
+test("service tab state is appended only for actionable quest states", () => {
+  assert.equal(serviceQuestTabState([{ state: "ready" }]), "quest ready to report");
+  assert.equal(serviceQuestTabState([{ state: "available" }]), "quest available");
+  assert.equal(serviceQuestTabState([{ state: "recruiting" }]), "recruitment available");
+  assert.equal(serviceQuestTabState([{ state: "underway" }]), null);
+  assert.equal(serviceQuestTabState([]), null);
+  assert.equal(
+    serviceQuestTabState([{ state: "underway" }, { state: "available" }]),
+    "quest available",
+  );
 });

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (883)
+## Files (866)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -63,7 +63,6 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-stdb-client/src/abandon_quest_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/accept_party_join_request_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/accept_quest_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/add_and_equip_item_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/agricultural_commodity_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/agricultural_limitation_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/agriculture_industry_type.rs` — Generated SpacetimeDB data type.
@@ -136,7 +135,6 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-stdb-client/src/charcoal_burning_industry_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/claim_simulation_run_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/committed_cut_type.rs` — Generated SpacetimeDB data type.
-- `crates/adventuresim-stdb-client/src/complete_quest_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/configure_simulation_character_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/connected_player_item_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/connected_player_type.rs` — Generated SpacetimeDB data type.
@@ -152,18 +150,12 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-stdb-client/src/create_named_character_with_id_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/create_recruitment_role_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/create_tactical_server_for_request_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/create_tactical_server_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/create_temporary_character_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/cropland_cover_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/crossing_traversal_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/crossing_watercourse_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/death_cause_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/death_source_type.rs` — Generated SpacetimeDB data type.
-- `crates/adventuresim-stdb-client/src/define_armor_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/define_clothing_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/define_item_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/define_shield_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/define_weapon_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/delete_recruitment_role_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/delete_saved_recruitment_role_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/deposit_party_inventory_item_reducer.rs` — Generated SpacetimeDB reducer interface.
@@ -188,7 +180,6 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-stdb-client/src/edge_endpoint_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/edge_progress_permille_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/elevation_meters_type.rs` — Generated SpacetimeDB data type.
-- `crates/adventuresim-stdb-client/src/end_tactical_server_by_instance_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/end_tactical_server_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/ensure_settlement_activity_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/enter_mission_reducer.rs` — Generated SpacetimeDB reducer interface.
@@ -237,7 +228,6 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-stdb-client/src/inferred_tree_species_profile_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/inland_water_access_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/inland_water_size_type.rs` — Generated SpacetimeDB data type.
-- `crates/adventuresim-stdb-client/src/insert_new_character_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/inventory_item_table.rs` — Generated SpacetimeDB table interface.
 - `crates/adventuresim-stdb-client/src/inventory_item_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/inventory_quantity_target_table.rs` — Generated SpacetimeDB table interface.
@@ -323,7 +313,6 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-stdb-client/src/quest_status_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/quest_table.rs` — Generated SpacetimeDB table interface.
 - `crates/adventuresim-stdb-client/src/quest_type.rs` — Generated SpacetimeDB data type.
-- `crates/adventuresim-stdb-client/src/record_local_npc_message_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/recruitment_requirements_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/refresh_capabilities_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/refresh_strategic_condition_reducer.rs` — Generated SpacetimeDB reducer interface.
@@ -375,15 +364,9 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-stdb-client/src/saved_recruitment_role_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/schedule_allocation_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/sedimentary_rock_type.rs` — Generated SpacetimeDB data type.
-- `crates/adventuresim-stdb-client/src/seed_bot_join_requests_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/seed_damaged_character_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/seed_party_companions_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/seed_religion_scholar_character_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/seed_sick_character_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/seed_simulation_disease_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/seed_simulation_equipment_damage_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/seed_simulation_world_reducer.rs` — Generated SpacetimeDB reducer interface.
-- `crates/adventuresim-stdb-client/src/seed_world_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/self_regard_type.rs` — Generated SpacetimeDB data type.
 - `crates/adventuresim-stdb-client/src/send_local_chat_message_reducer.rs` — Generated SpacetimeDB reducer interface.
 - `crates/adventuresim-stdb-client/src/set_character_religion_reducer.rs` — Generated SpacetimeDB reducer interface.


### PR DESCRIPTION
## Summary

- correct strategic navigation and styled guard/error states across settlement, camp, quest, and alchemy flows
- improve responsive rail behavior, touch and keyboard discoverability, modal focus handling, service-state accessibility, and character/inventory layouts
- remove prototype-facing copy and the temporary scene SVG emblems while retaining the environmental layout structure
- add regression coverage for navigation, responsive layouts, touch targets, modal focus, quest state labels, and overflow fixes

## Why

A full browser audit found misleading active navigation, invalid camp links, raw error responses, clipped or hidden narrow-layout content, hover-only interactions, inaccessible state announcements, and prototype-facing copy. These changes align the affected pages with the strategic UI guidelines and make the main flows clearer across desktop, tablet, mobile, keyboard, and touch use.

## User impact

Strategic pages now retain truthful context, remain usable across viewport sizes, expose interactions to keyboard and touch users, and present failures within the game shell. The temporary merchant and area SVG placeholders have been removed from the final result.

## Validation

- `cargo test -p strategic-web -- --test-threads=1` — 133 passed
- `node --test crates/strategic-web/tests/*.test.cjs` — 92 passed
- `cargo fmt --all -- --check`
- `python scripts/update_project_map.py --check`
- `git diff --check`
- browser QA across settlement overview/map/services, camp, quest, character, inventory, and guard pages at desktop, tablet, and mobile widths
