### PR TITLE
Improve strategic UI interactions

### DIFF
--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -3887,10 +3887,12 @@ async fn purchase_from_herbalist(
     session: Session,
     Form(form): Form<MerchantOfferForm>,
 ) -> Redirect {
+    let fallback = format!("/settlements/{id}/herbalist");
     let Some((character, _)) = get_active_character(&state, session.character_id_u64()).await
     else {
         return Redirect::to("/characters");
     };
+    let mut purchase_completed = false;
     // Prepared courses are individual equipment-like items, so this storefront
     // intentionally has no party-scope purchase path.
     if form.inventory_scope == "player"
@@ -3901,7 +3903,7 @@ async fn purchase_from_herbalist(
             .into_iter()
             .map(|entry| (entry.id, entry.quantity))
             .unzip();
-        if let Err(error) = state
+        match state
             .db
             .call(
                 "purchase_from_herbalist",
@@ -3914,10 +3916,17 @@ async fn purchase_from_herbalist(
             )
             .await
         {
-            tracing::warn!(%error, character_id = character.id, "herbalist purchase rejected");
+            Ok(()) => purchase_completed = true,
+            Err(error) => {
+                tracing::warn!(%error, character_id = character.id, "herbalist purchase rejected");
+            }
         }
     }
-    Redirect::to(&format!("/settlements/{id}/herbalist"))
+    if purchase_completed {
+        redirect_to_local(&form.return_to, &fallback)
+    } else {
+        Redirect::to(&fallback)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -148,7 +148,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 @if scripts == ScriptProfile::Strategic {
                     script src="/static/numeric-editor.js?v=shared-numeric-editor-2" defer {}
                     script src="/static/inventory-browser.js?v=coin-currencies-3" defer {}
-                    script src="/static/party-trade.js?v=strategic-dialogs-1" defer {}
+                    script src="/static/party-trade.js?v=inventory-numeric-editor-1" defer {}
                     script src="/static/equipment-toggle.js?v=functional-equipment-1" defer {}
                     script src="/static/party-notifications.js?v=standing-leadership-votes-5" defer {}
                     script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -272,6 +272,20 @@ pub fn alchemy_page(
     party_targets: &[InventoryQuantityTarget],
     party_scope: bool,
 ) -> Markup {
+    let scope = if party_scope { "party" } else { "personal" };
+    let return_to = format!(
+        "/locations/settlement/{}/alchemy?recipe={}&scope={scope}",
+        settlement.id, selected.item_id
+    );
+    let herbalist_href = format!(
+        "/settlements/{}/herbalist?return_to={}",
+        settlement.id,
+        return_to
+            .replace('%', "%25")
+            .replace('?', "%3F")
+            .replace('&', "%26")
+            .replace('=', "%3D")
+    );
     let recipes: Vec<_> = adventuresim_core::disease::MEDICATION_RECIPES
         .iter()
         .filter(|recipe| adventuresim_core::disease::can_prepare_medication(medicine, recipe))
@@ -293,7 +307,7 @@ pub fn alchemy_page(
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(character), &format!("/locations/settlement/{}", settlement.id), Some(character.id), true))
             (visual_stage("alchemy", "Alchemy", "A working table of herbs, vessels, and prepared medicines"))
-            a class="stage-context-link" href=(format!("/settlements/{}/herbalist", settlement.id)) {
+            a class="stage-context-link" href=(herbalist_href) {
                 "Return to the herbalist"
             }
             (settlement_chat_area_with_info("Alchemy", Some(character), &[format!("Selected recipe: {}", selected.name)]))
@@ -2508,11 +2522,9 @@ fn target_quantity(targets: &[InventoryQuantityTarget], item_id: &str) -> u32 {
 fn quantity_target_control(quantity: u32, target: u32, item_id: &str, party_scope: bool) -> Markup {
     html! {
         span class="inventory-target-control" data-target-control data-quantity=(quantity) data-item-id=(item_id) data-party-scope=(party_scope) title=(format!("Carrying {quantity}; target {target}")) {
-            span class="inventory-target-denominator" {
-                button type="button" class="inventory-target-step inventory-target-up" data-target-step="1" aria-label=(format!("Increase {} target", item_id)) { "⌃" }
-                span class="inventory-target-value" data-target-value { (target) }
-                button type="button" class="inventory-target-step inventory-target-down" data-target-step="-1" aria-label=(format!("Decrease {} target", item_id)) hidden[target == 0] { "⌄" }
-            }
+            span class="inventory-target-value" data-target-value role="button" tabindex="0"
+                aria-label=(format!("Target quantity for {item_id}"))
+                title=(format!("Click to edit the target quantity for {item_id}")) { (target) }
         }
     }
 }

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -411,6 +411,12 @@
   display: none;
 }
 
+.settlement-top-bar[data-environment="settlement"] .service-notification-badge {
+  top: auto;
+  right: calc(50% - var(--service-icon-size, 1.6rem) / 2 - 0.4rem);
+  bottom: calc(var(--service-icon-bottom, 1.2rem) + var(--service-icon-size, 1.6rem) - 0.4rem);
+}
+
 .service-tab-icon {
   position: relative;
   z-index: 2;

--- a/crates/strategic-web/static/css/utilities.css
+++ b/crates/strategic-web/static/css/utilities.css
@@ -88,7 +88,7 @@
 .inventory-target-step { opacity:0; border:0; background:transparent; color:var(--color-accent); line-height:.65rem; padding:0 .25rem; cursor:pointer; transition:opacity .12s; }
 .inventory-count:hover .inventory-target-step:not([hidden]),
 .inventory-count:focus-within .inventory-target-step:not([hidden]) { opacity:1; }
-.inventory-target-value { grid-row:2; }
+.inventory-target-value { grid-row:2; cursor:pointer; }
 .inventory-transfer-glyph { display:inline-flex; align-items:center; }
 .inventory-transfer-glyph i { display:block; width:.48rem; height:.48rem; border-top:2px solid currentColor; border-right:2px solid currentColor; transform:rotate(45deg); margin-left:-.16rem; }
 .inventory-transfer-glyph i:first-child { margin-left:0; }

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -94,17 +94,14 @@ function applyDynamicTransferModifiers(event) {
 }
 strategicTradeUi.applyDynamicTransferModifiers = applyDynamicTransferModifiers;
 
-function changeInventoryTarget(control, change) {
+function saveInventoryTarget(control, quantity) {
   const value = control?.querySelector("[data-target-value]");
   const row = control?.closest("tr");
   if (!value || !row) return;
 
-  const quantity = Math.max(0, Number(value.textContent) + change);
   value.textContent = String(quantity);
   row.dataset.target = String(quantity);
   control.title = `Carrying ${row.dataset.inventoryQuantity || 0}; target ${quantity}`;
-  const down = control.querySelector('[data-target-step="-1"]');
-  if (down) down.hidden = quantity === 0;
 
   window.strategicFetch("/api/inventory-target", {
     method: "POST",
@@ -113,6 +110,34 @@ function changeInventoryTarget(control, change) {
       quantity: String(quantity),
       party_scope: control.dataset.partyScope,
     }),
+  });
+}
+
+function editInventoryTarget(control) {
+  const display = control?.querySelector("[data-target-value]");
+  const initialValue = Number(display?.textContent);
+  if (!display || !Number.isSafeInteger(initialValue) || !window.StrategicNumericEditor) return;
+  window.StrategicNumericEditor.open({
+    display,
+    initialValue,
+    parse(text) {
+      const trimmed = String(text).trim();
+      if (!/^\d+$/.test(trimmed)) return null;
+      const parsed = Number(trimmed);
+      return Number.isSafeInteger(parsed) ? parsed : null;
+    },
+    format: String,
+    step: 1,
+    minimum: 0,
+    maximum: 4294967295,
+    anchor: control,
+    groupLabel: "Edit target quantity",
+    inputLabel: `Target quantity for ${control.dataset.itemId}`,
+    increaseLabel: "Increase target quantity by one",
+    decreaseLabel: "Decrease target quantity by one",
+    saveLabel: "Save target quantity",
+    cancelLabel: "Cancel target quantity edit",
+    onCommit: (quantity) => saveInventoryTarget(control, quantity),
   });
 }
 
@@ -325,10 +350,10 @@ document.addEventListener("click", (event) => {
     refreshInventoryPanel(root.querySelector('[data-inventory-pane]:not([hidden])'));
     return;
   }
-  const targetStep = clickTarget.closest("[data-target-step]");
-  if (targetStep) {
+  const targetValue = clickTarget.closest("[data-target-value]");
+  if (targetValue) {
     event.preventDefault();
-    changeInventoryTarget(targetStep.closest("[data-target-control]"), Number(targetStep.dataset.targetStep));
+    editInventoryTarget(targetValue.closest("[data-target-control]"));
     return;
   }
   const bulk = clickTarget.closest("[data-inventory-bulk]");
@@ -550,15 +575,13 @@ document.addEventListener("click", (event) => {
   form.querySelector("[type='submit']").disabled = false;
 });
 
-document.addEventListener("wheel", (event) => {
-  const cell = event.target.closest(".inventory-count");
-  const control = cell?.querySelector("[data-target-control]");
-  if (!control) return;
-  event.preventDefault();
-  changeInventoryTarget(control, event.deltaY < 0 ? 1 : -1);
-}, { passive: false });
-
 document.addEventListener("keydown", (event) => {
+  const targetValue = event.target.closest?.("[data-target-value]");
+  if (targetValue && (event.key === "Enter" || event.key === " ")) {
+    event.preventDefault();
+    editInventoryTarget(targetValue.closest("[data-target-control]"));
+    return;
+  }
   if (event.key === "Shift" || event.key === "Control") applyDynamicTransferModifiers(event);
 });
 

--- a/crates/strategic-web/tests/environment.test.cjs
+++ b/crates/strategic-web/tests/environment.test.cjs
@@ -76,6 +76,7 @@ test("settlement tabs layer tiered tintable buildings and proportional horizons 
   assert.match(layoutCss, /data-building-tier="city"[\s\S]*--service-icon-bottom: 1\.8rem[\s\S]*--service-icon-size: 1\.75rem/);
   assert.match(layoutCss, /data-environment="settlement"[\s\S]*\.settlement-services \.nav-tab \{[\s\S]*width: 5\.25rem[\s\S]*height: 6\.75rem/);
   assert.match(layoutCss, /\.service-notification-badge \{[\s\S]*z-index: 3/);
+  assert.match(layoutCss, /data-environment="settlement"[\s\S]*\.service-notification-badge \{[\s\S]*right: calc\(50% - var\(--service-icon-size, 1\.6rem\) \/ 2 - 0\.4rem\)[\s\S]*bottom: calc\(var\(--service-icon-bottom, 1\.2rem\) \+ var\(--service-icon-size, 1\.6rem\) - 0\.4rem\)/);
   assert.match(layoutCss, /\.nav-tab\.active \{[\s\S]*border-bottom: 3px solid var\(--accent-light\)/);
   assert.match(layoutCss, /\.nav-tab\.active::after \{[\s\S]*z-index: 4[\s\S]*bottom: 0[\s\S]*height: 3px/);
   assert.match(layoutCss, /\.settlement-top-bar \{[\s\S]*padding-inline: 0/);

--- a/crates/strategic-web/tests/numeric-editor.test.cjs
+++ b/crates/strategic-web/tests/numeric-editor.test.cjs
@@ -24,14 +24,18 @@ test("shared numeric editor steps, clamps, and recovers invalid drafts", () => {
   assert.equal(stepNumericValue("invalid", -1, decimalOptions), "-0.25");
 });
 
-test("skill allocation and provisioning both use the shared numeric editor", () => {
+test("skill allocation, provisioning, and inventory targets use the shared numeric editor", () => {
   const root = path.join(__dirname, "..", "static");
   const schedule = fs.readFileSync(path.join(root, "training-schedule.js"), "utf8");
   const travel = fs.readFileSync(path.join(root, "travel-planner.js"), "utf8");
+  const trade = fs.readFileSync(path.join(root, "party-trade.js"), "utf8");
   assert.match(schedule, /StrategicNumericEditor\.open/);
   assert.match(travel, /StrategicNumericEditor\.open/);
+  assert.match(trade, /StrategicNumericEditor\.open/);
   assert.match(travel, /step: \.25/);
   assert.match(travel, /minimum: -365/);
+  assert.match(trade, /step: 1/);
+  assert.match(trade, /maximum: 4294967295/);
 });
 
 test("shared numeric editor keeps its trigger in layout while positioning", () => {


### PR DESCRIPTION
## What changed

- replace inventory target step and wheel controls with the shared numeric editor
- return successful herbalist purchases to the selected alchemy recipe and inventory scope
- position settlement quest markers at the top-right of each service icon

## Why

These changes make target quantities easier to enter precisely, preserve the player's alchemy context while buying ingredients, and visually associate quest state with the service icon instead of the building facade.

## Impact

Strategic UI interactions are more consistent and keyboard accessible, while quest markers remain functionally unchanged and are only repositioned.

## Validation

- `cargo check -p strategic-web`
- `node --test crates/strategic-web/tests/environment.test.cjs crates/strategic-web/tests/service-quests.test.cjs crates/strategic-web/tests/numeric-editor.test.cjs`

The complete JavaScript suite was also attempted; 90 tests passed and one unrelated DOM test could not start because `linkedom` is not installed in the local environment.
