### PR TITLE
Improve strategic UI cohesion and tooltips

### DIFF
--- a/crates/strategic-web/src/templates/components.rs
+++ b/crates/strategic-web/src/templates/components.rs
@@ -95,8 +95,18 @@ pub fn item_icon_name(item_id: &str) -> &'static str {
 }
 
 pub fn item_type_icon(item_id: &str) -> Markup {
-    let readable = item_id.replace('_', " ");
+    let readable = item_display_name(item_id);
     game_icon(&format!("Item type: {readable}"), item_icon_name(item_id))
+}
+
+/// Turn a stable snake-case item identifier into player-facing copy without
+/// changing the identifier used by forms or client-side behavior.
+pub fn item_display_name(item_id: &str) -> String {
+    let mut readable = item_id.replace('_', " ");
+    if let Some(first) = readable.get_mut(0..1) {
+        first.make_ascii_uppercase();
+    }
+    readable
 }
 
 pub fn item_type_header() -> Markup {
@@ -362,13 +372,20 @@ mod icon_tests {
     fn icon_markup_is_local_accessible_and_header_is_compact() {
         let icon = item_type_icon("arming_sword").into_string();
         assert!(icon.contains("/static/icons/game/broadsword.svg"));
-        assert!(icon.contains("aria-label=\"Item type: arming sword\""));
+        assert!(icon.contains("aria-label=\"Item type: Arming sword\""));
         let header = item_type_header().into_string();
         assert!(header.contains("inventory-column-type"));
         assert!(header.contains("aria-label=\"Item type\""));
         let decorative = decorative_game_icon("sun").into_string();
         assert!(decorative.contains("aria-hidden=\"true\""));
         assert!(!decorative.contains("role=\"img\""));
+    }
+
+    #[test]
+    fn item_ids_are_humanized_for_display() {
+        assert_eq!(item_display_name("arming_sword"), "Arming sword");
+        assert_eq!(item_display_name("torch"), "Torch");
+        assert_eq!(item_display_name(""), "");
     }
 }
 

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -156,8 +156,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/base.css?v=environment-14";
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
-                link rel="stylesheet" href="/static/css/layout.css?v=responsive-rails-2";
-                link rel="stylesheet" href="/static/css/components.css?v=coin-currencies-3";
+                link rel="stylesheet" href="/static/css/layout.css?v=solid-content-surfaces-1";
+                link rel="stylesheet" href="/static/css/components.css?v=lowercase-display-type-1";
                 link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ui-overhaul-4";
                 link rel="stylesheet" href="/static/css/utilities.css?v=strategic-ui-overhaul-1";
 

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -156,14 +156,15 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/base.css?v=environment-14";
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
-                link rel="stylesheet" href="/static/css/layout.css?v=wilderness-horizons-1";
+                link rel="stylesheet" href="/static/css/layout.css?v=responsive-rails-2";
                 link rel="stylesheet" href="/static/css/components.css?v=coin-currencies-3";
-                link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ui-overhaul-1";
+                link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ui-overhaul-4";
                 link rel="stylesheet" href="/static/css/utilities.css?v=strategic-ui-overhaul-1";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
                 script src="/static/background-fetch.js?v=background-fetch-2" {}
+                script src="/static/tooltips.js?v=styled-tooltips-1" defer {}
                 script src="/static/medical-examination.js?v=strategic-dialogs-1" defer {}
                 @if scripts != ScriptProfile::Entry {
                     script src="/static/live-state.js?v=sse-3" defer {}

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -156,7 +156,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/base.css?v=environment-14";
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
-                link rel="stylesheet" href="/static/css/layout.css?v=solid-content-surfaces-1";
+                link rel="stylesheet" href="/static/css/layout.css?v=subtle-material-lines-1";
                 link rel="stylesheet" href="/static/css/components.css?v=lowercase-display-type-1";
                 link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ui-overhaul-4";
                 link rel="stylesheet" href="/static/css/utilities.css?v=strategic-ui-overhaul-1";

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -3,7 +3,7 @@
 use maud::{Markup, html};
 
 use super::inventory_browser::{InventoryBrowser, InventoryColumnSet};
-use super::{empty_state, item_type_icon, sidebar_section};
+use super::{empty_state, item_display_name, item_type_icon, sidebar_section};
 use crate::routes::travel::TravelDestination;
 use crate::spacetimedb::{
     AutoresolveReport, BattleLootItem, InventoryQuantityTarget, ItemDefinition, PartyInventoryItem,
@@ -187,10 +187,11 @@ pub fn quest_location_enemy_page(
                                 @let value = definition.and_then(|item| item.base_value).unwrap_or(0);
                                 @let current = pooled.iter().find(|pooled| pooled.item_id == entry.item_id).map_or(0, |pooled| pooled.quantity);
                                 @let target = inventory_target(targets, &entry.item_id);
+                                @let item_name = item_display_name(&entry.item_id);
                                 tr class="trade-inventory-row" data-loot-row data-count=(entry.quantity) data-current=(current) data-target=(target) {
                                     td class="inventory-item-type" { (item_type_icon(&entry.item_id)) }
                                     td class="inventory-item-name" { (super::settlement::item_name_with_quality(&entry.item_id, definition)) span class="inventory-row-actions" {
-                                        button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-loot-stage=(entry.id) data-transfer-mode="one" data-label-one=(format!("Move one {}", entry.item_id)) data-label-target=(format!("Move {} to target", entry.item_id)) data-label-all=(format!("Move all {}", entry.item_id)) aria-label=(format!("Move one {}", entry.item_id)) title=(format!("Move one {}", entry.item_id)) { (super::settlement::transfer_glyph(1)) }
+                                        button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-loot-stage=(entry.id) data-transfer-mode="one" data-label-one=(format!("Move one {item_name}")) data-label-target=(format!("Move {item_name} to target")) data-label-all=(format!("Move all {item_name}")) aria-label=(format!("Move one {item_name}")) title=(format!("Move one {item_name}")) { (super::settlement::transfer_glyph(1)) }
                                     } }
                                     td class="inventory-count" { (entry.quantity) }
                                     td class="inventory-weight" { (definition.map_or_else(|| "—".to_string(), |item| item.weight.to_string())) }

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -23,8 +23,9 @@ use std::{collections::BTreeSet, fmt, str::FromStr};
 use super::inventory_browser::{InventoryBrowser, InventoryColumnSet};
 use super::{
     camp_location_layout_with_session, decorative_game_icon, empty_state, game_icon,
-    item_type_header, item_type_icon, population_description, quest_location_layout_with_session,
-    religion_icon, settlement_layout_with_session, sidebar_section, stat_icon_path,
+    item_display_name, item_type_header, item_type_icon, population_description,
+    quest_location_layout_with_session, religion_icon, settlement_layout_with_session,
+    sidebar_section, stat_icon_path,
 };
 use crate::medical::MedicalPresentation;
 use crate::routes::travel::{TravelDestination, TravelProvisionForecast};
@@ -1941,11 +1942,9 @@ fn service_page(
                 div class="service-left-stack" {
                     div class="service-inventory-area" {
                         (sidebar_section("Church services", html! {
-                            p { "Faith: " strong { (religion_name(Some(&settlement.religion_id))) } }
-                            @if active_character.is_some() {
-                                p class="small-copy" { "Speak with the priest below to profess this church's faith. Renunciation is available only from your biography." }
+                            p title=[active_character.is_some().then_some("Speak with the priest to profess this faith. Renunciation is available from your biography. Shared conviction strengthens allied Charisma; conflicting conviction penalizes morale.")] {
+                                "Faith: " strong { (religion_name(Some(&settlement.religion_id))) }
                             }
-                            p class="text-muted small-copy" { "Shared conviction strengthens allied Charisma. Conflicting conviction turns that influence into a morale penalty." }
                         }))
                     }
                     (rest_service_menu("Temple", &settlement.id, "temple", rest_default_minutes, rest_summary))
@@ -2028,6 +2027,7 @@ fn party_trade_inventory_rail(
                             @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
                             @let target = target_quantity(recipient_targets, &item.item_id);
+                            @let item_name = item_display_name(&item.item_id);
                                 tr class=(if direction == "left" { "trade-inventory-row trade-row-player" } else { "trade-inventory-row trade-row-merchant" }) data-item-key=(&item.item_id) {
                                     td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                                     td class="inventory-item-name" {
@@ -2036,7 +2036,7 @@ fn party_trade_inventory_rail(
                                             @if is_equipped {
                                                 (disabled_transfer_button(direction, "Equipped items cannot be transferred"))
                                             } @else {
-                                                button type="button" class=(format!("trade-transfer trade-transfer-{direction} party-draft-transfer")) data-dynamic-transfer data-default-transfer-mode="one" data-from=(character.id) data-to=(recipient_id) data-item=(item.id) data-key=(&item.item_id) data-count=(item.qty) data-target=(target) data-transfer-mode="one" data-label-one=(format!("Transfer one {}", item.item_id)) data-label-target=(format!("Transfer {} to target", item.item_id)) data-label-all=(format!("Transfer all {}", item.item_id)) aria-label=(format!("Transfer one {}", item.item_id)) title=(format!("Transfer one {}", item.item_id)) { (transfer_glyph(1)) }
+                                                button type="button" class=(format!("trade-transfer trade-transfer-{direction} party-draft-transfer")) data-dynamic-transfer data-default-transfer-mode="one" data-from=(character.id) data-to=(recipient_id) data-item=(item.id) data-key=(&item.item_id) data-count=(item.qty) data-target=(target) data-transfer-mode="one" data-label-one=(format!("Transfer one {item_name}")) data-label-target=(format!("Transfer {item_name} to target")) data-label-all=(format!("Transfer all {item_name}")) aria-label=(format!("Transfer one {item_name}")) title=(format!("Transfer one {item_name}")) { (transfer_glyph(1)) }
                                             }
                                         }
                                     }
@@ -2071,6 +2071,7 @@ fn discard_inventory_rail(
                         @for item in inventory {
                             @let is_equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
+                            @let item_name = item_display_name(&item.item_id);
                             tr class="trade-inventory-row trade-row-player" data-discard-source=(item.id) data-item-key=(&item.item_id) {
                                 td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                                 td class="inventory-item-name" {
@@ -2082,11 +2083,11 @@ fn discard_inventory_rail(
                                             button type="button" class="trade-transfer trade-transfer-left"
                                             data-discard-item=(item.id) data-count=(item.qty)
                                             data-dynamic-transfer data-default-transfer-mode="one" data-transfer-mode="one"
-                                            data-label-one=(format!("Discard one {}", item.item_id))
-                                            data-label-target=(format!("Discard {} down to target", item.item_id))
-                                            data-label-all=(format!("Discard all {}", item.item_id))
-                                            aria-label=(format!("Discard {}", item.item_id))
-                                            title=(format!("Discard one {}", item.item_id)) { (transfer_glyph(1)) }
+                                            data-label-one=(format!("Discard one {item_name}"))
+                                            data-label-target=(format!("Discard {item_name} down to target"))
+                                            data-label-all=(format!("Discard all {item_name}"))
+                                            aria-label=(format!("Discard {item_name}"))
+                                            title=(format!("Discard one {item_name}")) { (transfer_glyph(1)) }
                                         }
                                     }
                                 }
@@ -2156,7 +2157,8 @@ pub fn live_merchant_shop_page(
                     );
                     @let sell_price = (item.base_value.unwrap_or(1) as f32 / 1.25).floor().max(1.0) as u32;
                     @let target = target_quantity(personal_targets, &item.id);
-                    tr class="trade-inventory-row trade-row-merchant" data-merchant-item=(&item.id) data-merchant-sell-price=(sell_price) data-herbalist-medication-name=[medication_recipe.map(|recipe| recipe.name)] { td class="inventory-item-type" { (item_type_icon(&item.id)) } td class="inventory-item-name" { (item_name_with_display(medication_recipe.map_or(item.id.as_str(), |recipe| recipe.name), Some(item))) @if !is_currency { (merchant_buy_controls(&item.id, buy_price, target, 999)) } } td class="inventory-count" hidden { "999" } td class="inventory-weight" { (weight_display(item.weight)) } td class="inventory-gold" { (buy_price) } }
+                    @let display_name = medication_recipe.map_or_else(|| item_display_name(&item.id), |recipe| recipe.name.to_owned());
+                    tr class="trade-inventory-row trade-row-merchant" data-merchant-item=(&item.id) data-merchant-sell-price=(sell_price) data-herbalist-medication-name=[medication_recipe.map(|recipe| recipe.name)] { td class="inventory-item-type" { (item_type_icon(&item.id)) } td class="inventory-item-name" { (item_name_with_display(&item.id, &display_name, Some(item))) @if !is_currency { (merchant_buy_controls(&item.id, buy_price, target, 999)) } } td class="inventory-count" hidden { "999" } td class="inventory-weight" { (weight_display(item.weight)) } td class="inventory-gold" { (buy_price) } }
                 }
             }))
             (inventory_footer_controls("buy", "Buy to targets", "Buy everything"))
@@ -2302,11 +2304,12 @@ pub fn party_pool_page(
                             @let value = definition.and_then(|definition| definition.base_value).unwrap_or(0) as u64;
                             @let target = target_quantity(personal_targets, &item.item_id);
                             @let current = inventory.iter().find(|personal| personal.item_id == item.item_id).map_or(0, |personal| personal.qty);
+                            @let item_name = item_display_name(&item.item_id);
                             tr class="trade-inventory-row" {
                                 td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                                 td class="inventory-item-name" {
                                     (item_name_with_quality(&item.item_id, definition))
-                                span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="withdraw" data-transfer-mode="one" data-count=(item.quantity) data-current=(current) data-target=(target) data-label-one=(format!("Withdraw one {}", item.item_id)) data-label-target=(format!("Withdraw {} to target", item.item_id)) data-label-all=(format!("Withdraw all {}", item.item_id)) title=(if value > stake { format!("Withdraw one {}; {} personal coin required", item.item_id, value - stake) } else { format!("Withdraw one {} using your stake", item.item_id) }) aria-label=(format!("Withdraw one {}", item.item_id)) { (transfer_glyph(1)) } }
+                                span class="inventory-row-actions" { button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="withdraw" data-transfer-mode="one" data-count=(item.quantity) data-current=(current) data-target=(target) data-label-one=(format!("Withdraw one {item_name}")) data-label-target=(format!("Withdraw {item_name} to target")) data-label-all=(format!("Withdraw all {item_name}")) title=(if value > stake { format!("Withdraw one {item_name}; {} personal coin required", value - stake) } else { format!("Withdraw one {item_name} using your stake") }) aria-label=(format!("Withdraw one {item_name}")) { (transfer_glyph(1)) } }
                                 }
                                 td class="inventory-count" { (quantity_target_control(item.quantity, target_quantity(party_targets, &item.item_id), &item.item_id, true)) }
                                 td class="inventory-weight" { (item_weight(definition)) }
@@ -2332,6 +2335,7 @@ pub fn party_pool_page(
                             @let equipped = equip.is_some_and(|equip| [equip.left_hand_item_id, equip.right_hand_item_id, equip.left_arm_armor_id, equip.right_arm_armor_id, equip.left_leg_armor_id, equip.right_leg_armor_id, equip.head_armor_id, equip.chest_armor_id, equip.stomach_armor_id].contains(&Some(item.id)));
                             @let target = target_quantity(party_targets, &item.item_id);
                             @let current = pooled.iter().find(|pooled| pooled.item_id == item.item_id).map_or(0, |pooled| pooled.quantity);
+                            @let item_name = item_display_name(&item.item_id);
                             tr class="trade-inventory-row" {
                                 td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                                 td class="inventory-item-name" {
@@ -2340,7 +2344,7 @@ pub fn party_pool_page(
                                         @if equipped {
                                             (disabled_transfer_button("left", "Equipped items cannot be deposited"))
                                         } @else {
-                                            button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="deposit" data-transfer-mode="one" data-count=(item.qty) data-current=(current) data-target=(target) data-label-one=(format!("Deposit one {}", item.item_id)) data-label-target=(format!("Deposit {} to target", item.item_id)) data-label-all=(format!("Deposit all {}", item.item_id)) aria-label=(format!("Deposit one {}", item.item_id)) title=(format!("Deposit one {}", item.item_id)) { (transfer_glyph(1)) }
+                                            button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="deposit" data-transfer-mode="one" data-count=(item.qty) data-current=(current) data-target=(target) data-label-one=(format!("Deposit one {item_name}")) data-label-target=(format!("Deposit {item_name} to target")) data-label-all=(format!("Deposit all {item_name}")) aria-label=(format!("Deposit one {item_name}")) title=(format!("Deposit one {item_name}")) { (transfer_glyph(1)) }
                                         }
                                     }
                                 }
@@ -2416,10 +2420,11 @@ fn equipment_checkbox(
         definition.slot != ItemSlot::None
             || definition.kind == crate::spacetimedb::ItemKind::Medication
     });
+    let item_name = item_display_name(&inventory.item_id);
     let label = if equipped {
-        format!("Unequip {}", inventory.item_id)
+        format!("Unequip {item_name}")
     } else {
-        format!("Equip {}", inventory.item_id)
+        format!("Equip {item_name}")
     };
     html! {
         input type="checkbox"
@@ -2448,11 +2453,13 @@ pub(super) fn item_name_with_quality(
                 data-item-kind="currency" data-currency-name=(currency_name) { "Coin" }
         }
     } else {
-        item_name_with_display(item_id, definition)
+        let display_name = item_display_name(item_id);
+        item_name_with_display(item_id, &display_name, definition)
     }
 }
 
 fn item_name_with_display(
+    item_id: &str,
     display_name: &str,
     definition: Option<&crate::spacetimedb::ItemDefinition>,
 ) -> Markup {
@@ -2487,7 +2494,7 @@ fn item_name_with_display(
     });
     html! {
         span class=(quality.map_or_else(|| "inventory-item-label".to_string(), |quality| format!("inventory-item-label item-quality-{quality}"))) title=[label]
-            data-item-name=(display_name)
+            data-item-name=(item_id)
             data-item-kind=[definition.map(|item| format!("{:?}", item.kind).to_ascii_lowercase())]
             data-stat-accuracy=[definition.map(|item| weight_display(item.accuracy))]
             data-stat-reach=[definition.map(|item| weight_display(item.reach))]
@@ -2542,11 +2549,12 @@ fn target_quantity(targets: &[InventoryQuantityTarget], item_id: &str) -> u32 {
 }
 
 fn quantity_target_control(quantity: u32, target: u32, item_id: &str, party_scope: bool) -> Markup {
+    let item_name = item_display_name(item_id);
     html! {
         span class="inventory-target-control" data-target-control data-quantity=(quantity) data-item-id=(item_id) data-party-scope=(party_scope) title=(format!("Carrying {quantity}; target {target}")) {
             span class="inventory-target-value" data-target-value role="button" tabindex="0"
-                aria-label=(format!("Target quantity for {item_id}"))
-                title=(format!("Click to edit the target quantity for {item_id}")) { (target) }
+                aria-label=(format!("Target quantity for {item_name}"))
+                title=(format!("Click to edit the target quantity for {item_name}")) { (target) }
         }
     }
 }
@@ -2562,8 +2570,9 @@ fn disabled_transfer_button(direction: &str, explanation: &str) -> Markup {
 }
 
 fn merchant_buy_controls(item_id: &str, price: u32, target: u32, available: u32) -> Markup {
+    let item_name = item_display_name(item_id);
     html! { span class="inventory-row-actions" {
-        button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-buy=(item_id) data-merchant-buy-price=(price) data-transfer-mode="one" data-target=(target) data-count=(available) data-label-one=(format!("Buy one {item_id}")) data-label-target=(format!("Buy {item_id} to target")) data-label-all=(format!("Buy all {item_id}")) aria-label=(format!("Buy one {item_id}")) title=(format!("Buy one {item_id}")) { (transfer_glyph(1)) }
+        button type="button" class="trade-transfer trade-transfer-right" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-buy=(item_id) data-merchant-buy-price=(price) data-transfer-mode="one" data-target=(target) data-count=(available) data-label-one=(format!("Buy one {item_name}")) data-label-target=(format!("Buy {item_name} to target")) data-label-all=(format!("Buy all {item_name}")) aria-label=(format!("Buy one {item_name}")) title=(format!("Buy one {item_name}")) { (transfer_glyph(1)) }
     } }
 }
 
@@ -2574,8 +2583,9 @@ fn merchant_sell_controls(
     quantity: u32,
     target: u32,
 ) -> Markup {
+    let item_name = item_display_name(item_id);
     html! { span class="inventory-row-actions" {
-        button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-sell=(id) data-item-name=(item_id) data-merchant-sell-price=(price) data-transfer-mode="one" data-count=(quantity) data-target=(target) data-label-one=(format!("Sell one {item_id}")) data-label-target=(format!("Sell surplus {item_id}")) data-label-all=(format!("Sell all {item_id}")) aria-label=(format!("Sell one {item_id}")) title=(format!("Sell one {item_id}")) { (transfer_glyph(1)) }
+        button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-sell=(id) data-item-name=(item_id) data-merchant-sell-price=(price) data-transfer-mode="one" data-count=(quantity) data-target=(target) data-label-one=(format!("Sell one {item_name}")) data-label-target=(format!("Sell surplus {item_name}")) data-label-all=(format!("Sell all {item_name}")) aria-label=(format!("Sell one {item_name}")) title=(format!("Sell one {item_name}")) { (transfer_glyph(1)) }
     } }
 }
 
@@ -2589,10 +2599,11 @@ fn merchant_sell_repair_controls(
     repair: Option<Markup>,
 ) -> Markup {
     let has_repair = repair.is_some();
+    let item_name = item_display_name(item_id);
     html! { div class=(if has_repair { "inventory-row-actions smith-player-actions" } else { "inventory-row-actions" }) {
         @if let Some(repair) = repair { (repair) }
         @if can_sell {
-            button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-sell=(id) data-item-name=(item_id) data-merchant-sell-price=(price) data-transfer-mode="one" data-count=(quantity) data-target=(target) data-label-one=(format!("Sell one {item_id}")) data-label-target=(format!("Sell surplus {item_id}")) data-label-all=(format!("Sell all {item_id}")) aria-label=(format!("Sell one {item_id}")) title=(format!("Sell one {item_id}")) { (transfer_glyph(1)) }
+            button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-merchant-sell=(id) data-item-name=(item_id) data-merchant-sell-price=(price) data-transfer-mode="one" data-count=(quantity) data-target=(target) data-label-one=(format!("Sell one {item_name}")) data-label-target=(format!("Sell surplus {item_name}")) data-label-all=(format!("Sell all {item_name}")) aria-label=(format!("Sell one {item_name}")) title=(format!("Sell one {item_name}")) { (transfer_glyph(1)) }
         } @else if has_repair {
             (disabled_transfer_button("left", "Equipped items cannot be sold"))
         }
@@ -4585,8 +4596,7 @@ fn chat_area(
 fn merchant_offers_rail(title: &str, unavailable_offers: &[&str]) -> Markup {
     html! {
         (sidebar_section(title, html! {
-            p class="small-copy" { "No stock is listed at present." }
-            ul class="service-offering-list" aria-label="Expected offerings" {
+            ul class="service-offering-list" aria-label="Expected offerings" title="No stock is listed at present" {
                 @for offer in unavailable_offers {
                     li { (decorative_game_icon("shop")) span { (offer) } }
                 }
@@ -4616,13 +4626,14 @@ fn inventory_rail(
                     tbody {
                     @for item in inventory {
                         @let definition = items.iter().find(|definition| definition.id == item.item_id);
+                        @let item_name = item_display_name(&item.item_id);
                         tr class=(if trade_action.is_some() { "trade-inventory-row" } else { "trade-inventory-row inventory-row-readonly" }) {
                             td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                             td class="inventory-item-name" {
                                 (item_name_with_quality(&item.item_id, definition))
                                 @if let Some((action, tooltip)) = trade_action {
                                 button type="button" class="trade-transfer trade-transfer-left" disabled
-                                    aria-label=(format!("{} {}", action, item.item_id))
+                                    aria-label=(format!("{action} {item_name}"))
                                     title=(tooltip) { "◀" }
                                 }
                             }
@@ -4672,12 +4683,13 @@ fn rest_service_menu(
     summary: Option<&RestSummary>,
 ) -> Markup {
     html! {
-    section class="rest-service-menu" aria-label=(format!("{} rest service", location)) {
+    section class="rest-service-menu" aria-label=(format!("{} rest service", location))
+        title=(if kind == "inn" { "A bed costs 1 coin per day. Injuries are tended before downtime." } else { "Sanctuary is free. Injuries are tended before downtime." }) {
         div class="rest-service-heading" { strong { "Rest" } }
         @if kind == "inn" {
-            p class="rest-service-copy" { "A bed costs 1 coin per day. Injuries are tended before any downtime." }
+            p class="rest-service-copy" { "1 coin / day · treatment included" }
         } @else {
-            p class="rest-service-copy" { "Sanctuary is freely offered to those down on their luck. Injuries are tended before any downtime." }
+            p class="rest-service-copy" { "Free · treatment included" }
         }
         form action=(format!("/settlements/{settlement_id}/rest/{kind}")) method="post" {
                 @let minutes = default_minutes.unwrap_or(0);
@@ -4698,7 +4710,10 @@ fn rest_service_menu(
                         onclick=(format!("const input=this.parentElement.querySelector('input'); input.value={}; input.dispatchEvent(new Event('input', {{bubbles:true}}));", healing_days.unwrap_or(0))) { "Until healed" }
                 }
                 */
-                button type="submit" class="btn btn-primary btn-small btn-block" data-rest-submit disabled[unit == "hours"] { "Rest" }
+                button type="submit" class="btn btn-primary btn-small btn-block" data-rest-submit disabled[unit == "hours"] title="Rest for the selected duration" {
+                    (decorative_game_icon("night-sleep"))
+                    span class="sr-only" { "Rest" }
+                }
         }
         @if let Some(summary) = summary {
             div class="rest-summary-overlay" role="dialog" aria-modal="true" aria-labelledby="rest-summary-title" {
@@ -4873,8 +4888,10 @@ mod tests {
             kind: ItemKind::Medication,
             ..Default::default()
         };
-        let rendered = item_name_with_display("Black Death tonic", Some(&definition)).into_string();
-        assert!(rendered.contains("data-item-name=\"Black Death tonic\""));
+        let rendered =
+            item_name_with_display("black_death_tonic", "Black Death tonic", Some(&definition))
+                .into_string();
+        assert!(rendered.contains("data-item-name=\"black_death_tonic\""));
         assert!(rendered.contains("data-item-kind=\"medication\""));
         assert!(rendered.contains(">Black Death tonic</span>"));
     }
@@ -5164,8 +5181,8 @@ mod tests {
         assert_eq!(rendered.matches("data-merchant-sell=\"").count(), 1);
         assert!(rendered.contains("data-dynamic-transfer"));
         assert!(rendered.contains("data-default-transfer-mode=\"one\""));
-        assert!(rendered.contains("data-label-target=\"Sell surplus torch\""));
-        assert!(rendered.contains("data-label-all=\"Sell all torch\""));
+        assert!(rendered.contains("data-label-target=\"Sell surplus Torch\""));
+        assert!(rendered.contains("data-label-all=\"Sell all Torch\""));
         assert!(rendered.contains("row-repair-form"));
         assert_eq!(rendered.matches("smith-player-actions").count(), 1);
     }

--- a/crates/strategic-web/static/css/base.css
+++ b/crates/strategic-web/static/css/base.css
@@ -1,15 +1,20 @@
-@import url('https://fonts.googleapis.com/css2?family=Texturina:opsz,wght@12..72,400..700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Grenze+Gotisch:wght@400;500;600;700&family=Texturina:opsz,wght@12..72,400..700&family=UnifrakturCook:wght@700&display=swap');
 
 :root {
   color-scheme: dark;
-  --font-display: 'Texturina'; --font-body: system-ui, sans-serif; --font-mono: monospace;
+  /* Three grades of period type: ceremonial labels can be richly blackletter,
+     while dense gameplay copy uses the more open Grenze Gotisch face. */
+  --font-display:'UnifrakturCook', 'Grenze Gotisch', 'Texturina', serif;
+  --font-heading:'Grenze Gotisch', 'Texturina', serif;
+  --font-body:'Grenze Gotisch', 'Texturina', serif;
+  --font-mono:'Grenze Gotisch', 'Texturina', serif;
   --font-size-xs:.75rem; --font-size-sm:.875rem; --font-size-base:1rem; --font-size-lg:1.125rem;
   --font-size-xl:1.25rem; --font-size-2xl:1.5rem; --font-size-3xl:2rem;
-  --bg-primary:#101216; --bg-secondary:#171a20; --bg-tertiary:#252a33;
+  --bg-primary:#171512; --bg-secondary:#211d18; --bg-tertiary:#302a23;
   --text-primary:#f4f6f8; --text-secondary:#d4dae1; --text-muted:#9ba6b2;
   --accent:#d5b36a; --accent-hover:#ead08e; --accent-light:#f0dda9; --accent-dark:#d5b36a;
-  --border-color:#3e4652; --border-light:#292f38; --border-accent:#8c7448;
-  --panel-bg:#181c22; --panel-border:#3e4652; --header-bg:#090b10; --sidebar-bg:#13171c;
+  --border-color:#51483d; --border-light:#342f29; --border-accent:#8c7448;
+  --panel-bg:#211e1a; --panel-border:#51483d; --header-bg:#100e0c; --sidebar-bg:#1b1815;
   --success:#7fbd85; --warning:#dfb85f; --danger:#e27777; --info:#82acd8;
   --gold-color:#dfb85f; --xp-color:#82acd8; --star-filled:#dfb85f; --star-empty:#3e4652;
   --icon-default:#f4f6f8; --icon-mental:#c9b9ff; --icon-physical:#f0d77b;
@@ -18,9 +23,12 @@
   --padding-sm:.5rem; --padding:1rem; --padding-lg:1.5rem; --radius:3px; --radius-lg:6px;
   --shadow-sm:0 1px 3px rgb(0 0 0 / 45%); --shadow-md:0 3px 8px rgb(0 0 0 / 55%);
   --shadow-lg:0 8px 24px rgb(0 0 0 / 65%); --transition-fast:150ms ease; --transition:250ms ease;
-  --building-surface:color-mix(in srgb, var(--active-building-tint, var(--sidebar-bg)) var(--building-light, 78%), black);
-  --building-interactive:color-mix(in srgb, var(--building-surface) 72%, black);
-  --building-interactive-hover:color-mix(in srgb, var(--building-surface) 86%, white 14%);
+  --content-surface:#211e1a;
+  --content-surface-recess:#181613;
+  --building-frame-tint:color-mix(in srgb, var(--active-building-tint, #604b32) 76%, #5d4d3b);
+  --building-surface:var(--content-surface-recess);
+  --building-interactive:color-mix(in srgb, var(--content-surface) 78%, black);
+  --building-interactive-hover:color-mix(in srgb, var(--content-surface) 84%, white 16%);
 }
 
 body { background:var(--bg-primary); color:var(--text-primary); }

--- a/crates/strategic-web/static/css/components.css
+++ b/crates/strategic-web/static/css/components.css
@@ -23,8 +23,8 @@
   font-family: var(--font-display), serif;
   font-size: var(--font-size-sm);
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  text-transform: none;
+  letter-spacing: 0.04em;
   color: var(--accent-dark);
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--panel-border);

--- a/crates/strategic-web/static/css/components.css
+++ b/crates/strategic-web/static/css/components.css
@@ -4,7 +4,9 @@
    PANELS (Cards/Containers)
    ============================================ */
 .panel {
-  background: var(--panel-bg);
+  background:
+    linear-gradient(rgb(255 255 255 / 1.5%), rgb(0 0 0 / 3%)),
+    var(--panel-bg);
   border: 1px solid var(--panel-border);
   border-radius: var(--radius);
   margin-bottom: 1rem;
@@ -26,7 +28,7 @@
   color: var(--accent-dark);
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--panel-border);
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--panel-bg) 82%, black);
 }
 
 .panel-body {
@@ -36,7 +38,7 @@
 .panel-footer {
   padding: 0.75rem 1rem;
   border-top: 1px solid var(--panel-border);
-  background: var(--bg-secondary);
+  background: color-mix(in srgb, var(--panel-bg) 82%, black);
 }
 
 /* ============================================
@@ -48,7 +50,7 @@
   justify-content: center;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
-  font-family: var(--font-display), serif;
+  font-family: var(--font-heading), serif;
   font-size: var(--font-size-sm);
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -152,7 +154,7 @@
 .form-label {
   display: block;
   margin-bottom: 0.375rem;
-  font-family: var(--font-display), serif;
+  font-family: var(--font-heading), serif;
   font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-primary);

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -220,7 +220,7 @@
   font-family: var(--font-display), serif;
   font-size: var(--font-size-sm);
   letter-spacing: 0.05em;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .settlement-location {
@@ -904,6 +904,14 @@ body:has(.settlement-top-bar) .main-grid {
   margin-bottom: 1.5rem;
 }
 
+/* Architectural textures belong to the exposed rail, never directly behind
+   copy, meters, or controls. Sections provide an opaque reading surface while
+   the building material remains visible in their surrounding gaps. */
+body:has(.settlement-top-bar[data-environment="settlement"])
+  :is(.left-sidebar, .right-sidebar) .sidebar-section {
+  background: var(--content-surface-recess);
+}
+
 .sidebar-section:last-child {
   margin-bottom: 0;
 }
@@ -912,8 +920,8 @@ body:has(.settlement-top-bar) .main-grid {
   font-family: var(--font-display), serif;
   font-size: var(--font-size-xs);
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
+  text-transform: none;
+  letter-spacing: 0.05em;
   color: var(--text-muted);
   padding-bottom: 0.5rem;
   margin-bottom: 0.75rem;
@@ -1004,7 +1012,6 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     var(--architectural-edge, repeating-linear-gradient(135deg, transparent 0 2.6rem, rgb(255 255 255 / 2%) 2.6rem 2.7rem)),
     var(--building-panel-recess);
   box-shadow:
-    inset calc(-1 * var(--left-rail-scrollbar-reserve, 0px)) 0 0 var(--building-frame),
     inset 0 0 0 1px rgb(0 0 0 / 42%),
     inset 0 0 1.25rem rgb(0 0 0 / 22%);
 }

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -51,7 +51,7 @@
   display: inline-flex;
   align-items: center;
   padding: 0.4rem 1rem;
-  font-family: var(--font-display), serif;
+  font-family: var(--font-heading), serif;
   font-size: var(--font-size-sm);
   font-weight: 600;
   color: var(--text-secondary);
@@ -239,13 +239,13 @@
   align-items: flex-start;
   gap: 0;
   overflow: visible;
-  border: 1px solid color-mix(in srgb, var(--active-building-tint) 65%, white);
+  border: 1px solid color-mix(in srgb, var(--building-frame-tint) 72%, white);
   background: var(--building-surface);
   box-shadow: inset 0 1px 2px #fff2, inset 0 -2px 3px #0009, 0 1px 3px #0008;
 }
 
 .settlement-name {
-  font-family: var(--font-display), serif;
+  font-family: var(--font-heading), serif;
   font-size: var(--font-size-lg);
   font-weight: 700;
   color: var(--text-primary);
@@ -667,7 +667,7 @@
   border-radius: 999px;
   background: #b4232c;
   color: #fff;
-  font: 700 0.68rem/1 sans-serif;
+  font: 700 0.68rem/1 var(--font-heading), serif;
 }
 
 .service-notification-badge[hidden] {
@@ -942,12 +942,52 @@ body:has(.settlement-top-bar) .main-grid {
   padding: var(--padding);
 }
 
+/* The selected building changes joinery, not the plaster. This lets semantic
+   reds, greens, and blues inside panels remain visually authoritative. */
+body:has(.nav-tab[data-service-id="map"].active) {
+  --architectural-edge: repeating-linear-gradient(0deg, transparent 0 1.15rem, rgb(222 215 196 / 9%) 1.15rem 1.22rem);
+}
+body:has(.nav-tab[data-service-id="merchants"].active) {
+  --architectural-edge: repeating-linear-gradient(135deg, transparent 0 2.5rem, rgb(230 207 169 / 8%) 2.5rem 2.62rem);
+}
+body:has(.nav-tab[data-service-id="weapons"].active) {
+  --architectural-edge: repeating-linear-gradient(45deg, transparent 0 1.4rem, rgb(236 211 174 / 8%) 1.4rem 1.5rem);
+}
+body:has(.nav-tab[data-service-id="armor"].active) {
+  --architectural-edge: radial-gradient(circle at .7rem .7rem, rgb(235 226 203 / 14%) 0 .1rem, transparent .12rem) 0 0 / 1.4rem 1.4rem;
+}
+body:has(.nav-tab[data-service-id="clothing"].active) {
+  --architectural-edge: repeating-linear-gradient(90deg, transparent 0 .62rem, rgb(242 220 187 / 6%) .62rem .68rem);
+}
+body:has(.nav-tab[data-service-id="herbalist"].active) {
+  --architectural-edge: repeating-radial-gradient(ellipse at 0 100%, transparent 0 .7rem, rgb(218 228 188 / 7%) .72rem .8rem, transparent .82rem 1.45rem);
+}
+body:has(.nav-tab[data-service-id="inn"].active) {
+  --architectural-edge: repeating-linear-gradient(0deg, transparent 0 2.1rem, rgb(237 204 153 / 8%) 2.1rem 2.25rem);
+}
+body:has(.nav-tab[data-service-id="religion"].active) {
+  --architectural-edge: repeating-linear-gradient(120deg, transparent 0 1.7rem, rgb(232 225 204 / 8%) 1.7rem 1.78rem);
+}
+
+body:has(.settlement-top-bar[data-environment="settlement"]) .center-content .panel {
+  border-color: color-mix(in srgb, var(--building-frame-tint) 52%, var(--panel-border));
+  box-shadow:
+    inset .18rem 0 color-mix(in srgb, var(--building-frame-tint) 62%, transparent),
+    inset -.18rem 0 color-mix(in srgb, var(--building-frame-tint) 62%, transparent),
+    var(--shadow-sm);
+}
+
+body:has(.settlement-top-bar[data-environment="settlement"]) .center-content .panel-header {
+  border-bottom-color: color-mix(in srgb, var(--building-frame-tint) 48%, var(--panel-border));
+  background-image: var(--architectural-edge, none);
+}
+
 /* Settlement rails resemble recessed wooden or stone wall panels. */
 body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, .right-sidebar) {
-  --building-frame: color-mix(in srgb, var(--building-surface) 88%, white);
+  --building-frame: color-mix(in srgb, var(--building-frame-tint) 88%, white);
   --building-frame-corner: color-mix(in srgb, var(--building-frame) 82%, white);
   --building-frame-corner-size: 1.35rem;
-  --building-panel-recess: color-mix(in srgb, var(--building-surface) 78%, black);
+  --building-panel-recess: var(--content-surface-recess);
   border: 0;
   position: relative;
   padding-block: var(--building-frame-corner-size);
@@ -961,6 +1001,7 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     linear-gradient(var(--building-frame), var(--building-frame)) center bottom / 100% 0.55rem no-repeat local,
     linear-gradient(var(--building-frame), var(--building-frame)) left center / 0.55rem 100% no-repeat local,
     linear-gradient(var(--building-frame), var(--building-frame)) calc(100% + var(--left-rail-scrollbar-reserve, 0px)) center / 0.55rem 100% no-repeat local,
+    var(--architectural-edge, repeating-linear-gradient(135deg, transparent 0 2.6rem, rgb(255 255 255 / 2%) 2.6rem 2.7rem)),
     var(--building-panel-recess);
   box-shadow:
     inset calc(-1 * var(--left-rail-scrollbar-reserve, 0px)) 0 0 var(--building-frame),
@@ -1023,7 +1064,7 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
   .main-grid:has(.inventory-browser) {
     grid-template-columns: 1fr;
   }
-  .main-grid {
+  body .app .main-grid {
     height: auto;
     min-height: 0;
     flex: 1;
@@ -1037,6 +1078,11 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     max-height: none;
     overflow: visible;
   }
+  .service-left-stack,
+  .service-inventory-area {
+    flex: none;
+    min-height: 0;
+  }
   .right-sidebar {
     display: block;
     grid-area: right;
@@ -1046,7 +1092,11 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     border-top: 1px solid var(--border-color);
     border-left: 0;
   }
-  .center-content { grid-area: main; min-height: 32rem; }
+  .center-content {
+    grid-area: main;
+    min-height: 32rem;
+    padding: 1rem;
+  }
   .top-bar {
     padding: 0 0.75rem;
   }
@@ -1055,6 +1105,16 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     min-height: var(--header-height);
     flex-wrap: wrap;
     padding-block: 0.5rem;
+  }
+  .settlement-top-bar .settlement-location,
+  .settlement-top-bar .top-bar-right {
+    position: relative;
+    inset: auto;
+    order: 1;
+    margin-inline: 0.5rem;
+  }
+  .settlement-top-bar .top-bar-right {
+    margin-left: auto;
   }
   .top-bar-left {
     min-width: auto;
@@ -1081,7 +1141,7 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     order: 3;
     width: 100%;
     gap: 0.62rem;
-    padding-top: 1.75rem;
+    padding: 0.75rem 0.5rem 0.35rem;
     overflow-x: auto;
     overflow-y: hidden;
     justify-content: flex-start;
@@ -1089,6 +1149,7 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     scrollbar-width: thin;
     mask-image: linear-gradient(to right, transparent, #000 0.75rem, #000 calc(100% - 0.75rem), transparent);
   }
+  .sidebar-section { margin-bottom: 1rem; }
   .settlement-top-bar[data-environment="settlement"] .settlement-services .nav-tab {
     --topbar-prop-baseline: -0.22rem;
     --topbar-prop-scale: 0.8855;

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -953,28 +953,28 @@ body:has(.settlement-top-bar[data-environment="settlement"])
 /* The selected building changes joinery, not the plaster. This lets semantic
    reds, greens, and blues inside panels remain visually authoritative. */
 body:has(.nav-tab[data-service-id="map"].active) {
-  --architectural-edge: repeating-linear-gradient(0deg, transparent 0 1.15rem, rgb(222 215 196 / 9%) 1.15rem 1.22rem);
+  --architectural-edge: repeating-linear-gradient(0deg, transparent 0 1.15rem, rgb(222 215 196 / 4%) 1.15rem 1.22rem);
 }
 body:has(.nav-tab[data-service-id="merchants"].active) {
-  --architectural-edge: repeating-linear-gradient(135deg, transparent 0 2.5rem, rgb(230 207 169 / 8%) 2.5rem 2.62rem);
+  --architectural-edge: repeating-linear-gradient(135deg, transparent 0 2.5rem, rgb(230 207 169 / 3%) 2.5rem 2.62rem);
 }
 body:has(.nav-tab[data-service-id="weapons"].active) {
-  --architectural-edge: repeating-linear-gradient(45deg, transparent 0 1.4rem, rgb(236 211 174 / 8%) 1.4rem 1.5rem);
+  --architectural-edge: repeating-linear-gradient(45deg, transparent 0 1.4rem, rgb(236 211 174 / 3%) 1.4rem 1.5rem);
 }
 body:has(.nav-tab[data-service-id="armor"].active) {
-  --architectural-edge: radial-gradient(circle at .7rem .7rem, rgb(235 226 203 / 14%) 0 .1rem, transparent .12rem) 0 0 / 1.4rem 1.4rem;
+  --architectural-edge: radial-gradient(circle at .7rem .7rem, rgb(235 226 203 / 6%) 0 .1rem, transparent .12rem) 0 0 / 1.4rem 1.4rem;
 }
 body:has(.nav-tab[data-service-id="clothing"].active) {
-  --architectural-edge: repeating-linear-gradient(90deg, transparent 0 .62rem, rgb(242 220 187 / 6%) .62rem .68rem);
+  --architectural-edge: repeating-linear-gradient(90deg, transparent 0 .62rem, rgb(242 220 187 / 3%) .62rem .68rem);
 }
 body:has(.nav-tab[data-service-id="herbalist"].active) {
-  --architectural-edge: repeating-radial-gradient(ellipse at 0 100%, transparent 0 .7rem, rgb(218 228 188 / 7%) .72rem .8rem, transparent .82rem 1.45rem);
+  --architectural-edge: repeating-radial-gradient(ellipse at 0 100%, transparent 0 .7rem, rgb(218 228 188 / 3%) .72rem .8rem, transparent .82rem 1.45rem);
 }
 body:has(.nav-tab[data-service-id="inn"].active) {
-  --architectural-edge: repeating-linear-gradient(0deg, transparent 0 2.1rem, rgb(237 204 153 / 8%) 2.1rem 2.25rem);
+  --architectural-edge: repeating-linear-gradient(0deg, transparent 0 2.1rem, rgb(237 204 153 / 4%) 2.1rem 2.25rem);
 }
 body:has(.nav-tab[data-service-id="religion"].active) {
-  --architectural-edge: repeating-linear-gradient(120deg, transparent 0 1.7rem, rgb(232 225 204 / 8%) 1.7rem 1.78rem);
+  --architectural-edge: repeating-linear-gradient(120deg, transparent 0 1.7rem, rgb(232 225 204 / 3%) 1.7rem 1.78rem);
 }
 
 body:has(.settlement-top-bar[data-environment="settlement"]) .center-content .panel {
@@ -1008,7 +1008,7 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     linear-gradient(var(--building-frame), var(--building-frame)) center top / 100% 0.55rem no-repeat local,
     linear-gradient(var(--building-frame), var(--building-frame)) center bottom / 100% 0.55rem no-repeat local,
     linear-gradient(var(--building-frame), var(--building-frame)) left center / 0.55rem 100% no-repeat local,
-    linear-gradient(var(--building-frame), var(--building-frame)) calc(100% + var(--left-rail-scrollbar-reserve, 0px)) center / 0.55rem 100% no-repeat local,
+    linear-gradient(var(--building-frame), var(--building-frame)) right center / 0.55rem 100% no-repeat local,
     var(--architectural-edge, repeating-linear-gradient(135deg, transparent 0 2.6rem, rgb(255 255 255 / 2%) 2.6rem 2.7rem)),
     var(--building-panel-recess);
   box-shadow:

--- a/crates/strategic-web/static/css/reset.css
+++ b/crates/strategic-web/static/css/reset.css
@@ -21,6 +21,7 @@ body {
   font-size: var(--font-size-base);
   color: var(--text-primary);
   background: var(--bg-primary);
+  font-variant-numeric: oldstyle-nums proportional-nums;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -28,6 +29,13 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.2;
   font-weight: 700;
   color: var(--text-primary);
+}
+
+/* Dense headings keep blackletter character without the deliberately ornate
+   display face used for stable landmarks and major page titles. */
+h3, h4, h5, h6,
+button, input, select, textarea {
+  font-family: var(--font-heading), serif;
 }
 
 h1 { font-size: var(--font-size-3xl); }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -315,6 +315,80 @@
 .travel-daylight-segment.sunset { background: #b96850; }
 .travel-daylight-segment.night { background: #14223a; }
 .travel-rail-tooltip { position: fixed; z-index: 500; min-width: max-content; padding: .2rem .35rem; border: 1px solid color-mix(in srgb, var(--text-muted) 45%, transparent); border-radius: .18rem; background: color-mix(in srgb, var(--panel-bg) 96%, #000); box-shadow: 0 .15rem .45rem #0008; color: var(--text-primary); font-size: .54rem; line-height: 1.1; pointer-events: none; transform: translateY(-50%); }
+
+/* One immediate tooltip layer replaces delayed, unstyled browser titles. JS
+   owns positioning; these rules own its consistent parchment-sign treatment. */
+#strategic-tooltip,
+.strategic-tooltip {
+  position: fixed;
+  z-index: 1000;
+  width: max-content;
+  max-width: min(20rem, calc(100vw - 1rem));
+  padding: .42rem .58rem .48rem;
+  border: 1px solid color-mix(in srgb, var(--building-frame-tint) 62%, #d8c59e);
+  border-radius: 2px;
+  background:
+    linear-gradient(rgb(255 255 255 / 3%), transparent),
+    color-mix(in srgb, var(--panel-bg) 94%, black);
+  box-shadow: 0 .35rem .9rem #000b, inset 0 0 0 1px rgb(0 0 0 / 45%);
+  color: var(--text-primary);
+  font-family: var(--font-body), serif;
+  font-size: .78rem;
+  font-weight: 500;
+  line-height: 1.3;
+  letter-spacing: .015em;
+  overflow-wrap: anywhere;
+  pointer-events: none;
+  text-align: left;
+}
+
+#strategic-tooltip[hidden],
+.strategic-tooltip[hidden] { display: none; }
+
+#strategic-tooltip::after,
+.strategic-tooltip::after {
+  position: absolute;
+  width: .45rem;
+  height: .45rem;
+  border-right: 1px solid color-mix(in srgb, var(--building-frame-tint) 62%, #d8c59e);
+  border-bottom: 1px solid color-mix(in srgb, var(--building-frame-tint) 62%, #d8c59e);
+  background: color-mix(in srgb, var(--panel-bg) 94%, black);
+  content: "";
+  transform: rotate(45deg);
+}
+
+#strategic-tooltip:is([data-placement="top"], :not([data-placement]))::after,
+.strategic-tooltip:is([data-placement="top"], :not([data-placement]))::after {
+  top: calc(100% - .2rem);
+  left: calc(50% - .225rem);
+}
+
+#strategic-tooltip[data-placement="bottom"]::after,
+.strategic-tooltip[data-placement="bottom"]::after {
+  bottom: calc(100% - .2rem);
+  left: calc(50% - .225rem);
+  transform: rotate(225deg);
+}
+
+#strategic-tooltip[data-placement="left"]::after,
+.strategic-tooltip[data-placement="left"]::after {
+  top: calc(50% - .225rem);
+  left: calc(100% - .2rem);
+  transform: rotate(315deg);
+}
+
+#strategic-tooltip[data-placement="right"]::after,
+.strategic-tooltip[data-placement="right"]::after {
+  top: calc(50% - .225rem);
+  right: calc(100% - .2rem);
+  transform: rotate(135deg);
+}
+
+/* Names are repeatedly scanned, so they use the readable blackletter grade. */
+:is(.item-name, .inventory-item-name, .inventory-name, .character-name,
+    .quest-name, .service-offering-list strong) {
+  font-family: var(--font-heading), serif;
+}
 .travel-resource-row.fatigue.warning .travel-resource-icon { color: var(--danger); }
 .travel-midnight-tick { position: absolute; z-index: 7; left: 100%; width: 1.05rem; border-top: 1px solid color-mix(in srgb, #fff 58%, transparent); transform: translateY(-50%); }
 .travel-midnight-tick svg { position: absolute; top: -.43rem; left: .58rem; width: .82rem; height: .82rem; }
@@ -1807,7 +1881,7 @@ body:has(.settlement-top-bar) .main-grid .settlement-card:hover {
   border-radius: 999px;
   background: #b4232c;
   color: #fff;
-  font: 700 0.68rem/1 sans-serif;
+  font: 700 0.68rem/1 var(--font-heading), serif;
 }
 
 .party-role-notification-badge[hidden] { display: none; }
@@ -1840,7 +1914,7 @@ body:has(.settlement-top-bar) .main-grid .settlement-card:hover {
   place-items: center;
   border: 1px solid #f2c66f;
   border-radius: 999px;
-  font: 800 0.72rem/1 sans-serif;
+  font: 800 0.72rem/1 var(--font-heading), serif;
 }
 
 .current-location-row {
@@ -3521,7 +3595,13 @@ body.chat-resizing {
 }
 
 @media (max-width: 768px) {
-  .settlement-main { min-height: 32rem; }
+  .settlement-main { min-height: 38rem; }
+  .service-left-sidebar .service-left-stack,
+  .service-left-sidebar .service-inventory-area {
+    flex: 0 0 auto;
+    height: auto;
+    min-height: 0;
+  }
   .party-portrait-overlay {
     right: 0.5rem;
     left: 0.5rem;
@@ -3573,7 +3653,7 @@ body.chat-resizing {
 }
 
 @media (max-width: 480px) {
-  .settlement-main { min-height: 27rem; }
+  .settlement-main { min-height: 32rem; }
   .service-visual-scene { min-height: 14rem; }
   .visual-scene-caption { align-items: flex-start; flex-direction: column; gap: 0.15rem; }
   .settlement-chat { --chat-panel-height: 9.5rem; min-height: 9.5rem; }

--- a/crates/strategic-web/static/tooltips.js
+++ b/crates/strategic-web/static/tooltips.js
@@ -1,0 +1,151 @@
+(() => {
+  const TOOLTIP_ID = 'strategic-tooltip';
+  const TOOLTIP_ATTRIBUTE = 'data-strategic-tooltip';
+  const VIEWPORT_MARGIN = 8;
+  const ANCHOR_GAP = 8;
+
+  const hasAccessibleName = (element) => {
+    if (element.hasAttribute('aria-label') || element.hasAttribute('aria-labelledby')) return true;
+    if (element.matches('img, area') && element.hasAttribute('alt')) return true;
+    if (element.matches('input[type="button"], input[type="submit"], input[type="reset"]') && element.value) return true;
+    return Boolean(element.textContent?.trim());
+  };
+
+  const createTooltipSystem = (documentRoot = document, windowRoot = window) => {
+    const documentElement = documentRoot.documentElement;
+    let tooltip = documentRoot.getElementById(TOOLTIP_ID);
+    if (!tooltip) {
+      tooltip = documentRoot.createElement('div');
+      tooltip.id = TOOLTIP_ID;
+      tooltip.className = 'strategic-tooltip';
+      tooltip.setAttribute('role', 'tooltip');
+      tooltip.hidden = true;
+      tooltip.setAttribute('aria-hidden', 'true');
+      documentRoot.body.append(tooltip);
+    }
+
+    let activeTarget = null;
+    let descriptionWasLinked = false;
+    let suppressFocusUntil = 0;
+
+    const enhance = (target) => {
+      if (!target?.getAttribute) return null;
+      const title = target.getAttribute('title');
+      if (title !== null) {
+        const text = title.trim();
+        target.removeAttribute('title');
+        if (!text) return null;
+        target.setAttribute(TOOLTIP_ATTRIBUTE, text);
+        if (!hasAccessibleName(target)) {
+          target.setAttribute('aria-label', text);
+          target.setAttribute('data-strategic-tooltip-generated-label', '');
+        }
+      }
+      return target.hasAttribute(TOOLTIP_ATTRIBUTE) ? target : null;
+    };
+
+    const unlinkDescription = () => {
+      if (!activeTarget || descriptionWasLinked) return;
+      const ids = (activeTarget.getAttribute('aria-describedby') || '')
+        .split(/\s+/)
+        .filter((id) => id && id !== TOOLTIP_ID);
+      if (ids.length) activeTarget.setAttribute('aria-describedby', ids.join(' '));
+      else activeTarget.removeAttribute('aria-describedby');
+    };
+
+    const hide = () => {
+      activeTarget?.removeEventListener('pointerleave', hide);
+      activeTarget?.removeEventListener('blur', hide);
+      unlinkDescription();
+      activeTarget = null;
+      descriptionWasLinked = false;
+      tooltip.hidden = true;
+      tooltip.setAttribute('aria-hidden', 'true');
+    };
+
+    const position = () => {
+      if (!activeTarget || tooltip.hidden || !activeTarget.isConnected) {
+        if (activeTarget && !activeTarget.isConnected) hide();
+        return;
+      }
+
+      const anchor = activeTarget.getBoundingClientRect();
+      const box = tooltip.getBoundingClientRect();
+      const viewportWidth = windowRoot.innerWidth || documentElement.clientWidth;
+      const viewportHeight = windowRoot.innerHeight || documentElement.clientHeight;
+      const maximumLeft = Math.max(VIEWPORT_MARGIN, viewportWidth - box.width - VIEWPORT_MARGIN);
+      const left = Math.min(maximumLeft, Math.max(VIEWPORT_MARGIN, anchor.left + anchor.width / 2 - box.width / 2));
+      let top = anchor.top - box.height - ANCHOR_GAP;
+      let placement = 'top';
+
+      if (top < VIEWPORT_MARGIN) {
+        top = anchor.bottom + ANCHOR_GAP;
+        placement = 'bottom';
+      }
+      top = Math.min(
+        Math.max(VIEWPORT_MARGIN, viewportHeight - box.height - VIEWPORT_MARGIN),
+        Math.max(VIEWPORT_MARGIN, top),
+      );
+
+      tooltip.dataset.placement = placement;
+      tooltip.style.left = `${Math.round(left)}px`;
+      tooltip.style.top = `${Math.round(top)}px`;
+    };
+
+    const show = (target) => {
+      target = enhance(target);
+      if (!target) return;
+      if (activeTarget !== target) {
+        hide();
+        activeTarget = target;
+        target.addEventListener('pointerleave', hide);
+        target.addEventListener('blur', hide);
+        const describedBy = (target.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
+        descriptionWasLinked = describedBy.includes(TOOLTIP_ID);
+        if (!descriptionWasLinked) target.setAttribute('aria-describedby', [...describedBy, TOOLTIP_ID].join(' '));
+      }
+      tooltip.textContent = target.getAttribute(TOOLTIP_ATTRIBUTE);
+      tooltip.hidden = false;
+      tooltip.setAttribute('aria-hidden', 'false');
+      position();
+    };
+
+    const tooltipTarget = (eventTarget) => eventTarget?.closest?.(`[title], [${TOOLTIP_ATTRIBUTE}]`);
+
+    documentRoot.addEventListener('pointerover', (event) => {
+      if (event.pointerType === 'touch') return;
+      show(tooltipTarget(event.target));
+    });
+    documentRoot.addEventListener('pointerout', (event) => {
+      if (!activeTarget || activeTarget.contains(event.relatedTarget)) return;
+      if (activeTarget.contains(event.target)) hide();
+    });
+    documentRoot.addEventListener('focusin', (event) => {
+      if (Date.now() < suppressFocusUntil) return;
+      show(tooltipTarget(event.target));
+    });
+    documentRoot.addEventListener('focusout', (event) => {
+      if (activeTarget?.contains(event.target) && !activeTarget.contains(event.relatedTarget)) hide();
+    });
+    documentRoot.addEventListener('pointerdown', (event) => {
+      if (event.pointerType !== 'touch') return;
+      suppressFocusUntil = Date.now() + 800;
+      hide();
+    });
+    documentRoot.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') hide();
+    });
+    windowRoot.addEventListener('resize', position);
+    windowRoot.addEventListener('scroll', position, true);
+
+    return { tooltip, enhance, show, hide, position, get activeTarget() { return activeTarget; } };
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { createTooltipSystem };
+  } else if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => createTooltipSystem(), { once: true });
+  } else {
+    createTooltipSystem();
+  }
+})();

--- a/crates/strategic-web/tests/environment.test.cjs
+++ b/crates/strategic-web/tests/environment.test.cjs
@@ -117,7 +117,7 @@ test("settlement smithies and wilderness tabs use independent non-interactive ef
   assert.match(layoutCss, /\.topbar-scene-effect-plane \{[\s\S]*bottom: var\(--topbar-prop-baseline\);[\s\S]*width: 6\.55rem;[\s\S]*height: 6\.55rem;[\s\S]*scale\(var\(--topbar-prop-scale\)\)/);
   assert.match(layoutCss, /@media \(max-width: 1200px\)[\s\S]*--topbar-prop-scale: 0\.8473;[\s\S]*data-environment="wilderness"[\s\S]*--topbar-prop-scale: 0\.8473;/);
   assert.match(layoutCss, /\.campfire-smoke \{[\s\S]*--smoke-rise-distance: -180px;/);
-  assert.match(layoutCss, /@media \(max-width: 768px\)[\s\S]*padding-top: 1\.75rem;[\s\S]*overflow-y: hidden;[\s\S]*--topbar-prop-scale: 0\.8855;[\s\S]*\.campfire-smoke \{[\s\S]*--smoke-rise-distance: -110px;/);
+  assert.match(layoutCss, /@media \(max-width: 768px\)[\s\S]*padding: 0\.75rem 0\.5rem 0\.35rem;[\s\S]*overflow-y: hidden;[\s\S]*--topbar-prop-scale: 0\.8855;[\s\S]*\.campfire-smoke \{[\s\S]*--smoke-rise-distance: -110px;/);
 
   const smokeFrames = layoutCss.match(/@keyframes wilderness-smoke-rise \{[\s\S]*?\n\}/)?.[0] ?? "";
   const flameFrames = layoutCss.match(/@keyframes wilderness-flame-flicker \{[\s\S]*?\n\}/)?.[0] ?? "";
@@ -161,12 +161,12 @@ test("wilderness headers select a tintable physical horizon", () => {
   }
 });
 
-test("settlement side panels use tint-derived beams and corner blocks", () => {
+test("settlement side panels use tint-derived frames around neutral recesses", () => {
   assert.match(layoutCss, /data-environment="settlement"[\s\S]*:is\(\.left-sidebar, \.right-sidebar\)/);
-  assert.match(layoutCss, /--building-frame: color-mix\(in srgb, var\(--building-surface\)/);
+  assert.match(layoutCss, /--building-frame: color-mix\(in srgb, var\(--building-frame-tint\)/);
   assert.match(layoutCss, /--building-frame-corner: color-mix/);
   assert.match(layoutCss, /--building-frame-corner-size: 1\.35rem/);
-  assert.match(layoutCss, /--building-panel-recess: color-mix/);
+  assert.match(layoutCss, /--building-panel-recess: var\(--content-surface-recess\)/);
   assert.match(layoutCss, /padding-block: var\(--building-frame-corner-size\)/);
   assert.match(layoutCss, /padding-inline: var\(--building-frame-corner-size\)/);
   assert.match(layoutCss, /border: 0/);

--- a/crates/strategic-web/tests/environment.test.cjs
+++ b/crates/strategic-web/tests/environment.test.cjs
@@ -176,6 +176,9 @@ test("settlement side panels use tint-derived frames around neutral recesses", (
   assert.match(layoutCss, /center top \/ 100% 0\.55rem no-repeat local/);
   assert.ok(layoutCss.indexOf("var(--left-rail-scrollbar-reserve, 0px)) bottom") < layoutCss.indexOf("center top / 100% 0.55rem"));
   assert.doesNotMatch(layoutCss, /:is\(\.left-sidebar, \.right-sidebar\)::after/);
+  for (const opacity of ["4%", "3%", "6%"]) {
+    assert.match(layoutCss, new RegExp(`architectural-edge:[^;]*\\/ ${opacity.replace("%", "\\%")}\\)`));
+  }
 });
 
 test("patterned rails keep text and controls on opaque reading surfaces", () => {
@@ -201,11 +204,11 @@ test("strategic left rails keep their scrollbars on the outer edge", () => {
 
 test("settlement frames compensate for the left scrollbar gutter", () => {
   assert.match(layoutCss, /calc\(100% \+ var\(--left-rail-scrollbar-reserve, 0px\)\) top/);
-  assert.match(layoutCss, /calc\(100% \+ var\(--left-rail-scrollbar-reserve, 0px\)\) center \/ 0\.55rem 100% no-repeat local/);
+  assert.match(layoutCss, /right center \/ 0\.55rem 100% no-repeat local/);
   assert.doesNotMatch(layoutCss, /inset calc\(-1 \* var\(--left-rail-scrollbar-reserve, 0px\)\) 0 0 var\(--building-frame\)/);
   assert.ok(
     layoutCss.indexOf("right top / var(--building-frame-corner-size)")
-      < layoutCss.indexOf("center / 0.55rem 100% no-repeat local"),
+      < layoutCss.indexOf("right center / 0.55rem 100% no-repeat local"),
   );
 });
 

--- a/crates/strategic-web/tests/environment.test.cjs
+++ b/crates/strategic-web/tests/environment.test.cjs
@@ -7,6 +7,7 @@ const source = fs.readFileSync("crates/strategic-web/static/strategic-time.js", 
 const buildingSource = fs.readFileSync("crates/strategic-web/static/building-state.js", "utf8");
 const baseCss = fs.readFileSync("crates/strategic-web/static/css/base.css", "utf8");
 const layoutCss = fs.readFileSync("crates/strategic-web/static/css/layout.css", "utf8");
+const componentsCss = fs.readFileSync("crates/strategic-web/static/css/components.css", "utf8");
 const strategicCss = fs.readFileSync("crates/strategic-web/static/css/strategic.css", "utf8");
 const layoutTemplate = fs.readFileSync("crates/strategic-web/src/templates/layout.rs", "utf8");
 const settlementTemplate = fs.readFileSync("crates/strategic-web/src/templates/settlement.rs", "utf8");
@@ -177,6 +178,19 @@ test("settlement side panels use tint-derived frames around neutral recesses", (
   assert.doesNotMatch(layoutCss, /:is\(\.left-sidebar, \.right-sidebar\)::after/);
 });
 
+test("patterned rails keep text and controls on opaque reading surfaces", () => {
+  assert.match(
+    layoutCss,
+    /data-environment="settlement"[\s\S]*:is\(\.left-sidebar, \.right-sidebar\) \.sidebar-section \{[\s\S]*background: var\(--content-surface-recess\)/,
+  );
+});
+
+test("ceremonial blackletter is never transformed to all caps", () => {
+  assert.match(layoutCss, /\.entry-message \{[\s\S]*font-family: var\(--font-display\)[\s\S]*text-transform: none/);
+  assert.match(layoutCss, /\.sidebar-header \{[\s\S]*font-family: var\(--font-display\)[\s\S]*text-transform: none/);
+  assert.match(componentsCss, /\.panel-header \{[\s\S]*font-family: var\(--font-display\)[\s\S]*text-transform: none/);
+});
+
 test("strategic left rails keep their scrollbars on the outer edge", () => {
   assert.match(layoutCss, /--left-rail-scrollbar-reserve: 8px;/);
   assert.match(layoutCss, /\.left-sidebar \{[\s\S]*direction: rtl;[\s\S]*scrollbar-gutter: stable;/);
@@ -188,7 +202,11 @@ test("strategic left rails keep their scrollbars on the outer edge", () => {
 test("settlement frames compensate for the left scrollbar gutter", () => {
   assert.match(layoutCss, /calc\(100% \+ var\(--left-rail-scrollbar-reserve, 0px\)\) top/);
   assert.match(layoutCss, /calc\(100% \+ var\(--left-rail-scrollbar-reserve, 0px\)\) center \/ 0\.55rem 100% no-repeat local/);
-  assert.match(layoutCss, /inset calc\(-1 \* var\(--left-rail-scrollbar-reserve, 0px\)\) 0 0 var\(--building-frame\)/);
+  assert.doesNotMatch(layoutCss, /inset calc\(-1 \* var\(--left-rail-scrollbar-reserve, 0px\)\) 0 0 var\(--building-frame\)/);
+  assert.ok(
+    layoutCss.indexOf("right top / var(--building-frame-corner-size)")
+      < layoutCss.indexOf("center / 0.55rem 100% no-repeat local"),
+  );
 });
 
 test("skill schedule columns fit inside a framed left rail", () => {

--- a/crates/strategic-web/tests/tooltips.test.cjs
+++ b/crates/strategic-web/tests/tooltips.test.cjs
@@ -1,0 +1,101 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const { parseHTML } = require('linkedom');
+
+const { createTooltipSystem } = require('../static/tooltips.js');
+
+function fixture(markup = '<button title="Open inventory">Bag</button>') {
+  const { window, document } = parseHTML(`<html><body>${markup}</body></html>`);
+  Object.defineProperties(window, {
+    innerWidth: { value: 320, configurable: true },
+    innerHeight: { value: 200, configurable: true },
+  });
+  const system = createTooltipSystem(document, window);
+  system.tooltip.getBoundingClientRect = () => ({ width: 100, height: 30 });
+  return { window, document, system };
+}
+
+function dispatch(window, target, type, properties = {}) {
+  const event = new window.Event(type, { bubbles: true });
+  Object.entries(properties).forEach(([key, value]) => Object.defineProperty(event, key, { value }));
+  target.dispatchEvent(event);
+  return event;
+}
+
+test('title tooltips enhance immediately while preserving an accessible description', () => {
+  const { window, document, system } = fixture();
+  const button = document.querySelector('button');
+  button.getBoundingClientRect = () => ({ left: 120, right: 160, top: 80, bottom: 100, width: 40, height: 20 });
+
+  dispatch(window, button, 'pointerover', { pointerType: 'mouse' });
+
+  assert.equal(button.hasAttribute('title'), false);
+  assert.equal(button.dataset.strategicTooltip, 'Open inventory');
+  assert.equal(button.getAttribute('aria-describedby'), 'strategic-tooltip');
+  assert.equal(system.tooltip.textContent, 'Open inventory');
+  assert.equal(system.tooltip.hidden, false);
+  assert.equal(system.tooltip.getAttribute('aria-hidden'), 'false');
+  assert.equal(system.tooltip.dataset.placement, 'top');
+  assert.equal(system.tooltip.style.left, '90px');
+  assert.equal(system.tooltip.style.top, '42px');
+
+  dispatch(window, button, 'pointerout', { pointerType: 'mouse', relatedTarget: document.body });
+  assert.equal(system.tooltip.hidden, true);
+  assert.equal(button.hasAttribute('aria-describedby'), false);
+
+  dispatch(window, button, 'pointerover', { pointerType: 'mouse' });
+  dispatch(window, button, 'pointerleave', { pointerType: 'mouse' });
+  assert.equal(system.tooltip.hidden, true);
+});
+
+test('an otherwise unnamed icon retains the title as its accessible name', () => {
+  const { window, document } = fixture('<span title="Armour condition"></span>');
+  const icon = document.querySelector('span');
+  dispatch(window, icon, 'focusin');
+  assert.equal(icon.getAttribute('aria-label'), 'Armour condition');
+  assert.equal(icon.hasAttribute('data-strategic-tooltip-generated-label'), true);
+});
+
+test('delegation supports replacement content and Escape and blur dismiss it', () => {
+  const { window, document, system } = fixture('<main></main>');
+  const dynamic = document.createElement('button');
+  dynamic.title = 'New live action';
+  dynamic.textContent = 'Action';
+  dynamic.getBoundingClientRect = () => ({ left: 5, right: 25, top: 3, bottom: 23, width: 20, height: 20 });
+  document.querySelector('main').append(dynamic);
+
+  dispatch(window, dynamic, 'focusin');
+  assert.equal(system.tooltip.textContent, 'New live action');
+  assert.equal(system.tooltip.dataset.placement, 'bottom');
+  assert.equal(system.tooltip.style.left, '8px');
+  assert.equal(system.tooltip.style.top, '31px');
+
+  dispatch(window, document, 'keydown', { key: 'Escape' });
+  assert.equal(system.tooltip.hidden, true);
+  dispatch(window, dynamic, 'focusin');
+  dispatch(window, dynamic, 'focusout', { relatedTarget: document.body });
+  assert.equal(system.tooltip.hidden, true);
+});
+
+test('touch pointers neither open nor leave a focused tooltip trapped', () => {
+  const { window, document, system } = fixture();
+  const button = document.querySelector('button');
+  dispatch(window, button, 'pointerover', { pointerType: 'touch' });
+  assert.equal(system.tooltip.hidden, true);
+
+  dispatch(window, button, 'pointerdown', { pointerType: 'touch' });
+  dispatch(window, button, 'focusin');
+  assert.equal(system.tooltip.hidden, true);
+});
+
+test('existing accessible names and descriptions are not overwritten', () => {
+  const { window, document, system } = fixture(
+    '<button aria-label="Bag" aria-describedby="inventory-help" title="Open inventory"></button>',
+  );
+  const button = document.querySelector('button');
+  dispatch(window, button, 'pointerover', { pointerType: 'mouse' });
+  assert.equal(button.getAttribute('aria-label'), 'Bag');
+  assert.equal(button.getAttribute('aria-describedby'), 'inventory-help strategic-tooltip');
+  system.hide();
+  assert.equal(button.getAttribute('aria-describedby'), 'inventory-help');
+});

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -814,6 +814,7 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/static/styles/timber-framed/building/village/weapons.png` — Binary game or UI asset.
 - `crates/strategic-web/static/styles/timber-framed/ornament/camp-tent/ornament.png` — Binary game or UI asset.
 - `crates/strategic-web/static/styles/timber-framed/ornament/encounter-boulders/ornament.png` — Binary game or UI asset.
+- `crates/strategic-web/static/tooltips.js` — Repository support file.
 - `crates/strategic-web/static/training-schedule.js` — Repository support file.
 - `crates/strategic-web/static/travel-planner.js` — Repository support file.
 - `crates/strategic-web/tests/building-assets.test.cjs` — Repository support file.
@@ -828,6 +829,7 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/tests/party-action-contract.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/rest-duration.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/service-quests.test.cjs` — Repository support file.
+- `crates/strategic-web/tests/tooltips.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/training-schedule.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/travel-planner-behavior.test.cjs` — Repository support file.
 - `docs/ARCHITECTURE.md` — Project documentation.
@@ -905,8 +907,6 @@ development, or wiki document before changing a subsystem.
 - `wiki/shared/Terrain.md` — Project documentation.
 - `wiki/strategic/Character.md` — Project documentation.
 - `wiki/strategic/Quests.md` — Project documentation.
-- `wiki/strategic/Settlement.md` — Project documentation.
-- `wiki/strategic/Settlement.md` — Project documentation.
 - `wiki/strategic/Settlement.md` — Project documentation.
 - `wiki/strategic/Time.md` — Project documentation.
 - `wiki/strategic/Trade.md` — Project documentation.


### PR DESCRIPTION
## Summary

- constrain strategic panel interiors to neutral brown and charcoal surfaces while retaining building-specific color in frames and architectural motifs
- establish readable and display-grade blackletter typography across frequently scanned and static interface text
- replace delayed browser titles with an immediate styled, accessible tooltip system
- reduce persistent explanatory copy, humanize visible item identifiers, and use compact icon actions where appropriate
- correct narrow-screen rail spacing, content overlap, and inventory overflow discovered during browser review

## Why

The strategic interface mixed broad service tints with gameplay-critical colors, used inconsistent typography and native tooltips, and exposed excessive prose and internal item identifiers. Narrow layouts also produced large empty regions and overlapping service content. This makes the interface more cohesive while preserving semantic meter colors and keeping detailed help readily available on demand.

## Validation

- repeated in-app browser reviews of map, merchant, weapons, inn, church, character, tooltip-related, and 768px layouts
- `cargo fmt --all -- --check`
- `cargo test -p strategic-web` (146 passed)
- strategic environment tests (14 passed)
- tooltip behavior tests (5 passed)
- `python scripts/update_project_map.py --check`
- `git diff --check`

The broader JavaScript suite still reports one unrelated pre-existing travel-planner source-contract failure; this change does not modify that module.
