### PR TITLE
License generated strategic map artifacts

### DIFF
--- a/MAP_DATA_LICENSE.md
+++ b/MAP_DATA_LICENSE.md
@@ -1,0 +1,77 @@
+# Strategic map and terrain data licence
+
+This notice accompanies these generated Adventure Simulator artifacts:
+
+- `strategic-map-v1.json`
+- `strategic-map-tiles-v1.pack`
+- `terrain-routing-v1.json`
+- `terrain-routing-v1.pack`
+
+## Licence boundary
+
+Except for the third-party material identified below, Adventure Simulator's
+copyright and similar rights in its original selection, classification,
+styling, arrangement, and other contributions to these generated artifacts are
+licensed under the [Creative Commons Attribution-ShareAlike 4.0 International
+licence](https://creativecommons.org/licenses/by-sa/4.0/).
+
+These generated data and image artifacts are not software and are not licensed
+under the repository's GNU Affero General Public License. CC BY-SA 4.0 does not
+replace or relicense the underlying datasets. Recipients must also comply with
+the applicable source terms below. To retain the required attribution in a
+reasonable form, redistribute this notice with the artifacts or provide a
+reasonably prominent link to an equivalent permanent copy.
+
+## Viabundus
+
+[Viabundus map of premodern European transport and mobility, version
+2](https://doi.org/10.5281/zenodo.16611998), by Bart Holterman, Maria Carina
+Dengg, Maartje A.B., and Kasper H. Andersen.
+
+The Zenodo description identifies the downloadable dataset as CC BY-SA, while
+its structured rights field identifies CC BY 4.0. Adventure Simulator
+conservatively treats the source and its adapted map material as [CC BY-SA
+4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Adventure Simulator clips, simplifies, classifies, and rasterizes Viabundus
+roads, ferries, settlements, and water geometry; it also projects active roads
+into the native-detail routing surface. These modifications are not endorsed
+by the Viabundus authors or institutions.
+
+## Copernicus DEM GLO-30
+
+[Copernicus DEM GLO-30](https://doi.org/10.5270/ESA-c5d3d65) is used under the
+Copernicus DEM licence, which permits reproduction, distribution, public
+communication, adaptation, modification, and combination subject to its
+conditions.
+
+Produced using Copernicus WorldDEM-30 © DLR e.V. 2010-2014 and © Airbus Defence
+and Space GmbH 2014-2018 provided under COPERNICUS by the European Union and
+ESA; all rights reserved.
+
+The organisations in charge of the Copernicus programme by law or by
+delegation do not incur any liability for any use of the Copernicus
+WorldDEM-30.
+
+Adventure Simulator resamples and classifies the elevation source into visual
+relief, hill and mountain presentation, and a native-detail routing surface.
+Neither the provider, the licensor, nor any organisation responsible for the
+Copernicus programme endorses Adventure Simulator or these modifications.
+
+## Copernicus Land Monitoring Service forest data
+
+Generated using European Union's Copernicus Land Monitoring Service
+information: [High Resolution Layer Forest 2018](https://doi.org/10.2909/82f93572-9888-47ef-97a1-5cac5985a26a).
+
+Adventure Simulator aggregates the available Tree Cover Density and leaf-type
+products, classifies canopy coverage, and naturalizes forest boundaries for map
+presentation and terrain routing. The source coverage and these modifications
+are identified in the generated manifests. No endorsement by the European
+Union or the Copernicus programme is implied.
+
+## No raw source redistribution
+
+The generated packs contain rendered tiles and compiled terrain values. They do
+not redistribute the original Viabundus CSV files, Copernicus DEM GeoTIFFs, or
+Copernicus forest source rasters. Source access remains subject to each
+provider's terms and distribution service.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Below are some guiding principles for _Adventure Simulator_ development.
 ### Open source software
 We tentatively intend to keep everything [AGPLv3](https://www.gnu.org/licenses/agpl-3.0.en.html), but we're willing to hear out the case for other licenses.
 
+The AGPL applies to Adventure Simulator software unless a file or artifact says
+otherwise. Generated strategic map tiles and terrain-routing packs are data
+artifacts with a separate licence boundary: project-owned contributions are
+offered under CC BY-SA 4.0 and underlying datasets retain their own terms. See
+[MAP_DATA_LICENSE.md](MAP_DATA_LICENSE.md) before distributing or hosting those
+artifacts.
+
 It's clear to us that _Adventure Simulator_ is very much the kind of project which will benefit from collaboration and indefinite iteration, which makes open source the obvious choice by a country mile. For instance, though our MVP for _Adventure Simulator_ is (deliberately)[^9] generic historical fantasy, we don't intend or hope for it to stay that way. The project's open source nature will allow modders to come in and take it in all sorts of unexpected directions in the future; they may create [total conversions](https://en.wikipedia.org/wiki/Total_conversion) to other fantasy settings, sci-fi settings, or... [something else entirely](https://fxtwitter.com/warlockracy/status/1489001741337169926).
 
 [^9]: Think of this as a high-effort tech demo in the spirit of Valve (cf. *Half-Life*). We really enjoy "weird fiction" like *Morrowind* and *Dune*, but at least for *Adventure Simulator*'s first iteration, the goal is to innovate in tech, not aesthetic. For now, our aesthetic is what has been proven to work.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,24 +2,14 @@
 
 ## Strategic map data
 
-The generated Paper map tiles adapt these datasets offline; the source raster
-and vector files are not shipped to the browser:
-
-- [Viabundus Pre-modern Street Map 2](https://doi.org/10.5281/zenodo.16611998),
-  conservatively treated as [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
-  Adventure Simulator clips, simplifies, classifies, and rasterizes the source
-  roads, ferries, settlements, and water geometry.
-- [Copernicus DEM GLO-30](https://doi.org/10.5270/ESA-c5d3d65). Credit: European
-  Union, Copernicus DEM GLO-30. Produced using Copernicus WorldDEM-30 © DLR e.V.
-  2010–2014 and © Airbus Defence and Space GmbH 2014–2018 provided under
-  COPERNICUS by the European Union and ESA; all rights reserved. Adventure
-  Simulator generalizes the elevation into map relief. Neither the European
-  Commission nor ESA is liable for use of Copernicus data and information.
-- [Copernicus HRL Forest 2018](https://doi.org/10.2909/82f93572-9888-47ef-97a1-5cac5985a26a).
-  © European Union, Copernicus Land Monitoring Service. Adventure Simulator
-  aggregates and procedurally reshapes the partial source coverage into sparse
-  and deep woodland bands. No endorsement by the European Union or Copernicus
-  programme is implied.
+The generated Paper map and terrain-routing packs adapt Viabundus Pre-modern
+Street Map 2, Copernicus DEM GLO-30, and Copernicus Land Monitoring Service
+forest data offline. Their canonical redistribution notice is
+[MAP_DATA_LICENSE.md](MAP_DATA_LICENSE.md). It applies CC BY-SA 4.0 to the
+project-owned contributions, excludes the generated data artifacts from the
+software AGPL, identifies modifications, and retains the source-specific
+attribution, liability, and no-endorsement terms. The compiler copies that
+notice beside every generated map or terrain pack.
 
 ## Game Icons
 

--- a/crates/adventuresim-world-import/src/bin/build-strategic-map.rs
+++ b/crates/adventuresim-world-import/src/bin/build-strategic-map.rs
@@ -21,6 +21,8 @@ const VIABUNDUS_DOI: &str = "https://doi.org/10.5281/zenodo.16611998";
 const RECORD_URL: &str = "https://zenodo.org/api/records/16611998";
 const BOUNDS: [f64; 4] = [-11.0, 43.0, 31.0, 70.0];
 const MAX_SOURCE_FILES: usize = 64;
+const DATA_LICENSE_FILENAME: &str = "STRATEGIC_MAP_DATA_LICENSE.md";
+const DATA_LICENSE: &str = include_str!("../../../../MAP_DATA_LICENSE.md");
 
 #[derive(Parser)]
 #[command(about = "Build the bounded AVIF strategic-map package from initialized world data")]
@@ -210,6 +212,12 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         fs::create_dir_all(parent)?;
     }
     fs::write(&args.tiles_output, tile_bytes)?;
+    write_data_license(&[
+        &args.output,
+        &args.tiles_output,
+        &args.terrain_output,
+        &args.terrain_pack_output,
+    ])?;
     println!(
         "Wrote {} roads, {} water polygons, {} elevation cells, {} contours, {} forest regions, and {} AVIF tiles to {} and {}",
         package.roads.len(),
@@ -228,6 +236,24 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         args.terrain_pack_output.display(),
         terrain.package_sha256
     );
+    Ok(())
+}
+
+fn write_data_license(outputs: &[&Path]) -> std::io::Result<()> {
+    let directories = outputs
+        .iter()
+        .map(|output| {
+            output
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf()
+        })
+        .collect::<BTreeSet<_>>();
+    for directory in directories {
+        fs::create_dir_all(&directory)?;
+        fs::write(directory.join(DATA_LICENSE_FILENAME), DATA_LICENSE)?;
+    }
     Ok(())
 }
 
@@ -821,6 +847,29 @@ mod tests {
         assert!(value["forest"].get("regions").is_none());
         fs::write(root.join("edges.csv"), b"changed").unwrap();
         assert!(build(&root, layers()).is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn generated_bundle_directories_receive_the_canonical_data_license() {
+        let root = fixture();
+        let map_dir = root.join("map");
+        let terrain_dir = root.join("terrain");
+        write_data_license(&[
+            &map_dir.join("strategic-map-v1.json"),
+            &map_dir.join("strategic-map-tiles-v1.pack"),
+            &terrain_dir.join("terrain-routing-v1.json"),
+            &terrain_dir.join("terrain-routing-v1.pack"),
+        ])
+        .unwrap();
+        assert_eq!(
+            fs::read_to_string(map_dir.join(DATA_LICENSE_FILENAME)).unwrap(),
+            DATA_LICENSE
+        );
+        assert_eq!(
+            fs::read_to_string(terrain_dir.join(DATA_LICENSE_FILENAME)).unwrap(),
+            DATA_LICENSE
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/strategic-web/src/routes/mod.rs
+++ b/crates/strategic-web/src/routes/mod.rs
@@ -468,6 +468,10 @@ pub(crate) async fn approve_party_action(
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route(
+            crate::strategic_map::DATA_LICENSE_PATH,
+            get(crate::strategic_map::data_license),
+        )
+        .route(
             "/map/tiles/{theme}/{zoom}/{x}/{tile}",
             get(crate::strategic_map::world_tile),
         )

--- a/crates/strategic-web/src/strategic_map.rs
+++ b/crates/strategic-web/src/strategic_map.rs
@@ -27,6 +27,8 @@ const DEFAULT_VIEW_HEIGHT: f64 = DEFAULT_VIEW_WIDTH / VIEW_ASPECT_RATIO;
 const ROUTE_MIN_VIEW_WIDTH: f64 = 90.0;
 const ROUTE_MIN_VIEW_HEIGHT: f64 = ROUTE_MIN_VIEW_WIDTH / VIEW_ASPECT_RATIO;
 pub(crate) const TILE_PATH_PREFIX: &str = "/map/tiles/";
+pub(crate) const DATA_LICENSE_PATH: &str = "/map/data-license";
+const DATA_LICENSE: &str = include_str!("../../../MAP_DATA_LICENSE.md");
 const PACKAGE_SCHEMA: u32 = 3;
 const RENDERER_REVISION: u32 = 7;
 const MIN_TILE_SIZE: u32 = 64;
@@ -242,6 +244,14 @@ fn pyramid_tile_entry_count(tile_size: u32, max_zoom: u8) -> usize {
 #[derive(Deserialize)]
 pub(crate) struct TileQuery {
     v: Option<String>,
+}
+
+pub(crate) async fn data_license() -> Response<Body> {
+    Response::builder()
+        .header(CONTENT_TYPE, "text/markdown; charset=utf-8")
+        .header(CACHE_CONTROL, "public, max-age=3600")
+        .body(Body::from(DATA_LICENSE))
+        .expect("map data licence response")
 }
 
 pub(crate) async fn world_tile(
@@ -545,6 +555,8 @@ pub fn strategic_map(
                     }
                 }
             }
+            a class="strategic-map-license-link" href=(DATA_LICENSE_PATH)
+                rel="license" target="_blank" { "Map data licence" }
         }
     }
 }
@@ -810,6 +822,10 @@ mod tests {
         assert!(!markup.contains("strategic-map-legend"));
         assert!(!markup.contains("strategic-map-attribution"));
         assert!(!markup.contains("Map data:"));
+        assert!(markup.contains("href=\"/map/data-license\""));
+        assert!(markup.contains("rel=\"license\""));
+        assert!(DATA_LICENSE.contains("Creative Commons Attribution-ShareAlike 4.0"));
+        assert!(DATA_LICENSE.contains("The organisations in charge of the Copernicus programme"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -158,7 +158,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/reset.css";
                 link rel="stylesheet" href="/static/css/layout.css?v=subtle-material-lines-1";
                 link rel="stylesheet" href="/static/css/components.css?v=lowercase-display-type-1";
-                link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ui-overhaul-4-paper-map-2";
+                link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ui-overhaul-4-paper-map-2-data-license-1";
                 link rel="stylesheet" href="/static/css/utilities.css?v=strategic-ui-overhaul-1";
 
                 // Datastar

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -4234,8 +4234,10 @@ body.chat-resizing {
 }
 /* Settlement map: cached AVIF world tiles under an interactive SVG overlay. */
 .settlement-map-main { min-width: 0; overflow: hidden; }
-.strategic-map { display: grid; grid-template-rows: minmax(20rem, 1fr); height: 100%; min-height: 32rem; background: #dce5dc; color: #202820; }
+.strategic-map { position: relative; display: grid; grid-template-rows: minmax(20rem, 1fr); height: 100%; min-height: 32rem; background: #dce5dc; color: #202820; }
 .strategic-map-svg { display: block; width: 100%; height: 100%; min-height: 20rem; cursor: grab; touch-action: none; background: var(--map-land); }
+.strategic-map-license-link { position: absolute; right: .45rem; bottom: .35rem; z-index: 3; padding: .14rem .32rem; border: 1px solid rgb(41 48 38 / 28%); background: rgb(244 238 211 / 86%); color: #30372b; font-size: .68rem; line-height: 1.15; text-decoration: none; }
+.strategic-map-license-link:hover, .strategic-map-license-link:focus-visible { background: #f4eed3; text-decoration: underline; }
 .strategic-map-svg:active { cursor: grabbing; }
 .strategic-map-svg:focus-visible { outline: 3px solid #173d72; outline-offset: -3px; }
 .map-tile-layer { pointer-events: none; image-rendering: auto; }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -24,6 +24,13 @@ import types shared by the compiler and strategic module. The strategic module
 accepts those records through reducers but never parses raw datasets or depends
 on native geospatial libraries.
 
+Generated strategic map tiles and terrain-routing packs are a separate data
+distribution boundary from the AGPL software. The offline compiler copies the
+canonical `MAP_DATA_LICENSE.md` terms beside each bundle, while strategic-web
+serves the same notice at `/map/data-license`. Deployments must retain that
+notice so source-specific attribution and pass-through conditions travel with
+the otherwise optional file-backed artifacts.
+
 Every gridded enrichment shares the canonical `SpatialGridSpec` described in
 `docs/SPATIAL_GRID.md`. The complete spec and inference-rules version are
 serialized in world metadata, so either changing alters the content-addressed

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -270,7 +270,11 @@ After Viabundus and the world-data inputs are installed, run `just
 build-strategic-map` to regenerate
 `target/strategic-map/strategic-map-v1.json` and the derived
 `target/strategic-map/strategic-map-tiles-v1.pack`, plus the independent
-`terrain-routing-v1.json`/`.pack` native-detail artifact. These deterministic presentation assets verify
+`terrain-routing-v1.json`/`.pack` native-detail artifact. The compiler also
+writes `STRATEGIC_MAP_DATA_LICENSE.md` beside every output directory. Keep that
+notice with any copied, published, or hosted bundle; it is the artifact-level
+licence and attribution boundary described by the repository's
+`MAP_DATA_LICENSE.md`. These deterministic presentation assets verify
 the initialized v2 edge and water files against
 their recorded SHA-256 identities, retains only active 1544 overview roads and
 ferries for presentation, and separately rasterizes every active full-precision
@@ -327,6 +331,11 @@ pin at its issuing settlement, route availability, current location, selection,
 and the computed terrain polyline to the selected destination remain in the authenticated
 HTML/SVG overlay and are never cached as
 part of the world asset.
+
+The public `/map/data-license` route serves the same canonical notice compiled
+into `strategic-web`. A compact `Map data licence` link overlays the map so the
+attribution and reuse terms remain discoverable without restoring the old
+legend or source-information block.
 
 `strategic-web` requires an authenticated `SPACETIMEDB_TOKEN` even when the
 optional terrain pack is absent. At startup it claims (or renews, using the same

--- a/docs/ELEVATION.md
+++ b/docs/ELEVATION.md
@@ -63,6 +63,12 @@ it into database rows or `ElevationCell` structs. Independently deflated
 surface, exact bounded canopy percentage, a native 15-degree hill bit, and an
 explicit infrastructure-crossing bit.
 
+The compiler writes `STRATEGIC_MAP_DATA_LICENSE.md` beside the terrain and map
+outputs. It contains the prescribed Copernicus WorldDEM-30 production credit,
+liability notice, modification statement, and the separate CC BY-SA licence
+for Adventure Simulator's contributions. Distribute that notice with the pack;
+the repository software's AGPL does not license these generated data artifacts.
+
 The manifest and pack are separately SHA-256 addressed. Readers reject wrong
 dimensions, overlapping or truncated chunks, digest mismatches, excess
 entries, and oversized decompression. Runtime decompression uses a

--- a/docs/FOREST_COVER.md
+++ b/docs/FOREST_COVER.md
@@ -112,6 +112,12 @@ presentation data: absent tiles stay absent, tile coverage is recorded in the
 map package, and no missing regional forest is inferred from a settlement
 sample.
 
+Published map and terrain packs retain the Copernicus source, modification,
+and no-endorsement statements in `STRATEGIC_MAP_DATA_LICENSE.md`, which the
+offline compiler writes beside every output directory. That notice must remain
+with redistributed bundles or be available through an equivalent prominent
+link.
+
 Forest cover is stored on settlements because it describes the immediate area
 and can drive timber and foraging products, scene vegetation density, visibility,
 encounters, and fuel availability. Continuous route or canonical regional

--- a/docs/SOURCE_MANIFESTS.md
+++ b/docs/SOURCE_MANIFESTS.md
@@ -42,8 +42,10 @@ against a malicious or noncanonical client.
 ## Operational notices and unresolved boundaries
 
 - **Viabundus:** retain attribution and CC BY-SA 4.0. The project applies a
-  conservative BY-SA treatment; compatibility with differently licensed
-  combined output remains unresolved.
+  conservative BY-SA treatment to its generated map and terrain contributions,
+  keeps those artifacts outside the software AGPL, and carries the complete
+  source-specific terms in `MAP_DATA_LICENSE.md`. This policy is specific to
+  those reviewed packs and does not authorize an unrelated combined output.
 - **Copernicus DEM:** retain the prescribed Copernicus/WorldDEM production
   credit and European Commission/ESA no-liability notice.
 - **HYDE 3.5:** retain HYDE attribution, the CC BY 3.0 licence link, and an

--- a/docs/VIABUNDUS.md
+++ b/docs/VIABUNDUS.md
@@ -75,6 +75,11 @@ positioned parchment texture keeps adjacent tile gutters identical.
 The stable `strategic-map-v1.json` and `strategic-map-tiles-v1.pack` filenames
 are versioned, not content-addressed; the pack digest query parameter is every
 tile route's cache key.
+Adventure Simulator's contributions to the generated map and terrain packs are
+distributed under CC BY-SA 4.0 rather than the repository software's AGPL.
+Every bundle must retain the generated `STRATEGIC_MAP_DATA_LICENSE.md` notice
+or provide a reasonably prominent link to the canonical `MAP_DATA_LICENSE.md`;
+the server exposes the latter at `/map/data-license`.
 The compact schema-3 deployment manifest carries renderer revision 7, reviewed
 source identities, coverage counts, and the indexed AVIF pyramid, but not the
 offline roads, compound water rings, elevation cells/contours, or forest

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (914)
+## Files (915)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -24,6 +24,7 @@ development, or wiki document before changing a subsystem.
 - `Cargo.lock` — Locked Rust dependency versions.
 - `Cargo.toml` — Cargo package/workspace manifest.
 - `LICENSE` — Repository support file.
+- `MAP_DATA_LICENSE.md` — Project documentation.
 - `README.md` — Component overview and usage notes.
 - `THIRD_PARTY_NOTICES.md` — Project documentation.
 - `assets/TownA.glb` — Binary game or UI asset.


### PR DESCRIPTION
## Summary

- add a canonical `MAP_DATA_LICENSE.md` that licenses Adventure Simulator's contributions to generated map and terrain artifacts under CC BY-SA 4.0 while retaining the underlying source terms
- preserve the Viabundus attribution and licensing ambiguity, the prescribed Copernicus WorldDEM-30 production and liability notices, and the Copernicus Land modification/no-endorsement statements
- have `build-strategic-map` copy `STRATEGIC_MAP_DATA_LICENSE.md` beside every generated map or terrain output directory
- expose the canonical notice at `/map/data-license` and add a compact legal link to the map without restoring the removed legend or source-information block
- document that generated data artifacts are outside the repository software's AGPL boundary

## Why

The generated AVIF and terrain packs combine adapted material from differently licensed sources. The existing third-party notice identified those sources but did not explicitly license the project's adapter contributions, distinguish the packs from AGPL software, or guarantee that the required notices accompanied copied bundles.

This change makes the licensing and attribution boundary travel with both offline artifacts and hosted maps. It does not redistribute the raw source datasets.

## Developer and operator impact

Anyone copying, publishing, or hosting a generated map or terrain bundle must retain the generated `STRATEGIC_MAP_DATA_LICENSE.md` notice or provide an equivalent prominent link. Existing build commands and pack schemas are unchanged.

## Checks

- `cargo test -p adventuresim-world-import --features strategic-map-renderer --bin build-strategic-map generated_bundle_directories_receive_the_canonical_data_license`
- `cargo test -p strategic-web strategic_map::tests` (17 passed)
- `node --test crates/strategic-web/tests/strategic-map-behavior.test.cjs` (14 passed; `linkedom` supplied from an isolated temporary dependency directory)
- `python scripts/update_project_map.py --check`
- `git diff --check`
