### PR TITLE
Bound world data and maps to the playable area

### DIFF
--- a/crates/adventuresim-terrain/src/builder.rs
+++ b/crates/adventuresim-terrain/src/builder.rs
@@ -20,15 +20,27 @@ pub struct Features {
 pub fn build(
     elevation_dir: &Path,
     forest_dir: &Path,
-    bounds: [i16; 4],
+    bounds: [f64; 4],
     manifest_path: &Path,
     pack_path: &Path,
     features: &Features,
 ) -> crate::Result<Manifest> {
+    let [west, south, east, north] = bounds;
+    if !bounds.into_iter().all(f64::is_finite) || west >= east || south >= north {
+        return Err(crate::Error::Validation(
+            "invalid terrain build bounds".into(),
+        ));
+    }
+    let source_bounds = [
+        west.floor() as i16,
+        south.floor() as i16,
+        east.ceil() as i16,
+        north.ceil() as i16,
+    ];
     let mut entries = Vec::new();
     let mut pack = Vec::new();
-    for south in bounds[1]..bounds[3] {
-        for west in bounds[0]..bounds[2] {
+    for south in source_bounds[1]..source_bounds[3] {
+        for west in source_bounds[0]..source_bounds[2] {
             let path = elevation_path(elevation_dir, south, west)?;
             let (width, height, elevations, synthetic_water) = if path.is_file() {
                 let mut decoder = Decoder::new(BufReader::new(File::open(&path)?))
@@ -79,6 +91,19 @@ pub fn build(
                         (width - chunk_x * u32::from(CHUNK_SIDE)).min(u32::from(CHUNK_SIDE));
                     let chunk_height =
                         (height - chunk_y * u32::from(CHUNK_SIDE)).min(u32::from(CHUNK_SIDE));
+                    if !chunk_intersects_bounds(
+                        south,
+                        west,
+                        width,
+                        height,
+                        chunk_x,
+                        chunk_y,
+                        chunk_width,
+                        chunk_height,
+                        bounds,
+                    ) {
+                        continue;
+                    }
                     let mut decoded =
                         Vec::with_capacity(chunk_width as usize * chunk_height as usize * 5);
                     for local_y in 0..chunk_height {
@@ -148,7 +173,7 @@ pub fn build(
     let content_sha256 = hex_sha(&pack);
     let mut manifest = Manifest {
         schema: SCHEMA,
-        bounds: bounds.map(f64::from),
+        bounds,
         source_resolution_m: 30,
         content_sha256,
         entries,
@@ -166,6 +191,51 @@ pub fn build(
     fs::write(pack_path, pack)?;
     fs::write(manifest_path, json)?;
     Ok(manifest)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn chunk_intersects_bounds(
+    south: i16,
+    west: i16,
+    tile_width: u32,
+    tile_height: u32,
+    chunk_x: u32,
+    chunk_y: u32,
+    chunk_width: u32,
+    chunk_height: u32,
+    bounds: [f64; 4],
+) -> bool {
+    let x = chunk_x * u32::from(CHUNK_SIDE);
+    let y = chunk_y * u32::from(CHUNK_SIDE);
+    let chunk_bounds = [
+        f64::from(west) + f64::from(x) / f64::from(tile_width),
+        f64::from(south + 1) - f64::from(y + chunk_height) / f64::from(tile_height),
+        f64::from(west) + f64::from(x + chunk_width) / f64::from(tile_width),
+        f64::from(south + 1) - f64::from(y) / f64::from(tile_height),
+    ];
+    chunk_bounds[2] > bounds[0]
+        && chunk_bounds[0] < bounds[2]
+        && chunk_bounds[3] > bounds[1]
+        && chunk_bounds[1] < bounds[3]
+}
+
+#[cfg(test)]
+mod bounds_tests {
+    use super::*;
+
+    #[test]
+    fn only_chunks_intersecting_exact_bounds_are_emitted() {
+        let bounds = [8.965, 50.877, 11.110, 52.211];
+        assert!(!chunk_intersects_bounds(
+            50, 8, 3_600, 3_600, 0, 0, 256, 256, bounds
+        ));
+        assert!(chunk_intersects_bounds(
+            50, 8, 3_600, 3_600, 13, 0, 256, 256, bounds
+        ));
+        assert!(!chunk_intersects_bounds(
+            52, 11, 3_600, 3_600, 0, 4, 256, 256, bounds
+        ));
+    }
 }
 
 fn native_cell_is_hilly(

--- a/crates/adventuresim-terrain/src/lib.rs
+++ b/crates/adventuresim-terrain/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
     time::Instant,
 };
 
-pub const SCHEMA: u32 = 2;
+pub const SCHEMA: u32 = 3;
 pub const CHUNK_SIDE: u16 = 256;
 pub const MAX_ENTRIES: usize = 20_000;
 pub const MAX_PACK_BYTES: usize = 2 * 1024 * 1024 * 1024;
@@ -216,6 +216,14 @@ impl TerrainPack {
         if !latitude.is_finite() || !longitude.is_finite() {
             return Ok(None);
         }
+        let [west_bound, south_bound, east_bound, north_bound] = self.bounds();
+        if longitude < west_bound
+            || longitude > east_bound
+            || latitude < south_bound
+            || latitude > north_bound
+        {
+            return Ok(None);
+        }
         let south = latitude.floor() as i16;
         let west = longitude.floor() as i16;
         let Some(&(tile_width, tile_height)) = self.tiles.get(&(south, west)) else {
@@ -353,6 +361,13 @@ impl TerrainPack {
             .into_iter()
             .all(f64::is_finite)
         {
+            return Err(Error::NoRoute);
+        }
+        let [west, south, east, north] = self.bounds();
+        let inside = |(latitude, longitude): (f64, f64)| {
+            longitude >= west && longitude <= east && latitude >= south && latitude <= north
+        };
+        if !inside(start) || !inside(goal) {
             return Err(Error::NoRoute);
         }
         for window in expanding_windows(start, goal, self.bounds()) {

--- a/crates/adventuresim-world-import/src/bin/build-strategic-map.rs
+++ b/crates/adventuresim-world-import/src/bin/build-strategic-map.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use adventuresim_world_schema::PLAYABLE_BOUNDS;
 use clap::Parser;
 use raster::{ElevationLayer, ForestLayer, MapRasterLayers};
 use serde::{Deserialize, Serialize};
@@ -15,11 +16,11 @@ mod raster;
 mod tiles;
 
 const PACKAGE_SCHEMA: u32 = 3;
-const RENDERER_REVISION: u32 = 7;
+const RENDERER_REVISION: u32 = 8;
 const YEAR: i32 = 1544;
 const VIABUNDUS_DOI: &str = "https://doi.org/10.5281/zenodo.16611998";
 const RECORD_URL: &str = "https://zenodo.org/api/records/16611998";
-const BOUNDS: [f64; 4] = [-11.0, 43.0, 31.0, 70.0];
+const BOUNDS: [f64; 4] = PLAYABLE_BOUNDS;
 const MAX_SOURCE_FILES: usize = 64;
 const DATA_LICENSE_FILENAME: &str = "STRATEGIC_MAP_DATA_LICENSE.md";
 const DATA_LICENSE: &str = include_str!("../../../../MAP_DATA_LICENSE.md");
@@ -187,7 +188,7 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let terrain = adventuresim_terrain::builder::build(
         &args.elevation_dir,
         &args.forest_cover_dir,
-        [5, 50, 16, 56],
+        BOUNDS,
         &args.terrain_output,
         &args.terrain_pack_output,
         &terrain_features,
@@ -258,6 +259,7 @@ fn write_data_license(outputs: &[&Path]) -> std::io::Result<()> {
 }
 
 fn build(root: &Path, layers: MapRasterLayers) -> Result<Package, Box<dyn std::error::Error>> {
+    let layers = clip_raster_layers(layers, BOUNDS);
     let manifest: SourceManifest =
         serde_json::from_slice(&fs::read(root.join(".viabundus-source.json"))?)?;
     if manifest.version != "2" || manifest.record_url != RECORD_URL {
@@ -399,6 +401,58 @@ fn build(root: &Path, layers: MapRasterLayers) -> Result<Package, Box<dyn std::e
     };
     validate_geometry(&package)?;
     Ok(package)
+}
+
+fn clip_raster_layers(mut layers: MapRasterLayers, bounds: [f64; 4]) -> MapRasterLayers {
+    layers.elevation.cells = layers
+        .elevation
+        .cells
+        .into_iter()
+        .filter_map(|mut cell| {
+            cell.bounds = bounds_intersection(cell.bounds, bounds)?;
+            Some(cell)
+        })
+        .collect();
+    layers.elevation.contours = layers
+        .elevation
+        .contours
+        .into_iter()
+        .flat_map(|contour| {
+            let points = contour.points.into_iter().map(Point).collect::<Vec<_>>();
+            clip_polyline(&points, bounds)
+                .into_iter()
+                .map(move |points| raster::ElevationContour {
+                    elevation_m: contour.elevation_m,
+                    points: points.into_iter().map(|point| point.0).collect(),
+                })
+        })
+        .collect();
+    layers.forest.coverage = layers
+        .forest
+        .coverage
+        .into_iter()
+        .filter_map(|coverage| bounds_intersection(coverage, bounds))
+        .collect();
+    layers.forest.regions = layers
+        .forest
+        .regions
+        .into_iter()
+        .filter_map(|mut region| {
+            region.bounds = bounds_intersection(region.bounds, bounds)?;
+            Some(region)
+        })
+        .collect();
+    layers
+}
+
+fn bounds_intersection(value: [f64; 4], bounds: [f64; 4]) -> Option<[f64; 4]> {
+    let clipped = [
+        value[0].max(bounds[0]),
+        value[1].max(bounds[1]),
+        value[2].min(bounds[2]),
+        value[3].min(bounds[3]),
+    ];
+    (clipped[0] < clipped[2] && clipped[1] < clipped[3]).then_some(clipped)
 }
 
 fn deployment_package(package: &Package) -> DeploymentPackage<'_> {
@@ -732,8 +786,8 @@ mod tests {
             NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed)
         ));
         fs::create_dir_all(&root).unwrap();
-        let edges = b"id,section,type,certainty,zoomlevel,fromyear,toyear,descriptionid,length,fromnode,tonode,wkt,slopemultiplier\n1,A,land,1,2,1500,,x,100,1,2,\"LINESTRING(10 53,10.5 53.2,11 53.3)\",1\n2,B,land,1,6,1500,,x,100,2,3,\"LINESTRING(11 53.3,11.123456 53.345678,11.5 53.5)\",1\n";
-        let water = b"WKT\n\"MULTIPOLYGON (((10 52,11 52,11 53,10 52)))\"\n";
+        let edges = b"id,section,type,certainty,zoomlevel,fromyear,toyear,descriptionid,length,fromnode,tonode,wkt,slopemultiplier\n1,A,land,1,2,1500,,x,100,1,2,\"LINESTRING(9 51,10 51.2,11 51.3)\",1\n2,B,land,1,6,1500,,x,100,2,3,\"LINESTRING(10 51.3,10.123456 51.345678,10.5 51.5)\",1\n";
+        let water = b"WKT\n\"MULTIPOLYGON (((9 51,10 51,10 52,9 51)))\"\n";
         fs::write(root.join("edges.csv"), edges).unwrap();
         fs::write(root.join("water-1500.csv"), water).unwrap();
         let manifest = serde_json::json!({"record_url":RECORD_URL,"version":"2","files":[
@@ -762,19 +816,19 @@ mod tests {
             elevation: ElevationLayer {
                 source: layer_source(),
                 cells: vec![raster::ElevationCell {
-                    bounds: [10.0, 53.0, 10.25, 53.25],
+                    bounds: [9.0, 51.0, 9.25, 51.25],
                     band_m: 100,
                 }],
                 contours: vec![raster::ElevationContour {
                     elevation_m: 100,
-                    points: vec![[10.0, 53.0], [10.25, 53.25]],
+                    points: vec![[9.0, 51.0], [9.25, 51.25]],
                 }],
             },
             forest: ForestLayer {
                 source: layer_source(),
-                coverage: vec![[10.0, 53.0, 11.0, 54.0]],
+                coverage: vec![[9.0, 51.0, 10.0, 52.0]],
                 regions: vec![raster::ForestRegion {
-                    bounds: [10.0, 53.0, 10.05, 53.05],
+                    bounds: [9.0, 51.0, 9.05, 51.05],
                     density: 2,
                     kind: "mixed".into(),
                 }],
@@ -829,7 +883,7 @@ mod tests {
         assert_eq!(first_manifest.gutter, 4);
         assert_eq!(first.roads.len(), 1);
         assert_eq!(first.routing_roads.len(), 2);
-        assert_eq!(first.routing_roads[1][1], Point([11.123456, 53.345678]));
+        assert_eq!(first.routing_roads[1][1], Point([10.123456, 51.345678]));
         assert_eq!(first.water.len(), 1);
         assert_eq!(first.water[0].rings.len(), 1);
 
@@ -900,17 +954,17 @@ mod tests {
     #[test]
     fn clipping_drops_outside_geometry_and_bounds_crossings() {
         assert!(clip_polyline(&[Point([-20.0, 40.0]), Point([-15.0, 41.0])], BOUNDS).is_empty());
-        let crossing = clip_polyline(&[Point([-20.0, 50.0]), Point([40.0, 50.0])], BOUNDS);
+        let crossing = clip_polyline(&[Point([0.0, 51.5]), Point([20.0, 51.5])], BOUNDS);
         assert_eq!(
             crossing,
-            vec![vec![Point([-11.0, 50.0]), Point([31.0, 50.0])]]
+            vec![vec![Point([BOUNDS[0], 51.5]), Point([BOUNDS[2], 51.5])]]
         );
         let polygon = clip_polygon(
             &[
-                Point([-20.0, 50.0]),
-                Point([0.0, 50.0]),
-                Point([0.0, 60.0]),
-                Point([-20.0, 50.0]),
+                Point([8.0, 51.0]),
+                Point([10.0, 51.0]),
+                Point([10.0, 53.0]),
+                Point([8.0, 51.0]),
             ],
             BOUNDS,
         );

--- a/crates/adventuresim-world-import/src/bin/build-strategic-map/tiles.rs
+++ b/crates/adventuresim-world-import/src/bin/build-strategic-map/tiles.rs
@@ -16,7 +16,7 @@ const MIN_TILE_SIZE: u32 = 64;
 const MAX_TILE_SIZE: u32 = 2_048;
 const MAX_TILE_COUNT: usize = 100_000;
 const RENDER_MARGIN: u32 = 12;
-const NATIVE_DETAIL_BOUNDS: [f64; 4] = [5.0, 50.0, 16.0, 56.0];
+const NATIVE_DETAIL_BOUNDS: [f64; 4] = adventuresim_world_schema::PLAYABLE_BOUNDS;
 const FOREST_CANOPY_THRESHOLD_PERCENT: f64 = 20.0;
 const CANOPY_CELLS_PER_DEGREE: usize = 1_000;
 const RELIEF_STEP_DEGREES: f64 = 0.01;
@@ -120,27 +120,16 @@ impl CanopyPyramid {
             return Err("terrain bounds cannot produce a canopy pyramid".into());
         }
         let mut coverage = vec![0_u8; width * height];
-        let west_degree = bounds[0].round() as i16;
-        let south_degree = bounds[1].round() as i16;
-        let east_degree = bounds[2].round() as i16;
-        let north_degree = bounds[3].round() as i16;
-        for south in south_degree..north_degree {
-            let row_base = usize::try_from(north_degree - south - 1)? * CANOPY_CELLS_PER_DEGREE;
-            for west in west_degree..east_degree {
-                let column_base = usize::try_from(west - west_degree)? * CANOPY_CELLS_PER_DEGREE;
-                for local_y in 0..CANOPY_CELLS_PER_DEGREE {
-                    let latitude = f64::from(south + 1)
-                        - (local_y as f64 + 0.5) / CANOPY_CELLS_PER_DEGREE as f64;
-                    let output = (row_base + local_y) * width + column_base;
-                    for local_x in 0..CANOPY_CELLS_PER_DEGREE {
-                        let longitude = f64::from(west)
-                            + (local_x as f64 + 0.5) / CANOPY_CELLS_PER_DEGREE as f64;
-                        let forest = terrain.cell(latitude, longitude)?.is_some_and(|cell| {
-                            f64::from(cell.canopy_percent) >= FOREST_CANOPY_THRESHOLD_PERCENT
-                        });
-                        coverage[output + local_x] = if forest { u8::MAX } else { 0 };
-                    }
-                }
+        let longitude_step = (bounds[2] - bounds[0]) / width as f64;
+        let latitude_step = (bounds[3] - bounds[1]) / height as f64;
+        for y in 0..height {
+            let latitude = bounds[3] - (y as f64 + 0.5) * latitude_step;
+            for x in 0..width {
+                let longitude = bounds[0] + (x as f64 + 0.5) * longitude_step;
+                let forest = terrain.cell(latitude, longitude)?.is_some_and(|cell| {
+                    f64::from(cell.canopy_percent) >= FOREST_CANOPY_THRESHOLD_PERCENT
+                });
+                coverage[y * width + x] = if forest { u8::MAX } else { 0 };
             }
         }
         Ok(Self::from_base(bounds, width, height, coverage))
@@ -332,7 +321,9 @@ impl Default for TileConfig {
     fn default() -> Self {
         Self {
             tile_size: 512,
-            max_zoom: 7,
+            // The bounded map reaches approximately 25 m/pixel at z3. The
+            // former continental map needed z7 for equivalent native detail.
+            max_zoom: 3,
         }
     }
 }

--- a/crates/adventuresim-world-import/src/builder.rs
+++ b/crates/adventuresim-world-import/src/builder.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use adventuresim_world_schema::{
-    CompiledWorld, SettlementAliasImport, SettlementDescriptionImport, SpatialGridSpec,
-    WorldBuildReport,
+    CompiledWorld, PLAYABLE_BOUNDS, SettlementAliasImport, SettlementDescriptionImport,
+    SpatialGridSpec, WorldBuildReport,
 };
 
 use crate::{
@@ -18,6 +18,7 @@ use crate::{
 pub struct WorldBuilder {
     year: i32,
     spatial_grid: SpatialGridSpec,
+    bounds: Option<[f64; 4]>,
 }
 
 /// Viabundus-only enrichment output used to inspect source-boundary behavior
@@ -34,6 +35,7 @@ impl WorldBuilder {
         Self {
             year,
             spatial_grid: SpatialGridSpec::default(),
+            bounds: None,
         }
     }
 
@@ -42,8 +44,19 @@ impl WorldBuilder {
         self
     }
 
+    /// Restrict source topology and settlements before enrichment begins.
+    pub const fn with_bounds(mut self, bounds: [f64; 4]) -> Self {
+        self.bounds = Some(bounds);
+        self
+    }
+
+    /// Apply the repository's authoritative MVP playable boundary.
+    pub const fn with_playable_bounds(self) -> Self {
+        self.with_bounds(PLAYABLE_BOUNDS)
+    }
+
     pub fn build_from_viabundus(self, directory: &Path) -> Result<ViabundusEnrichment> {
-        let draft = viabundus::compile(directory, self.year, self.spatial_grid)?;
+        let draft = viabundus::compile(directory, self.year, self.spatial_grid, self.bounds)?;
         Ok(ViabundusEnrichment {
             settlement_aliases: draft.settlement_aliases,
             settlement_descriptions: draft.settlement_descriptions,
@@ -65,7 +78,12 @@ impl WorldBuilder {
         drought_netcdf: &Path,
         hydrology_directory: &Path,
     ) -> Result<CompiledWorld> {
-        let draft = viabundus::compile(viabundus_directory, self.year, self.spatial_grid)?;
+        let draft = viabundus::compile(
+            viabundus_directory,
+            self.year,
+            self.spatial_grid,
+            self.bounds,
+        )?;
         let draft = elevation::enrich(draft, elevation_directory)?;
         let draft = land_use::enrich(draft, land_use_directory)?;
         let draft = forest_cover::enrich(draft, forest_cover_directory)?;

--- a/crates/adventuresim-world-import/src/main.rs
+++ b/crates/adventuresim-world-import/src/main.rs
@@ -77,8 +77,22 @@ struct Args {
 }
 
 fn main() -> ExitCode {
-    match run(Args::parse()) {
-        Ok(()) => ExitCode::SUCCESS,
+    let args = Args::parse();
+    let result = std::thread::Builder::new()
+        .name("world-import".into())
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || run(args))
+        .and_then(|thread| {
+            thread
+                .join()
+                .map_err(|_| std::io::Error::other("world importer worker thread panicked"))
+        });
+    match result {
+        Ok(Ok(())) => ExitCode::SUCCESS,
+        Ok(Err(error)) => {
+            eprintln!("error: {error}");
+            ExitCode::FAILURE
+        }
         Err(error) => {
             eprintln!("error: {error}");
             ExitCode::FAILURE
@@ -95,6 +109,7 @@ fn run(args: Args) -> Result<()> {
     }
     let world = WorldBuilder::new(args.year)
         .with_spatial_grid(SpatialGridSpec::new(args.grid_cell_size_meters))
+        .with_playable_bounds()
         .build_from_sources(
             &args.viabundus_dir,
             &args.elevation_dir,

--- a/crates/adventuresim-world-import/src/sources/drought.rs
+++ b/crates/adventuresim-world-import/src/sources/drought.rs
@@ -282,6 +282,7 @@ pub fn derive_profiles(
         viabundus_directory,
         year,
         adventuresim_world_schema::SpatialGridSpec::default(),
+        None,
     )?;
     let mut profiles = Vec::with_capacity(draft.settlements.len());
     for settlement in draft.settlements {
@@ -1014,6 +1015,7 @@ mod tests {
             Path::new(&viabundus),
             1544,
             adventuresim_world_schema::SpatialGridSpec::default(),
+            None,
         )
         .unwrap();
         let mut direct = 0;

--- a/crates/adventuresim-world-import/src/sources/potential_vegetation.rs
+++ b/crates/adventuresim-world-import/src/sources/potential_vegetation.rs
@@ -925,6 +925,7 @@ mod tests {
             Path::new(&viabundus),
             1544,
             SpatialGridSpec::default(),
+            None,
         )
         .unwrap();
         assert_eq!(raw.settlements.len(), 6_041);

--- a/crates/adventuresim-world-import/src/sources/tree_species.rs
+++ b/crates/adventuresim-world-import/src/sources/tree_species.rs
@@ -961,6 +961,7 @@ mod tests {
             Path::new(&viabundus),
             1544,
             adventuresim_world_schema::SpatialGridSpec::default(),
+            None,
         )
         .unwrap();
         let settlements = std::mem::take(&mut raw.settlements)

--- a/crates/adventuresim-world-import/src/sources/viabundus/mod.rs
+++ b/crates/adventuresim-world-import/src/sources/viabundus/mod.rs
@@ -5,6 +5,7 @@ use std::{
 
 use adventuresim_world_schema::{
     EdgeEndpoint, SpatialGridSpec, TravelEdgeKind, WorldBuildReport, WorldNodeImport,
+    coordinates_in_bounds,
 };
 use serde::{Deserialize, Deserializer, de};
 
@@ -83,6 +84,7 @@ pub(crate) fn compile(
     directory: &Path,
     year: i32,
     spatial_grid: SpatialGridSpec,
+    bounds: Option<[f64; 4]>,
 ) -> Result<WorldDraft<SettlementDraft>> {
     let nodes_path = require(directory, "nodes.csv")?;
     let edges_path = require(directory, "edges.csv")?;
@@ -184,9 +186,16 @@ pub(crate) fn compile(
             increment(&mut excluded_edges, "self-loop".into());
             continue;
         }
-        endpoint_ids.extend([from_node_id, to_node_id]);
         let from_node = &nodes_by_id[&from_node_id];
         let to_node = &nodes_by_id[&to_node_id];
+        if bounds.is_some_and(|bounds| {
+            !coordinates_in_bounds(from_node.longitude, from_node.latitude, bounds)
+                || !coordinates_in_bounds(to_node.longitude, to_node.latitude, bounds)
+        }) {
+            increment(&mut excluded_edges, "outside-playable-bounds".into());
+            continue;
+        }
+        endpoint_ids.extend([from_node_id, to_node_id]);
         let route = match kind {
             TravelEdgeKind::Ferry => TravelRouteDraft::Ferry,
             TravelEdgeKind::Land => TravelRouteDraft::Land {
@@ -229,6 +238,11 @@ pub(crate) fn compile(
         if !node.is_settlement || !node.settlement_interval.contains(year) {
             continue;
         }
+        if bounds
+            .is_some_and(|bounds| !coordinates_in_bounds(node.longitude, node.latitude, bounds))
+        {
+            continue;
+        }
         settlement_node_ids.insert(node.id);
         let population = population_by_node.get(&node.id).copied();
         let estimate = population.map(|(_, value)| value);
@@ -268,7 +282,13 @@ pub(crate) fn compile(
         let parents: Vec<_> = required_nodes
             .iter()
             .filter_map(|node_id| nodes_by_id[node_id].parent_node_id)
-            .filter(|parent_id| nodes_by_id.contains_key(parent_id))
+            .filter(|parent_id| {
+                nodes_by_id.get(parent_id).is_some_and(|parent| {
+                    bounds.is_none_or(|bounds| {
+                        coordinates_in_bounds(parent.longitude, parent.latitude, bounds)
+                    })
+                })
+            })
             .collect();
         let previous_len = required_nodes.len();
         required_nodes.extend(parents);
@@ -281,7 +301,9 @@ pub(crate) fn compile(
         .filter(|node| required_nodes.contains(&node.id))
         .map(|node| WorldNodeImport {
             id: node.id,
-            parent_node_id: node.parent_node_id,
+            parent_node_id: node
+                .parent_node_id
+                .filter(|parent| required_nodes.contains(parent)),
             latitude: node.latitude,
             longitude: node.longitude,
             is_settlement: node.is_settlement,

--- a/crates/adventuresim-world-import/tests/viabundus_fixture.rs
+++ b/crates/adventuresim-world-import/tests/viabundus_fixture.rs
@@ -32,3 +32,17 @@ fn parses_settlement_enrichment_into_domain_types() {
     assert_eq!(world.report.settlement_descriptions, 2);
     assert_eq!(world.report.deferred_settlement_descriptions["bridge"], 1);
 }
+
+#[test]
+fn playable_bounds_filter_topology_before_enrichment() {
+    let world = WorldBuilder::new(1544)
+        .with_bounds([10.68, 53.86, 10.69, 53.87])
+        .build_from_viabundus(&fixture_directory())
+        .unwrap();
+
+    assert_eq!(world.report.settlements, 1);
+    assert_eq!(world.report.nodes, 1);
+    assert_eq!(world.report.edges, 0);
+    assert_eq!(world.report.excluded_edges["outside-playable-bounds"], 1);
+    assert_eq!(world.settlement_aliases.len(), 1);
+}

--- a/crates/adventuresim-world-schema/src/lib.rs
+++ b/crates/adventuresim-world-schema/src/lib.rs
@@ -11,6 +11,39 @@ pub const WORLD_SCHEMA_VERSION: u32 = 23;
 pub const CURRENT_INFERENCE_RULES_VERSION: u32 = 7;
 pub const MAX_SOURCES_MARKDOWN_CHARS: usize = 32_768;
 
+/// Authoritative MVP playable area in `[west, south, east, north]` order.
+///
+/// Source rasters may be retained in the whole-degree envelope below, but
+/// canonical world records and generated artifacts must not expose geography
+/// outside these exact bounds.
+pub const PLAYABLE_BOUNDS: [f64; 4] = [8.965, 50.877, 11.110, 52.211];
+
+/// Smallest whole-degree source-tile envelope covering [`PLAYABLE_BOUNDS`].
+pub const PLAYABLE_SOURCE_TILE_BOUNDS: [i16; 4] = [8, 50, 12, 53];
+
+pub fn coordinates_in_bounds(longitude: f64, latitude: f64, bounds: [f64; 4]) -> bool {
+    let [west, south, east, north] = bounds;
+    longitude.is_finite()
+        && latitude.is_finite()
+        && longitude >= west
+        && longitude <= east
+        && latitude >= south
+        && latitude <= north
+}
+
+#[cfg(test)]
+mod playable_bounds_tests {
+    use super::*;
+
+    #[test]
+    fn playable_bounds_include_edges_and_reject_nonfinite_or_external_points() {
+        assert!(coordinates_in_bounds(8.965, 50.877, PLAYABLE_BOUNDS));
+        assert!(coordinates_in_bounds(11.110, 52.211, PLAYABLE_BOUNDS));
+        assert!(!coordinates_in_bounds(8.964, 51.0, PLAYABLE_BOUNDS));
+        assert!(!coordinates_in_bounds(f64::NAN, 51.0, PLAYABLE_BOUNDS));
+    }
+}
+
 /// Source and inference notes are deliberately unstructured Markdown for a
 /// future debug view. Keep the payload bounded even though the contents are
 /// not parsed into canonical provenance types.

--- a/crates/strategic-web/src/strategic_map.rs
+++ b/crates/strategic-web/src/strategic_map.rs
@@ -30,7 +30,7 @@ pub(crate) const TILE_PATH_PREFIX: &str = "/map/tiles/";
 pub(crate) const DATA_LICENSE_PATH: &str = "/map/data-license";
 const DATA_LICENSE: &str = include_str!("../../../MAP_DATA_LICENSE.md");
 const PACKAGE_SCHEMA: u32 = 3;
-const RENDERER_REVISION: u32 = 7;
+const RENDERER_REVISION: u32 = 8;
 const MIN_TILE_SIZE: u32 = 64;
 const MAX_TILE_SIZE: u32 = 2_048;
 const MAX_TILE_ENTRIES: usize = 100_000;
@@ -349,6 +349,24 @@ fn has_geographic_quest(quest: &Quest) -> bool {
         && quest.location_coord_y.is_finite()
 }
 
+fn has_geographic_source_in_bounds(settlement: &Settlement, bounds: [f64; 4]) -> bool {
+    has_geographic_source(settlement)
+        && adventuresim_world_schema::coordinates_in_bounds(
+            settlement.coord_x,
+            settlement.coord_y,
+            bounds,
+        )
+}
+
+fn has_geographic_quest_in_bounds(quest: &Quest, bounds: [f64; 4]) -> bool {
+    has_geographic_quest(quest)
+        && adventuresim_world_schema::coordinates_in_bounds(
+            quest.location_coord_x,
+            quest.location_coord_y,
+            bounds,
+        )
+}
+
 fn settlement_symbol_kind(category: &SettlementCategory) -> &'static str {
     match category {
         SettlementCategory::City | SettlementCategory::Capital => "city",
@@ -393,24 +411,25 @@ pub fn strategic_map(
     terrain_route: Option<&adventuresim_terrain::RoutePlan>,
 ) -> Markup {
     let package = &map.package;
-    let current = settlements
-        .iter()
-        .find(|settlement| settlement.id == current_id);
+    let current = settlements.iter().find(|settlement| {
+        settlement.id == current_id && has_geographic_source_in_bounds(settlement, package.bounds)
+    });
     let (origin_x, origin_y) = current.map_or((WIDTH / 2.0, HEIGHT / 2.0), |settlement| {
         project(settlement.coord_x, settlement.coord_y, package.bounds)
     });
     let settlement_destination = selected_id
         .and_then(|selected_id| {
             settlements.iter().find(|settlement| {
-                settlement.id == selected_id && has_geographic_source(settlement)
+                settlement.id == selected_id
+                    && has_geographic_source_in_bounds(settlement, package.bounds)
             })
         })
         .map(|settlement| project(settlement.coord_x, settlement.coord_y, package.bounds));
     let quest_destination = selected_id
         .and_then(|selected_id| {
-            quests
-                .iter()
-                .find(|quest| quest.id == selected_id && has_geographic_quest(quest))
+            quests.iter().find(|quest| {
+                quest.id == selected_id && has_geographic_quest_in_bounds(quest, package.bounds)
+            })
         })
         .map(|quest| {
             project(
@@ -479,7 +498,7 @@ pub fn strategic_map(
                                 x1=(format!("{origin_x:.3}")) y1=(format!("{origin_y:.3}"))
                                 x2=(format!("{destination_x:.3}")) y2=(format!("{destination_y:.3}")) {}
                         }
-                        @for settlement in settlements.iter().filter(|settlement| has_geographic_source(settlement)) {
+                        @for settlement in settlements.iter().filter(|settlement| has_geographic_source_in_bounds(settlement, package.bounds)) {
                             @let (x, y) = project(settlement.coord_x, settlement.coord_y, package.bounds);
                             @let is_current = settlement.id == current_id;
                             @let is_connected = connected_ids.contains(settlement.id.as_str());
@@ -511,7 +530,7 @@ pub fn strategic_map(
                                 }
                             }
                         }
-                        @for quest in quests.iter().filter(|quest| has_geographic_quest(quest)) {
+                        @for quest in quests.iter().filter(|quest| has_geographic_quest_in_bounds(quest, package.bounds)) {
                             @let (x, y) = project(quest.location_coord_x, quest.location_coord_y, package.bounds);
                             @let is_selected = selected_id == Some(quest.id.as_str());
                             @let is_active = quest.status != QuestStatus::Available;
@@ -541,7 +560,7 @@ pub fn strategic_map(
                         // Settlement symbols take pointer priority when a generated quest happens
                         // to overlap them. The visible/accessibility link remains above; this
                         // transparent duplicate is mouse-only and is rendered last in SVG order.
-                        @for settlement in settlements.iter().filter(|settlement| has_geographic_source(settlement)) {
+                        @for settlement in settlements.iter().filter(|settlement| has_geographic_source_in_bounds(settlement, package.bounds)) {
                             @let (x, y) = project(settlement.coord_x, settlement.coord_y, package.bounds);
                             a href=(format!("{map_path}?destination={}", settlement.id))
                                 class="map-settlement-hit-link" aria-hidden="true" tabindex="-1" {
@@ -776,6 +795,7 @@ mod tests {
             settlement("origin", "Origin", 10.0, 53.0),
             settlement("near", "Nearby", 11.0, 53.2),
             settlement("far", "Far away", 20.0, 60.0),
+            settlement("outside", "Outside package", 40.0, 80.0),
             source_less,
         ];
         let connected = BTreeSet::from(["near"]);
@@ -799,6 +819,7 @@ mod tests {
         assert!(markup.contains("?destination=near"));
         assert!(markup.contains("Nearby, direct route available"));
         assert!(markup.contains("Far away, no direct route"));
+        assert!(!markup.contains("Outside package"));
         assert!(!markup.contains("?destination=demo"));
         assert!(!markup.contains("role=\"img\""));
         assert!(markup.contains("aria-current=\"true\""));

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,15 @@ production NPC rows or persist tactical state.
 
 ## Offline world compilation
 
+The MVP playable area is the exact EPSG:4326 box
+`[8.965, 50.877, 11.110, 52.211]`. The shared world-schema constant is the
+authority for canonical import, map clipping, terrain lookup, and routing.
+Viabundus topology is filtered before environmental enrichment: settlements
+and edge endpoints outside the box are not canonical world records. Raster
+readers may consume the smallest enclosing whole-degree source cells
+`[8, 50, 12, 53]`, but generated manifests and runtime access retain the exact
+decimal boundary.
+
 Raw historical and geographic datasets are compiled outside SpacetimeDB by the
 native `adventuresim-world-import` crate. Each upstream format has an isolated
 source module; the outer builder combines them into a validated canonical

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -283,7 +283,7 @@ slopes and multi-scale relief, and reduces every available prepared forest tile
 into bounded canopy-density and leaf-type regions. Missing forest tiles remain absent and their coverage is
 reported as partial; they do not block map generation. The command clips and
 simplifies presentation geometry, renders a Paper AVIF pyramid through zoom
-level 7 (native detail at 5–16°E, 50–56°N), concatenates the independently addressable images into one pack,
+level 3 (approximately 25 m/pixel native detail within the exact 8.965–11.110°E, 50.877–52.211°N playable bounds), concatenates the independently addressable images into one pack,
 and embeds a digest
 over every presentation-affecting package field. The
 versioned filename is stable rather than content-addressed. Legacy Viabundus
@@ -353,7 +353,7 @@ bundle, set `STRATEGIC_MAP_PREVIEW_PNG` to an output path and run the focused
 `representative_paper_tile_has_deterministic_png_preview_hook` test with the
 `strategic-map-renderer` feature.
 
-The deployment manifest is schema 3 with renderer revision 7. It contains only
+The deployment manifest is schema 3 with renderer revision 8. It contains only
 bounds, attribution/source metadata, coverage counts, the tile index, and
 content digests; source roads, water rings, elevation cells/contours, and
 forest regions stay in the offline compiler and are not shipped to
@@ -408,7 +408,7 @@ Every source has `plan-*`, `init-*`, and `verify-*` targets. EU-Trees4F is an
 automated anonymous immutable download (`tree-species`); it is size/hash
 checked and atomically published. Copernicus forest uses the dedicated
 `scripts/init_forest_cover.py` workflow: it reads redacted Sentinel Hub OAuth
-credentials from `.env`, prepares the official 2018 TCD/DLT northern-Germany
+credentials from `.env`, prepares the official 2018 TCD/DLT playable-area
 coverage, resumes interrupted requests, and atomically publishes an exact
 size/SHA-256 inventory. Religion is a validation-only workflow and never
 mirrors the rights-reserved IEG images. GLO-30 (`glo30`) and EU-Hydro
@@ -432,8 +432,8 @@ The stacked compiler requires them; override that directory with
 `--land-use-dir`.
 
 Initialize the paired Copernicus TCD/DLT one-degree GeoTIFFs documented in
-`docs/FOREST_COVER.md` with `just init-forest-cover`. The default 66-tile
-northern-Germany set is written under
+`docs/FOREST_COVER.md` with `just init-forest-cover`. The default 12-tile
+playable-area set is written under
 `target/world-data-sources/raw/forest-cover/`; the world compiler can override
 that directory with `--forest-cover-dir`.
 

--- a/docs/ELEVATION.md
+++ b/docs/ELEVATION.md
@@ -55,8 +55,9 @@ elevation is never used as a proxy for terrain along an entire road edge.
 
 ## Native strategic terrain pack
 
-`build-strategic-map` compiles the initialized 5–16°E, 50–56°N source tiles
-into `terrain-routing-v1.json` and `terrain-routing-v1.pack`. The pack preserves
+`build-strategic-map` reads the 12 whole-degree source tiles intersecting the
+exact 8.965–11.110°E, 50.877–52.211°N playable bounds into
+`terrain-routing-v1.json` and `terrain-routing-v1.pack`. The pack preserves
 each source tile's native 1,800/2,400/3,600 by 3,600 grid instead of expanding
 it into database rows or `ElevationCell` structs. Independently deflated
 256×256 chunks carry signed elevation, road/open/sparse-woods/deep-woods/water
@@ -76,8 +77,9 @@ deterministic 32 MiB LRU. The compressed pack remains range-readable on disk,
 is size-checked before opening, and is stream-hashed at startup, so the complete
 native grid never resides in RAM. Chunk I/O and decompression occur outside the
 cache lock before a race-safe insert.
-Northern Germany's z7 paper tiles sample this pack. The rest of the world also
-has generalized z7 tiles, so zooming never produces blank uncovered cells.
+The bounded map's z3 paper tiles sample this pack at approximately 25 m/pixel.
+Every presentation tile lies inside native-detail coverage, so close zooming
+does not need continental fallback tiles.
 
 The same pack is the strategic pathfinding input. A bounded search window begins
 at the native nominal 30 m spacing and coarsens deterministically only when the
@@ -88,11 +90,9 @@ Water is impassable except where imported infrastructure marks a crossing.
 Search costs use seconds internally so rounding does not compound at every
 30 m cell; persisted journey time is rounded once to whole strategic minutes.
 
-The initialized land-focused GLO-30 request omits five reviewed, all-water
-North Sea cells (54–55°N at 5–7°E). The offline pack compiler represents only
-that explicit allowlist at the native 2,400×3,600 latitude-band geometry as
-zero-elevation impassable water. Any other missing source tile remains a hard
-build error; the exception cannot hide a land-coverage gap.
+Any missing source tile intersecting the playable boundary remains a hard
+build error. Whole source cells are retained internally, while the manifest,
+cell lookup, and route planner enforce the exact decimal playable bounds.
 
 Routes are simplified to at most 512 geographic points for transport and are
 stored only for an active journey together with exact ordered terrain-time

--- a/docs/FOREST_COVER.md
+++ b/docs/FOREST_COVER.md
@@ -10,7 +10,7 @@ about the exact historical tree cover around a settlement.
 - DLT dataset DOI: <https://doi.org/10.2909/82f93572-9888-47ef-97a1-5cac5985a26a>
 - Terms: Copernicus full, free, and open data policy
 
-Initialize the default northern-Germany coverage with:
+Initialize the default playable-area coverage with:
 
 ```bash
 just plan-forest-cover
@@ -25,13 +25,18 @@ credentials. They do not authorize direct CDSE OData or S3 object downloads;
 the initializer instead uses the official Sentinel Hub Process API and its
 public CLMS BYOC collections.
 
-The default integer EPSG:4326 bounds are 5-16 degrees east and 50-56 degrees
-north: 66 one-degree tiles covering Germany and useful adjoining parts of the
-Netherlands, Denmark, Poland, Czechia, and the Baltic coast. Override them with
-`--west`, `--south`, `--east`, and `--north`. Each request is independently
-restartable in a staging directory. The existing source directory is replaced
-only after all 132 output rasters verify; the previous directory is retained
-below `target/world-data-backups/`.
+The authoritative playable bounds are 8.965-11.110 degrees east and
+50.877-52.211 degrees north. The default integer EPSG:4326 source envelope is
+therefore 8-12 degrees east and 50-53 degrees north: the smallest 12
+one-degree tiles that cover the playable area. Override them with `--west`,
+`--south`, `--east`, and `--north`. Each request is independently restartable
+in a staging directory. The existing source directory is replaced only after
+all 24 output rasters verify; the previous directory is retained below
+`target/world-data-backups/`.
+When an existing installation already contains valid cells from the requested
+envelope, preparation reuses them in staging instead of downloading them
+again. This makes narrowing an older broad installation cheap and preserves
+the broad set in the normal recoverable backup.
 
 The prepared source inventory records the exact byte size and SHA-256 of every
 consumed TCD/DLT tile. A source-separated world-data bundle therefore pins the

--- a/docs/VIABUNDUS.md
+++ b/docs/VIABUNDUS.md
@@ -1,5 +1,12 @@
 # Viabundus world data
 
+Canonical MVP compilation retains only nodes, settlements, and complete road
+edges whose endpoints are within `[8.965, 50.877, 11.110, 52.211]`. This
+filter runs before environmental enrichment, so out-of-bounds settlements do
+not consume raster sampling work or enter SpacetimeDB. The independently
+generated presentation map clips full-precision road and water geometry at the
+same exact boundary.
+
 The strategic world-import pipeline uses **Viabundus Pre-modern Street Map 2**,
 version 2 (released 25 April 2025), edited by Bart Holterman et al.
 
@@ -80,7 +87,7 @@ distributed under CC BY-SA 4.0 rather than the repository software's AGPL.
 Every bundle must retain the generated `STRATEGIC_MAP_DATA_LICENSE.md` notice
 or provide a reasonably prominent link to the canonical `MAP_DATA_LICENSE.md`;
 the server exposes the latter at `/map/data-license`.
-The compact schema-3 deployment manifest carries renderer revision 7, reviewed
+The compact schema-3 deployment manifest carries renderer revision 8, reviewed
 source identities, coverage counts, and the indexed AVIF pyramid, but not the
 offline roads, compound water rings, elevation cells/contours, or forest
 regions used to render it. Its embedded SHA-256 covers every deployed field;

--- a/scripts/init_forest_cover.py
+++ b/scripts/init_forest_cover.py
@@ -9,6 +9,7 @@ import json
 import os
 from pathlib import Path
 import re
+import shutil
 import struct
 import tempfile
 import time
@@ -31,7 +32,7 @@ FORMAT = "adventuresim-copernicus-forest-2018-v1"
 SOURCE = "clms-forest-2018"
 VERSION = "2018"
 PIXELS = 1_000
-DEFAULT_BOUNDS = (5, 50, 16, 56)
+DEFAULT_BOUNDS = (8, 50, 12, 53)
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
 MAX_TOTAL_BYTES = 512 * 1024 * 1024
 ATTEMPTS = 6
@@ -451,6 +452,15 @@ def prepare(output: Path, env_file: Path, bounds: tuple[int, int, int, int]) -> 
                         continue
                     except RuntimeError:
                         destination.unlink(missing_ok=True)
+                existing = output / destination.name
+                if existing.is_file():
+                    try:
+                        validate_tiff(existing, latitude, longitude)
+                        shutil.copy2(existing, destination)
+                        complete += 1
+                        continue
+                    except RuntimeError:
+                        pass
                 print(f"[{complete + 1}/{len(names)}] {destination.name}", flush=True)
                 download_tiff(provider, kind, latitude, longitude, destination)
                 complete += 1

--- a/scripts/test_init_forest_cover.py
+++ b/scripts/test_init_forest_cover.py
@@ -38,15 +38,23 @@ class ForestCoverInitializerTests(unittest.TestCase):
             ):
                 self.assertEqual(module.credentials(path), ("environment", "secret"))
 
-    def test_default_plan_covers_northern_germany(self):
+    def test_default_plan_covers_playable_area_source_envelope(self):
         with tempfile.TemporaryDirectory() as directory:
             env = Path(directory) / ".env"
-            env.write_text("COPERNICUS_CLIENT_ID=x\nCOPERNICUS_CLIENT_SECRET=y\n")
+            client_id = "credential-client-id-marker"
+            client_secret = "credential-client-secret-marker"
+            env.write_text(
+                f"COPERNICUS_CLIENT_ID={client_id}\n"
+                f"COPERNICUS_CLIENT_SECRET={client_secret}\n"
+            )
             result = module.plan(env, Path(directory) / "forest", module.DEFAULT_BOUNDS)
-            self.assertEqual(result["degree_tiles"], 66)
-            self.assertEqual(result["prepared_files"], 132)
+            self.assertEqual(result["bounds"], [8, 50, 12, 53])
+            self.assertEqual(result["degree_tiles"], 12)
+            self.assertEqual(result["prepared_files"], 24)
             self.assertEqual(result["credential_preflight"], "present (values redacted)")
-            self.assertNotIn("x", json.dumps(result))
+            serialized = json.dumps(result)
+            self.assertNotIn(client_id, serialized)
+            self.assertNotIn(client_secret, serialized)
 
     def test_tile_names_are_importer_compatible(self):
         self.assertEqual(module.tile_key(53, 9), "N53_E009")


### PR DESCRIPTION
## Summary

- define the authoritative playable bounds as `[8.965, 50.877, 11.110, 52.211]`
- filter canonical Viabundus topology and settlements to those bounds
- limit forest acquisition to the 12 required one-degree source tiles, reusing verified existing rasters
- clip strategic-map raster layers and terrain chunks to the exact playable area
- reduce the bounded map pyramid to zoom 3 and filter strategic-web pins to package bounds
- document the new source envelope and bounded generation workflow

## Why

The map generator and world importer previously used broad continental or northern-Germany bounds. This retained unnecessary topology and generated a very large tile pyramid, while forest coverage—the most constrained per-tile source—was downloaded far beyond the intended game area.

## Impact

Generated strategic-map and terrain packages now contain only data intersecting the playable box. Canonical world imports retain only connected topology whose endpoints are inside the box. The default forest workflow requires 12 TCD/DLT tile pairs instead of the previous broad installation.

The importer also runs its source build on a larger worker-thread stack so large real datasets do not overflow the default Windows main-thread stack.

## Validation

- focused Cargo checks for world schema/import, terrain builder, and strategic web
- 17 importer binary tests
- 24 strategic-map renderer tests
- 18 terrain builder tests
- 17 strategic-map web tests
- 8 forest initializer tests
- `git diff --check`

## Known local-data finding

A fresh fully enriched `world-1544.json` remains blocked locally because the installed Elbe EU-Hydro SQLite database lacks OGC GeoPackage metadata and a checked source inventory. The bounded map and terrain artifacts generate successfully; this PR does not attempt to replace that external source.
