### PR TITLE
Fix strategic world import recovery

### DIFF
--- a/crates/adventuresim-world-import/src/lib.rs
+++ b/crates/adventuresim-world-import/src/lib.rs
@@ -19,3 +19,4 @@ pub use sources::forest_cover::{
     PREPARED_FOREST_FORMAT, PreparedForestRaster, read_prepared_forest_raster,
     validate_prepared_forest_manifest,
 };
+pub use validation::validate as validate_world;

--- a/crates/adventuresim-world-import/src/main.rs
+++ b/crates/adventuresim-world-import/src/main.rs
@@ -3,7 +3,9 @@ use std::{
     process::{Command, ExitCode},
 };
 
-use adventuresim_world_import::{Error, Result, WorldBuilder, derive_owda_profiles};
+use adventuresim_world_import::{
+    Error, Result, WorldBuilder, derive_owda_profiles, validate_world,
+};
 use adventuresim_world_schema::{
     AgriculturalLimitation, AvailableWaterCapacity, CationExchangeCapacity, CompiledWorld,
     CrossingTraversal, CrossingWatercourse, DerivedHistoricalVegetationCover,
@@ -64,6 +66,12 @@ struct Args {
     grid_cell_size_meters: GridCellSizeMeters,
     #[arg(long)]
     output: Option<PathBuf>,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "validate and optionally load an existing compiled world artifact"
+    )]
+    input: Option<PathBuf>,
     #[arg(long)]
     load: bool,
     #[arg(long, default_value = "spacetime")]
@@ -107,6 +115,24 @@ fn run(args: Args) -> Result<()> {
     if let Some(output) = &args.derive_owda_profiles {
         return derive_owda_profiles(&args.viabundus_dir, &args.drought_netcdf, output, args.year);
     }
+    if let Some(input) = &args.input {
+        let mut artifact = std::fs::read(input)?;
+        if artifact.last() == Some(&b'\n') {
+            artifact.pop();
+        }
+        if artifact.last() == Some(&b'\r') {
+            artifact.pop();
+        }
+        let world: CompiledWorld = serde_json::from_slice(&artifact)?;
+        validate_world(&world)?;
+        let artifact_id = blake3::hash(&artifact).to_hex().to_string();
+        print_world_summary(&world);
+        println!("Read compiled world from {}", input.display());
+        if args.load {
+            load_world(&world, &artifact_id, &args)?;
+        }
+        return Ok(());
+    }
     let world = WorldBuilder::new(args.year)
         .with_spatial_grid(SpatialGridSpec::new(args.grid_cell_size_meters))
         .with_playable_bounds()
@@ -134,7 +160,19 @@ fn run(args: Args) -> Result<()> {
     let artifact_id = blake3::hash(&artifact).to_hex().to_string();
     artifact.push(b'\n');
     std::fs::write(&output, artifact)?;
-    println!("{}", serde_json::to_string_pretty(&world.report)?);
+    print_world_summary(&world);
+    println!("Wrote compiled world to {}", output.display());
+    if args.load {
+        load_world(&world, &artifact_id, &args)?;
+    }
+    Ok(())
+}
+
+fn print_world_summary(world: &CompiledWorld) {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&world.report).expect("world report serializes")
+    );
     println!(
         "Source manifest {} ({} distributions):",
         world.metadata.manifest_digest,
@@ -152,11 +190,6 @@ fn run(args: Args) -> Result<()> {
             }
         );
     }
-    println!("Wrote compiled world to {}", output.display());
-    if args.load {
-        load_world(&world, &artifact_id, &args)?;
-    }
-    Ok(())
 }
 
 fn load_world(world: &CompiledWorld, artifact_id: &str, args: &Args) -> Result<()> {
@@ -259,7 +292,10 @@ fn serialize_batches<T>(
     batch_size: usize,
     encode: fn(&T) -> Result<Value>,
 ) -> Result<Vec<Vec<Value>>> {
-    let rows = rows.iter().map(encode).collect::<Result<Vec<_>>>()?;
+    let rows = rows
+        .iter()
+        .map(|row| encode(row).map(normalize_variant_keys))
+        .collect::<Result<Vec<_>>>()?;
     let mut batches = Vec::new();
     let mut batch = Vec::new();
     let mut code_units = 2;
@@ -288,6 +324,33 @@ fn serialize_batches<T>(
         batches.push(batch);
     }
     Ok(batches)
+}
+
+fn normalize_variant_keys(value: Value) -> Value {
+    match value {
+        Value::Array(values) => {
+            Value::Array(values.into_iter().map(normalize_variant_keys).collect())
+        }
+        Value::Object(values) => Value::Object(
+            values
+                .into_iter()
+                .map(|(key, value)| {
+                    let key = key
+                        .chars()
+                        .next()
+                        .filter(|character| character.is_ascii_uppercase())
+                        .map(|first| {
+                            let mut normalized = first.to_ascii_lowercase().to_string();
+                            normalized.push_str(&key[first.len_utf8()..]);
+                            normalized
+                        })
+                        .unwrap_or(key);
+                    (key, normalize_variant_keys(value))
+                })
+                .collect(),
+        ),
+        scalar => scalar,
+    }
 }
 
 fn encode_world_node(node: &WorldNodeImport) -> Result<Value> {
@@ -529,36 +592,36 @@ fn encode_religious_status(status: SettlementReligiousStatus) -> Value {
     };
     let arrangement = |value| match value {
         WesternChristianArrangement::CatholicLutheran { church } => json!({
-            "CatholicLutheran": { "church": enum_unit(match church {
+            "CatholicLutheran": enum_unit(match church {
                 adventuresim_world_schema::CatholicLutheranChurch::RomanCatholic => "RomanCatholic",
                 adventuresim_world_schema::CatholicLutheranChurch::Lutheran => "Lutheran",
-            }) }
+            })
         }),
         WesternChristianArrangement::CatholicReformed { church } => json!({
-            "CatholicReformed": { "church": enum_unit(match church {
+            "CatholicReformed": enum_unit(match church {
                 adventuresim_world_schema::CatholicReformedChurch::RomanCatholic => "RomanCatholic",
                 adventuresim_world_schema::CatholicReformedChurch::Reformed => "Reformed",
-            }) }
+            })
         }),
         WesternChristianArrangement::LutheranReformed { church } => json!({
-            "LutheranReformed": { "church": enum_unit(match church {
+            "LutheranReformed": enum_unit(match church {
                 adventuresim_world_schema::LutheranReformedChurch::Lutheran => "Lutheran",
                 adventuresim_world_schema::LutheranReformedChurch::Reformed => "Reformed",
-            }) }
+            })
         }),
     };
     match status {
         SettlementReligiousStatus::Established { religion: value } => {
-            json!({ "Established": { "religion": religion(value) } })
+            json!({ "Established": religion(value) })
         }
         SettlementReligiousStatus::Parity { arrangement: value } => {
-            json!({ "Parity": { "arrangement": arrangement(value) } })
+            json!({ "Parity": arrangement(value) })
         }
         SettlementReligiousStatus::MultiConfessional { arrangement: value } => {
-            json!({ "MultiConfessional": { "arrangement": arrangement(value) } })
+            json!({ "MultiConfessional": arrangement(value) })
         }
         SettlementReligiousStatus::LocallyDetermined { church } => {
-            json!({ "LocallyDetermined": { "church": religion(church) } })
+            json!({ "LocallyDetermined": religion(church) })
         }
     }
 }
@@ -1199,20 +1262,20 @@ mod tests {
         let batches = serialize_batches(&[edge], 100, encode_travel_edge).unwrap();
         assert_eq!(
             batches[0][0]["route"],
-            serde_json::json!({ "Land": { "bridge": { "some": { "To": [] } }, "water_crossings": [] } })
+            serde_json::json!({ "land": { "bridge": { "some": { "to": [] } }, "water_crossings": [] } })
         );
         assert_eq!(
             batches[0][0]["toll"],
-            serde_json::json!({ "some": { "From": [] } })
+            serde_json::json!({ "some": { "from": [] } })
         );
         assert_eq!(batches[0][0]["sources"], "- Test source.");
         assert_eq!(
             batches[0][0]["terrain"]["class"],
-            serde_json::json!({ "Flat": [] })
+            serde_json::json!({ "flat": [] })
         );
         assert_eq!(
             batches[0][0]["terrain"]["encounter_tags"][0],
-            serde_json::json!({ "Flat": [] })
+            serde_json::json!({ "flat": [] })
         );
     }
 
@@ -1349,7 +1412,7 @@ mod tests {
         assert_eq!(
             encode_settlement(&settlement).unwrap()["religious_status"],
             serde_json::json!({
-                "Established": { "religion": { "RomanCatholic": [] } }
+                "Established": { "RomanCatholic": [] }
             })
         );
         settlement.religious_status = SettlementReligiousStatus::MultiConfessional {
@@ -1361,9 +1424,7 @@ mod tests {
             encode_settlement(&settlement).unwrap()["religious_status"],
             serde_json::json!({
                 "MultiConfessional": {
-                    "arrangement": {
-                        "CatholicLutheran": { "church": { "Lutheran": [] } }
-                    }
+                    "CatholicLutheran": { "Lutheran": [] }
                 }
             })
         );

--- a/crates/adventuresim-world-import/src/sources/elevation.rs
+++ b/crates/adventuresim-world-import/src/sources/elevation.rs
@@ -356,10 +356,14 @@ impl Raster {
 
     fn pixel(&self, latitude: f64, longitude: f64) -> Result<(u32, u32)> {
         let (mut column, mut row) = self.georeference.nearest_pixel(latitude, longitude);
-        if longitude == 180.0 && column == i64::from(self.width) {
+        // Pixel-is-point tiles place their edge samples half a pixel inside the
+        // nominal degree boundary. Coordinates in that final half pixel round
+        // one index past the raster even though the nominal tile's edge sample
+        // remains closer than the adjacent tile's first sample.
+        if column == i64::from(self.width) {
             column -= 1;
         }
-        if latitude == -90.0 && row == i64::from(self.height) {
+        if row == i64::from(self.height) {
             row -= 1;
         }
         if column < 0 || row < 0 || column >= i64::from(self.width) || row >= i64::from(self.height)
@@ -530,27 +534,14 @@ impl RasterMetadata {
         })
     }
 
-    fn nearest_sample_tile(
-        &self,
-        mut tile: TileKey,
-        latitude: f64,
-        longitude: f64,
-    ) -> Result<TileKey> {
+    fn nearest_sample_tile(&self, tile: TileKey, latitude: f64, longitude: f64) -> Result<TileKey> {
         let (column, row) = self.georeference.nearest_pixel(latitude, longitude);
-        if column == i64::from(self.width) {
-            if tile.west < 179 {
-                tile.west += 1;
-            }
-        } else if !(0..i64::from(self.width)).contains(&column) {
+        if column != i64::from(self.width) && !(0..i64::from(self.width)).contains(&column) {
             return Err(Error::Validation(format!(
                 "longitude {longitude} is outside its parsed GLO-30 point grid"
             )));
         }
-        if row == i64::from(self.height) {
-            if tile.south > -90 {
-                tile.south -= 1;
-            }
-        } else if !(0..i64::from(self.height)).contains(&row) {
+        if row != i64::from(self.height) && !(0..i64::from(self.height)).contains(&row) {
             return Err(Error::Validation(format!(
                 "latitude {latitude} is outside its parsed GLO-30 point grid"
             )));
@@ -627,14 +618,9 @@ mod tests {
             georeference: raster.georeference,
         };
         let tile = TileKey { south: 48, west: 0 };
-        assert_eq!(
-            metadata.nearest_sample_tile(tile, 48.5, 0.7).unwrap().west,
-            1
-        );
-        assert_eq!(
-            metadata.nearest_sample_tile(tile, 48.3, 0.5).unwrap().south,
-            47
-        );
+        assert_eq!(metadata.nearest_sample_tile(tile, 48.5, 0.7).unwrap(), tile);
+        assert_eq!(metadata.nearest_sample_tile(tile, 48.3, 0.5).unwrap(), tile);
+        assert_eq!(raster.pixel(48.3, 0.7).unwrap(), (2, 2));
     }
 
     #[test]

--- a/crates/adventuresim-world-import/src/sources/hydrology.rs
+++ b/crates/adventuresim-world-import/src/sources/hydrology.rs
@@ -811,6 +811,11 @@ fn read_feature_table(
             "NULL".into()
         }
     };
+    // Some official EU-Hydro basin packages declare their categorical code
+    // fields as REAL even though every populated value is integral. Normalize
+    // those codes at the source boundary so rusqlite does not reject the row
+    // before the canonical sentinel and range handling below can run.
+    let integer_value = |name: &str| format!("CAST({} AS INTEGER)", value(name));
     let rtree = format!("rtree_{table}_{geometry_column}");
     let use_rtree = bounds.is_some()
         && layout.integer_primary_key.is_some()
@@ -849,9 +854,9 @@ fn read_feature_table(
     let sql = format!(
         "SELECT f.{}, {}, {}, {}, {} FROM {from}{where_clause}{order_by}",
         quote_identifier(geometry_column),
-        value("STRAHLER"),
-        value("HYP"),
-        value("NVS"),
+        integer_value("STRAHLER"),
+        integer_value("HYP"),
+        integer_value("NVS"),
         value("AREA_GEO"),
     );
     let mut statement = connection

--- a/crates/adventuresim-world-import/src/validation.rs
+++ b/crates/adventuresim-world-import/src/validation.rs
@@ -518,9 +518,33 @@ pub fn validate(world: &CompiledWorld) -> Result<()> {
             world.settlements.len(),
         )
     {
-        return Err(Error::Validation(
-            "build report counts do not match the compiled world".into(),
-        ));
+        let actual = serde_json::json!({
+            "nodes": world.nodes.len(),
+            "edges": world.edges.len(),
+            "settlements": world.settlements.len(),
+            "settlement_aliases": world.settlement_aliases.len(),
+            "settlement_descriptions": world.settlement_descriptions.len(),
+            "route_crossings": world.edges.iter().filter(|edge| edge.route.has_crossing()).count(),
+            "toll_edges": world.edges.iter().filter(|edge| edge.toll.is_some()).count(),
+            "tree_species_fallbacks": world.settlements.iter().filter(|settlement| matches!(settlement.tree_species, TreeSpeciesProfile::Inferred(_))).count(),
+            "tree_species_candidates": world.settlements.iter().map(|settlement| match &settlement.tree_species {
+                TreeSpeciesProfile::Modeled(profile) => profile.candidates().len(),
+                TreeSpeciesProfile::Inferred(profile) => profile.species().len(),
+            }).sum::<usize>(),
+            "soil_fallbacks": world.settlements.iter().filter(|settlement| settlement.soil.evidence == SoilEvidence::DeterministicInference).count(),
+            "geology_fallbacks": world.settlements.iter().filter(|settlement| matches!(settlement.geology, SurfaceGeology::Inferred(_))).count(),
+            "drought_fallbacks": world.settlements.iter().filter(|settlement| matches!(settlement.drought, DroughtProfile::Inferred(_))).count(),
+            "hydrology_landlocked_settlements": world.settlements.iter().filter(|settlement| settlement.hydrology == SettlementHydrology::default()).count(),
+            "hydrology_edge_crossings": world.edges.iter().map(|edge| match &edge.route {
+                TravelRoute::Land(route) => route.water_crossings.len(),
+                TravelRoute::Ferry(_) => 0,
+            }).sum::<usize>(),
+            "ferry_edges": world.edges.iter().filter(|edge| matches!(edge.route, TravelRoute::Ferry(_))).count(),
+        });
+        return Err(Error::Validation(format!(
+            "build report counts do not match the compiled world; report={} actual={actual}",
+            serde_json::to_string(&world.report).expect("world build report serializes")
+        )));
     }
     Ok(())
 }
@@ -689,11 +713,12 @@ fn land_use_counts_are_consistent(
     normalized: usize,
     settlements: usize,
 ) -> bool {
+    const HYDE_SOURCE_FILES: usize = 4;
     samples == settlements
         && fallbacks <= samples
         && normalized <= samples - fallbacks
-        && ((settlements == 0 && (rasters == 0 || rasters == 5))
-            || (settlements > 0 && rasters == 5))
+        && ((settlements == 0 && (rasters == 0 || rasters == HYDE_SOURCE_FILES))
+            || (settlements > 0 && rasters == HYDE_SOURCE_FILES))
 }
 
 fn elevation_counts_are_consistent(
@@ -835,13 +860,13 @@ mod tests {
 
     #[test]
     fn land_use_report_requires_all_source_rasters_and_samples() {
-        assert!(land_use_counts_are_consistent(5, 3, 1, 1, 3));
+        assert!(land_use_counts_are_consistent(4, 3, 1, 1, 3));
         assert!(land_use_counts_are_consistent(0, 0, 0, 0, 0));
-        assert!(land_use_counts_are_consistent(5, 0, 0, 0, 0));
-        assert!(!land_use_counts_are_consistent(4, 3, 0, 0, 3));
-        assert!(!land_use_counts_are_consistent(5, 2, 0, 0, 3));
-        assert!(!land_use_counts_are_consistent(5, 3, 4, 0, 3));
-        assert!(!land_use_counts_are_consistent(5, 3, 1, 3, 3));
+        assert!(land_use_counts_are_consistent(4, 0, 0, 0, 0));
+        assert!(!land_use_counts_are_consistent(5, 3, 0, 0, 3));
+        assert!(!land_use_counts_are_consistent(4, 2, 0, 0, 3));
+        assert!(!land_use_counts_are_consistent(4, 3, 4, 0, 3));
+        assert!(!land_use_counts_are_consistent(4, 3, 1, 3, 3));
     }
 
     #[test]

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -375,9 +375,16 @@ unstructured Markdown `sources` field for future debugging; it is persisted but
 not currently displayed. `just load-world` sends that same compiled
 data in bounded batches to a published local module. Run it after
 `just publish-reset`, without `_seed-world`, when using the historical world.
-Interrupted loads can be resumed with the identical compiled artifact. The
-module rejects a different artifact or any additional batches after completion;
-use `just publish-reset` before loading changed source data or a different year.
+Interrupted loads can be resumed without recompiling by loading the identical
+artifact directly:
+
+```powershell
+cargo run --package adventuresim-world-import --bin adventuresim-world-import -- --input target/world-1544.json --load --server http://localhost:3000 --database adventuresim
+```
+
+The module rejects a different artifact or any additional batches after
+completion; use `just publish-reset` before loading changed source data or a
+different year.
 
 The compiler defaults to the canonical 1,000 m spatial grid. Pass
 `--grid-cell-size-meters 250` (or another multiple of 250 from 250 through


### PR DESCRIPTION
## Summary

- add `--input` support so an existing compiled world artifact can be validated and loaded without recompilation
- normalize enum variant keys and religious-status payloads for SpacetimeDB SATS reducer calls
- handle official EU-Hydro integer codes stored as `REAL`, clamp GLO-30 edge samples to their nominal tile, and correct the HYDE source-file invariant
- improve build-report mismatch diagnostics and document interrupted-load recovery

## Root cause and impact

The historical world could compile only after working around several source-boundary mismatches, and the resulting artifact could not be loaded by the current module because its JSON enum representation did not match the SATS wire format. Interrupted loads also forced a full source recompilation.

This change makes the reviewed source data compile and load into the current strategic schema, while allowing operators to resume from the exact existing artifact. The tactical layer is unchanged.

## Validation

- `cargo fmt --package adventuresim-world-import -- --check`
- `cargo test --package adventuresim-world-import` (157 passed, 8 source-data-dependent tests ignored)
- compiled and validated schema-23 `target/world-1544.json`
- loaded a fresh local SpacetimeDB module to completion: 714 settlements, 1,228 nodes, and 1,451 travel edges
- launched the current strategic web build against the imported database and verified `/characters` and all stylesheet bundles render successfully
