### PR TITLE
Improve strategic environmental lighting and map UX

### DIFF
--- a/crates/strategic-web/src/strategic_map.rs
+++ b/crates/strategic-web/src/strategic_map.rs
@@ -457,6 +457,14 @@ pub fn strategic_map(
             data-map-tile-gutter=(package.tiles.gutter)
             data-map-tile-version=(&package.tiles.content_sha256) data-map-tile-root=(TILE_PATH_PREFIX)
             aria-label=(format!("Map around {}", current.map_or("the current settlement", |item| item.name.as_str()))) {
+            div class="strategic-map-controls" role="group" aria-label="Map controls" {
+                button type="button" class="strategic-map-control" data-map-action="zoom-in"
+                    aria-label="Zoom in" data-strategic-tooltip="Zoom in" { span aria-hidden="true" { "+" } }
+                button type="button" class="strategic-map-control" data-map-action="zoom-out"
+                    aria-label="Zoom out" data-strategic-tooltip="Zoom out" { span aria-hidden="true" { "−" } }
+                button type="button" class="strategic-map-control" data-map-action="reset"
+                    aria-label="Reset map view" data-strategic-tooltip="Reset map view" { span aria-hidden="true" { "↺" } }
+            }
             svg class="strategic-map-svg" data-map-svg viewBox=(view_box)
                 aria-labelledby="strategic-map-title strategic-map-description" tabindex="0" {
                 title id="strategic-map-title" { "Settlement road map" }
@@ -487,6 +495,7 @@ pub fn strategic_map(
                                 href=(tile_url("paper", initial_tile_zoom, x, y, &package.tiles.content_sha256)) {}
                         }
                     }
+                    rect class="map-atmosphere-layer" x="0" y="0" width="1200" height="800" aria-hidden="true" {}
                     g class="map-overlay-layer" {
                         @if let Some(route) = terrain_route {
                             @let points = route.points.iter().map(|point| { let (x,y)=project(point.longitude, point.latitude, package.bounds); format!("{x:.3},{y:.3}") }).collect::<Vec<_>>().join(" ");
@@ -508,12 +517,12 @@ pub fn strategic_map(
                             @let label_width = (settlement.name.chars().count() as u16 * 7 + 8).clamp(44, 180);
                             @let label = if is_current { format!("{}, current settlement", settlement.name) } else if is_connected { format!("{}, direct route available", settlement.name) } else { format!("{}, no direct route", settlement.name) };
                             a href=(format!("{map_path}?destination={}", settlement.id))
-                                class="map-pin-link" aria-label=(label) aria-current=[is_selected.then_some("true")]
+                                class="map-pin-link" aria-label=(&label) data-strategic-tooltip=(&label) aria-current=[is_selected.then_some("true")]
                                 data-map-pin data-settlement-id=(&settlement.id) data-connected=(is_connected) {
                                 g class=(format!("map-pin map-settlement map-settlement-{symbol_kind}{}{}{}", if is_current { " current" } else { "" }, if is_connected { " connected" } else { "" }, if is_selected { " selected" } else { "" }))
                                     transform=(format!("translate({x:.3} {y:.3})")) {
                                     g data-map-pin-symbol transform=(format!("scale({initial_pin_scale:.5})")) {
-                                        circle class="map-settlement-hit-area" r="13" {}
+                                        circle class="map-settlement-hit-area" r="24" {}
                                         @if is_selected { circle class="map-pin-selection" cy="-3" r="12" {} }
                                         use class="map-settlement-pictogram" aria-hidden="true"
                                             href=(format!("#map-settlement-{symbol_kind}-symbol")) {}
@@ -541,13 +550,13 @@ pub fn strategic_map(
                             };
                             @let label = format!("Quest: {}, {status_label}", quest.title);
                             a href=(format!("{map_path}?destination={}", quest.id))
-                                class="map-pin-link map-quest-link" aria-label=(label)
+                                class="map-pin-link map-quest-link" aria-label=(&label) data-strategic-tooltip=(&label)
                                 aria-current=[is_selected.then_some("true")]
                                 data-map-pin data-quest-id=(&quest.id) {
                                 g class=(format!("map-pin map-quest{}{}", if is_active { " active" } else { "" }, if is_selected { " selected" } else { "" }))
                                     transform=(format!("translate({x:.3} {y:.3})")) {
                                     g data-map-pin-symbol transform=(format!("scale({initial_pin_scale:.5})")) {
-                                        circle class="map-quest-hit-area" r="13" {}
+                                        circle class="map-quest-hit-area" r="24" {}
                                         @if is_selected { circle class="map-pin-selection" r="12" {} }
                                         path class="map-quest-shape" d="M0,-9 L9,0 L0,9 L-9,0 Z" {}
                                         path class="map-quest-mark" d="M0,-5 V2 M0,5 V6" {}
@@ -566,7 +575,7 @@ pub fn strategic_map(
                                 class="map-settlement-hit-link" aria-hidden="true" tabindex="-1" {
                                 g transform=(format!("translate({x:.3} {y:.3})")) {
                                     g data-map-pin-symbol transform=(format!("scale({initial_pin_scale:.5})")) {
-                                        circle class="map-settlement-hit-area map-settlement-hit-overlay" r="13" {}
+                                        circle class="map-settlement-hit-area map-settlement-hit-overlay" r="24" {}
                                     }
                                 }
                             }
@@ -787,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn tiled_map_has_canonical_pin_links_without_extra_chrome() {
+    fn tiled_map_has_canonical_pin_links_and_accessible_controls() {
         let map = map_bundle();
         let mut source_less = settlement("demo", "Demo", 0.0, 0.0);
         source_less.source_node_id = None;
@@ -815,9 +824,15 @@ mod tests {
         assert!(!markup.contains("data-map-theme-choice"));
         assert!(!markup.contains("strategic-map-toolbar"));
         assert!(!markup.contains("data-map-zoom"));
+        assert_eq!(markup.matches("class=\"strategic-map-control\"").count(), 3);
+        assert!(markup.contains("data-map-action=\"zoom-in\""));
+        assert!(markup.contains("data-map-action=\"zoom-out\""));
+        assert!(markup.contains("data-map-action=\"reset\""));
+        assert!(markup.contains("data-strategic-tooltip=\"Zoom in\""));
         assert!(markup.contains("tabindex=\"0\""));
         assert!(markup.contains("?destination=near"));
         assert!(markup.contains("Nearby, direct route available"));
+        assert!(markup.contains("data-strategic-tooltip=\"Nearby, direct route available\""));
         assert!(markup.contains("Far away, no direct route"));
         assert!(!markup.contains("Outside package"));
         assert!(!markup.contains("?destination=demo"));
@@ -829,11 +844,13 @@ mod tests {
         assert!(markup.contains("data-map-label-priority"));
         assert!(markup.contains("map-settlement-label-text"));
         assert!(markup.contains("map-tile-layer"));
+        assert!(markup.contains("map-atmosphere-layer"));
         assert!(markup.contains("map-overlay-layer"));
         assert!(markup.contains("data-map-selection-line"));
         assert!(markup.contains(TILE_PATH_PREFIX));
         assert!(markup.contains(&map.package.tiles.content_sha256));
         assert!(markup.contains("image"));
+        assert!(markup.contains("class=\"map-settlement-hit-area\" r=\"24\""));
         assert!(!markup.contains("class=\"map-elevation"));
         assert!(
             markup.len() < 50_000,

--- a/crates/strategic-web/src/strategic_map.rs
+++ b/crates/strategic-web/src/strategic_map.rs
@@ -522,7 +522,7 @@ pub fn strategic_map(
                                 g class=(format!("map-pin map-settlement map-settlement-{symbol_kind}{}{}{}", if is_current { " current" } else { "" }, if is_connected { " connected" } else { "" }, if is_selected { " selected" } else { "" }))
                                     transform=(format!("translate({x:.3} {y:.3})")) {
                                     g data-map-pin-symbol transform=(format!("scale({initial_pin_scale:.5})")) {
-                                        circle class="map-settlement-hit-area" r="24" {}
+                                        circle class="map-settlement-hit-area" r="13" {}
                                         @if is_selected { circle class="map-pin-selection" cy="-3" r="12" {} }
                                         use class="map-settlement-pictogram" aria-hidden="true"
                                             href=(format!("#map-settlement-{symbol_kind}-symbol")) {}
@@ -556,7 +556,7 @@ pub fn strategic_map(
                                 g class=(format!("map-pin map-quest{}{}", if is_active { " active" } else { "" }, if is_selected { " selected" } else { "" }))
                                     transform=(format!("translate({x:.3} {y:.3})")) {
                                     g data-map-pin-symbol transform=(format!("scale({initial_pin_scale:.5})")) {
-                                        circle class="map-quest-hit-area" r="24" {}
+                                        circle class="map-quest-hit-area" r="13" {}
                                         @if is_selected { circle class="map-pin-selection" r="12" {} }
                                         path class="map-quest-shape" d="M0,-9 L9,0 L0,9 L-9,0 Z" {}
                                         path class="map-quest-mark" d="M0,-5 V2 M0,5 V6" {}
@@ -575,7 +575,7 @@ pub fn strategic_map(
                                 class="map-settlement-hit-link" aria-hidden="true" tabindex="-1" {
                                 g transform=(format!("translate({x:.3} {y:.3})")) {
                                     g data-map-pin-symbol transform=(format!("scale({initial_pin_scale:.5})")) {
-                                        circle class="map-settlement-hit-area map-settlement-hit-overlay" r="24" {}
+                                        circle class="map-settlement-hit-area map-settlement-hit-overlay" r="13" {}
                                     }
                                 }
                             }
@@ -850,7 +850,7 @@ mod tests {
         assert!(markup.contains(TILE_PATH_PREFIX));
         assert!(markup.contains(&map.package.tiles.content_sha256));
         assert!(markup.contains("image"));
-        assert!(markup.contains("class=\"map-settlement-hit-area\" r=\"24\""));
+        assert!(markup.contains("class=\"map-settlement-hit-area\" r=\"13\""));
         assert!(!markup.contains("class=\"map-elevation"));
         assert!(
             markup.len() < 50_000,

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -156,9 +156,9 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/base.css?v=environment-14";
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
-                link rel="stylesheet" href="/static/css/layout.css?v=subtle-material-lines-1-dialogue-source-icons-2";
+                link rel="stylesheet" href="/static/css/layout.css?v=strategic-ux-review-1";
                 link rel="stylesheet" href="/static/css/components.css?v=lowercase-display-type-1";
-                link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ui-overhaul-4-paper-map-2-data-license-1-grouped-alcohol-2-grouped-food-1-rest-supplies-1-dialogue-pane-1-cooking-trade-1";
+                link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ux-review-1";
                 link rel="stylesheet" href="/static/css/utilities.css?v=strategic-ui-overhaul-1";
 
                 // Datastar
@@ -186,7 +186,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/strategic-condition.js?v=strategic-condition-3" defer {}
                     script src="/static/building-state.js?v=village-building-tabs-1" defer {}
                     script src="/static/travel-planner.js?v=travel-polish-6" defer {}
-                    script src="/static/strategic-map.js?v=responsive-map-viewport-1" defer {}
+                    script src="/static/strategic-map.js?v=map-controls-environment-1" defer {}
                     script src="/static/rest-duration.js?v=wake-time-3" defer {}
                 }
             }
@@ -277,7 +277,7 @@ fn settlement_top_bar(
                         data-service-id=(path)
                         data-service-label=(label)
                         aria-label=(label)
-                        title=(label)
+                        data-strategic-tooltip=(label)
                         aria-current=(if active_service == path { "page" } else { "false" })
                     {
                         span class="service-tab-building" aria-hidden="true" {}
@@ -306,7 +306,7 @@ fn settlement_top_bar(
                 }
             }
         }
-        script src="/static/strategic-time.js?v=wake-time-1" {}
+        script src="/static/strategic-time.js?v=continuous-environment-1" {}
     }
 }
 
@@ -344,7 +344,7 @@ fn quest_location_top_bar(
                     span class="nav-tab active quest-context-tab"
                         style=(format!("--building-tint:{enemy_tint}"))
                         data-location-view="camp"
-                        aria-current="page" aria-label="Camp" title="Camp" {
+                        aria-current="page" aria-label="Camp" data-strategic-tooltip="Camp" {
                         span class="service-tab-building wilderness-tab-prop" aria-hidden="true" {}
                         span class="topbar-scene-effect-plane" aria-hidden="true" {
                             @if camp_fire_lit {
@@ -359,7 +359,7 @@ fn quest_location_top_bar(
                     style=(format!("--building-tint:{map_tint}"))
                     data-location-view="map"
                     aria-current=(if active_tab == "map" { "page" } else { "false" })
-                    aria-label="Map" title="Map" {
+                    aria-label="Map" data-strategic-tooltip="Map" {
                     span class="service-tab-building wilderness-tab-prop" aria-hidden="true" {}
                 }
                 a href=(format!("/locations/quest/{}/enemy", location_id))
@@ -367,7 +367,7 @@ fn quest_location_top_bar(
                     style=(format!("--building-tint:{enemy_tint}"))
                     data-location-view="enemy"
                     aria-current=(if active_tab == "enemy" { "page" } else { "false" })
-                    aria-label="Enemy" title="Enemy" {
+                    aria-label="Enemy" data-strategic-tooltip="Enemy" {
                     span class="service-tab-building wilderness-tab-prop" aria-hidden="true" {}
                     span class="service-tab-icon service-tab-icon-enemy" aria-hidden="true" {}
                 }
@@ -379,7 +379,7 @@ fn quest_location_top_bar(
                 }
             }
         }
-        script src="/static/strategic-time.js?v=client-clock-2" {}
+        script src="/static/strategic-time.js?v=continuous-environment-1" {}
     }
 }
 

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -156,7 +156,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/base.css?v=environment-14";
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
-                link rel="stylesheet" href="/static/css/layout.css?v=strategic-ux-review-1";
+                link rel="stylesheet" href="/static/css/layout.css?v=strategic-ux-review-2";
                 link rel="stylesheet" href="/static/css/components.css?v=lowercase-display-type-1";
                 link rel="stylesheet" href="/static/css/strategic.css?v=strategic-ux-review-1";
                 link rel="stylesheet" href="/static/css/utilities.css?v=strategic-ui-overhaul-1";
@@ -165,7 +165,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
                 script src="/static/background-fetch.js?v=background-fetch-2" {}
                 script src="/static/developer-mode.js?v=dialogue-sources-1" defer {}
-                script src="/static/tooltips.js?v=styled-tooltips-1" defer {}
+                script src="/static/tooltips.js?v=styled-tooltips-2" defer {}
                 script src="/static/medical-examination.js?v=strategic-dialogs-1" defer {}
                 @if scripts != ScriptProfile::Entry {
                     script src="/static/live-state.js?v=sse-3" defer {}
@@ -186,7 +186,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/strategic-condition.js?v=strategic-condition-3" defer {}
                     script src="/static/building-state.js?v=village-building-tabs-1" defer {}
                     script src="/static/travel-planner.js?v=travel-polish-6" defer {}
-                    script src="/static/strategic-map.js?v=map-controls-environment-1" defer {}
+                    script src="/static/strategic-map.js?v=map-controls-environment-2" defer {}
                     script src="/static/rest-duration.js?v=wake-time-3" defer {}
                 }
             }
@@ -290,6 +290,7 @@ fn settlement_top_bar(
                             class=(format!("service-tab-icon service-tab-icon-{}", icon))
                             style=[(path == "religion").then(|| format!("--service-tab-icon: url('{}')", religion_icon_path(religion_id)))]
                             aria-hidden="true" {}
+                        span class="service-tab-label" aria-hidden="true" { (label) }
                         @if path == "map" {
                             span class="service-notification-badge service-map-quest-badge"
                                 data-map-quest-badge title="Active quest" aria-hidden="true" hidden { "!" }
@@ -341,9 +342,10 @@ fn quest_location_top_bar(
             }
             nav class="top-bar-center settlement-services" aria-label="Location views" {
                 @if active_tab == "camp" {
-                    span class="nav-tab active quest-context-tab"
+                    a href="/camp" class="nav-tab active quest-context-tab"
                         style=(format!("--building-tint:{enemy_tint}"))
                         data-location-view="camp"
+                        data-service-label="Camp"
                         aria-current="page" aria-label="Camp" data-strategic-tooltip="Camp" {
                         span class="service-tab-building wilderness-tab-prop" aria-hidden="true" {}
                         span class="topbar-scene-effect-plane" aria-hidden="true" {
@@ -352,24 +354,29 @@ fn quest_location_top_bar(
                             }
                             (smoke_effect("wilderness-smoke campfire-smoke"))
                         }
+                        span class="service-tab-label" aria-hidden="true" { "Camp" }
                     }
                 } @else {
                 a href=(format!("/locations/quest/{}", location_id))
                     class=(if active_tab == "map" { "nav-tab active" } else { "nav-tab" })
                     style=(format!("--building-tint:{map_tint}"))
                     data-location-view="map"
+                    data-service-label="Map"
                     aria-current=(if active_tab == "map" { "page" } else { "false" })
                     aria-label="Map" data-strategic-tooltip="Map" {
                     span class="service-tab-building wilderness-tab-prop" aria-hidden="true" {}
+                    span class="service-tab-label" aria-hidden="true" { "Map" }
                 }
                 a href=(format!("/locations/quest/{}/enemy", location_id))
                     class=(if active_tab == "enemy" { "nav-tab active" } else { "nav-tab" })
                     style=(format!("--building-tint:{enemy_tint}"))
                     data-location-view="enemy"
+                    data-service-label="Enemy"
                     aria-current=(if active_tab == "enemy" { "page" } else { "false" })
                     aria-label="Enemy" data-strategic-tooltip="Enemy" {
                     span class="service-tab-building wilderness-tab-prop" aria-hidden="true" {}
                     span class="service-tab-icon service-tab-icon-enemy" aria-hidden="true" {}
+                    span class="service-tab-label" aria-hidden="true" { "Enemy" }
                 }
                 }
             }
@@ -883,6 +890,9 @@ mod tests {
         assert!(rested_camp.contains("data-camp-fire=\"embers\""));
         assert!(!rested_camp.contains("campfire-flame"));
         assert_eq!(rested_camp.matches("campfire-smoke").count(), 1);
+        assert!(rested_camp.contains("href=\"/camp\""));
+        assert!(rested_camp.contains("data-service-label=\"Camp\""));
+        assert!(rested_camp.contains("class=\"service-tab-label\""));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/recruitment.rs
+++ b/crates/strategic-web/src/templates/recruitment.rs
@@ -484,6 +484,14 @@ fn party_check_target_form(
     target_position: f32,
     can_manage: bool,
 ) -> Markup {
+    let description = if contribution.abs() > 0.005 {
+        format!(
+            "{label}: {current:.1} {contribution:+.1} = {:.1}; target {target:.0}",
+            current + contribution
+        )
+    } else {
+        format!("{label}: {current:.1}; target {target:.0}")
+    };
     html! {
         form action="/party-recruitment/check-targets" method="post" class="party-check-target-form"
             data-party-check-target-form data-check-name=(field) {
@@ -493,11 +501,7 @@ fn party_check_target_form(
             div class=(if can_manage { "party-check-track party-check-track-editable" } else { "party-check-track" })
                 data-party-check-track data-check-name=(field) data-check-label=(label)
                 data-check-current=(current) data-check-target=(target)
-                title=(if contribution.abs() > 0.005 {
-                    format!("{label}: {current:.1} {contribution:+.1} = {:.1}; target {target:.0}", current + contribution)
-                } else {
-                    format!("{label}: {current:.1}; target {target:.0}")
-                }) {
+                tabindex="0" aria-label=(&description) data-strategic-tooltip=(&description) {
                 span class="party-check-current" style=(format!("width:{current_width:.1}%")) {}
                 @if contribution.abs() > 0.005 {
                     span class=(if contribution > 0.0 { "party-check-contribution" } else { "party-check-contribution party-check-contribution-negative" })

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -2445,7 +2445,7 @@ enum SurgeryItemRequirement {
 fn surgery_supply(label: &str, icon: &str, quantity: u32) -> Markup {
     let description = format!("{label}: {quantity} available");
     html! {
-        div class="surgery-supply" data-tooltip=(&description)
+        div class="surgery-supply" data-strategic-tooltip=(&description)
             aria-label=(&description) tabindex="0" {
             (decorative_game_icon(icon))
             span class="surgery-item-overlay surgery-item-quantity" aria-hidden="true" { "x" (quantity) }
@@ -2468,7 +2468,7 @@ fn surgery_item_requirement(requirement: SurgeryItemRequirement) -> Markup {
         }
     };
     html! {
-        span class="surgery-item-requirement" data-tooltip=(label)
+        span class="surgery-item-requirement" data-strategic-tooltip=(label)
             aria-label=(accessible_label) tabindex="0" {
             (decorative_game_icon(icon))
             @match requirement {
@@ -2539,7 +2539,7 @@ fn surgery_procedure_row(
     let unavailable_label = unavailable.map(|reason| format!("{label}: {reason}"));
     html! {
         form method="post" action=(action) class=(row_class)
-            data-tooltip=[unavailable] aria-label=[unavailable_label.as_deref()]
+            data-strategic-tooltip=[unavailable] aria-label=[unavailable_label.as_deref()]
             tabindex=[unavailable.map(|_| "0")] {
             input type="hidden" name="procedure" value=(procedure);
             @if let Some(projectile_id) = projectile_id {
@@ -6635,7 +6635,7 @@ mod tests {
     fn surgery_supplies_are_icon_counts_with_hover_labels() {
         let supply = surgery_supply("Bandages", "bandage-roll", 8).into_string();
         assert!(supply.contains("class=\"surgery-supply\""));
-        assert!(supply.contains("data-tooltip=\"Bandages: 8 available\""));
+        assert!(supply.contains("data-strategic-tooltip=\"Bandages: 8 available\""));
         assert!(supply.contains("bandage-roll.svg"));
         assert!(supply.contains(">x8</span>"));
         assert!(!supply.contains(">Bandages</span>"));
@@ -6645,18 +6645,18 @@ mod tests {
     fn surgery_item_icons_explain_consumed_reusable_and_equipped_supplies() {
         let bandage =
             surgery_item_requirement(SurgeryItemRequirement::BandageConsumed).into_string();
-        assert!(bandage.contains("data-tooltip=\"Expend one bandage\""));
+        assert!(bandage.contains("data-strategic-tooltip=\"Expend one bandage\""));
         assert!(bandage.contains(">x1</span>"));
 
         let kit =
             surgery_item_requirement(SurgeryItemRequirement::SurgeryKitReusable).into_string();
-        assert!(kit.contains("data-tooltip=\"Requires surgery kit\""));
+        assert!(kit.contains("data-strategic-tooltip=\"Requires surgery kit\""));
         assert!(kit.contains("aria-label=\"Requires surgery kit; reusable and not consumed\""));
         assert!(kit.contains("medical-pack.svg"));
         assert!(!kit.contains("surgery-item-overlay"));
 
         let splint = surgery_item_requirement(SurgeryItemRequirement::SplintEquipped).into_string();
-        assert!(splint.contains("data-tooltip=\"Equips 1 splint\""));
+        assert!(splint.contains("data-strategic-tooltip=\"Equips 1 splint\""));
         assert!(splint.contains("check-mark.svg"));
     }
 
@@ -6727,7 +6727,7 @@ mod tests {
         )
         .into_string();
         assert!(row.contains("surgery-procedure-unavailable"));
-        assert!(row.contains("data-tooltip=\"No injury is present\""));
+        assert!(row.contains("data-strategic-tooltip=\"No injury is present\""));
         assert!(row.contains("aria-label=\"Stitch: No injury is present\" tabindex=\"0\""));
         assert!(row.contains("disabled title=\"No injury is present\""));
         assert!(row.contains(">Stitch</button>"));

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -612,6 +612,7 @@
 }
 
 .settlement-services .nav-tab:hover { filter: brightness(1.12); }
+.service-tab-label { display: none; }
 .settlement-services .nav-tab:focus-visible { z-index: 5; outline: 2px solid var(--accent-light); outline-offset: 2px; }
 .settlement-services .nav-tab.active {
   color: var(--text-primary);
@@ -1250,4 +1251,27 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
   .center-content { min-height: 27rem; }
   .left-sidebar,
   .right-sidebar { padding: 0.85rem; }
+}
+
+@media (hover: none), (pointer: coarse) {
+  .service-tab-label {
+    position: absolute;
+    z-index: 5;
+    right: .12rem;
+    bottom: .28rem;
+    left: .12rem;
+    display: block;
+    overflow: hidden;
+    padding: .1rem .15rem .13rem;
+    border: 1px solid rgb(240 221 169 / 32%);
+    background: rgb(10 10 9 / 82%);
+    color: var(--text-primary);
+    font-size: .65rem;
+    font-weight: 700;
+    line-height: 1;
+    pointer-events: none;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -612,6 +612,7 @@
 }
 
 .settlement-services .nav-tab:hover { filter: brightness(1.12); }
+.settlement-services .nav-tab:focus-visible { z-index: 5; outline: 2px solid var(--accent-light); outline-offset: 2px; }
 .settlement-services .nav-tab.active {
   color: var(--text-primary);
   background: color-mix(in srgb, var(--building-tint) var(--building-light, 78%), black);
@@ -1203,11 +1204,11 @@ body:has(.settlement-top-bar[data-environment="settlement"]) :is(.left-sidebar, 
     order: 3;
     width: 100%;
     gap: 0.62rem;
-    padding: 0.75rem 0.5rem 0.35rem;
+    padding: 0.75rem 0.5rem 0.65rem;
     overflow-x: auto;
     overflow-y: hidden;
     justify-content: flex-start;
-    padding-bottom: 0.35rem;
+    padding-bottom: 0.65rem;
     scrollbar-width: thin;
     mask-image: linear-gradient(to right, transparent, #000 0.75rem, #000 calc(100% - 0.75rem), transparent);
   }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -1686,6 +1686,17 @@ body.activity-modal-open { overflow: hidden; }
     linear-gradient(#293a43 0 48%, #18261f 48% 100%);
 }
 
+.service-visual-scene::before {
+  position: absolute;
+  z-index: 2;
+  inset: 0;
+  background: var(--environment-tint, #28374d);
+  content: "";
+  mix-blend-mode: color;
+  opacity: var(--scene-atmosphere-opacity, .09);
+  pointer-events: none;
+}
+
 .visual-scene-sky,
 .visual-scene-horizon,
 .visual-scene-route { position: absolute; pointer-events: none; }
@@ -1717,8 +1728,9 @@ body.activity-modal-open { overflow: hidden; }
   background: rgb(7 11 10 / 78%);
   box-shadow: 0 0.3rem 1rem #0008;
 }
-.visual-scene-caption strong { font-family: var(--font-display), serif; font-size: var(--font-size-lg); }
-.visual-scene-caption span { color: #c9bfa9; font-size: var(--font-size-xs); text-transform: uppercase; letter-spacing: 0.08em; }
+.visual-scene-caption > * { min-width: 0; }
+.visual-scene-caption strong { overflow-wrap: anywhere; font-family: var(--font-display), serif; font-size: var(--font-size-lg); }
+.visual-scene-caption span { color: #c9bfa9; font-size: var(--font-size-xs); text-align: right; text-transform: uppercase; letter-spacing: 0.08em; }
 .service-visual-character .service-visual-scene { background: radial-gradient(circle at 50% 37%, #374a48, #172120 62%, #101513); }
 .service-visual-character .visual-scene-horizon { inset: 42% 28% -10%; border-radius: 48% 48% 0 0; clip-path: none; background: #111918; }
 .service-visual-character .visual-scene-route { display: none; }
@@ -1969,7 +1981,10 @@ body.activity-modal-open { overflow: hidden; }
   transform: translateX(-50%);
   white-space: nowrap;
 }
-.party-check-track:hover .party-check-exact { opacity: 1; }
+.party-check-track:hover .party-check-exact,
+.party-check-track:focus-visible .party-check-exact,
+.party-check-track:focus-within .party-check-exact { opacity: 1; }
+.party-check-track:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
 .party-check-target-handle {
   position: absolute;
   z-index: 3;
@@ -3884,6 +3899,7 @@ body.chat-resizing {
   .party-portrait-action,
   button.party-portrait-action { width: 2.75rem; height: 2.75rem; min-width: 2.75rem; min-height: 2.75rem; }
   .party-portrait-overlay { padding-bottom: 3.2rem; }
+  .party-check-track:focus .party-check-exact { opacity: 1; }
 }
 
 @media (max-width: 768px) {
@@ -3906,6 +3922,8 @@ body.chat-resizing {
     transform: none;
     scrollbar-width: thin;
   }
+  .visual-scene-caption { flex-wrap: wrap; gap: .25rem .65rem; }
+  .visual-scene-caption span { margin-left: auto; }
   .party-portrait-overlay > [data-party-portrait-members] { display: contents; }
   .party-role-group { flex: 0 0 auto; }
   .service-visual-scene { min-height: 18rem; }
@@ -4296,36 +4314,6 @@ body.chat-resizing {
     background: rgb(0 0 0 / 20%);
 }
 
-.surgery-supply::after,
-.surgery-item-requirement::after {
-    position: absolute;
-    z-index: 6;
-    right: 0;
-    bottom: calc(100% + .35rem);
-    max-width: 14rem;
-    padding: .3rem .45rem;
-    border: 1px solid rgb(255 255 255 / 20%);
-    background: var(--panel-bg, #241a15);
-    box-shadow: var(--shadow-sm);
-    color: var(--text-primary);
-    content: attr(data-tooltip);
-    font-size: .72rem;
-    line-height: 1.2;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(.2rem);
-    transition: opacity var(--transition-fast), transform var(--transition-fast);
-    white-space: nowrap;
-}
-
-.surgery-supply:hover::after,
-.surgery-supply:focus-visible::after,
-.surgery-item-requirement:hover::after,
-.surgery-item-requirement:focus-visible::after {
-    opacity: 1;
-    transform: translateY(0);
-}
-
 .surgery-supply:focus-visible,
 .surgery-item-requirement:focus-visible {
     outline: 2px solid var(--gold, #d8b36a);
@@ -4416,33 +4404,6 @@ body.chat-resizing {
     opacity: .38;
 }
 
-.surgery-procedure-unavailable::after {
-    position: absolute;
-    z-index: 6;
-    right: .4rem;
-    bottom: calc(100% + .35rem);
-    max-width: 14rem;
-    padding: .3rem .45rem;
-    border: 1px solid rgb(255 255 255 / 20%);
-    background: var(--panel-bg, #241a15);
-    box-shadow: var(--shadow-sm);
-    color: var(--text-primary);
-    content: attr(data-tooltip);
-    font-size: .72rem;
-    line-height: 1.2;
-    opacity: 0;
-    pointer-events: none;
-    transform: translateY(.2rem);
-    transition: opacity var(--transition-fast), transform var(--transition-fast);
-    white-space: nowrap;
-}
-
-.surgery-procedure-unavailable:hover::after,
-.surgery-procedure-unavailable:focus::after {
-    opacity: 1;
-    transform: translateY(0);
-}
-
 .surgery-procedure-unavailable:focus-visible {
     outline: 2px solid var(--gold, #d8b36a);
     outline-offset: 2px;
@@ -4515,22 +4476,31 @@ body.chat-resizing {
 .surgery-procedure > button {
     grid-column: 1 / -1;
 }
-/* Settlement map: cached AVIF world tiles under an interactive SVG overlay. */
+/* Settlement map: cached AVIF world tiles under an interactive SVG overlay.
+   Environmental light is confined to scenery; controls, labels, semantic pins,
+   and focus indicators retain their authored contrast at every character time. */
 .settlement-map-main { min-width: 0; overflow: hidden; }
-.strategic-map { position: relative; display: grid; grid-template-rows: minmax(20rem, 1fr); height: 100%; min-height: 32rem; background: #dce5dc; color: #202820; }
+.strategic-map { position: relative; display: grid; grid-template-rows: minmax(20rem, 1fr); height: 100%; min-height: 32rem; background: color-mix(in srgb, #dce5dc var(--map-surface-mix, 89%), var(--environment-tint, #28374d)); color: #202820; }
 .strategic-map-svg { display: block; width: 100%; height: 100%; min-height: 20rem; cursor: grab; touch-action: none; background: var(--map-land); }
+.strategic-map-controls { position: absolute; z-index: 5; top: .55rem; right: .55rem; display: flex; gap: .3rem; padding: .25rem; border: 1px solid rgb(223 208 171 / 42%); border-radius: 3px; background: rgb(20 18 15 / 88%); box-shadow: 0 .2rem .55rem #0008; }
+.strategic-map-control { display: grid; width: 2rem; height: 2rem; place-items: center; padding: 0; border: 1px solid var(--border-color); border-radius: 2px; background: var(--building-interactive); color: var(--text-primary); font-family: Georgia, serif; font-size: 1.15rem; font-weight: 700; line-height: 1; }
+.strategic-map-control:hover { border-color: var(--accent-light); background: var(--building-interactive-hover); }
+.strategic-map-control:focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; }
 .strategic-map-license-link { position: absolute; right: .45rem; bottom: .35rem; z-index: 3; padding: .14rem .32rem; border: 1px solid rgb(41 48 38 / 28%); background: rgb(244 238 211 / 86%); color: #30372b; font-size: .68rem; line-height: 1.15; text-decoration: none; }
 .strategic-map-license-link:hover, .strategic-map-license-link:focus-visible { background: #f4eed3; text-decoration: underline; }
 .strategic-map-svg:active { cursor: grabbing; }
 .strategic-map-svg:focus-visible { outline: 3px solid #173d72; outline-offset: -3px; }
 .map-tile-layer { pointer-events: none; image-rendering: auto; }
+.map-tile-layer image { filter: brightness(var(--map-light, .9)) saturate(var(--map-saturation, .9)); }
+.map-atmosphere-layer { fill: var(--environment-tint, #28374d); opacity: var(--map-atmosphere-opacity, .14); pointer-events: none; mix-blend-mode: color; }
 .map-overlay-layer { pointer-events: auto; }
-.strategic-map { --map-land: #e6e1cb; --map-water: #b8c9c5; --map-road: #6e654f; --map-ferry: #625f58; --map-pin: #6c6250; --map-connected: #8e2c24; --map-selected: #171511; --map-text: #241f18; --map-height-50: #ddd5ba; --map-height-100: #d4c9aa; --map-height-250: #c9b999; --map-height-500: #baa686; --map-height-1000: #aa9277; --map-height-1500: #987f6c; --map-height-2000: #826b60; --map-contour: #665b49; --map-forest: #73806a; --map-forest-conifer: #586a5d; }
+.strategic-map { --map-land: color-mix(in srgb, #e6e1cb var(--map-land-mix, 92%), var(--environment-tint, #28374d)); --map-water: #b8c9c5; --map-road: #6e654f; --map-ferry: #625f58; --map-pin: #5b5141; --map-connected: #7b201c; --map-selected: #171511; --map-text: #17130e; --map-height-50: #ddd5ba; --map-height-100: #d4c9aa; --map-height-250: #c9b999; --map-height-500: #baa686; --map-height-1000: #aa9277; --map-height-1500: #987f6c; --map-height-2000: #826b60; --map-contour: #665b49; --map-forest: #73806a; --map-forest-conifer: #586a5d; }
 .map-selection-line { pointer-events: none; fill: none; stroke: #9b2d28; stroke-width: 2.2; stroke-dasharray: 6 4; stroke-linecap: round; opacity: .82; vector-effect: non-scaling-stroke; }
 .map-pin-link:focus { outline: none; }
 .map-settlement-hit-area, .map-quest-hit-area { fill: transparent; stroke: none; }
 .map-settlement-pictogram { color: var(--map-pin); }
 .map-pin.connected .map-settlement-pictogram { color: var(--map-connected); }
+.map-pin.connected .map-settlement-ground { stroke-width: 3; stroke-dasharray: 2.5 2; }
 .map-pin.current .map-settlement-pictogram { color: #286436; }
 .map-settlement-ground { fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; vector-effect: non-scaling-stroke; }
 .map-settlement-shape { fill: color-mix(in srgb, currentColor 88%, var(--map-land)); stroke: #fffdf3; stroke-width: 1.15; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
@@ -4538,15 +4508,26 @@ body.chat-resizing {
 .map-pin-selection { fill: color-mix(in srgb, var(--map-land) 30%, transparent); stroke: var(--map-selected); stroke-width: 2.5; stroke-dasharray: 2 1; vector-effect: non-scaling-stroke; }
 .map-pin-current-mark { fill: #286436; stroke: #fffdf3; stroke-width: 1; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
 .map-pin-selected-mark { fill: none; stroke: var(--map-selected); stroke-width: 2.5; vector-effect: non-scaling-stroke; }
-.map-quest-shape { fill: #b07a22; stroke: #fffdf3; stroke-width: 1.3; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
+.map-quest-shape { fill: #8a5912; stroke: #fffdf3; stroke-width: 1.3; stroke-linejoin: round; vector-effect: non-scaling-stroke; }
 .map-quest.active .map-quest-shape { fill: #9b2d28; }
 .map-quest-mark { fill: none; stroke: #fffdf3; stroke-width: 1.8; stroke-linecap: round; vector-effect: non-scaling-stroke; }
-.map-pin-link:focus-visible .map-pin-selection, .map-pin-link:focus-visible .map-settlement-shape, .map-pin-link:focus-visible .map-quest-shape { stroke: #101010; stroke-width: 3; }
+.map-pin-link:hover .map-settlement-shape,
+.map-pin-link:hover .map-quest-shape { stroke: #fff8dc; stroke-width: 2.6; }
+.map-pin-link:focus-visible .map-pin-selection,
+.map-pin-link:focus-visible .map-settlement-shape,
+.map-pin-link:focus-visible .map-quest-shape { stroke: #fff8dc; stroke-width: 3.5; filter: drop-shadow(0 0 1px #050505) drop-shadow(0 0 2px #050505); }
 .map-settlement-label { pointer-events: none; }
 .map-settlement-label-text { fill: var(--map-text); stroke: color-mix(in srgb, var(--map-land) 88%, #fff); stroke-width: var(--map-label-stroke-width, 1px); paint-order: stroke fill; stroke-linejoin: round; font-family: Georgia, "Times New Roman", serif; font-size: var(--map-label-font-size, 4px); font-weight: 700; letter-spacing: .05em; }
 .map-pin.current .map-settlement-label-text, .map-pin.selected .map-settlement-label-text { font-style: italic; font-weight: 800; }
 .no-direct-route { padding: .55rem; border-left: 4px solid var(--warning, #9a6824); background: color-mix(in srgb, var(--warning, #9a6824) 10%, transparent); }
 @media (max-width: 720px) { .strategic-map { min-height: 26rem; } }
+@media (max-width: 480px) {
+  .visual-scene-caption { right: .65rem; bottom: .65rem; left: .65rem; flex-direction: column; align-items: flex-start; gap: .15rem; }
+  .visual-scene-caption span { margin-left: 0; text-align: left; }
+}
+@media (hover: none), (pointer: coarse) {
+  .strategic-map-control { width: 2.75rem; height: 2.75rem; }
+}
 @media (prefers-reduced-motion: reduce) { .strategic-map-svg { scroll-behavior: auto; } }
 .filth-status {
   width: 100%; margin: .75rem 0 0; outline: none;

--- a/crates/strategic-web/static/strategic-map.js
+++ b/crates/strategic-web/static/strategic-map.js
@@ -227,6 +227,14 @@
     if (globalThis.ResizeObserver) new ResizeObserver(resize).observe(svg);
     else globalThis.addEventListener?.("resize", resize);
     const zoom = (factor) => updateView(zoomedView(parseViewBox(svg), factor));
+    map.querySelectorAll("[data-map-action]").forEach((control) => {
+      control.addEventListener("click", () => {
+        if (control.dataset.mapAction === "zoom-in") zoom(0.8);
+        else if (control.dataset.mapAction === "zoom-out") zoom(1.25);
+        else if (control.dataset.mapAction === "reset") updateView(initial);
+        svg.focus?.({ preventScroll: true });
+      });
+    });
     svg.addEventListener("wheel", (event) => { event.preventDefault(); zoom(event.deltaY < 0 ? 0.85 : 1.18); }, { passive: false });
     svg.addEventListener("keydown", (event) => {
       const [, , width, height] = parseViewBox(svg);

--- a/crates/strategic-web/static/strategic-map.js
+++ b/crates/strategic-web/static/strategic-map.js
@@ -32,6 +32,16 @@
       symbol.setAttribute("transform", `scale(${scale.toFixed(5)})`);
     });
   };
+  const hitTargetRadius = (pixelWidth, coarsePointer) => (
+    coarsePointer && pixelWidth > 0 ? 24 * PIN_REFERENCE_WIDTH / pixelWidth : 13
+  );
+  const scaleHitTargets = (svg, pixelWidth) => {
+    const coarsePointer = globalThis.matchMedia?.("(pointer: coarse)")?.matches === true;
+    const radius = hitTargetRadius(pixelWidth, coarsePointer).toFixed(3);
+    svg.querySelectorAll(".map-settlement-hit-area, .map-quest-hit-area").forEach((target) => {
+      target.setAttribute("r", radius);
+    });
+  };
   const labelPriorityThreshold = (viewWidth) => {
     if (viewWidth > 700) return 80;
     if (viewWidth > 400) return 70;
@@ -100,6 +110,7 @@
   const writeViewBox = (svg, view) => {
     svg.setAttribute("viewBox", view.map((value) => value.toFixed(2)).join(" "));
     scalePins(svg, view[2]);
+    scaleHitTargets(svg, svg.getBoundingClientRect().width || PIN_REFERENCE_WIDTH);
     layoutLabels(svg, view);
   };
   const tileZoom = (viewWidth, pixelWidth, pixelRatio, maxZoom) => {
@@ -232,7 +243,6 @@
         if (control.dataset.mapAction === "zoom-in") zoom(0.8);
         else if (control.dataset.mapAction === "zoom-out") zoom(1.25);
         else if (control.dataset.mapAction === "reset") updateView(initial);
-        svg.focus?.({ preventScroll: true });
       });
     });
     svg.addEventListener("wheel", (event) => { event.preventDefault(); zoom(event.deltaY < 0 ? 0.85 : 1.18); }, { passive: false });
@@ -294,7 +304,7 @@
   };
 
   const initializeStrategicMaps = (root = document) => root.querySelectorAll("[data-strategic-map]").forEach((map) => initializeMap(map));
-  globalThis.StrategicMap = { boxesOverlap, initializeMap, labelPriorityThreshold, layoutLabels, parentTileFallback, parseViewBox, pannedView, renderTiles, resizedView, tileZoom, viewForElement, visibleTileRange, zoomedView };
+  globalThis.StrategicMap = { boxesOverlap, hitTargetRadius, initializeMap, labelPriorityThreshold, layoutLabels, parentTileFallback, parseViewBox, pannedView, renderTiles, resizedView, scaleHitTargets, tileZoom, viewForElement, visibleTileRange, zoomedView };
   initializeStrategicMaps();
   document.addEventListener("strategic-live-regions-refreshed", () => initializeStrategicMaps());
 })();

--- a/crates/strategic-web/static/strategic-time.js
+++ b/crates/strategic-web/static/strategic-time.js
@@ -11,18 +11,18 @@
   const lighting = (minutes) => {
     const hour = (minutes % 1440) / 60;
     const stops = [
-      [0, [3, 6, 16], [8, 13, 29], 0.98, 22],
-      [5, [15, 18, 35], [28, 31, 48], 0.78, 26],
-      [6, [111, 48, 38], [48, 56, 83], 0.2, 42],
-      [7, [219, 106, 57], [79, 105, 146], 0.02, 62],
-      [9, [73, 143, 204], [30, 91, 166], 0, 75],
-      [12, [84, 166, 230], [35, 108, 194], 0, 82],
-      [15, [69, 145, 210], [29, 91, 170], 0, 78],
-      [17, [78, 116, 168], [34, 69, 126], 0.02, 68],
-      [18, [218, 102, 55], [101, 57, 89], 0.18, 52],
-      [19, [105, 40, 42], [39, 32, 57], 0.68, 34],
-      [21, [7, 10, 23], [11, 16, 35], 0.98, 24],
-      [24, [3, 6, 16], [8, 13, 29], 0.98, 22],
+      [0, [3, 6, 16], [8, 13, 29], 0.98, 22, 0],
+      [5, [15, 18, 35], [28, 31, 48], 0.78, 26, 0.08],
+      [6, [111, 48, 38], [48, 56, 83], 0.2, 42, 0.78],
+      [7, [219, 106, 57], [79, 105, 146], 0.02, 62, 1],
+      [9, [73, 143, 204], [30, 91, 166], 0, 75, 0.18],
+      [12, [84, 166, 230], [35, 108, 194], 0, 82, 0.06],
+      [15, [69, 145, 210], [29, 91, 170], 0, 78, 0.12],
+      [17, [78, 116, 168], [34, 69, 126], 0.02, 68, 0.45],
+      [18, [218, 102, 55], [101, 57, 89], 0.18, 52, 1],
+      [19, [105, 40, 42], [39, 32, 57], 0.68, 34, 0.68],
+      [21, [7, 10, 23], [11, 16, 35], 0.98, 24, 0.05],
+      [24, [3, 6, 16], [8, 13, 29], 0.98, 22, 0],
     ];
     const right = stops.findIndex(([at]) => at >= hour);
     const left = Math.max(0, right - 1);
@@ -37,11 +37,16 @@
     const glow = daylight
       ? (twilight < 2 ? "rgb(255 169 94 / 76%)" : "rgb(255 244 194 / 82%)")
       : "rgb(181 207 255 / 42%)";
+    const building = stops[left][4] + (stops[right][4] - stops[left][4]) * amount;
+    const light = Math.max(0, Math.min(1, (building - 22) / 60));
+    const warmth = stops[left][5] + (stops[right][5] - stops[left][5]) * amount;
     return {
       low: rgb(mix(stops[left][1], stops[right][1], amount)),
       high: rgb(mix(stops[left][2], stops[right][2], amount)),
       stars: stops[left][3] + (stops[right][3] - stops[left][3]) * amount,
-      building: Math.round(stops[left][4] + (stops[right][4] - stops[left][4]) * amount),
+      building: Math.round(building),
+      light,
+      warmth,
       glowX,
       glowY,
       glow,
@@ -58,6 +63,15 @@
     root.setProperty("--sky-glow-y", `${value.glowY}%`);
     root.setProperty("--star-opacity", value.stars.toFixed(2));
     root.setProperty("--building-light", `${value.building}%`);
+    root.setProperty("--environment-light", value.light.toFixed(3));
+    root.setProperty("--environment-warmth", value.warmth.toFixed(3));
+    root.setProperty("--environment-tint", value.high);
+    root.setProperty("--map-light", (0.62 + value.light * 0.38).toFixed(3));
+    root.setProperty("--map-saturation", (0.7 + value.light * 0.3).toFixed(3));
+    root.setProperty("--map-atmosphere-opacity", (0.3 - value.light * 0.22 + value.warmth * 0.05).toFixed(3));
+    root.setProperty("--scene-atmosphere-opacity", ((0.3 - value.light * 0.22 + value.warmth * 0.05) * 0.65).toFixed(3));
+    root.setProperty("--map-surface-mix", `${(62 + value.light * 38).toFixed(1)}%`);
+    root.setProperty("--map-land-mix", `${(70 + value.light * 30).toFixed(1)}%`);
   };
 
   window.strategicTimeLighting = lighting;

--- a/crates/strategic-web/static/tooltips.js
+++ b/crates/strategic-web/static/tooltips.js
@@ -100,8 +100,10 @@
         activeTarget = target;
         target.addEventListener('pointerleave', hide);
         target.addEventListener('blur', hide);
+        const tooltipText = target.getAttribute(TOOLTIP_ATTRIBUTE).trim();
         const describedBy = (target.getAttribute('aria-describedby') || '').split(/\s+/).filter(Boolean);
-        descriptionWasLinked = describedBy.includes(TOOLTIP_ID);
+        const repeatsAccessibleName = target.getAttribute('aria-label')?.trim() === tooltipText;
+        descriptionWasLinked = describedBy.includes(TOOLTIP_ID) || repeatsAccessibleName;
         if (!descriptionWasLinked) target.setAttribute('aria-describedby', [...describedBy, TOOLTIP_ID].join(' '));
       }
       tooltip.textContent = target.getAttribute(TOOLTIP_ATTRIBUTE);

--- a/crates/strategic-web/tests/environment.test.cjs
+++ b/crates/strategic-web/tests/environment.test.cjs
@@ -203,7 +203,11 @@ test("wilderness headers select a tintable physical horizon", () => {
 
 test("service silhouettes expose names through the shared tooltip and keep active state non-color", () => {
   assert.match(layoutTemplate, /data-service-label=\(label\)[\s\S]*data-strategic-tooltip=\(label\)/);
+  assert.match(layoutTemplate, /href="\/camp" class="nav-tab active quest-context-tab"[\s\S]*data-service-label="Camp"/);
+  assert.match(layoutTemplate, /data-location-view="map"[\s\S]*data-service-label="Map"/);
+  assert.match(layoutTemplate, /data-location-view="enemy"[\s\S]*data-service-label="Enemy"/);
   assert.match(layoutCss, /\.settlement-services \.nav-tab:focus-visible/);
+  assert.match(layoutCss, /@media \(hover: none\), \(pointer: coarse\)[\s\S]*\.service-tab-label \{[\s\S]*display: block/);
   assert.match(layoutCss, /\.nav-tab\.active::after[\s\S]*height: 3px/);
   assert.match(layoutCss, /padding: 0\.75rem 0\.5rem 0\.65rem/);
 });

--- a/crates/strategic-web/tests/environment.test.cjs
+++ b/crates/strategic-web/tests/environment.test.cjs
@@ -9,6 +9,8 @@ const baseCss = fs.readFileSync("crates/strategic-web/static/css/base.css", "utf
 const layoutCss = fs.readFileSync("crates/strategic-web/static/css/layout.css", "utf8");
 const componentsCss = fs.readFileSync("crates/strategic-web/static/css/components.css", "utf8");
 const strategicCss = fs.readFileSync("crates/strategic-web/static/css/strategic.css", "utf8");
+const recruitmentTemplate = fs.readFileSync("crates/strategic-web/src/templates/recruitment.rs", "utf8");
+const appliedStyles = new Map();
 
 test("grouped inventory disclosures stay beside their labels in narrow merchant rails", () => {
   assert.match(strategicCss, /:is\(\.currency-parent-row, \.alcohol-parent-row, \.food-parent-row\) \.inventory-item-label \{[\s\S]*display: inline-block;[\s\S]*max-width: calc\(100% - 1\.5rem\);/);
@@ -23,7 +25,7 @@ const window = {
 };
 vm.runInNewContext(source, {
   window,
-  document: { documentElement: { style: { setProperty() {} } }, querySelectorAll: () => [] },
+  document: { documentElement: { style: { setProperty(name, value) { appliedStyles.set(name, value); } } }, querySelectorAll: () => [] },
   Promise,
 });
 
@@ -60,6 +62,38 @@ test("daytime sky is bright while strategic surfaces stay building-derived", () 
   assert.match(baseCss, /--building-interactive:color-mix/);
   assert.match(strategicCss, /\.trade-inventory-row \{[\s\S]*background: var\(--building-interactive\)/);
   assert.match(strategicCss, /\.main-grid \.btn:not\(\.btn-danger\)[\s\S]*background: var\(--building-interactive\)/);
+});
+
+test("continuous environment tokens cover night, dawn, noon, sunset, and twilight", () => {
+  const at = (hour) => window.strategicTimeLighting(hour * 60);
+  const [midnight, dawn, noon, sunset, twilight] = [0, 6, 12, 18, 19].map(at);
+  assert.equal(midnight.light, 0);
+  assert.equal(noon.light, 1);
+  assert.ok(dawn.light > midnight.light && dawn.light < noon.light);
+  assert.ok(sunset.light > twilight.light && sunset.light < noon.light);
+  assert.ok(dawn.warmth > .7 && sunset.warmth > .9 && midnight.warmth === 0);
+  for (const hour of [0, 5, 6, 7, 9, 12, 15, 17, 18, 19, 21]) {
+    const before = window.strategicTimeLighting(((hour * 60 - 1) + 1440) % 1440);
+    const after = window.strategicTimeLighting((hour * 60 + 1) % 1440);
+    assert.ok(Math.abs(before.light - after.light) < .02, `light discontinuity at ${hour}:00`);
+    assert.ok(Math.abs(before.warmth - after.warmth) < .04, `warmth discontinuity at ${hour}:00`);
+  }
+
+  window.strategicTimeApplyLighting(99);
+  for (const token of [
+    "--environment-light", "--environment-warmth", "--environment-tint",
+    "--map-light", "--map-saturation", "--map-atmosphere-opacity", "--scene-atmosphere-opacity",
+    "--map-surface-mix", "--map-land-mix",
+  ]) assert.ok(appliedStyles.has(token), `${token} was not applied`);
+  assert.ok(Number(appliedStyles.get("--map-light")) >= .62);
+});
+
+test("environmental map treatment is scoped away from semantic overlays and controls", () => {
+  assert.match(strategicCss, /\.map-tile-layer image \{ filter: brightness\(var\(--map-light/);
+  assert.match(strategicCss, /\.map-atmosphere-layer \{[^}]*var\(--environment-tint/);
+  assert.doesNotMatch(strategicCss, /\.map-overlay-layer[^}]*filter:/);
+  assert.doesNotMatch(strategicCss, /\.strategic-map-control[^}]*--map-light/);
+  assert.match(strategicCss, /\.map-pin-link:focus-visible[\s\S]*#fff8dc[\s\S]*drop-shadow/);
 });
 
 test("settlement tabs layer tiered tintable buildings and proportional horizons beneath service icons", () => {
@@ -123,7 +157,7 @@ test("settlement smithies and wilderness tabs use independent non-interactive ef
   assert.match(layoutCss, /\.topbar-scene-effect-plane \{[\s\S]*bottom: var\(--topbar-prop-baseline\);[\s\S]*width: 6\.55rem;[\s\S]*height: 6\.55rem;[\s\S]*scale\(var\(--topbar-prop-scale\)\)/);
   assert.match(layoutCss, /@media \(max-width: 1200px\)[\s\S]*--topbar-prop-scale: 0\.8473;[\s\S]*data-environment="wilderness"[\s\S]*--topbar-prop-scale: 0\.8473;/);
   assert.match(layoutCss, /\.campfire-smoke \{[\s\S]*--smoke-rise-distance: -180px;/);
-  assert.match(layoutCss, /@media \(max-width: 768px\)[\s\S]*padding: 0\.75rem 0\.5rem 0\.35rem;[\s\S]*overflow-y: hidden;[\s\S]*--topbar-prop-scale: 0\.8855;[\s\S]*\.campfire-smoke \{[\s\S]*--smoke-rise-distance: -110px;/);
+  assert.match(layoutCss, /@media \(max-width: 768px\)[\s\S]*padding: 0\.75rem 0\.5rem 0\.65rem;[\s\S]*overflow-y: hidden;[\s\S]*--topbar-prop-scale: 0\.8855;[\s\S]*\.campfire-smoke \{[\s\S]*--smoke-rise-distance: -110px;/);
 
   const smokeFrames = layoutCss.match(/@keyframes wilderness-smoke-rise \{[\s\S]*?\n\}/)?.[0] ?? "";
   const flameFrames = layoutCss.match(/@keyframes wilderness-flame-flicker \{[\s\S]*?\n\}/)?.[0] ?? "";
@@ -165,6 +199,19 @@ test("wilderness headers select a tintable physical horizon", () => {
   for (const variant of ["forest", "grassland", "hills"]) {
     assert.match(layoutCss, new RegExp(`data-wilderness-variant="${variant}"[\\s\\S]*background/wilderness/${variant}\\.png`));
   }
+});
+
+test("service silhouettes expose names through the shared tooltip and keep active state non-color", () => {
+  assert.match(layoutTemplate, /data-service-label=\(label\)[\s\S]*data-strategic-tooltip=\(label\)/);
+  assert.match(layoutCss, /\.settlement-services \.nav-tab:focus-visible/);
+  assert.match(layoutCss, /\.nav-tab\.active::after[\s\S]*height: 3px/);
+  assert.match(layoutCss, /padding: 0\.75rem 0\.5rem 0\.65rem/);
+});
+
+test("party check exact values have keyboard and shared-tooltip paths", () => {
+  assert.match(recruitmentTemplate, /data-party-check-track[\s\S]*tabindex="0"[\s\S]*data-strategic-tooltip=\(&description\)/);
+  assert.match(strategicCss, /\.party-check-track:focus-visible \.party-check-exact/);
+  assert.match(strategicCss, /\.party-check-track:focus-visible \{ outline:/);
 });
 
 test("settlement side panels use tint-derived frames around neutral recesses", () => {

--- a/crates/strategic-web/tests/strategic-map-behavior.test.cjs
+++ b/crates/strategic-web/tests/strategic-map-behavior.test.cjs
@@ -7,9 +7,9 @@ const { parseHTML } = require("linkedom");
 
 const source = fs.readFileSync(path.join(__dirname, "..", "static", "strategic-map.js"), "utf8");
 
-const load = ({ ResizeObserver } = {}) => {
+const load = ({ ResizeObserver, matchMedia } = {}) => {
   const { document } = parseHTML(`<main></main>`);
-  const context = { document, localStorage: null, ResizeObserver };
+  const context = { document, localStorage: null, ResizeObserver, matchMedia };
   context.globalThis = context;
   vm.runInNewContext(source, context);
   return { document, helpers: context.StrategicMap };
@@ -83,13 +83,34 @@ test("visible controls zoom and reset through the shared camera", () => {
   const map = document.querySelector("section");
   helpers.initializeMap(map);
   const svg = map.querySelector("svg");
-  map.querySelector('[data-map-action="zoom-in"]').click();
+  const zoomIn = map.querySelector('[data-map-action="zoom-in"]');
+  zoomIn.focus();
+  zoomIn.click();
   assert.equal(svg.getAttribute("viewBox"), "140.00 120.00 320.00 160.00");
+  if (document.activeElement) assert.equal(document.activeElement, zoomIn);
   map.querySelector('[data-map-action="zoom-out"]').click();
   assert.equal(svg.getAttribute("viewBox"), "100.00 100.00 400.00 200.00");
   map.querySelector('[data-map-action="zoom-in"]').click();
   map.querySelector('[data-map-action="reset"]').click();
   assert.equal(svg.getAttribute("viewBox"), "100.00 100.00 400.00 200.00");
+  assert.doesNotMatch(source, /svg\.focus/);
+});
+
+test("hit targets stay compact for fine pointers and resolve to 48 screen pixels for coarse pointers", () => {
+  const fine = load();
+  assert.equal(fine.helpers.hitTargetRadius(1200, false), 13);
+  assert.equal(fine.helpers.hitTargetRadius(390, false), 13);
+  assert.equal(fine.helpers.hitTargetRadius(390, true), 24);
+  assert.equal(fine.helpers.hitTargetRadius(780, true), 12);
+
+  const coarse = load({ matchMedia: () => ({ matches: true }) });
+  coarse.document.body.innerHTML = `<svg><circle class="map-settlement-hit-area" r="13"></circle><circle class="map-settlement-hit-area map-settlement-hit-overlay" r="13"></circle><circle class="map-quest-hit-area" r="13"></circle></svg>`;
+  const svg = coarse.document.querySelector("svg");
+  coarse.helpers.scaleHitTargets(svg, 780);
+  assert.deepEqual(
+    [...svg.querySelectorAll("circle")].map((target) => target.getAttribute("r")),
+    ["12.000", "12.000", "12.000"],
+  );
 });
 
 test("pin symbols retain their screen size while zooming and resetting", () => {

--- a/crates/strategic-web/tests/strategic-map-behavior.test.cjs
+++ b/crates/strategic-web/tests/strategic-map-behavior.test.cjs
@@ -74,6 +74,24 @@ test("keyboard pan and reset change only the SVG viewBox", () => {
   assert.equal(svg.getAttribute("viewBox"), "100.00 100.00 400.00 200.00");
 });
 
+test("visible controls zoom and reset through the shared camera", () => {
+  const { document, helpers } = load();
+  document.body.innerHTML = `<section data-strategic-map>
+    <button data-map-action="zoom-in"></button><button data-map-action="zoom-out"></button><button data-map-action="reset"></button>
+    <svg data-map-svg viewBox="100 100 400 200"></svg>
+  </section>`;
+  const map = document.querySelector("section");
+  helpers.initializeMap(map);
+  const svg = map.querySelector("svg");
+  map.querySelector('[data-map-action="zoom-in"]').click();
+  assert.equal(svg.getAttribute("viewBox"), "140.00 120.00 320.00 160.00");
+  map.querySelector('[data-map-action="zoom-out"]').click();
+  assert.equal(svg.getAttribute("viewBox"), "100.00 100.00 400.00 200.00");
+  map.querySelector('[data-map-action="zoom-in"]').click();
+  map.querySelector('[data-map-action="reset"]').click();
+  assert.equal(svg.getAttribute("viewBox"), "100.00 100.00 400.00 200.00");
+});
+
 test("pin symbols retain their screen size while zooming and resetting", () => {
   const { document, helpers } = load();
   document.body.innerHTML = `<section data-strategic-map><svg data-map-svg viewBox="100 100 195 130"><g data-map-pin-symbol></g></svg></section>`;
@@ -92,7 +110,7 @@ test("pin symbols retain their screen size while zooming and resetting", () => {
   assert.equal(symbol.getAttribute("transform"), "scale(0.50000)");
 });
 
-test("two-pointer pinch zooms without visible controls", () => {
+test("two-pointer pinch remains available independently of visible controls", () => {
   const { document, helpers } = load();
   document.body.innerHTML = `<section data-strategic-map><svg data-map-svg viewBox="100 100 400 200"></svg></section>`;
   const map = document.querySelector("section");

--- a/crates/strategic-web/tests/tooltips.test.cjs
+++ b/crates/strategic-web/tests/tooltips.test.cjs
@@ -100,6 +100,19 @@ test('existing accessible names and descriptions are not overwritten', () => {
   assert.equal(button.getAttribute('aria-describedby'), 'inventory-help');
 });
 
+test('tooltip text identical to the accessible name is not linked as a duplicate description', () => {
+  const { window, document, system } = fixture(
+    '<button aria-label="Zoom in" aria-describedby="map-help" data-strategic-tooltip="Zoom in"></button>',
+  );
+  const button = document.querySelector('button');
+  dispatch(window, button, 'focusin');
+  assert.equal(system.tooltip.textContent, 'Zoom in');
+  assert.equal(system.tooltip.hidden, false);
+  assert.equal(button.getAttribute('aria-describedby'), 'map-help');
+  system.hide();
+  assert.equal(button.getAttribute('aria-describedby'), 'map-help');
+});
+
 test('nested meter segments show their own multiline value tooltip', () => {
   const { window, document, system } = fixture(
     '<div data-strategic-tooltip="Filth system"><span data-strategic-tooltip="Blood\n24"></span></div>',


### PR DESCRIPTION
## Summary

- extend the existing continuous character-time lighting curve into reusable normalized environmental tokens
- apply a readable night floor and atmospheric tint to map and scene scenery while keeping controls, text, pins, labels, and focus rings at authored contrast
- add visible accessible map zoom/reset controls, immediate pin/service tooltips, responsive hit targets, stronger hover/focus feedback, and a non-color connected-route cue
- add touch-visible service labels, preserve keyboard focus on map controls, improve responsive stage containment, and unify surgery tooltips

## Motivation

The settlement header already interpolated continuously through night, dawn, day, sunset, and twilight, but that environmental treatment stopped at the header. At night the paper map and several ambient stage surfaces remained visually bright, producing a jarring split scene. The map also hid core camera controls, icon-only service navigation was undiscoverable on touch, and some hover-only details lacked complete keyboard/coarse-pointer paths.

## Notable implementation choices

- Environmental variables are continuous outputs of the existing 12-stop curve; there is no binary theme switch.
- Text-bearing surfaces remain opaque and dark. Only scenic/map tile layers are tinted, with a 62% map brightness floor.
- Semantic pins, labels, controls, focus rings, and the licence link stay outside the atmospheric filter.
- Fine-pointer pin hit zones stay compact; coarse-pointer zones resolve to roughly 48 CSS pixels independent of map width.
- Service buildings remain the primary navigation silhouettes, with shared mouse/keyboard tooltips and compact labels on coarse pointers.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p strategic-web` — 187 passed
- targeted Node environment/map/tooltip suites — 44 passed
- `git diff --check`
- `python scripts/update_project_map.py --check`

Two independent reviews were completed. All medium findings were remediated: button focus retention, screen-sized coarse pin targets, touch-visible service labels/focusable Camp navigation, and duplicate screen-reader tooltip descriptions.

## Manual demo

1. Start the isolated strategic stack and open a settlement map at character time 01:39.
2. Confirm map tiles/base are cool and subdued while labels, route pins, focus halos, controls, and licence remain readable.
3. Compare dawn, noon, sunset, twilight, and midnight; transitions should remain continuous with no theme swap.
4. Exercise +/-/reset, wheel, keyboard +/−/Home/arrows, drag, pinch, and ordinary pin link navigation.
5. At 1280×720 and 390px, inspect settlement overview, map, merchant, weapons, armour, clothing, herbalist, inn, and church for service labels, caption wrapping, and touch target sizing.

## Risk / rollback

The main browser compatibility risk is SVG atmospheric blending. Tile brightness and saturation still provide the readable night floor if a browser handles the color blend differently. The two commits can be reverted without schema or persisted-data changes.
