### PR TITLE
Fix surgery and meta-skill rail interactions

### DIFF
--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -5238,11 +5238,14 @@ fn attribute_group_with_labels(
             Some(side) => format!("attribute-group limb-attribute-column {side}"),
             None => "attribute-group".to_owned(),
         }) {
-            @if let Some(base) = surgery_base {
-                a class="limb-surgery-link" href=(format!("{base}/{slug}")) aria-label=(format!("Treat {name}")) {}
-            }
             div class="attribute-group-heading" { (name) }
-            (regional_health_bar(name, health, medical, region, injuries, projectiles))
+            @if let Some(base) = surgery_base {
+                a class="limb-surgery-link" href=(format!("{base}/{slug}")) aria-label=(format!("Treat {name}")) {
+                    (regional_health_bar(name, health, medical, region, injuries, projectiles))
+                }
+            } @else {
+                (regional_health_bar(name, health, medical, region, injuries, projectiles))
+            }
             @for (attribute_name, icon, value) in rows {
                 (attribute_row(attribute_name, icon, *value, health, show_labels))
             }
@@ -8185,6 +8188,32 @@ mod tests {
         assert!(markup.contains("Phlegmatic"));
         assert!(markup.contains("role=\"meter\""));
         assert!(markup.contains("Chest:"));
+    }
+
+    #[test]
+    fn surgery_selection_link_only_wraps_the_region_health_bar() {
+        let markup = attribute_group(
+            "Head",
+            "head",
+            0.75,
+            &crate::medical::MedicalPresentation::default(),
+            6,
+            Some("/place/party/1/surgery"),
+            &[],
+            &[],
+            &[("Intelligence", "intelligence", 3.0)],
+        )
+        .into_string();
+
+        let link_start = markup.find("class=\"limb-surgery-link\"").unwrap();
+        let health_bar = markup.find("class=\"attribute-health-bar\"").unwrap();
+        let link_end = markup[link_start..].find("</a>").unwrap() + link_start;
+        let attribute_row = markup.find("class=\"party-attribute-row\"").unwrap();
+
+        assert!(link_start < health_bar);
+        assert!(health_bar < link_end);
+        assert!(link_end < attribute_row);
+        assert!(markup.contains("aria-label=\"Treat Head\""));
     }
 
     #[test]

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -4190,10 +4190,10 @@ body.chat-resizing {
 }
 
 .limb-surgery-link {
-    position: absolute;
-    inset: 0;
-    z-index: 3;
+    display: block;
     border-radius: .25rem;
+    color: inherit;
+    text-decoration: none;
 }
 
 .limb-surgery-link:hover,

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -3209,7 +3209,11 @@ button.party-portrait-action {
 .religion-auto-toggle-label input { width: 0.9rem; height: 0.9rem; margin: 0; }
 
 .religion-expand-cell {
+  position: sticky;
+  z-index: 2;
+  right: 0;
   padding-left: 0.15rem !important;
+  background: var(--content-surface-recess, var(--panel-bg));
   text-align: center;
 }
 

--- a/crates/strategic-web/tests/environment.test.cjs
+++ b/crates/strategic-web/tests/environment.test.cjs
@@ -274,6 +274,7 @@ test("skill schedule columns fit inside a framed left rail", () => {
   assert.match(strategicCss, /\.skill-schedule \.religion-auto-column \{ width: 1\.45rem; \}/);
   assert.match(strategicCss, /\.skill-schedule \.party-skill-time-column \{ width: 2\.25rem; \}/);
   assert.match(strategicCss, /\.skill-schedule \.religion-expand-column \{ width: 1\.35rem; \}/);
+  assert.match(strategicCss, /\.religion-expand-cell \{[\s\S]*position: sticky;[\s\S]*right: 0;[\s\S]*background:/);
 });
 
 test("character selection actions wrap long adventurer names inside their cards", () => {


### PR DESCRIPTION
## Summary

- wrap each surgery selection link around only the corresponding limb health bar
- remove the absolute full-attribute-group surgery overlay
- add a regression test proving attribute rows remain outside the surgery link
- pin meta-skill disclosure cells to the visible edge of narrow skill rails
- add a responsive CSS regression check for the disclosure column

## Why

The surgery link previously covered the entire limb attribute group at a higher stacking level. That made limb selection take pointer priority over the Strength and Agility attribute tooltips associated with the limb.

With this change, the health bar remains the surgery selection target while attribute icons and rank bars retain their own hover interactions.

At intermediate viewport widths, fixed skill-schedule columns could also grow wider than the 20% desktop rail. Because the rail clips horizontal overflow, the final disclosure column disappeared. Keeping that column sticky at the rail's right edge preserves the Religion, Melee, Ranged, Defense, Social, and Terrain expansion controls while the flexible skill meter yields space.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p strategic-web` (189 passed)
- `node --test crates/strategic-web/tests/environment.test.cjs` (21 passed)
