### PR TITLE
Fix stale strategic test fixtures

### DIFF
--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -8842,8 +8842,8 @@ fn reconstruct_legacy_journey_coordinates(
 mod departure_invariant_tests {
     use super::{
         CampDurationMode, JourneyRoutePlan, JourneyRoutePoint, JourneyTerrainKind,
-        JourneyTerrainSpan, Party, PartyJourneyRoute, common_movement_prefix,
-        departure_snapshot_allows_travel, party_can_continue_travel,
+        JourneyTerrainSpan, JourneyTerrainWeights, Party, PartyJourneyRoute,
+        common_movement_prefix, departure_snapshot_allows_travel, party_can_continue_travel,
         reconstruct_legacy_journey_coordinates, route_position_at_minute, set_party_journey_state,
         straight_line_distance_m, validate_journey_route_payload,
         zero_boundary_requires_settlement,
@@ -9050,7 +9050,7 @@ mod departure_invariant_tests {
             camp_remaining_minutes: 30,
             pooled_water_ml: 0.0,
             medicine_target: 0.0,
-            charisma_target: 0.0,
+            command_target: 0.0,
             religion_target: 0.0,
         };
         set_party_journey_state(

--- a/crates/adventuresim-world-import/src/manifest.rs
+++ b/crates/adventuresim-world-import/src/manifest.rs
@@ -961,7 +961,7 @@ mod tests {
     fn fixture_digest_is_stable() {
         assert_eq!(
             digest(1544, SpatialGridSpec::default(), &[fixture()]).unwrap(),
-            "0d048b844e3b9e5291e8478381c6b61028b185c9dc71ff2020798a5efe804680"
+            "b6166d29d426a36050e44965d18db006f4602fde2fd9ebd58e96df0bee41a1a8"
         );
     }
 


### PR DESCRIPTION
## Summary

- update the strategic journey test fixture from the removed `charisma_target` field to `command_target`
- import `JourneyTerrainWeights` in the journey test module
- refresh the canonical world-manifest fixture digest for world schema version 24

## Root cause

The strategic test-only fixtures lagged behind the Social/Command schema replacement and the latest world schema version, so compiling or running the relevant suites exposed stale field/import and golden-digest failures.

## Impact

Strategic test fixtures compile against the current schema, and the manifest golden test now reflects the canonical schema-24 identity.

## Validation

- `cargo test -p adventuresim-core -p adventuresim-strategic-sim -p strategic-web -p adventuresim-world-import -p adventuresim-world-schema -p adventuresim-dialogue -p adventuresim-stdb-client`
- `spacetime build`
- `cargo fmt --all -- --check`
- `git diff --check`

Browser JavaScript tests were not run because Node.js is not installed in the local environment.
