### PR TITLE
Unify character action dialogs

### DIFF
--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -21,6 +21,7 @@ use futures_util::{
     future::join_all,
     stream::{self, StreamExt},
 };
+use maud::Markup;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -50,7 +51,12 @@ impl BuildingQuery {
     fn append_to(&self, path: String) -> String {
         self.valid().map_or_else(
             || path.clone(),
-            |building| format!("{path}?building={building}"),
+            |building| {
+                format!(
+                    "{path}{}building={building}",
+                    if path.contains('?') { "&" } else { "?" }
+                )
+            },
         )
     }
 
@@ -61,7 +67,7 @@ impl BuildingQuery {
 
 #[cfg(test)]
 mod building_query_tests {
-    use super::BuildingQuery;
+    use super::{BuildingQuery, character_details_path};
 
     #[test]
     fn building_query_is_closed_and_preserved_on_redirects() {
@@ -74,6 +80,10 @@ mod building_query_tests {
             valid.append_to("/locations/settlement/x/party/1".into()),
             "/locations/settlement/x/party/1?building=inn"
         );
+        assert_eq!(
+            valid.append_to("/locations/settlement/x/party/1?cook=true".into()),
+            "/locations/settlement/x/party/1?cook=true&building=inn"
+        );
         let invalid = BuildingQuery {
             building: Some("../religion".into()),
             ..Default::default()
@@ -82,6 +92,22 @@ mod building_query_tests {
         assert_eq!(
             invalid.append_to("/locations/settlement/x/party/1".into()),
             "/locations/settlement/x/party/1"
+        );
+    }
+
+    #[test]
+    fn examination_returns_to_the_same_character_shell_and_building() {
+        let building = BuildingQuery {
+            building: Some("inn".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            building.append_to(character_details_path("settlement", "x", 7, Some(7))),
+            "/locations/settlement/x/party/7?building=inn"
+        );
+        assert_eq!(
+            building.append_to(character_details_path("settlement", "x", 7, Some(3))),
+            "/locations/settlement/x/party/7/stats?building=inn"
         );
     }
 }
@@ -116,9 +142,9 @@ use crate::templates::settlement::{
     ActivityPreviewRates, CampTravelDestination, LocationKind, LocationView, MerchantShop,
     RestSummary, SoapRestPreview, SocialPresentation, alchemy_page, camp_page,
     live_merchant_shop_page, merchants_page, party_discard_page, party_inventory_page,
-    party_personal_page, party_pool_page, party_social_page, party_stats_page, religion_page,
+    party_personal_page, party_pool_page, party_social_dialog, party_stats_page, religion_page,
     rest_default_minutes, rest_result_page, settlement_map_page, settlement_overview_page,
-    surgery_page,
+    surgery_dialog,
 };
 
 pub fn routes() -> Router<AppState> {
@@ -310,6 +336,7 @@ fn parse_surgery_limb(slug: &str) -> Option<LimbRegion> {
 async fn surgery(
     State(state): State<AppState>,
     Path((kind, id, patient_id, limb)): Path<(String, String, u64, String)>,
+    Query(building): Query<BuildingQuery>,
     session: Session,
 ) -> Html<String> {
     let Some(actor_id) = session.character_id_u64() else {
@@ -318,13 +345,14 @@ async fn surgery(
     let Some(selected_limb) = parse_surgery_limb(&limb) else {
         return Html("<h1>Limb not found</h1>".into());
     };
-    let location = match resolve_location(&state, &kind, &id).await {
+    let mut location = match resolve_location(&state, &kind, &id).await {
         LocationLookup::Found(location) => location,
         LocationLookup::NotFound => return Html("<h1>Location not found</h1>".into()),
         LocationLookup::Unavailable => {
             return Html("<h1>Strategic data is unavailable</h1>".into());
         }
     };
+    location.active_building = building.valid().map(str::to_owned);
     let Some((active, _)) = get_active_character(&state, Some(actor_id)).await else {
         return Html("<h1>Choose a character first</h1>".into());
     };
@@ -431,39 +459,48 @@ async fn surgery(
         })
         .map(|item| item.qty)
         .sum();
-    let patient_capability = get_character_capability(&state, patient_id).await;
-    let patient_attributes =
-        query_single::<CharacterAttributes>(&state, "character_attributes", patient_id).await;
-    let patient_skills =
-        query_single::<CharacterSkills>(&state, "character_skills", patient_id).await;
-    let patient_limbs = query_single::<CharacterLimbs>(&state, "character_limbs", patient_id).await;
-    let medical = medical_presentation(&state, actor_id, patient_id).await;
-    let combat_profile = get_combat_training_profile(&state, patient_id).await;
-    Html(
-        surgery_page(
-            &location,
-            &active,
-            &patient,
-            &party_members,
-            patient_capability.as_ref(),
-            patient_attributes.as_ref(),
-            patient_skills.as_ref(),
-            patient_limbs.as_ref(),
-            &medical,
-            combat_profile,
-            &injuries,
-            &projectiles,
-            selected_limb,
-            quantity("bandage"),
-            quantity("surgery_kit"),
-            available_splints,
-            quantity("soft_soap"),
-            alcohol_count,
-            selected_alcohol,
-            procedure_checks,
+    let dialog = surgery_dialog(
+        &location,
+        &active,
+        &patient,
+        &injuries,
+        &projectiles,
+        selected_limb,
+        quantity("bandage"),
+        quantity("surgery_kit"),
+        available_splints,
+        quantity("soft_soap"),
+        alcohol_count,
+        selected_alcohol,
+        procedure_checks,
+    );
+    if patient_id == active.id {
+        render_party_personal(
+            &state,
+            &kind,
+            &id,
+            patient_id,
+            building,
+            &session,
+            Some(dialog),
+            Some(&limb),
+            false,
         )
-        .into_string(),
-    )
+        .await
+    } else {
+        render_party_stats(
+            &state,
+            &kind,
+            &id,
+            patient_id,
+            building,
+            &session,
+            Some(dialog),
+            Some(&limb),
+            false,
+        )
+        .await
+    }
 }
 
 #[derive(Deserialize)]
@@ -530,15 +567,16 @@ mod surgery_reducer_argument_tests {
 async fn perform_surgery(
     State(state): State<AppState>,
     Path((kind, id, patient_id, limb)): Path<(String, String, u64, String)>,
+    Query(building): Query<BuildingQuery>,
     session: Session,
     Form(form): Form<SurgeryProcedureForm>,
 ) -> Redirect {
     let destination = format!("/locations/{kind}/{id}/party/{patient_id}/surgery/{limb}");
     let Some(actor_id) = session.character_id_u64() else {
-        return Redirect::to(&destination);
+        return Redirect::to(&building.append_to(destination));
     };
     if parse_surgery_limb(&limb).is_none() {
-        return Redirect::to(&destination);
+        return Redirect::to(&building.append_to(destination));
     }
     if let Err(error) = state
         .db
@@ -557,7 +595,7 @@ async fn perform_surgery(
     {
         tracing::warn!(?error, "Manual surgery procedure failed");
     }
-    Redirect::to(&destination)
+    Redirect::to(&building.append_to(destination))
 }
 
 #[derive(Default, Deserialize)]
@@ -2593,6 +2631,32 @@ async fn party_personal(
     Query(building): Query<BuildingQuery>,
     session: Session,
 ) -> Html<String> {
+    render_party_personal(
+        &state,
+        &kind,
+        &id,
+        character_id,
+        building,
+        &session,
+        None,
+        None,
+        false,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn render_party_personal(
+    state: &AppState,
+    kind: &str,
+    id: &str,
+    character_id: u64,
+    building: BuildingQuery,
+    session: &Session,
+    dialog: Option<Markup>,
+    surgery_open: Option<&str>,
+    social_open: bool,
+) -> Html<String> {
     let mut location = match resolve_location(&state, &kind, &id).await {
         LocationLookup::Found(location) => location,
         LocationLookup::NotFound => return Html("<h1>Location not found</h1>".to_string()),
@@ -2764,6 +2828,9 @@ async fn party_personal(
             &active_inventory,
             &food_lots,
             &item_definitions,
+            dialog,
+            surgery_open,
+            social_open,
         )
         .into_string(),
     )
@@ -2779,6 +2846,7 @@ struct CookFoodForm {
 async fn cook_food(
     State(state): State<AppState>,
     Path((kind, id, character_id)): Path<(String, String, u64)>,
+    Query(building): Query<BuildingQuery>,
     session: Session,
     Form(form): Form<CookFoodForm>,
 ) -> Response {
@@ -2830,9 +2898,9 @@ async fn cook_food(
         tracing::warn!(%error, character_id, "cooking failed");
         return (StatusCode::BAD_REQUEST, error.to_string()).into_response();
     }
-    Redirect::to(&format!(
+    Redirect::to(&building.append_to(format!(
         "/locations/{kind}/{id}/party/{character_id}?cook=true"
-    ))
+    )))
     .into_response()
 }
 
@@ -3576,6 +3644,32 @@ async fn party_stats(
     Query(building): Query<BuildingQuery>,
     session: Session,
 ) -> Html<String> {
+    render_party_stats(
+        &state,
+        &kind,
+        &id,
+        character_id,
+        building,
+        &session,
+        None,
+        None,
+        false,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn render_party_stats(
+    state: &AppState,
+    kind: &str,
+    id: &str,
+    character_id: u64,
+    building: BuildingQuery,
+    session: &Session,
+    dialog: Option<Markup>,
+    surgery_open: Option<&str>,
+    social_open: bool,
+) -> Html<String> {
     let mut location = match resolve_location(&state, &kind, &id).await {
         LocationLookup::Found(location) => location,
         LocationLookup::NotFound => return Html("<h1>Location not found</h1>".to_string()),
@@ -3721,6 +3815,9 @@ async fn party_stats(
             &injuries,
             &projectiles,
             &filth,
+            dialog,
+            surgery_open,
+            social_open,
         )
         .into_string(),
     )
@@ -3792,9 +3889,11 @@ pub(crate) async fn medical_presentation(
 async fn examine_patient(
     State(state): State<AppState>,
     Path((kind, id, target_id)): Path<(String, String, u64)>,
+    Query(building): Query<BuildingQuery>,
     session: Session,
 ) -> Redirect {
-    if let Some(doctor_id) = session.character_id_u64()
+    let doctor_id = session.character_id_u64();
+    if let Some(doctor_id) = doctor_id
         && let Err(error) = state
             .db
             .call("examine_patient", &[json!(doctor_id), json!(target_id)])
@@ -3802,15 +3901,17 @@ async fn examine_patient(
     {
         tracing::warn!(%error, doctor_id, target_id, "patient examination rejected");
     }
-    Redirect::to(&format!("/locations/{kind}/{id}/party/{target_id}/stats"))
+    Redirect::to(&building.append_to(character_details_path(&kind, &id, target_id, doctor_id)))
 }
 
 async fn dismiss_medical_examination(
     State(state): State<AppState>,
     Path((kind, id, target_id, examination_id)): Path<(String, String, u64, u64)>,
+    Query(building): Query<BuildingQuery>,
     session: Session,
 ) -> Redirect {
-    if let Some(doctor_id) = session.character_id_u64()
+    let doctor_id = session.character_id_u64();
+    if let Some(doctor_id) = doctor_id
         && let Err(error) = state
             .db
             .call(
@@ -3821,7 +3922,15 @@ async fn dismiss_medical_examination(
     {
         tracing::warn!(%error, doctor_id, target_id, examination_id, "examination dismissal rejected");
     }
-    Redirect::to(&format!("/locations/{kind}/{id}/party/{target_id}/stats"))
+    Redirect::to(&building.append_to(character_details_path(&kind, &id, target_id, doctor_id)))
+}
+
+fn character_details_path(kind: &str, id: &str, target_id: u64, viewer_id: Option<u64>) -> String {
+    if viewer_id == Some(target_id) {
+        format!("/locations/{kind}/{id}/party/{target_id}")
+    } else {
+        format!("/locations/{kind}/{id}/party/{target_id}/stats")
+    }
 }
 
 async fn get_strategic_condition(
@@ -3895,18 +4004,7 @@ async fn party_social(
         return Html("<h1>Social actions require a living, co-located party member</h1>".into());
     }
     let party_members = get_active_party_members(&state, Some(&active)).await;
-    let attributes =
-        query_single::<CharacterAttributes>(&state, "character_attributes", target_id).await;
-    let limbs = query_single::<CharacterLimbs>(&state, "character_limbs", target_id).await;
-    let condition = get_strategic_condition(&state, target_id).await;
     let sources = get_morale_sources(&state, target_id).await;
-    let filth = state
-        .db
-        .query::<CharacterFilth>(&format!(
-            "SELECT * FROM character_filth WHERE character_id = {target_id}"
-        ))
-        .await
-        .unwrap_or_default();
     let actor_sources = get_morale_sources(&state, active.id).await;
     let mut shared_concerns = actor_sources
         .iter()
@@ -3986,21 +4084,34 @@ async fn party_social(
         shared_concerns,
         unavailable: !beliefs_available || !affinity_available || !familiarity_available,
     };
-    Html(
-        party_social_page(
-            &location,
-            &selected,
-            &active,
-            &party_members,
-            attributes.as_ref(),
-            limbs.as_ref(),
-            condition.as_ref(),
-            &sources,
-            &filth,
-            &social,
+    let dialog = party_social_dialog(&location, &selected, &active, &sources, &social);
+    if target_id == active.id {
+        render_party_personal(
+            &state,
+            &kind,
+            &id,
+            target_id,
+            building,
+            &session,
+            Some(dialog),
+            None,
+            true,
         )
-        .into_string(),
-    )
+        .await
+    } else {
+        render_party_stats(
+            &state,
+            &kind,
+            &id,
+            target_id,
+            building,
+            &session,
+            Some(dialog),
+            None,
+            true,
+        )
+        .await
+    }
 }
 
 #[derive(Deserialize)]

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -167,6 +167,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 script src="/static/developer-mode.js?v=dialogue-sources-1" defer {}
                 script src="/static/tooltips.js?v=styled-tooltips-2" defer {}
                 script src="/static/medical-examination.js?v=strategic-dialogs-1" defer {}
+                script src="/static/character-action-dialog.js?v=character-actions-1" defer {}
                 @if scripts != ScriptProfile::Entry {
                     script src="/static/live-state.js?v=sse-3" defer {}
                     script src="/static/live-regions.js?v=floating-time-editor-1" defer {}

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -1890,20 +1890,21 @@ pub fn party_personal_page(
     food_lots: &[FoodLot],
     item_definitions: &[ItemDefinition],
 ) -> Markup {
-    if cooking {
-        return cooking_activity_page(
-            location,
-            active_character,
-            party_members,
-            inventory,
-            food_lots,
-            item_definitions,
-        );
-    }
+    let cooking_href = location.preserve_building(format!(
+        "{}/party/{}?cook=true",
+        location.base_path(),
+        active_character.id
+    ));
+    let examination_action = format!(
+        "{}/party/{}/examine",
+        location.base_path(),
+        active_character.id
+    );
+    let cooking_open = cooking && medical.examination_id.is_none();
     let content = html! {
         aside class="left-sidebar" {
-            (party_attributes_rail("Your attributes", attributes, limbs, medical, Some(&format!("{}/party/{}/surgery", location.base_path(), active_character.id)), injuries, projectiles))
-            (strategic_condition_rail(condition, morale_sources, filth, &location.preserve_building(format!("{}/party/{}/social", location.base_path(), active_character.id))))
+            (party_attributes_rail("Your attributes", attributes, limbs, medical, Some((&format!("{}/party/{}/surgery", location.base_path(), active_character.id), None)), injuries, projectiles))
+            (strategic_condition_rail(condition, morale_sources, filth, &location.preserve_building(format!("{}/party/{}/social", location.base_path(), active_character.id)), false))
             (medical_rail(medical, &location.base_path(), active_character.id, active_character.id, true))
             @if let Some(demand) = religious_demand {
                 (religious_demand_rail(demand, &location.base_path(), active_character.id))
@@ -1930,16 +1931,24 @@ pub fn party_personal_page(
                 Some(activity_preview), religion_id.is_some(), prayer_religion_check,
                 religion_id.or(location.religion_id.as_deref()),
                 combat_profile,
+                CharacterSkillActions {
+                    cooking_href: Some(&cooking_href),
+                    cooking_open,
+                    examination_action: can_examine.then_some(examination_action.as_str()),
+                    examination_open: medical.examination_id.is_some(),
+                },
             ))
+        }
+        @if cooking_open {
+            (cooking_activity_dialog(location, active_character, inventory, food_lots, item_definitions))
         }
     };
     location.render_layout("Party", content, Some(&active_character.name))
 }
 
-fn cooking_activity_page(
+fn cooking_activity_dialog(
     location: &LocationView,
     active_character: &Character,
-    party_members: &[Character],
     inventory: &[InventoryItem],
     food_lots: &[FoodLot],
     item_definitions: &[ItemDefinition],
@@ -1960,9 +1969,16 @@ fn cooking_activity_page(
                 .any(|lot| lot.inventory_item_id == Some(item.id))
         })
         .collect::<Vec<_>>();
-    let content = html! {
-        div class="cooking-activity" data-cooking-activity {
-            aside class="left-sidebar cooking-pot" aria-label="Cooking pot" {
+    html! {
+        div class="character-action-overlay" data-character-action-dialog data-initial-focus="[data-cooking-method]:checked" {
+            a class="character-action-backdrop" href=(format!("{}/party/{}", location.base_path(), active_character.id)) aria-label="Close cooking dialog" {}
+            section class="character-action-dialog cooking-dialog" role="dialog" aria-modal="true" aria-labelledby="cooking-dialog-title" tabindex="-1" {
+            header class="character-action-dialog-header" {
+                h2 id="cooking-dialog-title" { "Cooking" }
+                a class="character-action-dialog-close" href=(format!("{}/party/{}", location.base_path(), active_character.id)) aria-label="Close cooking dialog" { "×" }
+            }
+            div class="cooking-activity" data-cooking-activity {
+            aside class="cooking-pot" aria-label="Cooking pot" {
                 (sidebar_section("Pot", html! {
                     p class="text-muted small-copy cooking-pot-empty" data-cooking-pot-empty {
                         "Transfer ingredients here to prepare a meal."
@@ -1970,8 +1986,7 @@ fn cooking_activity_page(
                     (trade_inventory_table("cooking-pot-left", InventoryColumnSet::Basic, true, false, false, html! {}))
                 }))
             }
-            main class="center-content settlement-main party-member-stage cooking-stage" {
-                (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(active_character.id), false))
+            main class="cooking-stage" {
                 section class="cooking-workspace" aria-label="Cooking workspace" {
                     div class="cooking-method-list" aria-label="Cooking instrument" {
                         (cooking_method("pan-fry", "Pan-fry", "meal", pan, "A pan is required", false))
@@ -1993,7 +2008,7 @@ fn cooking_activity_page(
                     }
                 }
             }
-            aside class="right-sidebar cooking-ingredients" aria-label="Ingredient inventory" {
+            aside class="cooking-ingredients" aria-label="Ingredient inventory" {
                 @let title = format!("{}'s inventory", active_character.name);
                 (sidebar_section(&title, html! {
                     @if ingredients.is_empty() {
@@ -2036,9 +2051,10 @@ fn cooking_activity_page(
                     }
                 }))
             }
+            }
+            }
         }
-    };
-    location.render_layout("Cooking", content, Some(&active_character.name))
+    }
 }
 
 fn cooking_method(
@@ -2169,10 +2185,11 @@ pub fn party_stats_page(
 ) -> Markup {
     let selected_attributes_title = format!("{}'s attributes", selected.name);
     let selected_skills_title = format!("{}'s skills", selected.name);
+    let examination_action = format!("{}/party/{}/examine", location.base_path(), selected.id);
     let content = html! {
         aside class="left-sidebar" {
-            (party_attributes_rail(&selected_attributes_title, selected_attributes, selected_limbs, medical, Some(&format!("{}/party/{}/surgery", location.base_path(), selected.id)), injuries, projectiles))
-            (strategic_condition_rail(condition, morale_sources, filth, &location.preserve_building(format!("{}/party/{}/social", location.base_path(), selected.id))))
+            (party_attributes_rail(&selected_attributes_title, selected_attributes, selected_limbs, medical, Some((&format!("{}/party/{}/surgery", location.base_path(), selected.id), None)), injuries, projectiles))
+            (strategic_condition_rail(condition, morale_sources, filth, &location.preserve_building(format!("{}/party/{}/social", location.base_path(), selected.id)), false))
             (medical_rail(medical, &location.base_path(), active_character.id, selected.id, true))
         }
         main class="center-content settlement-main party-member-stage" {
@@ -2201,6 +2218,11 @@ pub fn party_stats_page(
                 &selected_skills_title, selected_skills, selected_limbs, None, None, None,
                 religion_id.is_some(), 0.0, religion_id.or(location.religion_id.as_deref()),
                 combat_profile,
+                CharacterSkillActions {
+                    examination_action: can_examine.then_some(examination_action.as_str()),
+                    examination_open: medical.examination_id.is_some(),
+                    ..Default::default()
+                },
             ))
             @if selected.id != active_character.id {
                 @if active_character.party_id == selected.party_id {
@@ -2380,14 +2402,29 @@ pub fn party_social_page(
     let content = html! {
         aside class="left-sidebar" {
             (party_attributes_rail(&attribute_title, attributes, limbs, &medical, None, &[], &[]))
-            (strategic_condition_rail(condition, morale_sources, filth, &social_href))
+            (strategic_condition_rail(condition, morale_sources, filth, &social_href, true))
         }
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(selected.id), false))
             (visual_stage("character", &selected.name, "Relationship and morale"))
             (player_chat_area(selected, active_character))
         }
-        aside class="right-sidebar social-rail" data-social-panel data-target-id=(selected.id) {
+        aside class="right-sidebar" {
+            (sidebar_section("Summary", html! {
+                dl class="social-biography" {
+                    div { dt { "Age" } dd { (selected.age_years) } }
+                    div { dt { "Religion" } dd { (religion_name(social.religion_id.as_deref())) } }
+                }
+            }))
+        }
+        div class="character-action-overlay" data-character-action-dialog {
+            a class="character-action-backdrop" href=(if is_self { format!("{}/party/{}", location.base_path(), selected.id) } else { format!("{}/party/{}/stats", location.base_path(), selected.id) }) aria-label="Close social dialog" {}
+            section class="character-action-dialog social-dialog" role="dialog" aria-modal="true" aria-labelledby="social-dialog-title" tabindex="-1" {
+                header class="character-action-dialog-header" {
+                    h2 id="social-dialog-title" { "Social — " (selected.name) }
+                    a class="character-action-dialog-close" href=(if is_self { format!("{}/party/{}", location.base_path(), selected.id) } else { format!("{}/party/{}/stats", location.base_path(), selected.id) }) aria-label="Close social dialog" { "×" }
+                }
+                div class="social-rail" data-social-panel data-target-id=(selected.id) {
             (sidebar_section("What you believe", html! {
                 dl class="social-biography" {
                     div { dt { "Age" } dd { (selected.age_years) } }
@@ -2459,6 +2496,8 @@ pub fn party_social_page(
                     }
                 }
             }))
+                }
+            }
         }
     };
     location.render_layout("Social", content, Some(&selected.name))
@@ -2655,8 +2694,7 @@ fn surgery_procedure_row(
     }
 }
 
-/// Manual limb treatment replaces the ordinary right rail while retaining the
-/// portrait stage and a keyboard-navigable list of every limb on the left.
+/// Manual limb treatment is an SSR-open dialog over the ordinary character rails.
 #[allow(clippy::too_many_arguments)]
 pub fn surgery_page(
     location: &LocationView,
@@ -2698,17 +2736,25 @@ pub fn surgery_page(
     let stitching_skill = procedure_skill("stitch");
     let content = html! {
         aside class="left-sidebar" {
-            (character_summary_rail(capability))
-            (party_attributes_rail(&format!("{}'s attributes", patient.name), attributes, limbs, medical, Some(&base), injuries, projectiles))
-            (party_skills_rail(&format!("{}'s skills", patient.name), skills, limbs, None, None, None, false, 0.0, None, combat_profile))
+            (party_attributes_rail(&format!("{}'s attributes", patient.name), attributes, limbs, medical, Some((&base, Some(surgery_limb_slug(selected_limb)))), injuries, projectiles))
         }
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(patient.id), false))
             (visual_stage("npc", &patient.name, &format!("TODO: {} portrait", patient.name.to_lowercase())))
             (player_chat_area(patient, active_character))
         }
-        aside class="right-sidebar surgery-rail" {
-            (sidebar_section(&format!("{} — {}", patient.name, surgery_limb_name(selected_limb)), html! {
+        aside class="right-sidebar" {
+            (character_summary_rail(capability))
+            (party_skills_rail(&format!("{}'s skills", patient.name), skills, limbs, None, None, None, false, 0.0, None, combat_profile, CharacterSkillActions::default()))
+        }
+        div class="character-action-overlay" data-character-action-dialog {
+            a class="character-action-backdrop" href=(if self_treatment { format!("{}/party/{}", location.base_path(), patient.id) } else { format!("{}/party/{}/stats", location.base_path(), patient.id) }) aria-label="Close surgery dialog" {}
+            section class="character-action-dialog surgery-dialog" role="dialog" aria-modal="true" aria-labelledby="surgery-dialog-title" tabindex="-1" {
+                header class="character-action-dialog-header" {
+                    h2 id="surgery-dialog-title" { (patient.name) " — " (surgery_limb_name(selected_limb)) }
+                    a class="character-action-dialog-close" href=(if self_treatment { format!("{}/party/{}", location.base_path(), patient.id) } else { format!("{}/party/{}/stats", location.base_path(), patient.id) }) aria-label="Close surgery dialog" { "×" }
+                }
+                div class="surgery-rail" {
                 div class="surgery-supplies" aria-label="Surgery supplies" {
                     (surgery_supply("Bandages", "bandage-roll", bandages))
                     (surgery_supply("Surgery kits", "medical-pack", surgery_kits))
@@ -2736,7 +2782,8 @@ pub fn surgery_page(
                         p class="text-muted small-copy" { "Bruising must heal on its own." }
                     }
                 }
-            }))
+                }
+            }
         }
     };
     location.render_layout("Surgery", content, Some(&active_character.name))
@@ -3743,6 +3790,66 @@ fn trade_inventory_table_header(show_equipped: bool, condition_header: Option<Ma
     } } }
 }
 
+#[derive(Clone, Copy, Default)]
+struct CharacterSkillActions<'a> {
+    cooking_href: Option<&'a str>,
+    cooking_open: bool,
+    examination_action: Option<&'a str>,
+    examination_open: bool,
+}
+
+#[derive(Clone, Copy)]
+enum SkillAction<'a> {
+    Get {
+        href: &'a str,
+        label: &'a str,
+        open: bool,
+    },
+    Post {
+        href: &'a str,
+        label: &'a str,
+        open: bool,
+    },
+}
+
+fn skill_action_icon(name: &str, icon: &str, action: SkillAction<'_>, inside_form: bool) -> Markup {
+    let (href, label, open) = match action {
+        SkillAction::Get { href, label, open } | SkillAction::Post { href, label, open } => {
+            (href, label, open)
+        }
+    };
+    html! {
+        @match action {
+            SkillAction::Get { .. } => {
+                a class=(if open { "character-menu-button is-open" } else { "character-menu-button" })
+                    href=(href) title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open) {
+                    span class="stat-icon" style=(format!("--stat-icon: url('/static/icons/game/{icon}.svg')")) aria-hidden="true" {}
+                    @if open { span class="sr-only" { " (open)" } }
+                }
+            }
+            SkillAction::Post { .. } => {
+                @if inside_form {
+                    button type="submit" class=(if open { "character-menu-button is-open" } else { "character-menu-button" })
+                        formaction=(href) formmethod="post"
+                        title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open) {
+                        span class="stat-icon" style=(format!("--stat-icon: url('/static/icons/game/{icon}.svg')")) aria-hidden="true" {}
+                        @if open { span class="sr-only" { " (open)" } }
+                    }
+                } @else {
+                    form method="post" action=(href) class="character-menu-button-form" {
+                        button type="submit" class=(if open { "character-menu-button is-open" } else { "character-menu-button" })
+                            title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open) {
+                            span class="stat-icon" style=(format!("--stat-icon: url('/static/icons/game/{icon}.svg')")) aria-hidden="true" {}
+                            @if open { span class="sr-only" { " (open)" } }
+                        }
+                    }
+                }
+            }
+        }
+        span class="sr-only" { (name) }
+    }
+}
+
 fn party_skills_rail(
     title: &str,
     skills: Option<&CharacterSkills>,
@@ -3754,6 +3861,7 @@ fn party_skills_rail(
     prayer_religion_check: f32,
     training_religion_id: Option<&str>,
     combat_profile: CombatTrainingProfile,
+    actions: CharacterSkillActions<'_>,
 ) -> Markup {
     let head_health = limbs.map_or(1.0, |limbs| limbs.head_health);
     let upper_health = limbs.map_or(1.0, |limbs| {
@@ -3773,6 +3881,7 @@ fn party_skills_rail(
                             activity_preview, professes_religion, prayer_religion_check,
                             training_religion_id.and_then(OfficialReligion::from_id),
                             combat_profile, action.starts_with("/locations/settlement/"),
+                            actions,
                         ))
                         div class="schedule-save-status" data-schedule-save-status role="status" aria-live="polite" hidden {
                             span { "Schedule could not be saved." }
@@ -3790,6 +3899,7 @@ fn party_skills_rail(
                         professes_religion, prayer_religion_check,
                         training_religion_id.and_then(OfficialReligion::from_id),
                         combat_profile, false,
+                        actions,
                     ))
                     script src="/static/training-schedule.js?v=apprentice-system-1" {}
                 }
@@ -3814,6 +3924,7 @@ fn skills_table(
     training_religion: Option<OfficialReligion>,
     combat_profile: CombatTrainingProfile,
     immediate_actions: bool,
+    actions: CharacterSkillActions<'_>,
 ) -> Markup {
     html! {
             table class="party-skills-table" {
@@ -3843,18 +3954,18 @@ fn skills_table(
                     th scope="col" aria-label="Skill details" {}
                 } }
                 tbody {
-                    @if skills.will_hours > 0.0 { (party_skill_row("Will", "will", Skill::Will, skills.will_hours, head_health, schedule.is_some())) }
+                    @if skills.will_hours > 0.0 { (party_skill_row("Will", "will", Skill::Will, skills.will_hours, head_health, schedule.is_some(), None)) }
                     (social_skill_rows(skills, head_health, schedule))
-                    @if skills.medicine_hours > 0.0 { (party_skill_row("Medicine", "medicine", Skill::Medicine, skills.medicine_hours, head_health, schedule.is_some())) }
-                    (party_skill_row("Cooking", "cooking", Skill::Cooking, skills.cooking_hours, head_health, schedule.is_some()))
+                    @if skills.medicine_hours > 0.0 { (party_skill_row("Medicine", "medicine", Skill::Medicine, skills.medicine_hours, head_health, schedule.is_some(), actions.examination_action.map(|href| SkillAction::Post { href, label: "Perform medical examination (15 minutes)", open: actions.examination_open }))) }
+                    (party_skill_row("Cooking", "cooking", Skill::Cooking, skills.cooking_hours, head_health, schedule.is_some(), actions.cooking_href.map(|href| SkillAction::Get { href, label: "Open cooking menu", open: actions.cooking_open })))
                     (religion_skill_rows(skills, head_health, schedule, training_religion))
                     (language_skill_rows(skills, schedule.is_some()))
                     (combat_skill_rows(skills, head_health, upper_health, lower_health, schedule, combat_profile))
-                    @if skills.stealth_hours > 0.0 { (party_skill_row("Stealth", "stealth", Skill::Stealth, skills.stealth_hours, upper_health, schedule.is_some())) }
+                    @if skills.stealth_hours > 0.0 { (party_skill_row("Stealth", "stealth", Skill::Stealth, skills.stealth_hours, upper_health, schedule.is_some(), None)) }
                     (terrain_skill_rows(skills, schedule.is_some()))
-                    @if skills.anatomy_hours > 0.0 { (party_skill_row("Anatomy", "surgeon", Skill::Anatomy, skills.anatomy_hours, head_health, schedule.is_some())) }
-                    @if skills.tailoring_hours > 0.0 { (party_skill_row("Tailoring", "sewing-needle", Skill::Tailoring, skills.tailoring_hours, upper_health, schedule.is_some())) }
-                    @if skills.smithing_hours > 0.0 { (party_skill_row("Smithing", "smithing", Skill::Smithing, skills.smithing_hours, upper_health, schedule.is_some())) }
+                    @if skills.anatomy_hours > 0.0 { (party_skill_row("Anatomy", "surgeon", Skill::Anatomy, skills.anatomy_hours, head_health, schedule.is_some(), None)) }
+                    @if skills.tailoring_hours > 0.0 { (party_skill_row("Tailoring", "sewing-needle", Skill::Tailoring, skills.tailoring_hours, upper_health, schedule.is_some(), None)) }
+                    @if skills.smithing_hours > 0.0 { (party_skill_row("Smithing", "smithing", Skill::Smithing, skills.smithing_hours, upper_health, schedule.is_some(), None)) }
                     @if let Some(schedule) = schedule {
                         @let preview = activity_preview.unwrap_or_default();
                         tr class="schedule-divider" { td colspan="9" {} }
@@ -4258,6 +4369,7 @@ fn party_skill_row(
     hours: f32,
     health: f32,
     schedule_context: bool,
+    action: Option<SkillAction<'_>>,
 ) -> Markup {
     let rank = skill.training_rank(hours);
     let effective_rank = rank * health.clamp(0.0, 1.0);
@@ -4265,7 +4377,11 @@ fn party_skill_row(
     html! {
         tr class="party-skill-row" {
             th scope="row" class="party-skill-name party-skill-icon-cell" {
-                (stat_icon(name, "skills", icon, false))
+                @if let Some(action) = action {
+                    (skill_action_icon(name, icon, action, schedule_context))
+                } @else {
+                    (stat_icon(name, "skills", icon, false))
+                }
             }
             td class="party-skill-meter" colspan=[schedule_context.then_some("7")] {
                 (skill_rank_bar(rank, effective_rank, &format!("{invested_hours} hours invested"), skill_rail_bar_options()))
@@ -4612,7 +4728,8 @@ fn schedule_icon(label: &str, icon: &str, actionable: bool, activity: &str) -> M
     html! {
         @if actionable {
             button type="button" class="schedule-activity-button" data-activity-open=(activity)
-                aria-label=(format!("Perform {label} now")) title=(format!("Perform {label} now")) {
+                aria-label=(format!("Perform {label} now")) title=(format!("Perform {label} now"))
+                aria-haspopup="dialog" aria-expanded="false" {
                 span class="stat-icon schedule-special-icon"
                     style=(format!("--stat-icon: url('/static/icons/game/{icon}.svg')"))
                     aria-hidden="true" {}
@@ -4717,7 +4834,7 @@ pub(crate) fn character_stats_panel(
         (party_attributes_rail(&format!("{}'s attributes", character.name), attributes, limbs, medical, None, &[], &[]))
         (party_skills_rail(
             &format!("{}'s skills", character.name), skills, limbs, None, None, None,
-            false, 0.0, None, CombatTrainingProfile::default(),
+            false, 0.0, None, CombatTrainingProfile::default(), CharacterSkillActions::default(),
         ))
         (medical_rail(medical, "", 0, character.id, false))
     }
@@ -4956,6 +5073,7 @@ fn strategic_condition_rail(
     _morale_sources: &[crate::spacetimedb::CharacterMoraleSource],
     filth: &[crate::spacetimedb::CharacterFilth],
     social_href: &str,
+    social_open: bool,
 ) -> Markup {
     let Some(condition) = condition else {
         return html! {};
@@ -4995,7 +5113,7 @@ fn strategic_condition_rail(
     ];
     html! {
         (sidebar_section("Status", html! {
-            a class=(if condition.fear > 0.0 { "morale-meter is-fearful" } else { "morale-meter" }) href=(social_href) style=(meter_style) aria-label=(format!(
+            div class=(if condition.fear > 0.0 { "morale-meter is-fearful" } else { "morale-meter" }) style=(meter_style) role="meter" aria-valuemin="-5" aria-valuemax="5" aria-valuenow=(format!("{:.1}", condition.morale)) aria-label=(format!(
                 "Morale {:.1}; fear {}; inspiration {:.1}%",
                 condition.morale,
                 percent(condition.fear),
@@ -5003,7 +5121,13 @@ fn strategic_condition_rail(
             )) {
                 div class="morale-meter-heading" {
                     strong class="metric-label" { (decorative_game_icon("sun")) span { "Morale" } }
-                    span { (format!("{:+.1}", condition.morale)) }
+                    span class="morale-meter-value" { (format!("{:+.1}", condition.morale)) }
+                    a class=(if social_open { "character-menu-button is-open" } else { "character-menu-button" })
+                        href=(social_href) title="Open social menu" aria-label="Open social menu"
+                        aria-haspopup="dialog" aria-expanded=(social_open) {
+                        span class="stat-icon" style="--stat-icon: url('/static/icons/game/social.svg')" aria-hidden="true" {}
+                        @if social_open { span class="sr-only" { " (open)" } }
+                    }
                 }
                 div class="morale-meter-track" aria-hidden="true" {
                     span class="morale-meter-fear" {}
@@ -5225,7 +5349,7 @@ fn party_attributes_rail(
     attributes: Option<&CharacterAttributes>,
     limbs: Option<&CharacterLimbs>,
     medical: &MedicalPresentation,
-    surgery_base: Option<&str>,
+    surgery: Option<(&str, Option<&str>)>,
     injuries: &[LimbInjury],
     projectiles: &[RetainedProjectile],
 ) -> Markup {
@@ -5242,35 +5366,35 @@ fn party_attributes_rail(
     html! {
         (sidebar_section(title, html! {
             div class="party-attributes-list" aria-label="Character attributes" {
-                (attribute_group("Head", "head", head_health, medical, 6, surgery_base, injuries, projectiles, &[
+                (attribute_group("Head", "head", head_health, medical, 6, surgery, injuries, projectiles, &[
                     ("Intelligence", "intelligence", attributes.intelligence),
                     ("Instinct", "instinct", attributes.instinct),
                     ("Eyesight", "eyesight", attributes.eyesight),
                     ("Hearing", "hearing", attributes.hearing),
                 ]))
-                (attribute_group("Chest", "chest", chest_health, medical, 4, surgery_base, injuries, projectiles, &[
+                (attribute_group("Chest", "chest", chest_health, medical, 4, surgery, injuries, projectiles, &[
                     ("Endurance", "endurance", attributes.endurance),
                 ]))
-                (attribute_group("Stomach", "stomach", stomach_health, medical, 5, surgery_base, injuries, projectiles, &[
+                (attribute_group("Stomach", "stomach", stomach_health, medical, 5, surgery, injuries, projectiles, &[
                     ("Immunity", "immunity", attributes.immunity),
                     ("Gut", "gut", attributes.gut),
                 ]))
                 div class="limb-attribute-pair" {
-                    (limb_attribute_column("Left arm", "left-arm", "limb-left", left_arm_health, medical, 0, surgery_base, injuries, projectiles, &[
+                    (limb_attribute_column("Left arm", "left-arm", "limb-left", left_arm_health, medical, 0, surgery, injuries, projectiles, &[
                         ("Strength", "strength-arm", attributes.left_arm_strength),
                         ("Agility", "agility-arm", attributes.left_arm_agility),
                     ]))
-                    (limb_attribute_column("Right arm", "right-arm", "limb-right", right_arm_health, medical, 1, surgery_base, injuries, projectiles, &[
+                    (limb_attribute_column("Right arm", "right-arm", "limb-right", right_arm_health, medical, 1, surgery, injuries, projectiles, &[
                         ("Strength", "strength-arm", attributes.right_arm_strength),
                         ("Agility", "agility-arm", attributes.right_arm_agility),
                     ]))
                 }
                 div class="limb-attribute-pair" {
-                    (limb_attribute_column("Left leg", "left-leg", "limb-left", left_leg_health, medical, 2, surgery_base, injuries, projectiles, &[
+                    (limb_attribute_column("Left leg", "left-leg", "limb-left", left_leg_health, medical, 2, surgery, injuries, projectiles, &[
                         ("Strength", "strength-leg", attributes.left_leg_strength),
                         ("Agility", "agility-leg", attributes.left_leg_agility),
                     ]))
-                    (limb_attribute_column("Right leg", "right-leg", "limb-right", right_leg_health, medical, 3, surgery_base, injuries, projectiles, &[
+                    (limb_attribute_column("Right leg", "right-leg", "limb-right", right_leg_health, medical, 3, surgery, injuries, projectiles, &[
                         ("Strength", "strength-leg", attributes.right_leg_strength),
                         ("Agility", "agility-leg", attributes.right_leg_agility),
                     ]))
@@ -5287,7 +5411,7 @@ fn limb_attribute_column(
     health: f32,
     medical: &MedicalPresentation,
     region: usize,
-    surgery_base: Option<&str>,
+    surgery: Option<(&str, Option<&str>)>,
     injuries: &[LimbInjury],
     projectiles: &[RetainedProjectile],
     rows: &[(&str, &str, f32)],
@@ -5298,7 +5422,7 @@ fn limb_attribute_column(
         health,
         medical,
         region,
-        surgery_base,
+        surgery,
         injuries,
         projectiles,
         rows,
@@ -5313,7 +5437,7 @@ fn attribute_group(
     health: f32,
     medical: &MedicalPresentation,
     region: usize,
-    surgery_base: Option<&str>,
+    surgery: Option<(&str, Option<&str>)>,
     injuries: &[LimbInjury],
     projectiles: &[RetainedProjectile],
     rows: &[(&str, &str, f32)],
@@ -5324,7 +5448,7 @@ fn attribute_group(
         health,
         medical,
         region,
-        surgery_base,
+        surgery,
         injuries,
         projectiles,
         rows,
@@ -5339,7 +5463,7 @@ fn attribute_group_with_labels(
     health: f32,
     medical: &MedicalPresentation,
     region: usize,
-    surgery_base: Option<&str>,
+    surgery: Option<(&str, Option<&str>)>,
     injuries: &[LimbInjury],
     projectiles: &[RetainedProjectile],
     rows: &[(&str, &str, f32)],
@@ -5352,14 +5476,19 @@ fn attribute_group_with_labels(
             Some(side) => format!("attribute-group limb-attribute-column {side}"),
             None => "attribute-group".to_owned(),
         }) {
-            div class="attribute-group-heading" { (name) }
-            @if let Some(base) = surgery_base {
-                a class="limb-surgery-link" href=(format!("{base}/{slug}")) aria-label=(format!("Treat {name}")) {
-                    (regional_health_bar(name, health, medical, region, injuries, projectiles))
+            div class="attribute-group-heading" {
+                span { (name) }
+                @if let Some((base, open_limb)) = surgery {
+                    @let open = open_limb == Some(slug);
+                    a class=(if open { "character-menu-button limb-surgery-button is-open" } else { "character-menu-button limb-surgery-button" })
+                        href=(format!("{base}/{slug}")) title=(format!("Treat {name}")) aria-label=(format!("Open surgery menu for {name}"))
+                        aria-haspopup="dialog" aria-expanded=(open) {
+                        span class="stat-icon" style="--stat-icon: url('/static/icons/game/scalpel.svg')" aria-hidden="true" {}
+                        @if open { span class="sr-only" { " (open)" } }
+                    }
                 }
-            } @else {
-                (regional_health_bar(name, health, medical, region, injuries, projectiles))
             }
+            (regional_health_bar(name, health, medical, region, injuries, projectiles))
             @for (attribute_name, icon, value) in rows {
                 (attribute_row(attribute_name, icon, *value, health, show_labels))
             }
@@ -5599,16 +5728,6 @@ pub(crate) fn party_portrait_overlay(
                         }
                         @if member.alive && active_character.is_some_and(|character| character.alive) {
                         span class="party-portrait-actions" aria-label=(format!("Actions for {}", member.name)) {
-                            @if is_active {
-                                a href=(format!("{location_path}/party/{}?cook=true", member.id))
-                                    class="party-portrait-action party-cooking-action"
-                                    title="Cook"
-                                    aria-label="Cook" {
-                                    span class="party-action-icon"
-                                        style="--party-action-icon: url('/static/icons/game/meal.svg')"
-                                        aria-hidden="true" {}
-                                }
-                            }
                             @if is_active && can_examine && location_path.starts_with("/locations/settlement/") {
                                 a href=(format!("{location_path}/alchemy"))
                                     class="party-portrait-action party-alchemy-action"
@@ -5617,17 +5736,6 @@ pub(crate) fn party_portrait_overlay(
                                     span class="party-action-icon"
                                         style="--party-action-icon: url('/static/icons/game/medical-pack.svg')"
                                         role="img" aria-label="Alchemy" {}
-                                }
-                            }
-                            @if can_examine {
-                                form method="post" action=(format!("{}/party/{}/examine", location_path, member.id)) {
-                                    button type="submit" class="party-portrait-action party-medical-examine"
-                                        title=(format!("Examine {} (15 minutes)", member.name))
-                                        aria-label=(format!("Examine {} (15 minutes)", member.name)) {
-                                        span class="party-action-icon"
-                                            style="--party-action-icon: url('/static/icons/game/scalpel.svg')"
-                                            aria-hidden="true" {}
-                                    }
                                 }
                             }
                             a href=(format!("{}/party/{}/inventory", location_path, member.id))
@@ -6187,8 +6295,11 @@ mod tests {
             check_multiplier: 1.0,
             status: "ready".into(),
         };
-        let markup = strategic_condition_rail(Some(&condition), &[], &[], "/social").into_string();
-        assert!(markup.contains("<a class=\"morale-meter\" href=\"/social\""));
+        let markup =
+            strategic_condition_rail(Some(&condition), &[], &[], "/social", false).into_string();
+        assert!(markup.contains("class=\"morale-meter\""));
+        assert!(markup.contains("href=\"/social\" title=\"Open social menu\""));
+        assert!(markup.contains("aria-haspopup=\"dialog\" aria-expanded=\"false\""));
         let water = markup.find("Water").expect("water meter");
         let filth = markup.find("Filth").expect("filth meter");
         assert!(water < filth);
@@ -6997,6 +7108,7 @@ mod tests {
             Some(OfficialReligion::Judaism),
             CombatTrainingProfile::default(),
             false,
+            CharacterSkillActions::default(),
         )
         .into_string();
 
@@ -7064,6 +7176,7 @@ mod tests {
             0.0,
             Some("judaism"),
             CombatTrainingProfile::default(),
+            CharacterSkillActions::default(),
         )
         .into_string();
         assert!(!rail.contains("class=\"sidebar-header\">Your skills"));
@@ -7084,6 +7197,7 @@ mod tests {
             0.0,
             Some("judaism"),
             CombatTrainingProfile::default(),
+            CharacterSkillActions::default(),
         )
         .into_string();
         assert!(settlement_rail.contains("data-activity-modal"));
@@ -8321,7 +8435,7 @@ mod tests {
     }
 
     #[test]
-    fn medicine_portrait_action_is_contextual_and_quotes_examination_time() {
+    fn medicine_action_moves_from_portrait_to_the_skill_icon() {
         let doctor = Character {
             id: 1,
             name: "Doctor".into(),
@@ -8335,16 +8449,32 @@ mod tests {
             alive: true,
             temporary: false,
         };
-        let hidden =
-            party_portrait_overlay(&[doctor.clone()], Some(&doctor), "/place", Some(1), false)
-                .into_string();
-        let visible =
-            party_portrait_overlay(&[doctor.clone()], Some(&doctor), "/place", Some(1), true)
-                .into_string();
-        assert!(!hidden.contains("/examine"));
-        assert!(visible.contains("/party/1/examine"));
-        assert!(visible.contains("Examine Doctor (15 minutes)"));
-        assert!(visible.contains("party-medical-examine"));
+        let portrait = party_portrait_overlay(
+            &[doctor.clone()],
+            Some(&doctor),
+            "/locations/settlement/willowmere",
+            Some(1),
+            true,
+        )
+        .into_string();
+        assert!(!portrait.contains("/examine"));
+        assert!(!portrait.contains("party-medical-examine"));
+        assert!(portrait.contains("party-alchemy-action"));
+
+        let skill = skill_action_icon(
+            "Medicine",
+            "medicine",
+            SkillAction::Post {
+                href: "/place/party/1/examine",
+                label: "Perform medical examination (15 minutes)",
+                open: false,
+            },
+            false,
+        )
+        .into_string();
+        assert!(skill.contains("/place/party/1/examine"));
+        assert!(skill.contains("Perform medical examination (15 minutes)"));
+        assert!(skill.contains("aria-haspopup=\"dialog\" aria-expanded=\"false\""));
     }
 
     #[test]
@@ -8408,29 +8538,30 @@ mod tests {
     }
 
     #[test]
-    fn surgery_selection_link_only_wraps_the_region_health_bar() {
+    fn surgery_button_is_explicit_and_the_health_meter_is_not_clickable() {
         let markup = attribute_group(
             "Head",
             "head",
             0.75,
             &crate::medical::MedicalPresentation::default(),
             6,
-            Some("/place/party/1/surgery"),
+            Some(("/place/party/1/surgery", None)),
             &[],
             &[],
             &[("Intelligence", "intelligence", 3.0)],
         )
         .into_string();
 
-        let link_start = markup.find("class=\"limb-surgery-link\"").unwrap();
+        let link_start = markup.find("limb-surgery-button").unwrap();
         let health_bar = markup.find("class=\"attribute-health-bar\"").unwrap();
         let link_end = markup[link_start..].find("</a>").unwrap() + link_start;
         let attribute_row = markup.find("class=\"party-attribute-row\"").unwrap();
 
-        assert!(link_start < health_bar);
-        assert!(health_bar < link_end);
+        assert!(link_start < link_end);
+        assert!(link_end < health_bar);
         assert!(link_end < attribute_row);
-        assert!(markup.contains("aria-label=\"Treat Head\""));
+        assert!(markup.contains("aria-label=\"Open surgery menu for Head\""));
+        assert!(markup.contains("aria-haspopup=\"dialog\" aria-expanded=\"false\""));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement.rs
+++ b/crates/strategic-web/src/templates/settlement.rs
@@ -269,7 +269,10 @@ impl LocationView {
         self.active_building
             .as_deref()
             .map_or(path.clone(), |building| {
-                format!("{path}?building={building}")
+                format!(
+                    "{path}{}building={building}",
+                    if path.contains('?') { "&" } else { "?" }
+                )
             })
     }
 
@@ -1889,22 +1892,30 @@ pub fn party_personal_page(
     inventory: &[InventoryItem],
     food_lots: &[FoodLot],
     item_definitions: &[ItemDefinition],
+    character_action_dialog: Option<Markup>,
+    surgery_open: Option<&str>,
+    social_open: bool,
 ) -> Markup {
     let cooking_href = location.preserve_building(format!(
         "{}/party/{}?cook=true",
         location.base_path(),
         active_character.id
     ));
-    let examination_action = format!(
+    let examination_action = location.preserve_building(format!(
         "{}/party/{}/examine",
         location.base_path(),
         active_character.id
-    );
+    ));
     let cooking_open = cooking && medical.examination_id.is_none();
+    let surgery_path_template = location.preserve_building(format!(
+        "{}/party/{}/surgery/__limb__",
+        location.base_path(),
+        active_character.id
+    ));
     let content = html! {
         aside class="left-sidebar" {
-            (party_attributes_rail("Your attributes", attributes, limbs, medical, Some((&format!("{}/party/{}/surgery", location.base_path(), active_character.id), None)), injuries, projectiles))
-            (strategic_condition_rail(condition, morale_sources, filth, &location.preserve_building(format!("{}/party/{}/social", location.base_path(), active_character.id)), false))
+            (party_attributes_rail("Your attributes", attributes, limbs, medical, Some((&surgery_path_template, surgery_open)), injuries, projectiles))
+            (strategic_condition_rail(condition, morale_sources, filth, &location.preserve_building(format!("{}/party/{}/social", location.base_path(), active_character.id)), social_open))
             (medical_rail(medical, &location.base_path(), active_character.id, active_character.id, true))
             @if let Some(demand) = religious_demand {
                 (religious_demand_rail(demand, &location.base_path(), active_character.id))
@@ -1920,7 +1931,7 @@ pub fn party_personal_page(
             ))
             (visual_stage("character", &active_character.name, "Your identity, condition, and capabilities"))
             (settlement_chat_area(&active_character.name, Some(active_character)))
-            (medical_examination_popup(medical, &location.base_path(), active_character.id, limbs, injuries, projectiles))
+            (medical_examination_popup(medical, location, active_character.id, limbs, injuries, projectiles))
         }
         aside class="right-sidebar" {
             (character_summary_rail(capability))
@@ -1941,6 +1952,8 @@ pub fn party_personal_page(
         }
         @if cooking_open {
             (cooking_activity_dialog(location, active_character, inventory, food_lots, item_definitions))
+        } @else if medical.examination_id.is_none() {
+            @if let Some(dialog) = character_action_dialog { (dialog) }
         }
     };
     location.render_layout("Party", content, Some(&active_character.name))
@@ -1953,6 +1966,16 @@ fn cooking_activity_dialog(
     food_lots: &[FoodLot],
     item_definitions: &[ItemDefinition],
 ) -> Markup {
+    let close_href = location.preserve_building(format!(
+        "{}/party/{}",
+        location.base_path(),
+        active_character.id
+    ));
+    let cook_action = location.preserve_building(format!(
+        "{}/party/{}/cook",
+        location.base_path(),
+        active_character.id
+    ));
     let owns = |item_id: &str| {
         inventory
             .iter()
@@ -1971,11 +1994,11 @@ fn cooking_activity_dialog(
         .collect::<Vec<_>>();
     html! {
         div class="character-action-overlay" data-character-action-dialog data-initial-focus="[data-cooking-method]:checked" {
-            a class="character-action-backdrop" href=(format!("{}/party/{}", location.base_path(), active_character.id)) aria-label="Close cooking dialog" {}
+            a class="character-action-backdrop" href=(&close_href) aria-label="Close cooking dialog" {}
             section class="character-action-dialog cooking-dialog" role="dialog" aria-modal="true" aria-labelledby="cooking-dialog-title" tabindex="-1" {
             header class="character-action-dialog-header" {
                 h2 id="cooking-dialog-title" { "Cooking" }
-                a class="character-action-dialog-close" href=(format!("{}/party/{}", location.base_path(), active_character.id)) aria-label="Close cooking dialog" { "×" }
+                a class="character-action-dialog-close" href=(&close_href) aria-label="Close cooking dialog" { "×" }
             }
             div class="cooking-activity" data-cooking-activity {
             aside class="cooking-pot" aria-label="Cooking pot" {
@@ -1999,11 +2022,11 @@ fn cooking_activity_dialog(
                     p class="text-muted small-copy" { "Cooking scene placeholder" }
                 }
                 form id="cooking-submit-form" class="cooking-submit-form" method="post"
-                    action=(format!("{}/party/{}/cook", location.base_path(), active_character.id)) {
+                    action=(&cook_action) {
                     input type="hidden" name="inventory_item_ids" value="" data-cooking-ids;
                     input type="hidden" name="quantities" value="" data-cooking-quantities;
                     div class="party-offer cooking-actions" {
-                        a class="party-offer-cancel" href=(format!("{}/party/{}", location.base_path(), active_character.id)) { "Cancel" }
+                        a class="party-offer-cancel" href=(&close_href) { "Cancel" }
                         button type="submit" disabled title="Select at least one ingredient" data-cook-submit { "Cook" }
                     }
                 }
@@ -2182,15 +2205,30 @@ pub fn party_stats_page(
     injuries: &[LimbInjury],
     projectiles: &[RetainedProjectile],
     filth: &[crate::spacetimedb::CharacterFilth],
+    character_action_dialog: Option<Markup>,
+    surgery_open: Option<&str>,
+    social_open: bool,
 ) -> Markup {
     let selected_attributes_title = format!("{}'s attributes", selected.name);
     let selected_skills_title = format!("{}'s skills", selected.name);
-    let examination_action = format!("{}/party/{}/examine", location.base_path(), selected.id);
+    let examination_action = location.preserve_building(format!(
+        "{}/party/{}/examine",
+        location.base_path(),
+        selected.id
+    ));
+    let surgery_path_template = location.preserve_building(format!(
+        "{}/party/{}/surgery/__limb__",
+        location.base_path(),
+        selected.id
+    ));
     let content = html! {
         aside class="left-sidebar" {
-            (party_attributes_rail(&selected_attributes_title, selected_attributes, selected_limbs, medical, Some((&format!("{}/party/{}/surgery", location.base_path(), selected.id), None)), injuries, projectiles))
-            (strategic_condition_rail(condition, morale_sources, filth, &location.preserve_building(format!("{}/party/{}/social", location.base_path(), selected.id)), false))
+            (party_attributes_rail(&selected_attributes_title, selected_attributes, selected_limbs, medical, Some((&surgery_path_template, surgery_open)), injuries, projectiles))
+            (strategic_condition_rail(condition, morale_sources, filth, &location.preserve_building(format!("{}/party/{}/social", location.base_path(), selected.id)), social_open))
             (medical_rail(medical, &location.base_path(), active_character.id, selected.id, true))
+        }
+        @if medical.examination_id.is_none() {
+            @if let Some(dialog) = character_action_dialog { (dialog) }
         }
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(
@@ -2202,7 +2240,7 @@ pub fn party_stats_page(
             ))
             (visual_stage("character", &selected.name, "Party member identity and capabilities"))
             (player_chat_area(selected, active_character))
-            (medical_examination_popup(medical, &location.base_path(), selected.id, selected_limbs, injuries, projectiles))
+            (medical_examination_popup(medical, location, selected.id, selected_limbs, injuries, projectiles))
         }
         aside class="right-sidebar" {
             (character_summary_rail(capability))
@@ -2365,16 +2403,11 @@ fn belief_tooltip(belief: &crate::spacetimedb::SocialBelief) -> String {
 
 /// Dedicated social view. It intentionally receives observer-specific beliefs
 /// rather than authoritative personality.
-pub fn party_social_page(
+pub fn party_social_dialog(
     location: &LocationView,
     selected: &Character,
     active_character: &Character,
-    party_members: &[Character],
-    attributes: Option<&CharacterAttributes>,
-    limbs: Option<&CharacterLimbs>,
-    condition: Option<&CharacterStrategicCondition>,
     morale_sources: &[crate::spacetimedb::CharacterMoraleSource],
-    filth: &[crate::spacetimedb::CharacterFilth],
     social: &SocialPresentation,
 ) -> Markup {
     let social_href = location.preserve_building(format!(
@@ -2397,32 +2430,18 @@ pub fn party_social_page(
     } else {
         "uncertain"
     };
-    let medical = MedicalPresentation::default();
-    let attribute_title = format!("{}'s attributes", selected.name);
-    let content = html! {
-        aside class="left-sidebar" {
-            (party_attributes_rail(&attribute_title, attributes, limbs, &medical, None, &[], &[]))
-            (strategic_condition_rail(condition, morale_sources, filth, &social_href, true))
-        }
-        main class="center-content settlement-main party-member-stage" {
-            (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(selected.id), false))
-            (visual_stage("character", &selected.name, "Relationship and morale"))
-            (player_chat_area(selected, active_character))
-        }
-        aside class="right-sidebar" {
-            (sidebar_section("Summary", html! {
-                dl class="social-biography" {
-                    div { dt { "Age" } dd { (selected.age_years) } }
-                    div { dt { "Religion" } dd { (religion_name(social.religion_id.as_deref())) } }
-                }
-            }))
-        }
+    let close_href = location.preserve_building(if is_self {
+        format!("{}/party/{}", location.base_path(), selected.id)
+    } else {
+        format!("{}/party/{}/stats", location.base_path(), selected.id)
+    });
+    html! {
         div class="character-action-overlay" data-character-action-dialog {
-            a class="character-action-backdrop" href=(if is_self { format!("{}/party/{}", location.base_path(), selected.id) } else { format!("{}/party/{}/stats", location.base_path(), selected.id) }) aria-label="Close social dialog" {}
+            a class="character-action-backdrop" href=(&close_href) aria-label="Close social dialog" {}
             section class="character-action-dialog social-dialog" role="dialog" aria-modal="true" aria-labelledby="social-dialog-title" tabindex="-1" {
                 header class="character-action-dialog-header" {
                     h2 id="social-dialog-title" { "Social — " (selected.name) }
-                    a class="character-action-dialog-close" href=(if is_self { format!("{}/party/{}", location.base_path(), selected.id) } else { format!("{}/party/{}/stats", location.base_path(), selected.id) }) aria-label="Close social dialog" { "×" }
+                    a class="character-action-dialog-close" href=(&close_href) aria-label="Close social dialog" { "×" }
                 }
                 div class="social-rail" data-social-panel data-target-id=(selected.id) {
             (sidebar_section("What you believe", html! {
@@ -2499,8 +2518,7 @@ pub fn party_social_page(
                 }
             }
         }
-    };
-    location.render_layout("Social", content, Some(&selected.name))
+    }
 }
 
 fn surgery_limb_name(limb: LimbRegion) -> &'static str {
@@ -2696,17 +2714,10 @@ fn surgery_procedure_row(
 
 /// Manual limb treatment is an SSR-open dialog over the ordinary character rails.
 #[allow(clippy::too_many_arguments)]
-pub fn surgery_page(
+pub fn surgery_dialog(
     location: &LocationView,
     active_character: &Character,
     patient: &Character,
-    party_members: &[Character],
-    capability: Option<&CharacterCapability>,
-    attributes: Option<&CharacterAttributes>,
-    skills: Option<&CharacterSkills>,
-    limbs: Option<&CharacterLimbs>,
-    medical: &MedicalPresentation,
-    combat_profile: CombatTrainingProfile,
     injuries: &[LimbInjury],
     projectiles: &[RetainedProjectile],
     selected_limb: LimbRegion,
@@ -2718,8 +2729,12 @@ pub fn surgery_page(
     selected_alcohol: Option<&str>,
     procedure_checks: [f32; 3],
 ) -> Markup {
-    let base = format!("{}/party/{}/surgery", location.base_path(), patient.id);
-    let action = format!("{base}/{}/procedure", surgery_limb_slug(selected_limb));
+    let action = location.preserve_building(format!(
+        "{}/party/{}/surgery/{}/procedure",
+        location.base_path(),
+        patient.id,
+        surgery_limb_slug(selected_limb)
+    ));
     let selected = injuries.iter().find(|injury| injury.limb == selected_limb);
     let cut = selected.map_or(0.0, |injury| injury.cut_damage.max(0.0));
     let bruise = selected.map_or(0.0, |injury| injury.bruise_damage.max(0.0));
@@ -2734,25 +2749,18 @@ pub fn surgery_page(
     let anatomy_skill = procedure_skill("bandage");
     let extraction_skill = procedure_skill("extract");
     let stitching_skill = procedure_skill("stitch");
-    let content = html! {
-        aside class="left-sidebar" {
-            (party_attributes_rail(&format!("{}'s attributes", patient.name), attributes, limbs, medical, Some((&base, Some(surgery_limb_slug(selected_limb)))), injuries, projectiles))
-        }
-        main class="center-content settlement-main party-member-stage" {
-            (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(patient.id), false))
-            (visual_stage("npc", &patient.name, &format!("TODO: {} portrait", patient.name.to_lowercase())))
-            (player_chat_area(patient, active_character))
-        }
-        aside class="right-sidebar" {
-            (character_summary_rail(capability))
-            (party_skills_rail(&format!("{}'s skills", patient.name), skills, limbs, None, None, None, false, 0.0, None, combat_profile, CharacterSkillActions::default()))
-        }
+    let close_href = location.preserve_building(if self_treatment {
+        format!("{}/party/{}", location.base_path(), patient.id)
+    } else {
+        format!("{}/party/{}/stats", location.base_path(), patient.id)
+    });
+    html! {
         div class="character-action-overlay" data-character-action-dialog {
-            a class="character-action-backdrop" href=(if self_treatment { format!("{}/party/{}", location.base_path(), patient.id) } else { format!("{}/party/{}/stats", location.base_path(), patient.id) }) aria-label="Close surgery dialog" {}
+            a class="character-action-backdrop" href=(&close_href) aria-label="Close surgery dialog" {}
             section class="character-action-dialog surgery-dialog" role="dialog" aria-modal="true" aria-labelledby="surgery-dialog-title" tabindex="-1" {
                 header class="character-action-dialog-header" {
                     h2 id="surgery-dialog-title" { (patient.name) " — " (surgery_limb_name(selected_limb)) }
-                    a class="character-action-dialog-close" href=(if self_treatment { format!("{}/party/{}", location.base_path(), patient.id) } else { format!("{}/party/{}/stats", location.base_path(), patient.id) }) aria-label="Close surgery dialog" { "×" }
+                    a class="character-action-dialog-close" href=(&close_href) aria-label="Close surgery dialog" { "×" }
                 }
                 div class="surgery-rail" {
                 div class="surgery-supplies" aria-label="Surgery supplies" {
@@ -2785,8 +2793,7 @@ pub fn surgery_page(
                 }
             }
         }
-    };
-    location.render_layout("Surgery", content, Some(&active_character.name))
+    }
 }
 
 fn service_page(
@@ -3822,7 +3829,8 @@ fn skill_action_icon(name: &str, icon: &str, action: SkillAction<'_>, inside_for
         @match action {
             SkillAction::Get { .. } => {
                 a class=(if open { "character-menu-button is-open" } else { "character-menu-button" })
-                    href=(href) title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open) {
+                    href=(href) title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open)
+                    data-dialog-opener=(href) {
                     span class="stat-icon" style=(format!("--stat-icon: url('/static/icons/game/{icon}.svg')")) aria-hidden="true" {}
                     @if open { span class="sr-only" { " (open)" } }
                 }
@@ -3831,14 +3839,16 @@ fn skill_action_icon(name: &str, icon: &str, action: SkillAction<'_>, inside_for
                 @if inside_form {
                     button type="submit" class=(if open { "character-menu-button is-open" } else { "character-menu-button" })
                         formaction=(href) formmethod="post"
-                        title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open) {
+                        title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open)
+                        data-dialog-opener=(href) {
                         span class="stat-icon" style=(format!("--stat-icon: url('/static/icons/game/{icon}.svg')")) aria-hidden="true" {}
                         @if open { span class="sr-only" { " (open)" } }
                     }
                 } @else {
                     form method="post" action=(href) class="character-menu-button-form" {
                         button type="submit" class=(if open { "character-menu-button is-open" } else { "character-menu-button" })
-                            title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open) {
+                            title=(label) aria-label=(label) aria-haspopup="dialog" aria-expanded=(open)
+                            data-dialog-opener=(href) {
                             span class="stat-icon" style=(format!("--stat-icon: url('/static/icons/game/{icon}.svg')")) aria-hidden="true" {}
                             @if open { span class="sr-only" { " (open)" } }
                         }
@@ -5259,7 +5269,7 @@ fn medical_rail(
 
 fn medical_examination_popup(
     medical: &MedicalPresentation,
-    location_path: &str,
+    location: &LocationView,
     target_id: u64,
     limbs: Option<&CharacterLimbs>,
     injuries: &[LimbInjury],
@@ -5268,10 +5278,14 @@ fn medical_examination_popup(
     let Some(examination_id) = medical.examination_id else {
         return html! {};
     };
+    let dismiss_url = location.preserve_building(format!(
+        "{}/party/{target_id}/examination/{examination_id}/dismiss",
+        location.base_path()
+    ));
     html! {
         div class="medical-examination-overlay" role="dialog" aria-modal="true" aria-labelledby="medical-examination-title"
             data-medical-examination
-            data-dismiss-url=(format!("{location_path}/party/{target_id}/examination/{examination_id}/dismiss")) {
+            data-dismiss-url=(&dismiss_url) {
             section class="medical-examination-popup" {
                 header class="medical-examination-heading" {
                     div {
@@ -5280,7 +5294,7 @@ fn medical_examination_popup(
                             p class="text-muted small-copy" { "Observed at personal minute " (examined_at) "." }
                         }
                     }
-                    form method="post" action=(format!("{location_path}/party/{target_id}/examination/{examination_id}/dismiss")) {
+                    form method="post" action=(&dismiss_url) {
                         button type="submit" class="medical-examination-close" aria-label="Close examination findings" { "×" }
                     }
                 }
@@ -5478,10 +5492,10 @@ fn attribute_group_with_labels(
         }) {
             div class="attribute-group-heading" {
                 span { (name) }
-                @if let Some((base, open_limb)) = surgery {
+                @if let Some((path_template, open_limb)) = surgery {
                     @let open = open_limb == Some(slug);
                     a class=(if open { "character-menu-button limb-surgery-button is-open" } else { "character-menu-button limb-surgery-button" })
-                        href=(format!("{base}/{slug}")) title=(format!("Treat {name}")) aria-label=(format!("Open surgery menu for {name}"))
+                        href=(path_template.replace("__limb__", slug)) title=(format!("Treat {name}")) aria-label=(format!("Open surgery menu for {name}"))
                         aria-haspopup="dialog" aria-expanded=(open) {
                         span class="stat-icon" style="--stat-icon: url('/static/icons/game/scalpel.svg')" aria-hidden="true" {}
                         @if open { span class="sr-only" { " (open)" } }
@@ -8499,8 +8513,16 @@ mod tests {
         assert!(!sidebar.contains("Possible ailments"));
         assert!(!sidebar.contains("Observed at personal minute"));
 
+        let location = LocationView {
+            kind: LocationKind::Quest,
+            id: "location".into(),
+            name: "Location".into(),
+            religion_id: None,
+            category: None,
+            active_building: Some("inn".into()),
+        };
         let popup =
-            medical_examination_popup(&presentation, "/location", 2, None, &[], &[]).into_string();
+            medical_examination_popup(&presentation, &location, 2, None, &[], &[]).into_string();
         assert!(popup.contains("medical-examination-overlay"));
         assert!(popup.contains("aria-modal=\"true\""));
         assert!(popup.contains("Possible ailments"));
@@ -8511,6 +8533,7 @@ mod tests {
         assert!(popup.contains('×'));
         assert!(!popup.contains("This result is discarded"));
         assert!(popup.contains("/examination/44/dismiss"));
+        assert!(popup.contains("?building=inn"));
         assert!(popup.contains("data-medical-examination"));
         let lifecycle = include_str!("../../static/medical-examination.js");
         assert!(lifecycle.contains("pagehide"));

--- a/crates/strategic-web/static/character-action-dialog.js
+++ b/crates/strategic-web/static/character-action-dialog.js
@@ -1,0 +1,72 @@
+(() => {
+  const FOCUSABLE = [
+    "a[href]", "button:not(:disabled)", "input:not([type='hidden']):not(:disabled)",
+    "select:not(:disabled)", "textarea:not(:disabled)", "[tabindex]:not([tabindex='-1'])",
+  ].join(",");
+
+  const visible = (root) => [...root.querySelectorAll(FOCUSABLE)]
+    .filter((element) => !element.hidden && !element.closest("[hidden]") && element.getAttribute("aria-hidden") !== "true");
+
+  const wrappedFocusIndex = (length, current, backwards) => {
+    if (length <= 0) return -1;
+    if (current < 0) return backwards ? length - 1 : 0;
+    if (backwards && current === 0) return length - 1;
+    if (!backwards && current === length - 1) return 0;
+    return current + (backwards ? -1 : 1);
+  };
+
+  if (typeof module !== "undefined") module.exports = { wrappedFocusIndex };
+  if (typeof document === "undefined") return;
+
+  const restoreKey = "adventuresim-character-dialog-opener";
+  document.addEventListener("click", (event) => {
+    const opener = event.target.closest?.("[aria-haspopup='dialog']");
+    if (opener?.getAttribute("aria-label")) {
+      sessionStorage.setItem(restoreKey, opener.getAttribute("aria-label"));
+    }
+    if (event.target.closest?.(".character-action-dialog-close, .character-action-backdrop")) {
+      sessionStorage.setItem(`${restoreKey}-pending`, "true");
+    }
+  });
+
+  const overlays = [...document.querySelectorAll("[data-character-action-dialog]")];
+  const overlay = overlays[0];
+  overlays.slice(1).forEach((extra) => { extra.hidden = true; });
+  if (!overlay) {
+    document.body.classList.remove("character-action-dialog-open");
+    if (sessionStorage.getItem(`${restoreKey}-pending`) === "true") {
+      sessionStorage.removeItem(`${restoreKey}-pending`);
+      const label = sessionStorage.getItem(restoreKey);
+      if (label) {
+        requestAnimationFrame(() => [...document.querySelectorAll("[aria-haspopup='dialog']")]
+          .find((element) => element.getAttribute("aria-label") === label)?.focus());
+      }
+    }
+    return;
+  }
+
+  document.body.classList.add("character-action-dialog-open");
+  const dialog = overlay.querySelector("[role='dialog']");
+  const close = overlay.querySelector(".character-action-dialog-close");
+  requestAnimationFrame(() => {
+    const preferred = overlay.dataset.initialFocus && dialog.querySelector(overlay.dataset.initialFocus);
+    (preferred || visible(dialog)[0] || dialog).focus?.();
+  });
+
+  overlay.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && close) {
+      event.preventDefault();
+      sessionStorage.setItem(`${restoreKey}-pending`, "true");
+      close.click();
+      return;
+    }
+    if (event.key !== "Tab") return;
+    const focusables = visible(dialog);
+    const current = focusables.indexOf(document.activeElement);
+    const next = wrappedFocusIndex(focusables.length, current, event.shiftKey);
+    if (next >= 0 && (current < 0 || next !== current + (event.shiftKey ? -1 : 1))) {
+      event.preventDefault();
+      focusables[next].focus();
+    }
+  });
+})();

--- a/crates/strategic-web/static/character-action-dialog.js
+++ b/crates/strategic-web/static/character-action-dialog.js
@@ -14,17 +14,19 @@
     if (!backwards && current === length - 1) return 0;
     return current + (backwards ? -1 : 1);
   };
+  const dialogOwnsBodyLock = (hasCharacterDialog, hasExamination) => hasCharacterDialog || hasExamination;
+  const openerIdentity = (opener) => opener?.dataset?.dialogOpener || opener?.getAttribute?.("aria-label") || null;
 
-  if (typeof module !== "undefined") module.exports = { wrappedFocusIndex };
+  if (typeof module !== "undefined") module.exports = { wrappedFocusIndex, dialogOwnsBodyLock, openerIdentity };
   if (typeof document === "undefined") return;
 
   const restoreKey = "adventuresim-character-dialog-opener";
   document.addEventListener("click", (event) => {
     const opener = event.target.closest?.("[aria-haspopup='dialog']");
-    if (opener?.getAttribute("aria-label")) {
-      sessionStorage.setItem(restoreKey, opener.getAttribute("aria-label"));
+    if (opener) {
+      sessionStorage.setItem(restoreKey, openerIdentity(opener));
     }
-    if (event.target.closest?.(".character-action-dialog-close, .character-action-backdrop")) {
+    if (event.target.closest?.(".character-action-dialog-close, .character-action-backdrop, .medical-examination-close")) {
       sessionStorage.setItem(`${restoreKey}-pending`, "true");
     }
   });
@@ -33,13 +35,17 @@
   const overlay = overlays[0];
   overlays.slice(1).forEach((extra) => { extra.hidden = true; });
   if (!overlay) {
+    if (dialogOwnsBodyLock(false, Boolean(document.querySelector("[data-medical-examination]")))) {
+      document.body.classList.add("character-action-dialog-open");
+      return;
+    }
     document.body.classList.remove("character-action-dialog-open");
     if (sessionStorage.getItem(`${restoreKey}-pending`) === "true") {
       sessionStorage.removeItem(`${restoreKey}-pending`);
-      const label = sessionStorage.getItem(restoreKey);
-      if (label) {
+      const identity = sessionStorage.getItem(restoreKey);
+      if (identity) {
         requestAnimationFrame(() => [...document.querySelectorAll("[aria-haspopup='dialog']")]
-          .find((element) => element.getAttribute("aria-label") === label)?.focus());
+          .find((element) => openerIdentity(element) === identity)?.focus());
       }
     }
     return;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -538,7 +538,14 @@
   color: #000;
 }
 
-.cooking-activity { display: contents; }
+.cooking-activity {
+  display: grid;
+  grid-template-columns: minmax(12rem, 0.8fr) minmax(18rem, 1.4fr) minmax(14rem, 1fr);
+  min-height: min(36rem, 75vh);
+}
+
+.cooking-activity > * { min-width: 0; padding: .75rem; overflow: auto; }
+.cooking-stage { position: relative; min-height: 24rem; border-inline: 1px solid var(--border-light); }
 
 .cooking-pot .inventory-browser {
   transition: opacity 120ms ease;
@@ -1524,13 +1531,24 @@ body:has(.settlement-top-bar) .main-grid .settlement-card:hover {
 
 .schedule-activity-button {
   display: grid;
-  width: 100%;
-  padding: 0;
-  border: 0;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  margin-inline: auto;
+  padding: .18rem;
+  border: 2px solid;
+  border-color: #eee #353535 #353535 #eee;
   place-items: center;
-  background: transparent;
+  background: #858585;
   color: inherit;
   cursor: pointer;
+  box-shadow: 1px 1px 0 #050505;
+}
+.schedule-activity-button:active,
+.schedule-activity-button[aria-expanded="true"] {
+  border-color: #353535 #eee #eee #353535;
+  box-shadow: inset 1px 1px 0 #050505;
+  transform: translate(1px, 1px);
 }
 .schedule-activity-button:focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; }
 .schedule-activity-button:hover .schedule-special-icon { filter: brightness(1.25); }
@@ -1555,6 +1573,78 @@ body.activity-modal-open { overflow: hidden; }
 .activity-duration-summary { display: flex; justify-content: space-between; margin: 0; color: var(--text-muted); font-variant-numeric: tabular-nums; }
 .activity-preview-table { width: 100%; margin-bottom: 1rem; }
 .activity-submit { width: 100%; padding: 0.55rem; cursor: pointer; }
+
+body.character-action-dialog-open { overflow: hidden; }
+.character-action-overlay {
+  position: fixed;
+  z-index: 1050;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+.character-action-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgb(0 0 0 / 72%);
+}
+.character-action-dialog {
+  position: relative;
+  width: min(44rem, 100%);
+  max-height: calc(100vh - 2rem);
+  overflow: auto;
+  padding: 1rem;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  outline: none;
+  background: var(--panel-bg);
+  box-shadow: 0 1rem 3rem rgb(0 0 0 / 70%);
+}
+.character-action-dialog:focus-visible { box-shadow: 0 0 0 2px var(--accent-light), 0 1rem 3rem rgb(0 0 0 / 70%); }
+.character-action-dialog-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: .85rem; }
+.character-action-dialog-header h2 { margin: 0; }
+.character-action-dialog-close { color: inherit; font-size: 1.65rem; line-height: 1; text-decoration: none; }
+.cooking-dialog { width: min(76rem, 100%); padding: 0; }
+.cooking-dialog > .character-action-dialog-header { padding: 1rem 1rem 0; }
+.social-dialog { width: min(52rem, 100%); }
+.surgery-dialog { width: min(48rem, 100%); }
+
+.character-menu-button-form { display: inline; margin: 0; }
+.character-menu-button {
+  display: inline-grid;
+  box-sizing: border-box;
+  width: 1.85rem;
+  min-width: 1.85rem;
+  height: 1.85rem;
+  padding: .16rem;
+  border: 2px solid;
+  border-color: #eee #353535 #353535 #eee;
+  place-items: center;
+  background: #858585;
+  box-shadow: 1px 1px 0 #050505;
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+.character-menu-button:hover { filter: brightness(1.12); }
+.character-menu-button:focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; }
+.character-menu-button:active,
+.character-menu-button.is-open,
+.character-menu-button[aria-expanded="true"] {
+  border-color: #353535 #eee #eee #353535;
+  box-shadow: inset 1px 1px 0 #050505;
+  transform: translate(1px, 1px);
+}
+.character-menu-button .stat-icon { width: 1.15rem; height: 1.15rem; }
+
+@media (pointer: coarse) {
+  .character-menu-button { width: 2.5rem; min-width: 2.5rem; height: 2.5rem; }
+  .schedule-activity-button { width: 2.5rem; min-width: 2.5rem; height: 2.5rem; }
+}
+@media (max-width: 760px) {
+  .cooking-activity { grid-template-columns: 1fr; }
+  .cooking-stage { min-height: 22rem; border-inline: 0; border-block: 1px solid var(--border-light); }
+}
 
 .rest-consumable-indicators {
   display: flex;
@@ -2603,9 +2693,7 @@ button.party-portrait-action {
   outline: none;
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
-.morale-meter { color: inherit; text-decoration: none; cursor: pointer; }
-.morale-meter:hover,
-.morale-meter:focus-visible { border-color: var(--accent-hover); outline: none; box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-hover) 35%, transparent); }
+.morale-meter { color: inherit; }
 
 :root {
   --incap-pain: #d973a2;
@@ -2625,7 +2713,8 @@ button.party-portrait-action {
 }
 
 .morale-meter-heading { margin-bottom: 0.35rem; }
-.morale-meter-heading span { grid-column: 2; font-variant-numeric: tabular-nums; font-weight: 800; }
+.morale-meter-heading .morale-meter-value { grid-column: 2; font-variant-numeric: tabular-nums; font-weight: 800; }
+.morale-meter-heading .character-menu-button { grid-column: 3; justify-self: end; }
 
 .morale-meter-track {
   position: relative;
@@ -3405,6 +3494,11 @@ button.party-portrait-action {
 }
 
 .attribute-group-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .35rem;
+  min-height: 1.85rem;
   color: var(--text-primary);
   font-size: var(--font-size-xs);
   font-weight: 700;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -1640,6 +1640,8 @@ body.character-action-dialog-open { overflow: hidden; }
 @media (pointer: coarse) {
   .character-menu-button { width: 2.5rem; min-width: 2.5rem; height: 2.5rem; }
   .schedule-activity-button { width: 2.5rem; min-width: 2.5rem; height: 2.5rem; }
+  .party-skill-name-column,
+  .skill-schedule .party-skill-name-column { width: 2.75rem; }
 }
 @media (max-width: 760px) {
   .cooking-activity { grid-template-columns: 1fr; }

--- a/crates/strategic-web/static/immediate-activity.js
+++ b/crates/strategic-web/static/immediate-activity.js
@@ -94,6 +94,7 @@
     const close = () => {
       modal.hidden = true;
       document.body.classList.remove('activity-modal-open');
+      state.opener?.setAttribute('aria-expanded', 'false');
       state.opener?.focus();
       document.dispatchEvent(new Event('strategic-editor-idle'));
     };
@@ -119,6 +120,7 @@
         ? schedule?.elements.namedItem(serviceName)?.value || '' : '';
       modal.hidden = false;
       document.body.classList.add('activity-modal-open');
+      button.setAttribute('aria-expanded', 'true');
       render();
       panel.focus();
     };

--- a/crates/strategic-web/static/medical-examination.js
+++ b/crates/strategic-web/static/medical-examination.js
@@ -41,7 +41,10 @@ if (typeof module !== "undefined") module.exports = { wrappedDialogFocusIndex };
 
   const examination = document.querySelector("[data-medical-examination]");
   const restSummary = document.querySelector(".rest-summary-overlay[role='dialog']");
-  if (examination) focusDialog(examination);
+  if (examination) {
+    document.body.classList.add("character-action-dialog-open");
+    focusDialog(examination);
+  }
   else if (restSummary) focusDialog(restSummary);
 
   document.addEventListener("keydown", (event) => {

--- a/crates/strategic-web/tests/character-action-dialog.test.cjs
+++ b/crates/strategic-web/tests/character-action-dialog.test.cjs
@@ -3,15 +3,27 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 
-const { wrappedFocusIndex } = require("../static/character-action-dialog.js");
+const {
+  wrappedFocusIndex, dialogOwnsBodyLock, openerIdentity,
+} = require("../static/character-action-dialog.js");
 const template = fs.readFileSync(path.join(__dirname, "../src/templates/settlement.rs"), "utf8");
 const styles = fs.readFileSync(path.join(__dirname, "../static/css/strategic.css"), "utf8");
+const routes = fs.readFileSync(path.join(__dirname, "../src/routes/settlements.rs"), "utf8");
 
 test("character dialogs trap focus in either direction", () => {
   assert.equal(wrappedFocusIndex(3, 0, true), 2);
   assert.equal(wrappedFocusIndex(3, 2, false), 0);
   assert.equal(wrappedFocusIndex(3, -1, false), 0);
   assert.equal(wrappedFocusIndex(0, -1, false), -1);
+});
+
+test("medical findings retain body lock and stable cross-document opener identity", () => {
+  assert.equal(dialogOwnsBodyLock(false, true), true);
+  assert.equal(dialogOwnsBodyLock(false, false), false);
+  assert.equal(openerIdentity({ dataset: { dialogOpener: "/party/2/examine?building=inn" } }), "/party/2/examine?building=inn");
+  const lifecycle = fs.readFileSync(path.join(__dirname, "../static/character-action-dialog.js"), "utf8");
+  assert.match(lifecycle, /medical-examination-close/);
+  assert.match(lifecycle, /restoreKey}-pending/);
 });
 
 test("character actions use one dialog and raised-button contract", () => {
@@ -23,6 +35,18 @@ test("character actions use one dialog and raised-button contract", () => {
   assert.match(template, /role="dialog" aria-modal="true" aria-labelledby="cooking-dialog-title"/);
   assert.match(styles, /border-color: #eee #353535 #353535 #eee/);
   assert.match(styles, /border-color: #353535 #eee #eee #353535/);
+  assert.match(styles, /\.skill-schedule \.party-skill-name-column \{ width: 2\.75rem; \}/);
+});
+
+test("social and surgery inject overlays into the ordinary character renderers", () => {
+  assert.match(routes, /render_party_personal\([\s\S]*Some\(dialog\)/);
+  assert.match(routes, /render_party_stats\([\s\S]*Some\(dialog\)/);
+  const socialDialog = template.slice(template.indexOf("pub fn party_social_dialog"), template.indexOf("fn surgery_limb_name"));
+  const surgeryDialog = template.slice(template.indexOf("pub fn surgery_dialog"), template.indexOf("fn service_page"));
+  assert.doesNotMatch(socialDialog, /left-sidebar|right-sidebar|render_layout/);
+  assert.doesNotMatch(surgeryDialog, /left-sidebar|right-sidebar|render_layout/);
+  assert.match(socialDialog, /preserve_building/);
+  assert.match(surgeryDialog, /preserve_building/);
 });
 
 test("portrait tray keeps unrelated actions but drops cooking and examination launchers", () => {

--- a/crates/strategic-web/tests/character-action-dialog.test.cjs
+++ b/crates/strategic-web/tests/character-action-dialog.test.cjs
@@ -1,0 +1,37 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { wrappedFocusIndex } = require("../static/character-action-dialog.js");
+const template = fs.readFileSync(path.join(__dirname, "../src/templates/settlement.rs"), "utf8");
+const styles = fs.readFileSync(path.join(__dirname, "../static/css/strategic.css"), "utf8");
+
+test("character dialogs trap focus in either direction", () => {
+  assert.equal(wrappedFocusIndex(3, 0, true), 2);
+  assert.equal(wrappedFocusIndex(3, 2, false), 0);
+  assert.equal(wrappedFocusIndex(3, -1, false), 0);
+  assert.equal(wrappedFocusIndex(0, -1, false), -1);
+});
+
+test("character actions use one dialog and raised-button contract", () => {
+  assert.match(template, /data-character-action-dialog/);
+  assert.match(template, /aria-haspopup="dialog" aria-expanded=\(open\)/);
+  assert.match(template, /character-menu-button limb-surgery-button/);
+  assert.match(template, /role="dialog" aria-modal="true" aria-labelledby="surgery-dialog-title"/);
+  assert.match(template, /role="dialog" aria-modal="true" aria-labelledby="social-dialog-title"/);
+  assert.match(template, /role="dialog" aria-modal="true" aria-labelledby="cooking-dialog-title"/);
+  assert.match(styles, /border-color: #eee #353535 #353535 #eee/);
+  assert.match(styles, /border-color: #353535 #eee #eee #353535/);
+});
+
+test("portrait tray keeps unrelated actions but drops cooking and examination launchers", () => {
+  const start = template.indexOf("pub(crate) fn party_portrait_overlay");
+  const end = template.indexOf("pub(crate) fn settlement_chat_area", start);
+  const portrait = template.slice(start, end);
+  assert.doesNotMatch(portrait, /party-cooking-action/);
+  assert.doesNotMatch(portrait, /party-medical-examine/);
+  assert.match(portrait, /party-alchemy-action/);
+  assert.match(portrait, /party-member-remove/);
+  assert.match(portrait, /\/inventory/);
+});

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -521,6 +521,15 @@ SpacetimeDB. The tactical WASM page remains under
 `crates/adventuresim-stdb-module/static/tactical.html` and is served by
 `strategic-web` at `/tactical/tactical.html`.
 
+Character-sheet action menus follow one interaction contract. Raised,
+old-school beveled icon buttons open modal dialogs; flat skill icons and meters
+are informational. Surgery buttons sit beside limb headings, Social sits beside
+Morale, and Medicine and Cooking use their skill icons. Activity icons use the
+same raised treatment. An inset button means its dialog is open. Dialogs retain
+the underlying rails, lock page scrolling, trap focus, close with Escape, and
+return focus to their launcher. Portrait hover controls remain reserved for
+inventory, membership, alchemy, and other portrait-specific actions.
+
 The local strategic UI is anonymous and single-user. Its cookie selects the
 active character; it does not establish a user identity. The default
 `127.0.0.1:8080` bind is therefore intentional. A non-loopback development bind
@@ -596,7 +605,8 @@ Start the isolated strategic stack with the guarded visual fixtures:
 just web-isolated-strategic social-demo 23100
 ```
 
-Select **Social Demo**, open **Greta the Guard**, and select the Morale meter.
+Select **Social Demo**, open **Greta the Guard**, and press the raised Social
+icon beside the Morale meter.
 The fixture includes defeat and injury penalties, established Familiarity,
 positive Affinity, and one deliberately incorrect perceived sensitivity so the
 privacy boundary and outcome rules are visible. The bootstrap capability is

--- a/docs/FOOD_AND_COOKING.md
+++ b/docs/FOOD_AND_COOKING.md
@@ -25,8 +25,10 @@ applies and an unresolved Dysentery episode prevents duplicate infection.
 
 ## Cooking
 
-Hovering the active character portrait exposes a cooking icon that opens the
-cooking panel. It uses the same two-sided inventory browser as trading and
+The active character's Cooking skill icon is a raised menu button; flat skill
+icons remain informational. Activating Cooking opens a wide, responsive modal
+dialog over the unchanged character sheet. It uses the same two-sided inventory
+browser as trading and
 looting: the cooking pot is on the left, the character's full inventory is on
 the right, and transfer arrows stage bounded amounts of food between them. The
 center shows a placeholder cooking scene, Cook and Cancel, and a horizontal

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -689,6 +689,7 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/src/templates/settlement.rs` — Strategic web server-rendered template.
 - `crates/strategic-web/static/background-fetch.js` — Repository support file.
 - `crates/strategic-web/static/building-state.js` — Repository support file.
+- `crates/strategic-web/static/character-action-dialog.js` — Repository support file.
 - `crates/strategic-web/static/chat-resize.js` — Repository support file.
 - `crates/strategic-web/static/cooking.js` — Repository support file.
 - `crates/strategic-web/static/css/base.css` — Browser UI styling.
@@ -919,6 +920,7 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/static/training-schedule.js` — Repository support file.
 - `crates/strategic-web/static/travel-planner.js` — Repository support file.
 - `crates/strategic-web/tests/building-assets.test.cjs` — Repository support file.
+- `crates/strategic-web/tests/character-action-dialog.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/cooking.dom.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/cooking.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/currency-backend-source.test.cjs` — Repository support file.
@@ -940,8 +942,6 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/tests/tooltips.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/training-schedule.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/travel-planner-behavior.test.cjs` — Repository support file.
-- `docs/ARCHITECTURE.md` — Project documentation.
-- `docs/ARCHITECTURE.md` — Project documentation.
 - `docs/ARCHITECTURE.md` — Project documentation.
 - `docs/DEVELOPING.md` — Project documentation.
 - `docs/DIALOGUE.md` — Project documentation.

--- a/wiki/shared/Health.md
+++ b/wiki/shared/Health.md
@@ -132,7 +132,21 @@ During recovery, the existing bounded party Medicine check supplies **1 percenta
 
 Autoresolve calculates every hit through the shared melee and ranged exchanges and commits its body part, cut and blunt shares, and projectile kind. Strategic wounds are split per limb into cuts, bruising, and fracture severity. Fracture severity is a condition within blunt trauma and never adds a second copy of the hit's health damage. Cuts remain open after battle: they deteriorate at 2.5% health per day and drain blood in proportion to wound size until manually bandaged. Bandaging consumes one bandage and permanently stabilizes that wound; its health-bar segment changes from solid red to banded pink. Bruising heals without a procedure. A single blunt hit over 18% limb health creates fracture severity proportional to the excess. Untreated fractures are graphite grey, while splinted fractures use lighter grey bands so treatment state is not communicated by color alone.
 
-Clicking any limb preserves the character sheet and replaces its right rail with surgery. The normal limb bar and surgery view share the same per-limb cut, bruise, fracture, bandage, and projectile state. Procedures show supplies, time, and difficulty but keep infection odds hidden. The treating character and patient must share a location, party, and personal character time; the lagging participant waits to the later clock, then only those participants advance by the procedure duration. Self-treatment applies a 2.5-point penalty to the resulting procedure check. Bandaging and splinting use Anatomy. Stitching averages Anatomy and Tailoring and requires a reusable surgery kit; its quality accelerates healing. A splint's exact inventory row moves into a separate limb-applied slot while retaining its weight and owner, never displaces armor, and returns automatically when the fracture heals; anyone may remove it.
+Each limb heading has an explicit raised surgery icon button beside its
+informational health meter. Activating it preserves both character rails and
+opens that limb's surgery interface as a modal dialog; the button remains
+visibly inset while the dialog is open. The normal limb bar and surgery dialog
+share the same per-limb cut, bruise, fracture, bandage, and projectile state.
+Procedures show supplies, time, and difficulty but keep infection odds hidden.
+The treating character and patient must share a location, party, and personal
+character time; the lagging participant waits to the later clock, then only
+those participants advance by the procedure duration. Self-treatment applies a
+2.5-point penalty to the resulting procedure check. Bandaging and splinting use
+Anatomy. Stitching averages Anatomy and Tailoring and requires a reusable
+surgery kit; its quality accelerates healing. A splint's exact inventory row
+moves into a separate limb-applied slot while retaining its weight and owner,
+never displaces armor, and returns automatically when the fracture heals;
+anyone may remove it.
 
 Bandaging, stitching, and projectile extraction may optionally consume one unit
 of the acting character's soft soap. Soap improves infection control independently

--- a/wiki/shared/Morale.md
+++ b/wiki/shared/Morale.md
@@ -1,5 +1,12 @@
 Morale is a signed strategic stat. Zero is emotionally neutral. Negative morale creates fear incapacitation, while surplus morale above zero lets a character with Command lift the spirits of allies who are below zero.
 
+The character-sheet morale meter is informational. A raised Social meta-skill
+icon beside its heading opens the observer-specific morale sources, beliefs,
+and available social actions in a modal dialog without replacing either
+character rail. The icon remains inset while that dialog is open; the privacy
+boundary remains the active observer's beliefs rather than authoritative
+personality state.
+
 # Morale sources
 
 Every current morale effect is retained as a named signed source for the UI. Positive and negative sources are ranked separately by absolute magnitude. The strongest source on each side contributes fully, the second contributes one half, the third one third, and so on. Will mitigates only the ranked negative contributions:

--- a/wiki/strategic/Settlement.md
+++ b/wiki/strategic/Settlement.md
@@ -104,10 +104,12 @@ The default chat channel is **Local**. NPC conversations belong to the active pa
 
 Clicking any filled character portrait selects that character. The left rail shows their automatic capability summary before attributes and skills, while the right rail shows their age, sparse personality tags, and religion. Neutral personality axes are omitted, and each shown tag has a tooltip stating its exact morale multiplier and any event-duration multiplier. On one's own biography, hovering or focusing the Religion entry reveals a **Renounce** action when the character currently professes a faith. Numeric skill tags appear only at rating 3 or better and show their name without the underlying score. Athletics combines the climbing and swimming evaluations. These tags reuse the shared stat, skill, equipment, armor, and encumbrance calculations; injuries do not affect recruitment tags. Heavy weapons require at least 4 kg weapon weight and average arm strength 3. The shared weapon-precision scale replaces the former precise, slash, pierce, and blunt recruitment tags: 0.5 is club/hammer precision, 1.0 axe precision, 1.5 sword/spear precision, and 2.0 rapier/bodkin precision. Encumbrance includes all carried inventory, not only equipped items.
 
-A living active character with Medicine 2 or better also sees a medical action
-icon in the contextual controls beneath each living party portrait. It begins
-the 15-minute examination directly; the character details rail does not repeat
-the action. The same character sees an alchemy action beneath their own portrait.
+A living active character with Medicine 2 or better sees the selected
+character's Medicine skill icon as a raised action button. It begins the
+15-minute examination directly and presents the one-shot findings as a modal
+dialog; the portrait hover controls do not duplicate this action. The active
+character's Cooking skill icon similarly opens cooking. The same character
+continues to see an alchemy action beneath their own portrait.
 Alchemy lists all recipes at or below their Medicine rank regardless of current
 diagnoses, and its ingredient rail switches between personal and party inventory
 while retaining the normal quantity-target controls. Herbalists greet visitors


### PR DESCRIPTION
## Summary

- replace clickable limb and morale meters with explicit raised icon buttons
- move medical examination and cooking launchers from portrait hover actions to their associated skill icons
- give immediate activity icons the same old-school raised/pressed treatment
- render Surgery, Social, and Cooking as accessible overlays over the unchanged character-details shell
- preserve active building, selected character, focus, scroll locking, and server-authoritative form behavior across dialog navigation
- update gameplay/development documentation and the generated project map

## Motivation

Character actions previously used three different interaction patterns: hidden portrait-hover controls, flat icons with unclear affordance, and links that replaced an opposite rail. This establishes a consistent rule: raised contextual icons open action dialogs, while flat icons and meters remain informational.

## Notable implementation choices

- Existing surgery, social, cooking, and examination reducers and authorization boundaries remain unchanged.
- Social and Surgery inject overlay-only markup into the shared personal/stats renderers so the underlying page does not change.
- Dialog launchers use conventional top/left highlight and bottom/right shadow, reverse while open, and expose dialog state to assistive technology.
- Cross-document dialog navigation retains the active building and restores focus to a stable opener identity.
- Portrait inventory, alchemy, and membership actions remain in place.

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p strategic-web`
- `cargo test -p strategic-web` — 193 passed
- focused Node dialog/activity/cooking tests — 14 passed
- `python scripts/update_project_map.py --check`
- `git diff --check 4905ab7...HEAD`

Two independent reviews were run. Their findings about query composition, unchanged background rails, building context, self-examination routing, modal body locking, focus restoration, and coarse-pointer sizing were remediated in `46a7189`.

## Manual demo

The isolated strategic demo did not become available. `just web-isolated-strategic character-actions 23900` reached generated SpacetimeDB binding verification, but the WASM module build exited with code `-1` and no diagnostics before the server bound its loopback port. No screenshot is attached; compile, rendering-contract, lifecycle, and unit coverage pass.

## Risk and rollback

The change is limited to strategic-web routing/rendering, dialog lifecycle assets, tests, and behavior documentation. It does not change database schema, strategic reducers, or tactical persistence. Reverting the two commits restores the previous interaction patterns.
