### PR TITLE
Compile modular quest content from YAML

### DIFF
--- a/content/quests/bestiary.yaml
+++ b/content/quests/bestiary.yaml
@@ -1,0 +1,154 @@
+{
+  "monsters": [
+    {
+      "id": "bandit", "name": "Bandit", "singular": "Bandit", "plural": "Bandits", "aliases": ["brigand"],
+      "base_weight": 80, "curation_weight": 70, "northern_germany_prior": 130,
+      "combat": {"rig":"humanoid","speed_m_per_minute":80,"weight_kg":70.0,"attack":"blade","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":50,"stealth":50,"morale":50,"protection":"armored","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":0,"temperament":"cautious","encounter_scale_basis_points":10000,"loot_item_id":"katzbalger"},
+      "investigation": {"habitats":["road","open","sparse_woods","camp","ruin"],"activity":"any","victim_tags":["travelers","merchants"],"tracks":["boot_prints"],"wounds":["weapon_cuts"],"disturbances":["disturbed_goods"],"sounds":["voices"],"silhouettes":["armed_people"],"odors":[],"mistaken_for":["deserter","poacher","smuggler"],"distinguishing_clues":["weapon_cuts"],"preparation_advice":"Bring armor and an anti-armor weapon; expect an organized group.","evidence_visibility":60,"identification_challenge":false,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "deserter", "name": "Deserter", "singular": "deserter", "plural": "deserters", "aliases": ["runaway soldier"],
+      "base_weight": 30, "curation_weight": 35, "northern_germany_prior": 130,
+      "combat": {"rig":"humanoid","speed_m_per_minute":82,"weight_kg":72.0,"attack":"spear","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1100,"perception":55,"stealth":45,"morale":60,"protection":"armored","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":0,"temperament":"disciplined","encounter_scale_basis_points":10000,"loot_item_id":"spear"},
+      "investigation": {"habitats":["road","camp","ruin"],"activity":"any","victim_tags":["travelers"],"tracks":["boot_prints"],"wounds":["weapon_cuts"],"disturbances":["camp_debris"],"sounds":["marching"],"silhouettes":["armed_people"],"odors":[],"mistaken_for":["bandit","town_watch"],"distinguishing_clues":["military_kit"],"preparation_advice":"Expect military weapons, formation discipline, and armor.","evidence_visibility":65,"identification_challenge":false,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "poacher", "name": "Poacher", "singular": "poacher", "plural": "poachers", "aliases": ["illegal hunter"],
+      "base_weight": 35, "curation_weight": 40, "northern_germany_prior": 130,
+      "combat": {"rig":"humanoid","speed_m_per_minute":84,"weight_kg":68.0,"attack":"bow","ranged":true,"precision_bonus_milli":500,"training_multiplier_milli":1000,"perception":65,"stealth":65,"morale":40,"protection":"hide","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":0,"temperament":"elusive","encounter_scale_basis_points":10000,"loot_item_id":"self_bow"},
+      "investigation": {"habitats":["sparse_woods","deep_woods","camp"],"activity":"any","victim_tags":["gamekeepers","livestock"],"tracks":["boot_prints"],"wounds":["arrow_shafts"],"disturbances":["snares"],"sounds":["bowstring"],"silhouettes":["armed_people"],"odors":["woodsmoke"],"mistaken_for":["bandit"],"distinguishing_clues":["arrow_shafts"],"preparation_advice":"Use cover and close quickly against skilled bow fire.","evidence_visibility":55,"identification_challenge":false,"location_challenge":true,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "smuggler", "name": "Smuggler", "singular": "smuggler", "plural": "smugglers", "aliases": ["contraband runner"],
+      "base_weight": 25, "curation_weight": 35, "northern_germany_prior": 130,
+      "combat": {"rig":"humanoid","speed_m_per_minute":83,"weight_kg":70.0,"attack":"blade","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":55,"stealth":60,"morale":45,"protection":"hide","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":0,"temperament":"cautious","encounter_scale_basis_points":10000,"loot_item_id":"knife"},
+      "investigation": {"habitats":["road","cave","occupied_house"],"activity":"night","victim_tags":["merchants"],"tracks":["boot_prints"],"wounds":["weapon_cuts"],"disturbances":["disturbed_goods"],"sounds":["whispers"],"silhouettes":["armed_people"],"odors":[],"mistaken_for":["bandit"],"distinguishing_clues":["contraband"],"preparation_advice":"Watch exits and bring enough people to prevent escape.","evidence_visibility":45,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "cultist", "name": "Cultist", "singular": "cultist", "plural": "cultists", "aliases": ["secret worshipper"],
+      "base_weight": 16, "curation_weight": 30, "northern_germany_prior": 70,
+      "combat": {"rig":"humanoid","speed_m_per_minute":78,"weight_kg":67.0,"attack":"knife","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":50,"stealth":50,"morale":70,"protection":"unarmored","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":15,"temperament":"aggressive","encounter_scale_basis_points":10000,"loot_item_id":"knife"},
+      "investigation": {"habitats":["ruin","cave","occupied_house"],"activity":"night","victim_tags":["isolated_people"],"tracks":["boot_prints"],"wounds":["knife_wounds"],"disturbances":["ritual_marks"],"sounds":["chanting"],"silhouettes":["armed_people"],"odors":["sulfur_odor"],"mistaken_for":["bandit"],"distinguishing_clues":["ritual_marks"],"preparation_advice":"Resolve and religious knowledge help against frightening rites.","evidence_visibility":50,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":["courage"]}
+    },
+    {
+      "id": "grave_robber", "name": "Grave robber", "singular": "grave robber", "plural": "grave robbers", "aliases": ["resurrectionist"],
+      "base_weight": 18, "curation_weight": 30, "northern_germany_prior": 130,
+      "combat": {"rig":"humanoid","speed_m_per_minute":78,"weight_kg":68.0,"attack":"blunt","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":900,"perception":45,"stealth":55,"morale":35,"protection":"unarmored","resistance_joules":0,"padding_joules":0,"disease_risk":10,"fear":0,"temperament":"cowardly","encounter_scale_basis_points":10000,"loot_item_id":"club"},
+      "investigation": {"habitats":["crypt","graveyard","occupied_house"],"activity":"night","victim_tags":["burials"],"tracks":["boot_prints"],"wounds":["blunt_damage"],"disturbances":["grave_soil"],"sounds":["digging"],"silhouettes":["armed_people"],"odors":["corpse_odor"],"mistaken_for":["ghoul"],"distinguishing_clues":["tool_marks"],"preparation_advice":"They are ordinary people but may carry digging tools as weapons.","evidence_visibility":70,"identification_challenge":true,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "town_watch", "name": "Town watch", "singular": "Town watch", "plural": "Town watch", "aliases": ["guard"],
+      "base_weight": 1, "curation_weight": 1, "northern_germany_prior": 130,
+      "combat": {"rig":"humanoid","speed_m_per_minute":80,"weight_kg":72.0,"attack":"spear","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1100,"perception":60,"stealth":35,"morale":65,"protection":"shielded","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":0,"temperament":"disciplined","encounter_scale_basis_points":10000,"loot_item_id":"spear"},
+      "investigation": {"habitats":["road","open","occupied_house"],"activity":"any","victim_tags":["criminals"],"tracks":["boot_prints"],"wounds":["weapon_cuts"],"disturbances":["official_seals"],"sounds":["orders"],"silhouettes":["armed_people"],"odors":[],"mistaken_for":["deserter"],"distinguishing_clues":["official_seals"],"preparation_advice":"Avoid fighting lawful authorities.","evidence_visibility":90,"identification_challenge":false,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "armed_retainer", "name": "Armed retainer", "singular": "armed retainer", "plural": "armed retainers", "aliases": ["man-at-arms"],
+      "base_weight": 5, "curation_weight": 10, "northern_germany_prior": 130,
+      "combat": {"rig":"humanoid","speed_m_per_minute":82,"weight_kg":75.0,"attack":"blade","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1200,"perception":55,"stealth":40,"morale":70,"protection":"armored","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":0,"temperament":"disciplined","encounter_scale_basis_points":8500,"loot_item_id":"arming_sword"},
+      "investigation": {"habitats":["road","open","occupied_house"],"activity":"day","victim_tags":["rivals"],"tracks":["boot_prints"],"wounds":["weapon_cuts"],"disturbances":["heraldry"],"sounds":["orders"],"silhouettes":["armed_people"],"odors":[],"mistaken_for":["town_watch"],"distinguishing_clues":["heraldry"],"preparation_advice":"Expect trained, armored professionals.","evidence_visibility":85,"identification_challenge":false,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "angry_mob", "name": "Angry mob", "singular": "Angry townsman", "plural": "Angry townsfolk", "aliases": ["mob"],
+      "base_weight": 8, "curation_weight": 12, "northern_germany_prior": 130,
+      "combat": {"rig":"humanoid","speed_m_per_minute":75,"weight_kg":68.0,"attack":"blunt","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":700,"perception":45,"stealth":20,"morale":45,"protection":"unarmored","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":0,"temperament":"aggressive","encounter_scale_basis_points":14000,"loot_item_id":"club"},
+      "investigation": {"habitats":["road","open","occupied_house"],"activity":"any","victim_tags":["outsiders"],"tracks":["boot_prints"],"wounds":["blunt_damage"],"disturbances":["broken_goods"],"sounds":["shouting"],"silhouettes":["armed_people"],"odors":["smoke"],"mistaken_for":["bandit"],"distinguishing_clues":["local_slogans"],"preparation_advice":"Avoid being surrounded by a large but poorly equipped crowd.","evidence_visibility":95,"identification_challenge":false,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "wolf", "name": "Wolf", "singular": "Wolf", "plural": "Wolves", "aliases": [],
+      "base_weight": 70, "curation_weight": 65, "northern_germany_prior": 140,
+      "combat": {"rig":"quadruped","speed_m_per_minute":105,"weight_kg":42.0,"attack":"bite","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":70,"stealth":65,"morale":45,"protection":"hide","resistance_joules":0,"padding_joules":25,"disease_risk":5,"fear":0,"temperament":"cautious","encounter_scale_basis_points":12000,"loot_item_id":null},
+      "investigation": {"habitats":["open","sparse_woods","deep_woods"],"activity":"night","victim_tags":["livestock","isolated_people"],"tracks":["pawprints"],"wounds":["bite_wounds"],"disturbances":["broken_foliage"],"sounds":["howling"],"silhouettes":["doglike_beast"],"odors":["animal_odor"],"mistaken_for":["feral_dog","spectral_hound","werewolf"],"distinguishing_clues":["pack_tracks"],"preparation_advice":"Bring spears and protect the flanks against a pack.","evidence_visibility":75,"identification_challenge":false,"location_challenge":true,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "boar", "name": "Boar", "singular": "boar", "plural": "boars", "aliases": [],
+      "base_weight": 35, "curation_weight": 35, "northern_germany_prior": 140,
+      "combat": {"rig":"quadruped","speed_m_per_minute":95,"weight_kg":95.0,"attack":"tusk","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":50,"stealth":45,"morale":70,"protection":"hide","resistance_joules":0,"padding_joules":45,"disease_risk":0,"fear":0,"temperament":"aggressive","encounter_scale_basis_points":8000,"loot_item_id":null},
+      "investigation": {"habitats":["open","sparse_woods","deep_woods"],"activity":"any","victim_tags":["farmers","crops"],"tracks":["hoofprints"],"wounds":["tusk_wounds"],"disturbances":["rooted_soil"],"sounds":["grunting"],"silhouettes":["large_animal"],"odors":["animal_odor"],"mistaken_for":["bear"],"distinguishing_clues":["rooted_soil"],"preparation_advice":"Use a long spear and do not meet its charge unsupported.","evidence_visibility":80,"identification_challenge":false,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "bear", "name": "Bear", "singular": "bear", "plural": "bears", "aliases": [],
+      "base_weight": 20, "curation_weight": 30, "northern_germany_prior": 140,
+      "combat": {"rig":"quadruped","speed_m_per_minute":92,"weight_kg":260.0,"attack":"claw","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":65,"stealth":45,"morale":85,"protection":"hide","resistance_joules":0,"padding_joules":80,"disease_risk":0,"fear":10,"temperament":"aggressive","encounter_scale_basis_points":4500,"loot_item_id":null},
+      "investigation": {"habitats":["sparse_woods","deep_woods","cave"],"activity":"any","victim_tags":["livestock","foragers"],"tracks":["pawprints"],"wounds":["claw_marks"],"disturbances":["broken_foliage"],"sounds":["roaring"],"silhouettes":["large_animal","large_upright_beast"],"odors":["animal_odor"],"mistaken_for":["wild_man","werewolf"],"distinguishing_clues":["large_pawprints"],"preparation_advice":"Bring polearms and several disciplined fighters for one very large animal.","evidence_visibility":75,"identification_challenge":false,"location_challenge":true,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "feral_dog", "name": "Feral dog", "singular": "feral dog", "plural": "feral dogs", "aliases": [],
+      "base_weight": 45, "curation_weight": 35, "northern_germany_prior": 140,
+      "combat": {"rig":"quadruped","speed_m_per_minute":100,"weight_kg":30.0,"attack":"bite","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":900,"perception":60,"stealth":55,"morale":35,"protection":"hide","resistance_joules":0,"padding_joules":15,"disease_risk":10,"fear":0,"temperament":"cautious","encounter_scale_basis_points":13000,"loot_item_id":null},
+      "investigation": {"habitats":["road","open","ruin"],"activity":"any","victim_tags":["livestock","refuse"],"tracks":["pawprints"],"wounds":["bite_wounds"],"disturbances":["disturbed_goods"],"sounds":["barking"],"silhouettes":["doglike_beast"],"odors":["animal_odor"],"mistaken_for":["wolf","trained_dog"],"distinguishing_clues":["human_refuse"],"preparation_advice":"Keep formation against a quick pack.","evidence_visibility":75,"identification_challenge":true,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "trained_dog", "name": "Trained dog", "singular": "trained dog", "plural": "trained dogs", "aliases": ["war dog"],
+      "base_weight": 12, "curation_weight": 20, "northern_germany_prior": 140,
+      "combat": {"rig":"quadruped","speed_m_per_minute":105,"weight_kg":35.0,"attack":"bite","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1100,"perception":70,"stealth":50,"morale":65,"protection":"hide","resistance_joules":0,"padding_joules":20,"disease_risk":0,"fear":0,"temperament":"disciplined","encounter_scale_basis_points":11000,"loot_item_id":null},
+      "investigation": {"habitats":["road","open","camp","occupied_house"],"activity":"any","victim_tags":["intruders"],"tracks":["pawprints"],"wounds":["bite_wounds"],"disturbances":["collar_marks"],"sounds":["barking"],"silhouettes":["doglike_beast"],"odors":["animal_odor"],"mistaken_for":["feral_dog"],"distinguishing_clues":["collar_marks"],"preparation_advice":"Expect coordinated attacks directed by handlers.","evidence_visibility":80,"identification_challenge":true,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "goblin", "name": "Goblin", "singular": "goblin", "plural": "goblins", "aliases": [],
+      "base_weight": 70, "curation_weight": 65, "northern_germany_prior": 70,
+      "combat": {"rig":"humanoid","speed_m_per_minute":88,"weight_kg":38.0,"attack":"bow","ranged":true,"precision_bonus_milli":300,"training_multiplier_milli":800,"perception":60,"stealth":65,"morale":30,"protection":"hide","resistance_joules":0,"padding_joules":0,"disease_risk":5,"fear":0,"temperament":"cowardly","encounter_scale_basis_points":15000,"loot_item_id":"self_bow"},
+      "investigation": {"habitats":["cave","ruin","camp","deep_woods"],"activity":"night","victim_tags":["livestock","travelers"],"tracks":["small_bare_tracks"],"wounds":["arrow_shafts"],"disturbances":["disturbed_goods"],"sounds":["high_voices"],"silhouettes":["small_upright_figures"],"odors":["woodsmoke"],"mistaken_for":["kobold"],"distinguishing_clues":["small_bare_tracks"],"preparation_advice":"Bring shields and armor for numerous weak archers.","evidence_visibility":70,"identification_challenge":false,"location_challenge":true,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "orc", "name": "Orc", "singular": "orc", "plural": "orcs", "aliases": [],
+      "base_weight": 35, "curation_weight": 50, "northern_germany_prior": 70,
+      "combat": {"rig":"humanoid","speed_m_per_minute":82,"weight_kg":105.0,"attack":"blade","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":50,"stealth":35,"morale":75,"protection":"armored","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":5,"temperament":"aggressive","encounter_scale_basis_points":7000,"loot_item_id":"falchion"},
+      "investigation": {"habitats":["cave","ruin","camp","mine"],"activity":"any","victim_tags":["travelers","settlements"],"tracks":["large_boot_prints"],"wounds":["weapon_cuts"],"disturbances":["broken_foliage"],"sounds":["deep_voices"],"silhouettes":["large_upright_beast","armed_people"],"odors":["woodsmoke"],"mistaken_for":["wild_man"],"distinguishing_clues":["heavy_weapon_cuts"],"preparation_advice":"Use anti-armor weapons and polearms against fewer, powerful opponents.","evidence_visibility":80,"identification_challenge":false,"location_challenge":false,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "skeleton", "name": "Skeleton", "singular": "skeleton", "plural": "skeletons", "aliases": ["animated bones"],
+      "base_weight": 45, "curation_weight": 70, "northern_germany_prior": 70,
+      "combat": {"rig":"humanoid","speed_m_per_minute":62,"weight_kg":18.0,"attack":"blade","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":700,"perception":40,"stealth":35,"morale":100,"protection":"bone","resistance_joules":150,"padding_joules":0,"disease_risk":0,"fear":20,"temperament":"relentless","encounter_scale_basis_points":11000,"loot_item_id":"arming_sword"},
+      "investigation": {"habitats":["crypt","graveyard","ruin","occupied_house","deep_woods"],"activity":"night","victim_tags":["gravekeepers","travelers"],"tracks":["grave_soil"],"wounds":["weapon_cuts"],"disturbances":["bone_dust"],"sounds":["rattling"],"silhouettes":["walking_dead"],"odors":["grave_soil"],"mistaken_for":["revenant","grave_robber"],"distinguishing_clues":["bone_dust"],"preparation_advice":"Use blunt weapons: bone has edge resistance but essentially no innate padding.","evidence_visibility":75,"identification_challenge":false,"location_challenge":false,"countermeasure_hypotheses":["shattering_blow"]}
+    },
+    {
+      "id": "ghoul", "name": "Ghoul", "singular": "ghoul", "plural": "ghouls", "aliases": ["corpse eater"],
+      "base_weight": 40, "curation_weight": 70, "northern_germany_prior": 70,
+      "combat": {"rig":"humanoid","speed_m_per_minute":88,"weight_kg":58.0,"attack":"claw","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":900,"perception":60,"stealth":65,"morale":90,"protection":"hide","resistance_joules":0,"padding_joules":15,"disease_risk":35,"fear":15,"temperament":"aggressive","encounter_scale_basis_points":9000,"loot_item_id":null},
+      "investigation": {"habitats":["crypt","graveyard","ruin","cave"],"activity":"night","victim_tags":["corpses","isolated_people"],"tracks":["bare_tracks"],"wounds":["claw_marks","bite_wounds"],"disturbances":["opened_graves"],"sounds":["scraping"],"silhouettes":["gaunt_human","walking_dead"],"odors":["corpse_odor"],"mistaken_for":["nachzehrer","grave_robber"],"distinguishing_clues":["gnawed_bones"],"preparation_advice":"Protect against claws and disease; expect fast attacks in darkness.","evidence_visibility":65,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":["fire"]}
+    },
+    {
+      "id": "revenant", "name": "Revenant", "singular": "revenant", "plural": "revenants", "aliases": ["wiederganger"],
+      "base_weight": 14, "curation_weight": 35, "northern_germany_prior": 70,
+      "combat": {"rig":"humanoid","speed_m_per_minute":65,"weight_kg":75.0,"attack":"blunt","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":55,"stealth":40,"morale":100,"protection":"supernatural","resistance_joules":80,"padding_joules":20,"disease_risk":20,"fear":25,"temperament":"relentless","encounter_scale_basis_points":5000,"loot_item_id":null},
+      "investigation": {"habitats":["crypt","graveyard","occupied_house"],"activity":"night","victim_tags":["relatives","enemies"],"tracks":["grave_soil"],"wounds":["blunt_damage"],"disturbances":["opened_graves"],"sounds":["familiar_voice"],"silhouettes":["walking_dead","gaunt_human"],"odors":["corpse_odor"],"mistaken_for":["skeleton","nachzehrer"],"distinguishing_clues":["personal_grudge"],"preparation_advice":"Research the deceased and bring protection against a tireless human-sized foe.","evidence_visibility":45,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":["fire"]}
+    },
+    {
+      "id": "werewolf", "name": "Werewolf", "singular": "werewolf", "plural": "werewolves", "aliases": ["wolf-man"],
+      "base_weight": 25, "curation_weight": 60, "northern_germany_prior": 70,
+      "combat": {"rig":"humanoid","speed_m_per_minute":105,"weight_kg":110.0,"attack":"claw","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1100,"perception":75,"stealth":70,"morale":90,"protection":"hide","resistance_joules":0,"padding_joules":45,"disease_risk":15,"fear":20,"temperament":"aggressive","encounter_scale_basis_points":4000,"loot_item_id":null},
+      "investigation": {"habitats":["deep_woods","cave","occupied_house"],"activity":"night","victim_tags":["isolated_people","livestock"],"tracks":["pawprints","boot_prints"],"wounds":["claw_marks","bite_wounds"],"disturbances":["broken_foliage"],"sounds":["howling"],"silhouettes":["large_upright_beast","doglike_beast"],"odors":["animal_odor"],"mistaken_for":["wolf","wild_man","bear"],"distinguishing_clues":["changing_tracks"],"preparation_advice":"Bring a strong armored party; silver remains an investigative hypothesis, not a damage multiplier.","evidence_visibility":45,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":["silver"]}
+    },
+    {
+      "id": "alp", "name": "Alp", "singular": "alp", "plural": "alps", "aliases": ["night oppressor"],
+      "base_weight": 8, "curation_weight": 30, "northern_germany_prior": 115,
+      "combat": {"rig":"humanoid","speed_m_per_minute":78,"weight_kg":55.0,"attack":"claw","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":800,"perception":70,"stealth":85,"morale":35,"protection":"unarmored","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":20,"temperament":"elusive","encounter_scale_basis_points":6500,"loot_item_id":null},
+      "investigation": {"habitats":["occupied_house","ruin"],"activity":"night","victim_tags":["sleepers"],"tracks":[],"wounds":[],"disturbances":["disturbed_bedding"],"sounds":["breathing"],"silhouettes":["unseen_night_visitor"],"odors":[],"mistaken_for":["kobold"],"distinguishing_clues":["sleeping_victim"],"preparation_advice":"Identification and keeping watch matter more than raw combat power.","evidence_visibility":20,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":["daylight"]}
+    },
+    {
+      "id": "kobold", "name": "Kobold", "singular": "kobold", "plural": "kobolds", "aliases": ["house spirit"],
+      "base_weight": 15, "curation_weight": 45, "northern_germany_prior": 115,
+      "combat": {"rig":"humanoid","speed_m_per_minute":82,"weight_kg":30.0,"attack":"knife","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":700,"perception":60,"stealth":80,"morale":25,"protection":"unarmored","resistance_joules":0,"padding_joules":0,"disease_risk":0,"fear":5,"temperament":"elusive","encounter_scale_basis_points":13000,"loot_item_id":"knife"},
+      "investigation": {"habitats":["occupied_house","mine","cave"],"activity":"night","victim_tags":["households","miners"],"tracks":["small_bare_tracks"],"wounds":[],"disturbances":["moved_goods"],"sounds":["knocking"],"silhouettes":["small_upright_figures","unseen_night_visitor"],"odors":[],"mistaken_for":["goblin","alp"],"distinguishing_clues":["helpful_mischief"],"preparation_advice":"Careful identification may make combat unnecessary.","evidence_visibility":25,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "wild_man", "name": "Wild man", "singular": "Wild man", "plural": "Wild men", "aliases": ["woodwose"],
+      "base_weight": 18, "curation_weight": 45, "northern_germany_prior": 115,
+      "combat": {"rig":"humanoid","speed_m_per_minute":88,"weight_kg":95.0,"attack":"blunt","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":900,"perception":70,"stealth":75,"morale":65,"protection":"hide","resistance_joules":0,"padding_joules":35,"disease_risk":0,"fear":5,"temperament":"cautious","encounter_scale_basis_points":6000,"loot_item_id":"club"},
+      "investigation": {"habitats":["deep_woods","cave","ruin"],"activity":"any","victim_tags":["woodcutters","livestock"],"tracks":["large_bare_tracks"],"wounds":["blunt_damage"],"disturbances":["broken_foliage"],"sounds":["calls"],"silhouettes":["large_upright_beast","gaunt_human"],"odors":["animal_odor"],"mistaken_for":["werewolf","bear","orc"],"distinguishing_clues":["woven_branches"],"preparation_advice":"Track carefully and consider whether negotiation is possible.","evidence_visibility":50,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":[]}
+    },
+    {
+      "id": "spectral_hound", "name": "Spectral hound", "singular": "spectral hound", "plural": "spectral hounds", "aliases": ["black dog"],
+      "base_weight": 7, "curation_weight": 35, "northern_germany_prior": 115,
+      "combat": {"rig":"quadruped","speed_m_per_minute":115,"weight_kg":48.0,"attack":"bite","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":1000,"perception":80,"stealth":80,"morale":100,"protection":"supernatural","resistance_joules":50,"padding_joules":10,"disease_risk":0,"fear":35,"temperament":"relentless","encounter_scale_basis_points":4500,"loot_item_id":null},
+      "investigation": {"habitats":["road","graveyard","ruin"],"activity":"night","victim_tags":["night_travelers"],"tracks":["pawprints"],"wounds":["bite_wounds"],"disturbances":["cold_patch"],"sounds":["howling"],"silhouettes":["doglike_beast"],"odors":[],"mistaken_for":["wolf","feral_dog"],"distinguishing_clues":["cold_patch"],"preparation_advice":"Courage and reliable light help against a terrifying nocturnal hound.","evidence_visibility":25,"identification_challenge":true,"location_challenge":true,"countermeasure_hypotheses":["courage","daylight"]}
+    },
+    {
+      "id": "nachzehrer", "name": "Nachzehrer", "singular": "nachzehrer", "plural": "nachzehrer", "aliases": ["grave eater"],
+      "base_weight": 6, "curation_weight": 40, "northern_germany_prior": 115,
+      "combat": {"rig":"humanoid","speed_m_per_minute":58,"weight_kg":78.0,"attack":"bite","ranged":false,"precision_bonus_milli":0,"training_multiplier_milli":800,"perception":45,"stealth":30,"morale":100,"protection":"supernatural","resistance_joules":70,"padding_joules":25,"disease_risk":45,"fear":30,"temperament":"relentless","encounter_scale_basis_points":4500,"loot_item_id":null},
+      "investigation": {"habitats":["crypt","graveyard"],"activity":"night","victim_tags":["families","burials"],"tracks":["grave_soil"],"wounds":["bite_wounds"],"disturbances":["damaged_shroud"],"sounds":["chewing"],"silhouettes":["walking_dead","unseen_night_visitor"],"odors":["corpse_odor"],"mistaken_for":["ghoul","revenant"],"distinguishing_clues":["missing_blood"],"preparation_advice":"Inspect graves and protect against disease before confronting it.","evidence_visibility":35,"identification_challenge":true,"location_challenge":false,"countermeasure_hypotheses":["fire"]}
+    }
+  ]
+}

--- a/content/quests/generation.yaml
+++ b/content/quests/generation.yaml
@@ -1,0 +1,144 @@
+{
+  "templates": [
+    {"id":"recurring_depredation","label":"Recurring depredation","routes":["physical_trail","pattern_surveillance","social_inquiry"],"objectives":["defeat","drive_off"],"cause_finales":{"*":["defeat","drive_off"]},"consequence_profile":"recurring_depredation","incident_interval_minutes":2880,"maximum_incidents":5},
+    {"id":"disappearance_or_loss","label":"Disappearance or loss","routes":["physical_trail","social_inquiry"],"objectives":["rescue","retrieve_return","expose"],"cause_finales":{"hostile":["rescue"],"concealment":["rescue"],"incidental_loss":["retrieve_return"],"fabricated":["expose"]},"consequence_profile":"disappearance_or_loss","incident_interval_minutes":2880,"maximum_incidents":5}
+  ],
+  "consequences": [
+    {"id":"recurring_undead","family":"recurring_depredation","causes":["ghoul","werewolf"],"symptom":"night_screams","buy_bps":400,"sell_penalty_bps":200,"encounter_frequency_bps":700,"encounter_archetype":"undead","disease_intensity":180,"public_summary":"Locals report troubling sounds and disappearances after dark."},
+    {"id":"recurring_livestock","family":"recurring_depredation","causes":["wolf","goblin"],"symptom":"vanished_livestock","buy_bps":700,"sell_penalty_bps":300,"encounter_frequency_bps":1000,"encounter_archetype":"goblins","disease_intensity":0,"public_summary":"Livestock have been disappearing from nearby holdings."},
+    {"id":"recurring_default","family":"recurring_depredation","causes":["*"],"symptom":"missing_caravans","buy_bps":1200,"sell_penalty_bps":500,"encounter_frequency_bps":1500,"encounter_archetype":"bandits","disease_intensity":0,"public_summary":"Several expected caravans have not arrived."},
+    {"id":"loss_default","family":"disappearance_or_loss","causes":["*"],"symptom":"empty_stalls","buy_bps":900,"sell_penalty_bps":400,"encounter_frequency_bps":500,"encounter_archetype":null,"disease_intensity":0,"public_summary":"A disappearance has disrupted work and trade, but nobody agrees on the cause."}
+  ],
+  "relations": [
+    {"id":"family","candidates":[
+      {"id":"recurring_depredation","plausibility":100,"curation":100,"hard_zero_reason":null,"required_bridge":null,"factors":["family_rotation"]},
+      {"id":"disappearance_or_loss","plausibility":100,"curation":100,"hard_zero_reason":null,"required_bridge":null,"factors":["family_rotation"]}
+    ]},
+    {"id":"cause.recurring_depredation","candidates":[
+      {"id":"bandit","plausibility":75,"curation":80,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"goblin","plausibility":70,"curation":75,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"ghoul","plausibility":40,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"skeleton","plausibility":35,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"werewolf","plausibility":45,"curation":60,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"smuggler","plausibility":25,"curation":65,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"wolf","plausibility":65,"curation":65,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]}
+    ]},
+    {"id":"cause.disappearance_or_loss","candidates":[
+      {"id":"bandit","plausibility":75,"curation":80,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"goblin","plausibility":30,"curation":75,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"ghoul","plausibility":40,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"skeleton","plausibility":35,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"werewolf","plausibility":25,"curation":60,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"smuggler","plausibility":60,"curation":65,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"wolf","plausibility":20,"curation":65,"hard_zero_reason":null,"required_bridge":null,"factors":["bestiary"]},
+      {"id":"concealment","plausibility":35,"curation":75,"hard_zero_reason":null,"required_bridge":null,"factors":["nonhostile"]},
+      {"id":"incidental_loss","plausibility":40,"curation":65,"hard_zero_reason":null,"required_bridge":null,"factors":["nonhostile"]},
+      {"id":"fabricated","plausibility":20,"curation":55,"hard_zero_reason":null,"required_bridge":null,"factors":["nonhostile"]}
+    ]},
+    {"id":"site.skeleton","candidates":[
+      {"id":"crypt","plausibility":95,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["natural_habitat"]},
+      {"id":"occupied_house","plausibility":3,"curation":70,"hard_zero_reason":null,"required_bridge":"skeletons_occupied_house","factors":["rare_bridge"]}
+    ]},
+    {"id":"site.wolf","candidates":[
+      {"id":"abandoned_farm","plausibility":80,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["common"]},
+      {"id":"crypt","plausibility":0,"curation":0,"hard_zero_reason":"A quadruped pack cannot maintain a sealed crypt.","required_bridge":null,"factors":["impossible"]}
+    ]},
+    {"id":"circumstance.child","candidates":[
+      {"id":"night_window","plausibility":90,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["household"]},
+      {"id":"adult_venue","plausibility":2,"curation":70,"hard_zero_reason":null,"required_bridge":"child_at_adult_venue","factors":["rare_venue"]},
+      {"id":"road","plausibility":55,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["travel"]}
+    ]},
+    {"id":"circumstance.cleric","candidates":[
+      {"id":"grave_duty","plausibility":70,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["vocation"]},
+      {"id":"adult_venue","plausibility":0,"curation":0,"hard_zero_reason":"The assigned cleric witness is not present in the adult venue.","required_bridge":null,"factors":["impossible_venue"]}
+    ]},
+    {"id":"reliability.baseline","candidates":[
+      {"id":"truthful","plausibility":65,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["baseline"]},
+      {"id":"mistaken","plausibility":25,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["possible"]},
+      {"id":"evasive","plausibility":25,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["possible"]},
+      {"id":"deceptive","plausibility":25,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["possible"]},
+      {"id":"partly_truthful","plausibility":45,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["partial"]}
+    ]},
+    {"id":"reliability.child","candidates":[
+      {"id":"truthful","plausibility":65,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["baseline"]},
+      {"id":"mistaken","plausibility":70,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["darkness"]},
+      {"id":"deceptive","plausibility":0,"curation":0,"hard_zero_reason":"The initial child account is not authored as deliberate fabrication.","required_bridge":null,"factors":["child_hard_zero"]}
+    ]},
+    {"id":"reliability.embarrassing_context","candidates":[
+      {"id":"evasive","plausibility":75,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"reliability.fabricated_claim","candidates":[
+      {"id":"deceptive","plausibility":80,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"reliability.night_window","candidates":[
+      {"id":"mistaken","plausibility":70,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"account.baseline","candidates":[
+      {"id":"visual","plausibility":60,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"heard","plausibility":30,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"tracks","plausibility":45,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"account.night_window","candidates":[
+      {"id":"visual","plausibility":60,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"heard","plausibility":80,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"tracks","plausibility":45,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"account.mistaken","candidates":[
+      {"id":"visual","plausibility":60,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"heard","plausibility":30,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"tracks","plausibility":0,"curation":0,"hard_zero_reason":"A mistaken eyewitness does not provide the precise track account.","required_bridge":null}
+    ]},
+    {"id":"route.recurring_depredation","candidates":[
+      {"id":"direct","plausibility":70,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"cautious","plausibility":45,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"route.disappearance_or_loss","candidates":[
+      {"id":"direct","plausibility":55,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"cautious","plausibility":75,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"pattern.recurring_depredation","candidates":[
+      {"id":"nightly","plausibility":60,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"roadside","plausibility":55,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"victim_specific","plausibility":30,"curation":65,"hard_zero_reason":null,"required_bridge":null},{"id":"irregular","plausibility":35,"curation":55,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"pattern.disappearance_or_loss","candidates":[
+      {"id":"nightly","plausibility":60,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"roadside","plausibility":55,"curation":70,"hard_zero_reason":null,"required_bridge":null},{"id":"victim_specific","plausibility":70,"curation":65,"hard_zero_reason":null,"required_bridge":null},{"id":"irregular","plausibility":35,"curation":55,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"evidence.baseline","candidates":[
+      {"id":"footprints","plausibility":45,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["possible"]},
+      {"id":"cloth_scrap","plausibility":45,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["portable"]},
+      {"id":"bone_dust","plausibility":25,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["possible"]},
+      {"id":"bloodless_corpse","plausibility":25,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["possible"]},
+      {"id":"dropped_token","plausibility":45,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["portable"]},
+      {"id":"drag_marks","plausibility":25,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["possible"]},
+      {"id":"ledger_entry","plausibility":25,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["possible"]}
+    ]},
+    {"id":"evidence.fabricated_claim","candidates":[
+      {"id":"bloodless_corpse","plausibility":0,"curation":0,"hard_zero_reason":"A fabricated loss cannot create a canonical corpse clue.","required_bridge":null,"factors":["fabrication_hard_zero"]},
+      {"id":"ledger_entry","plausibility":80,"curation":70,"hard_zero_reason":null,"required_bridge":null,"factors":["record"]}
+    ]},
+    {"id":"evidence.skeleton","candidates":[
+      {"id":"bone_dust","plausibility":90,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"evidence.incidental_loss","candidates":[
+      {"id":"ledger_entry","plausibility":70,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"evidence.trackable_ground","candidates":[
+      {"id":"footprints","plausibility":75,"curation":70,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"description.armed_people","candidates":[
+      {"id":"bandit","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"deserter","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"poacher","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"smuggler","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"cultist","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"grave_robber","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"town_watch","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"armed_retainer","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"angry_mob","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"orc","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"description.small_upright_figures","candidates":[
+      {"id":"goblin","plausibility":100,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"kobold","plausibility":80,"curation":100,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"description.large_upright_beast","candidates":[
+      {"id":"werewolf","plausibility":95,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"wild_man","plausibility":85,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"orc","plausibility":70,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"bear","plausibility":45,"curation":100,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"description.gaunt_human","candidates":[
+      {"id":"ghoul","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"revenant","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"wild_man","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"description.walking_dead","candidates":[
+      {"id":"skeleton","plausibility":100,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"ghoul","plausibility":80,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"revenant","plausibility":80,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"nachzehrer","plausibility":80,"curation":100,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"description.large_animal","candidates":[
+      {"id":"boar","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"bear","plausibility":60,"curation":100,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"description.doglike_beast","candidates":[
+      {"id":"spectral_hound","plausibility":65,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"wolf","plausibility":100,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"feral_dog","plausibility":85,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"trained_dog","plausibility":85,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"werewolf","plausibility":35,"curation":100,"hard_zero_reason":null,"required_bridge":null}
+    ]},
+    {"id":"description.unseen_night_visitor","candidates":[
+      {"id":"alp","plausibility":100,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"nachzehrer","plausibility":45,"curation":100,"hard_zero_reason":null,"required_bridge":null},{"id":"kobold","plausibility":55,"curation":100,"hard_zero_reason":null,"required_bridge":null}
+    ]}
+  ]
+}

--- a/content/quests/investigation.yaml
+++ b/content/quests/investigation.yaml
@@ -9,7 +9,12 @@
     {"id":"ledger_entry","portrait_label":"Ledger","portrait_icon":"open-book","base_description":"A ledger lies open to a page of terse entries.","topics":[{"id":"totals","label":"column totals","inspection_description":"The sums are routine and mostly balanced.","check":null},{"id":"correction","label":"corrected entry","inspection_description":"One line has been scraped and rewritten.","check":{"stat":"intelligence","difficulty_min_milli":1200,"difficulty_max_milli":4000,"success_description":"You reconstruct an original entry that contradicts the public account.","reveals_clue":true}}]}
   ],
   "witness_demographics": [
-    {"id":"child","label":"child"},{"id":"laborer","label":"laborer"},{"id":"merchant","label":"merchant"},{"id":"cleric","label":"cleric"},{"id":"guard","label":"guard"},{"id":"noble","label":"noble"}
+    {"id":"child","label":"child","match_rules":[{"priority":100,"age_bands":["child","adolescent"],"sexes":[],"professions":[],"local_roles":[],"fallback":false}]},
+    {"id":"laborer","label":"laborer","match_rules":[{"priority":0,"age_bands":[],"sexes":[],"professions":[],"local_roles":[],"fallback":true}]},
+    {"id":"merchant","label":"merchant","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["merchant","innkeeper"],"local_roles":[],"fallback":false}]},
+    {"id":"cleric","label":"cleric","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["cleric"],"local_roles":[],"fallback":false}]},
+    {"id":"guard","label":"guard","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["guard","soldier"],"local_roles":[],"fallback":false},{"priority":90,"age_bands":[],"sexes":[],"professions":[],"local_roles":["retainer"],"fallback":false}]},
+    {"id":"noble","label":"noble","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["noble"],"local_roles":[],"fallback":false},{"priority":90,"age_bands":[],"sexes":[],"professions":[],"local_roles":["lord"],"fallback":false}]}
   ],
   "circumstances": [
     {"id":"night_window","statement":"looking from a window after dark"},{"id":"secret_riverside","statement":"at a secluded riverside meeting"},{"id":"adult_venue","statement":"near an adult venue"},{"id":"road","statement":"while traveling the road"},{"id":"grave_duty","statement":"while attending the graves"},{"id":"livestock_watch","statement":"while watching livestock"}
@@ -28,7 +33,7 @@
     {"id":"armed_people","text":"a group of armed figures"},{"id":"small_upright_figures","text":"several small figures moving upright"},{"id":"large_upright_beast","text":"a large shape that seemed to stand upright"},{"id":"gaunt_human","text":"a gaunt, human-shaped figure"},{"id":"walking_dead","text":"a person moving with a stiff, shambling gait"},{"id":"large_animal","text":"the silhouette of a large animal"},{"id":"doglike_beast","text":"a low, dog-shaped beast"},{"id":"unseen_night_visitor","text":"something hidden in the darkness"}
   ],
   "bridges": [
-    {"id":"skeletons_occupied_house","explanation":"A grave robber moved animated remains into a shuttered house.","lead_summary":"Grave clay and cart ruts connect the house to the crypt."},
-    {"id":"child_at_adult_venue","explanation":"The child was fetching an adult relative from outside the venue.","lead_summary":"An errand token corroborates why the child waited outside."}
+    {"id":"skeletons_occupied_house","explanation":"A grave robber moved animated remains into a shuttered house.","lead_summary":"Grave clay and cart ruts connect the house to the crypt.","event_suffix":"bridge:skeleton_house","evidence_id":"grave_clay","action_ids":{"recurring_depredation":"search","disappearance_or_loss":"inspect_last_known"}},
+    {"id":"child_at_adult_venue","explanation":"The child was fetching an adult relative from outside the venue.","lead_summary":"An errand token corroborates why the child waited outside.","event_suffix":"bridge:child_venue","evidence_id":"errand_token","action_ids":{"recurring_depredation":"watch","disappearance_or_loss":"locate_contact"}}
   ]
 }

--- a/content/quests/investigation.yaml
+++ b/content/quests/investigation.yaml
@@ -1,0 +1,34 @@
+{
+  "evidence": [
+    {"id":"footprints","portrait_label":"Footprints","portrait_icon":"wingfoot","base_description":"You see a trail of footprints pressed into the ground.","topics":[{"id":"spacing","label":"spacing between the prints","inspection_description":"The stride is uneven where the ground rises.","check":null},{"id":"edges","label":"edges of the prints","inspection_description":"The edges are easy to overlook among loose soil.","check":{"stat":"eyesight","difficulty_min_milli":1200,"difficulty_max_milli":4000,"success_description":"You notice the freshest prints continue away from the apparent trail.","reveals_clue":true}}]},
+    {"id":"cloth_scrap","portrait_label":"Torn cloth","portrait_icon":"clothes","base_description":"A scrap of cloth hangs from a rough edge.","topics":[{"id":"weave","label":"weave of the cloth","inspection_description":"It is ordinary, coarse cloth.","check":null},{"id":"snag","label":"place where it snagged","inspection_description":"The fibers are badly frayed.","check":{"stat":"eyesight","difficulty_min_milli":1200,"difficulty_max_milli":4000,"success_description":"You see that the cloth caught while its wearer moved toward a concealed path.","reveals_clue":true}}]},
+    {"id":"bone_dust","portrait_label":"Bone dust","portrait_icon":"death-skull","base_description":"Pale fragments and dust lie scattered over the surface.","topics":[{"id":"fragments","label":"larger fragments","inspection_description":"They are dry and brittle.","check":null},{"id":"residue","label":"fine residue","inspection_description":"The powder resembles old bone.","check":{"stat":"intelligence","difficulty_min_milli":1200,"difficulty_max_milli":4000,"success_description":"You distinguish worked grave material from ordinary animal remains.","reveals_clue":true}}]},
+    {"id":"bloodless_corpse","portrait_label":"Bloodless corpse","portrait_icon":"bleeding-wound","base_description":"A body lies here with remarkably little blood around it.","topics":[{"id":"clothing","label":"clothing","inspection_description":"The clothing is disordered but otherwise unremarkable.","check":null},{"id":"wounds","label":"wounds","inspection_description":"The marks are small and difficult to read.","check":{"stat":"intelligence","difficulty_min_milli":1200,"difficulty_max_milli":4000,"success_description":"You determine that the lack of blood cannot be explained by the visible wounds alone.","reveals_clue":true}}]},
+    {"id":"dropped_token","portrait_label":"Dropped token","portrait_icon":"coins","base_description":"A small personal token lies where someone dropped it.","topics":[{"id":"face","label":"worn face","inspection_description":"Handling has smoothed most of its detail.","check":null},{"id":"edge","label":"marked edge","inspection_description":"Faint scratches run around the edge.","check":{"stat":"eyesight","difficulty_min_milli":1200,"difficulty_max_milli":4000,"success_description":"You recognize a deliberate ownership mark associated with a local group.","reveals_clue":true}}]},
+    {"id":"drag_marks","portrait_label":"Drag marks","portrait_icon":"eye-target","base_description":"Long disturbances score the dirt and crushed vegetation.","topics":[{"id":"furrows","label":"deepest furrows","inspection_description":"Something heavy passed over this ground.","check":null},{"id":"interruptions","label":"interruptions in the marks","inspection_description":"The trail is confused where the surface hardens.","check":{"stat":"instinct","difficulty_min_milli":1200,"difficulty_max_milli":4000,"success_description":"You recover the direction of travel from repeated disturbances beyond the hard ground.","reveals_clue":true}}]},
+    {"id":"ledger_entry","portrait_label":"Ledger","portrait_icon":"open-book","base_description":"A ledger lies open to a page of terse entries.","topics":[{"id":"totals","label":"column totals","inspection_description":"The sums are routine and mostly balanced.","check":null},{"id":"correction","label":"corrected entry","inspection_description":"One line has been scraped and rewritten.","check":{"stat":"intelligence","difficulty_min_milli":1200,"difficulty_max_milli":4000,"success_description":"You reconstruct an original entry that contradicts the public account.","reveals_clue":true}}]}
+  ],
+  "witness_demographics": [
+    {"id":"child","label":"child"},{"id":"laborer","label":"laborer"},{"id":"merchant","label":"merchant"},{"id":"cleric","label":"cleric"},{"id":"guard","label":"guard"},{"id":"noble","label":"noble"}
+  ],
+  "circumstances": [
+    {"id":"night_window","statement":"looking from a window after dark"},{"id":"secret_riverside","statement":"at a secluded riverside meeting"},{"id":"adult_venue","statement":"near an adult venue"},{"id":"road","statement":"while traveling the road"},{"id":"grave_duty","statement":"while attending the graves"},{"id":"livestock_watch","statement":"while watching livestock"}
+  ],
+  "sites": [
+    {"id":"cave","label":"a cave beyond the fields","terrain":"underground","habitat":"cave"},
+    {"id":"crypt","label":"the old crypt","terrain":"underground","habitat":"crypt"},
+    {"id":"forest_camp","label":"a camp in the woods","terrain":"forest","habitat":"camp"},
+    {"id":"occupied_house","label":"an occupied house","terrain":"settlement","habitat":"occupied_house"},
+    {"id":"riverside","label":"a secluded bend in the river","terrain":"road","habitat":"open"},
+    {"id":"graveyard","label":"the old graveyard","terrain":"settlement","habitat":"graveyard"},
+    {"id":"roadside","label":"a lonely stretch of road","terrain":"road","habitat":"road"},
+    {"id":"abandoned_farm","label":"an abandoned farm","terrain":"forest","habitat":"ruin"}
+  ],
+  "descriptions": [
+    {"id":"armed_people","text":"a group of armed figures"},{"id":"small_upright_figures","text":"several small figures moving upright"},{"id":"large_upright_beast","text":"a large shape that seemed to stand upright"},{"id":"gaunt_human","text":"a gaunt, human-shaped figure"},{"id":"walking_dead","text":"a person moving with a stiff, shambling gait"},{"id":"large_animal","text":"the silhouette of a large animal"},{"id":"doglike_beast","text":"a low, dog-shaped beast"},{"id":"unseen_night_visitor","text":"something hidden in the darkness"}
+  ],
+  "bridges": [
+    {"id":"skeletons_occupied_house","explanation":"A grave robber moved animated remains into a shuttered house.","lead_summary":"Grave clay and cart ruts connect the house to the crypt."},
+    {"id":"child_at_adult_venue","explanation":"The child was fetching an adult relative from outside the venue.","lead_summary":"An errand token corroborates why the child waited outside."}
+  ]
+}

--- a/content/quests/investigation.yaml
+++ b/content/quests/investigation.yaml
@@ -14,7 +14,7 @@
     {"id":"merchant","label":"merchant","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["merchant","innkeeper"],"local_roles":[],"fallback":false}]},
     {"id":"cleric","label":"cleric","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["cleric"],"local_roles":[],"fallback":false}]},
     {"id":"guard","label":"guard","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["guard","soldier"],"local_roles":[],"fallback":false},{"priority":90,"age_bands":[],"sexes":[],"professions":[],"local_roles":["retainer"],"fallback":false}]},
-    {"id":"noble","label":"noble","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["noble"],"local_roles":[],"fallback":false},{"priority":90,"age_bands":[],"sexes":[],"professions":[],"local_roles":["lord"],"fallback":false}]}
+    {"id":"noble","label":"noble","match_rules":[{"priority":80,"age_bands":[],"sexes":[],"professions":["noble"],"local_roles":[],"fallback":false}]}
   ],
   "circumstances": [
     {"id":"night_window","statement":"looking from a window after dark"},{"id":"secret_riverside","statement":"at a secluded riverside meeting"},{"id":"adult_venue","statement":"near an adult venue"},{"id":"road","statement":"while traveling the road"},{"id":"grave_duty","statement":"while attending the graves"},{"id":"livestock_watch","statement":"while watching livestock"}

--- a/crates/adventuresim-core/Cargo.toml
+++ b/crates/adventuresim-core/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 repository.workspace = true
 license.workspace = true
+build = "build.rs"
 
 [dependencies]
 enum-assoc = "1.3.0"
@@ -14,6 +15,11 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 adventuresim-world-schema.workspace = true
+
+[build-dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+sha2.workspace = true
 
 [lints]
 workspace = true

--- a/crates/adventuresim-core/build.rs
+++ b/crates/adventuresim-core/build.rs
@@ -1,0 +1,189 @@
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::{
+    collections::BTreeSet,
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+#[derive(Deserialize)]
+struct Document {
+    #[serde(default)]
+    monsters: Vec<Identified>,
+    #[serde(default)]
+    evidence: Vec<Identified>,
+    #[serde(default)]
+    witness_demographics: Vec<Identified>,
+    #[serde(default)]
+    circumstances: Vec<Identified>,
+    #[serde(default)]
+    sites: Vec<Identified>,
+    #[serde(default)]
+    descriptions: Vec<Identified>,
+    #[serde(default)]
+    templates: Vec<Identified>,
+    #[serde(default)]
+    relations: Vec<Relation>,
+    #[serde(default)]
+    bridges: Vec<Identified>,
+}
+
+#[derive(Deserialize)]
+struct Identified {
+    id: String,
+}
+
+#[derive(Deserialize)]
+struct Relation {
+    id: String,
+    candidates: Vec<RelationCandidate>,
+}
+
+#[derive(Deserialize)]
+struct RelationCandidate {
+    id: String,
+    plausibility: u32,
+    curation: u32,
+    #[serde(default)]
+    hard_zero_reason: Option<String>,
+    #[serde(default)]
+    required_bridge: Option<String>,
+}
+
+fn valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 128
+        && id.bytes().all(|b| {
+            b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'_' | b'-' | b'.' | b':')
+        })
+}
+
+fn insert(ids: &mut BTreeSet<String>, kind: &str, id: &str, file: &str) {
+    assert!(valid_id(id), "{file}: invalid {kind} id {id:?}");
+    assert!(
+        ids.insert(format!("{kind}:{id}")),
+        "{file}: duplicate {kind} id {id}"
+    );
+}
+
+fn main() {
+    let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../..");
+    let content = root.join("content/quests");
+    println!("cargo:rerun-if-changed={}", content.display());
+    let mut files: Vec<_> = fs::read_dir(&content)
+        .expect("content/quests must exist")
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "yaml")
+        })
+        .collect();
+    files.sort();
+
+    let mut documents = Vec::new();
+    let mut digest = Sha256::new();
+    let mut ids = BTreeSet::new();
+    let mut bridge_ids = BTreeSet::new();
+    let mut pending_bridges = Vec::new();
+    for file in files {
+        let relative = file
+            .strip_prefix(&root)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+        let text = fs::read_to_string(&file).unwrap();
+        digest.update(relative.as_bytes());
+        digest.update([0]);
+        digest.update(text.as_bytes());
+        // As with dialogue, quest YAML deliberately uses JSON's strict,
+        // diff-friendly YAML subset so deployed binaries need no YAML parser.
+        let value: serde_json::Value =
+            serde_json::from_str(&text).unwrap_or_else(|error| panic!("{relative}: {error}"));
+        let document: Document = serde_json::from_value(value.clone())
+            .unwrap_or_else(|error| panic!("{relative}: invalid quest catalog: {error}"));
+        for item in &document.monsters {
+            insert(&mut ids, "monster", &item.id, &relative);
+        }
+        for item in &document.evidence {
+            insert(&mut ids, "evidence", &item.id, &relative);
+        }
+        for item in &document.witness_demographics {
+            insert(&mut ids, "witness_demographic", &item.id, &relative);
+        }
+        for item in &document.circumstances {
+            insert(&mut ids, "circumstance", &item.id, &relative);
+        }
+        for item in &document.sites {
+            insert(&mut ids, "site", &item.id, &relative);
+        }
+        for item in &document.descriptions {
+            insert(&mut ids, "description", &item.id, &relative);
+        }
+        for item in &document.templates {
+            insert(&mut ids, "template", &item.id, &relative);
+        }
+        for item in &document.bridges {
+            insert(&mut ids, "bridge", &item.id, &relative);
+            bridge_ids.insert(item.id.clone());
+        }
+        for relation in &document.relations {
+            insert(&mut ids, "relation", &relation.id, &relative);
+            assert!(
+                !relation.candidates.is_empty(),
+                "{relative}: relation {} has no candidates",
+                relation.id
+            );
+            let mut candidates = BTreeSet::new();
+            for candidate in &relation.candidates {
+                assert!(
+                    candidates.insert(&candidate.id),
+                    "{relative}: relation {} has duplicate candidate {}",
+                    relation.id,
+                    candidate.id
+                );
+                assert!(
+                    valid_id(&candidate.id),
+                    "{relative}: relation {} has invalid candidate id {}",
+                    relation.id,
+                    candidate.id
+                );
+                let zero = candidate.plausibility == 0 || candidate.curation == 0;
+                assert_eq!(
+                    zero,
+                    candidate.hard_zero_reason.is_some(),
+                    "{relative}: relation {} candidate {} must pair zero weight with a reason",
+                    relation.id,
+                    candidate.id
+                );
+                if let Some(reason) = &candidate.hard_zero_reason {
+                    assert!(
+                        !reason.trim().is_empty(),
+                        "{relative}: empty hard-zero reason in {}",
+                        relation.id
+                    );
+                }
+                if let Some(bridge) = &candidate.required_bridge {
+                    pending_bridges.push((relative.clone(), relation.id.clone(), bridge.clone()));
+                }
+            }
+        }
+        documents.push(value);
+    }
+    for (file, relation, bridge) in pending_bridges {
+        assert!(
+            bridge_ids.contains(&bridge),
+            "{file}: relation {relation} references missing bridge {bridge}"
+        );
+    }
+    assert!(!documents.is_empty(), "content/quests contains no YAML");
+    let json = serde_json::to_string(&documents).unwrap();
+    let digest = format!("{:x}", digest.finalize());
+    fs::write(
+        Path::new(&env::var("OUT_DIR").unwrap()).join("quest_catalog.rs"),
+        format!(
+            "pub const QUEST_CATALOG_JSON: &str = {json:?};\n\
+             pub const QUEST_CATALOG_DIGEST: &str = {digest:?};\n"
+        ),
+    )
+    .unwrap();
+}

--- a/crates/adventuresim-core/build.rs
+++ b/crates/adventuresim-core/build.rs
@@ -1,70 +1,10 @@
-use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::{
-    collections::BTreeSet,
     env, fs,
     path::{Path, PathBuf},
 };
-
-#[derive(Deserialize)]
-struct Document {
-    #[serde(default)]
-    monsters: Vec<Identified>,
-    #[serde(default)]
-    evidence: Vec<Identified>,
-    #[serde(default)]
-    witness_demographics: Vec<Identified>,
-    #[serde(default)]
-    circumstances: Vec<Identified>,
-    #[serde(default)]
-    sites: Vec<Identified>,
-    #[serde(default)]
-    descriptions: Vec<Identified>,
-    #[serde(default)]
-    templates: Vec<Identified>,
-    #[serde(default)]
-    relations: Vec<Relation>,
-    #[serde(default)]
-    bridges: Vec<Identified>,
-}
-
-#[derive(Deserialize)]
-struct Identified {
-    id: String,
-}
-
-#[derive(Deserialize)]
-struct Relation {
-    id: String,
-    candidates: Vec<RelationCandidate>,
-}
-
-#[derive(Deserialize)]
-struct RelationCandidate {
-    id: String,
-    plausibility: u32,
-    curation: u32,
-    #[serde(default)]
-    hard_zero_reason: Option<String>,
-    #[serde(default)]
-    required_bridge: Option<String>,
-}
-
-fn valid_id(id: &str) -> bool {
-    !id.is_empty()
-        && id.len() <= 128
-        && id.bytes().all(|b| {
-            b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'_' | b'-' | b'.' | b':')
-        })
-}
-
-fn insert(ids: &mut BTreeSet<String>, kind: &str, id: &str, file: &str) {
-    assert!(valid_id(id), "{file}: invalid {kind} id {id:?}");
-    assert!(
-        ids.insert(format!("{kind}:{id}")),
-        "{file}: duplicate {kind} id {id}"
-    );
-}
+#[path = "src/quest_catalog_validation.rs"]
+mod quest_catalog_validation;
 
 fn main() {
     let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("../..");
@@ -81,10 +21,8 @@ fn main() {
     files.sort();
 
     let mut documents = Vec::new();
+    let mut source_files = Vec::new();
     let mut digest = Sha256::new();
-    let mut ids = BTreeSet::new();
-    let mut bridge_ids = BTreeSet::new();
-    let mut pending_bridges = Vec::new();
     for file in files {
         let relative = file
             .strip_prefix(&root)
@@ -99,83 +37,12 @@ fn main() {
         // diff-friendly YAML subset so deployed binaries need no YAML parser.
         let value: serde_json::Value =
             serde_json::from_str(&text).unwrap_or_else(|error| panic!("{relative}: {error}"));
-        let document: Document = serde_json::from_value(value.clone())
-            .unwrap_or_else(|error| panic!("{relative}: invalid quest catalog: {error}"));
-        for item in &document.monsters {
-            insert(&mut ids, "monster", &item.id, &relative);
-        }
-        for item in &document.evidence {
-            insert(&mut ids, "evidence", &item.id, &relative);
-        }
-        for item in &document.witness_demographics {
-            insert(&mut ids, "witness_demographic", &item.id, &relative);
-        }
-        for item in &document.circumstances {
-            insert(&mut ids, "circumstance", &item.id, &relative);
-        }
-        for item in &document.sites {
-            insert(&mut ids, "site", &item.id, &relative);
-        }
-        for item in &document.descriptions {
-            insert(&mut ids, "description", &item.id, &relative);
-        }
-        for item in &document.templates {
-            insert(&mut ids, "template", &item.id, &relative);
-        }
-        for item in &document.bridges {
-            insert(&mut ids, "bridge", &item.id, &relative);
-            bridge_ids.insert(item.id.clone());
-        }
-        for relation in &document.relations {
-            insert(&mut ids, "relation", &relation.id, &relative);
-            assert!(
-                !relation.candidates.is_empty(),
-                "{relative}: relation {} has no candidates",
-                relation.id
-            );
-            let mut candidates = BTreeSet::new();
-            for candidate in &relation.candidates {
-                assert!(
-                    candidates.insert(&candidate.id),
-                    "{relative}: relation {} has duplicate candidate {}",
-                    relation.id,
-                    candidate.id
-                );
-                assert!(
-                    valid_id(&candidate.id),
-                    "{relative}: relation {} has invalid candidate id {}",
-                    relation.id,
-                    candidate.id
-                );
-                let zero = candidate.plausibility == 0 || candidate.curation == 0;
-                assert_eq!(
-                    zero,
-                    candidate.hard_zero_reason.is_some(),
-                    "{relative}: relation {} candidate {} must pair zero weight with a reason",
-                    relation.id,
-                    candidate.id
-                );
-                if let Some(reason) = &candidate.hard_zero_reason {
-                    assert!(
-                        !reason.trim().is_empty(),
-                        "{relative}: empty hard-zero reason in {}",
-                        relation.id
-                    );
-                }
-                if let Some(bridge) = &candidate.required_bridge {
-                    pending_bridges.push((relative.clone(), relation.id.clone(), bridge.clone()));
-                }
-            }
-        }
         documents.push(value);
-    }
-    for (file, relation, bridge) in pending_bridges {
-        assert!(
-            bridge_ids.contains(&bridge),
-            "{file}: relation {relation} references missing bridge {bridge}"
-        );
+        source_files.push(relative);
     }
     assert!(!documents.is_empty(), "content/quests contains no YAML");
+    quest_catalog_validation::validate_documents(&documents, &source_files)
+        .unwrap_or_else(|error| panic!("{error}"));
     let json = serde_json::to_string(&documents).unwrap();
     let digest = format!("{:x}", digest.finalize());
     fs::write(

--- a/crates/adventuresim-core/src/bestiary.rs
+++ b/crates/adventuresim-core/src/bestiary.rs
@@ -294,41 +294,64 @@ impl<'de> Deserialize<'de> for ReportDescription {
             .map_err(|_| serde::de::Error::custom("invalid description ID"))
     }
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum EvidenceKind {
-    BootPrints,
-    SmallBareTracks,
-    Hoofprints,
-    Pawprints,
-    ClawMarks,
-    GnawedBones,
-    GraveSoil,
-    NoBreath,
-    WeaponCuts,
-    ArrowShafts,
-    CorpseOdor,
-    SulfurOdor,
-    ColdPatch,
-    MissingBlood,
-    DisturbedGoods,
-    HumanSpeech,
-    AnimalOdor,
-    BrokenFoliage,
-    BiteWounds,
-    BluntDamage,
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EvidenceKind(ThreatId);
+impl EvidenceKind {
+    #[allow(non_upper_case_globals)]
+    pub const BootPrints: Self = Self(ThreatId::from_static("boot_prints"));
+    #[allow(non_upper_case_globals)]
+    pub const SmallBareTracks: Self = Self(ThreatId::from_static("small_bare_tracks"));
+    #[allow(non_upper_case_globals)]
+    pub const Hoofprints: Self = Self(ThreatId::from_static("hoofprints"));
+    #[allow(non_upper_case_globals)]
+    pub const Pawprints: Self = Self(ThreatId::from_static("pawprints"));
+    #[allow(non_upper_case_globals)]
+    pub const ClawMarks: Self = Self(ThreatId::from_static("claw_marks"));
+    #[allow(non_upper_case_globals)]
+    pub const GnawedBones: Self = Self(ThreatId::from_static("gnawed_bones"));
+    #[allow(non_upper_case_globals)]
+    pub const GraveSoil: Self = Self(ThreatId::from_static("grave_soil"));
+    #[allow(non_upper_case_globals)]
+    pub const NoBreath: Self = Self(ThreatId::from_static("no_breath"));
+    #[allow(non_upper_case_globals)]
+    pub const WeaponCuts: Self = Self(ThreatId::from_static("weapon_cuts"));
+    #[allow(non_upper_case_globals)]
+    pub const ArrowShafts: Self = Self(ThreatId::from_static("arrow_shafts"));
+    #[allow(non_upper_case_globals)]
+    pub const CorpseOdor: Self = Self(ThreatId::from_static("corpse_odor"));
+    #[allow(non_upper_case_globals)]
+    pub const SulfurOdor: Self = Self(ThreatId::from_static("sulfur_odor"));
+    #[allow(non_upper_case_globals)]
+    pub const ColdPatch: Self = Self(ThreatId::from_static("cold_patch"));
+    #[allow(non_upper_case_globals)]
+    pub const MissingBlood: Self = Self(ThreatId::from_static("missing_blood"));
+    #[allow(non_upper_case_globals)]
+    pub const DisturbedGoods: Self = Self(ThreatId::from_static("disturbed_goods"));
+    #[allow(non_upper_case_globals)]
+    pub const HumanSpeech: Self = Self(ThreatId::from_static("human_speech"));
+    #[allow(non_upper_case_globals)]
+    pub const AnimalOdor: Self = Self(ThreatId::from_static("animal_odor"));
+    #[allow(non_upper_case_globals)]
+    pub const BrokenFoliage: Self = Self(ThreatId::from_static("broken_foliage"));
+    #[allow(non_upper_case_globals)]
+    pub const BiteWounds: Self = Self(ThreatId::from_static("bite_wounds"));
+    #[allow(non_upper_case_globals)]
+    pub const BluntDamage: Self = Self(ThreatId::from_static("blunt_damage"));
+    pub fn try_new(value: &str) -> Result<Self, UnknownThreatId> {
+        ThreatId::try_new(value).map(Self)
+    }
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CatalogCountermeasure {
-    ShatteringBlow,
-    AntiArmor,
-    Fire,
-    Silver,
-    Daylight,
-    Courage,
-    NoSpecial,
+impl core::fmt::Debug for EvidenceKind {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CountermeasureHypothesis {
+    ShatteringBlow,
     Fire,
     Silver,
     Daylight,
@@ -417,886 +440,7 @@ pub struct ThreatProfile {
     pub investigation: InvestigationProfile,
 }
 
-const HUMANS: &[ThreatId] = &[
-    ThreatId::Bandit,
-    ThreatId::Deserter,
-    ThreatId::Poacher,
-    ThreatId::Smuggler,
-    ThreatId::Cultist,
-    ThreatId::GraveRobber,
-    ThreatId::TownWatch,
-    ThreatId::ArmedRetainer,
-    ThreatId::AngryMob,
-];
-const DOGS: &[ThreatId] = &[
-    ThreatId::Wolf,
-    ThreatId::FeralDog,
-    ThreatId::TrainedDog,
-    ThreatId::SpectralHound,
-    ThreatId::Werewolf,
-];
-const UPRIGHT: &[ThreatId] = &[
-    ThreatId::Werewolf,
-    ThreatId::WildMan,
-    ThreatId::Orc,
-    ThreatId::Bear,
-];
-const UNDEAD: &[ThreatId] = &[
-    ThreatId::Skeleton,
-    ThreatId::Ghoul,
-    ThreatId::Revenant,
-    ThreatId::Nachzehrer,
-];
-
-const fn combat(
-    rig: RigTopology,
-    speed: u32,
-    weight: f32,
-    attack: AttackStyle,
-    ranged: bool,
-    protection: Protection,
-    countermeasure: CatalogCountermeasure,
-    temperament: Temperament,
-    loot: Option<&'static str>,
-) -> CombatProfile {
-    CombatProfile {
-        rig,
-        speed_m_per_minute: speed,
-        weight_kg: weight,
-        attack,
-        ranged,
-        precision_bonus: if ranged { 0.5 } else { 0.0 },
-        training_multiplier: 1.0,
-        perception: if ranged { 65 } else { 50 },
-        stealth: 50,
-        morale: 50,
-        protection,
-        innate_protection: if matches!(countermeasure, CatalogCountermeasure::ShatteringBlow) {
-            // Bone resists an edge but provides no soft layer to dissipate a
-            // crushing impact. Penetration still acts through the ordinary
-            // resistance calculation rather than a species damage modifier.
-            InnateProtection {
-                resistance_joules: 150.0,
-                padding_joules: 0.0,
-            }
-        } else {
-            InnateProtection {
-                resistance_joules: 0.0,
-                padding_joules: 0.0,
-            }
-        },
-        disease_risk: 0,
-        fear: 0,
-        temperament,
-        encounter_scale_basis_points: 10_000,
-        loot_item_id: loot,
-    }
-}
-
-const fn investigation(
-    habitats: &'static [Habitat],
-    activity: ActivityTime,
-    silhouettes: &'static [ReportDescription],
-    mistaken_for: &'static [ThreatId],
-    clues: &'static [EvidenceKind],
-    advice: &'static str,
-) -> InvestigationProfile {
-    InvestigationProfile {
-        habitats,
-        activity,
-        victim_tags: &["travelers", "livestock"],
-        tracks: &[EvidenceKind::BootPrints],
-        wounds: &[EvidenceKind::WeaponCuts],
-        disturbances: &[EvidenceKind::DisturbedGoods],
-        sounds: &["movement", "voices"],
-        silhouettes,
-        odors: &[],
-        mistaken_for,
-        distinguishing_clues: clues,
-        preparation_advice: advice,
-        evidence_visibility: 60,
-        identification_challenge: false,
-        location_challenge: false,
-        countermeasure_hypotheses: &[],
-    }
-}
-
-fn legacy_profile(id: ThreatId) -> ThreatProfile {
-    use ActivityTime::*;
-    use AttackStyle::*;
-    use CatalogCountermeasure::*;
-    use Habitat::*;
-    use Protection::*;
-    #[allow(non_upper_case_globals)]
-    const ArmedPeople: ReportDescription = ReportDescription::ArmedPeople;
-    #[allow(non_upper_case_globals)]
-    const SmallUprightFigures: ReportDescription = ReportDescription::SmallUprightFigures;
-    #[allow(non_upper_case_globals)]
-    const LargeUprightBeast: ReportDescription = ReportDescription::LargeUprightBeast;
-    #[allow(non_upper_case_globals)]
-    const GauntHuman: ReportDescription = ReportDescription::GauntHuman;
-    #[allow(non_upper_case_globals)]
-    const WalkingDead: ReportDescription = ReportDescription::WalkingDead;
-    #[allow(non_upper_case_globals)]
-    const LargeAnimal: ReportDescription = ReportDescription::LargeAnimal;
-    #[allow(non_upper_case_globals)]
-    const DoglikeBeast: ReportDescription = ReportDescription::DoglikeBeast;
-    #[allow(non_upper_case_globals)]
-    const UnseenNightVisitor: ReportDescription = ReportDescription::UnseenNightVisitor;
-    use RigTopology::*;
-    use Temperament::*;
-    let (name, aliases, base, curate, mut c, mut i): (
-        &'static str,
-        &'static [&'static str],
-        u16,
-        u16,
-        CombatProfile,
-        InvestigationProfile,
-    ) = match id {
-        ThreatId::Bandit => (
-            "Bandit",
-            &["brigand"] as &[_],
-            80,
-            70,
-            combat(
-                Humanoid,
-                80,
-                70.0,
-                Blade,
-                false,
-                Armored,
-                AntiArmor,
-                Cautious,
-                Some("katzbalger"),
-            ),
-            investigation(
-                &[Road, Open, SparseWoods, Camp, Ruin],
-                Any,
-                &[ArmedPeople],
-                HUMANS,
-                &[EvidenceKind::BootPrints, EvidenceKind::WeaponCuts],
-                "Bring armor and an anti-armor weapon; expect an organized group.",
-            ),
-        ),
-        ThreatId::Deserter => (
-            "Deserter",
-            &["runaway soldier"],
-            30,
-            35,
-            combat(
-                Humanoid,
-                82,
-                72.0,
-                Spear,
-                false,
-                Armored,
-                AntiArmor,
-                Disciplined,
-                Some("spear"),
-            ),
-            investigation(
-                &[Road, Camp, Ruin],
-                Any,
-                &[ArmedPeople],
-                HUMANS,
-                &[EvidenceKind::WeaponCuts, EvidenceKind::HumanSpeech],
-                "Expect military weapons, formation discipline, and armor.",
-            ),
-        ),
-        ThreatId::Poacher => (
-            "Poacher",
-            &["illegal hunter"],
-            35,
-            40,
-            combat(
-                Humanoid,
-                84,
-                68.0,
-                Bow,
-                true,
-                Hide,
-                NoSpecial,
-                Elusive,
-                Some("self_bow"),
-            ),
-            investigation(
-                &[SparseWoods, DeepWoods, Camp],
-                Any,
-                &[ArmedPeople],
-                HUMANS,
-                &[EvidenceKind::ArrowShafts, EvidenceKind::BootPrints],
-                "Use cover and close quickly against skilled bow fire.",
-            ),
-        ),
-        ThreatId::Smuggler => (
-            "Smuggler",
-            &["contraband runner"],
-            25,
-            35,
-            combat(
-                Humanoid,
-                83,
-                70.0,
-                Blade,
-                false,
-                Hide,
-                NoSpecial,
-                Cautious,
-                Some("knife"),
-            ),
-            investigation(
-                &[Road, Cave, OccupiedHouse],
-                Night,
-                &[ArmedPeople],
-                HUMANS,
-                &[EvidenceKind::DisturbedGoods, EvidenceKind::HumanSpeech],
-                "Watch exits and bring enough people to prevent escape.",
-            ),
-        ),
-        ThreatId::Cultist => (
-            "Cultist",
-            &["secret worshipper"],
-            16,
-            30,
-            combat(
-                Humanoid,
-                78,
-                67.0,
-                Knife,
-                false,
-                Unarmored,
-                Courage,
-                Aggressive,
-                Some("knife"),
-            ),
-            investigation(
-                &[Ruin, Cave, OccupiedHouse],
-                Night,
-                &[ArmedPeople],
-                HUMANS,
-                &[EvidenceKind::SulfurOdor, EvidenceKind::HumanSpeech],
-                "Resolve and religious knowledge help against frightening rites.",
-            ),
-        ),
-        ThreatId::GraveRobber => (
-            "Grave robber",
-            &["resurrectionist"],
-            18,
-            30,
-            combat(
-                Humanoid,
-                80,
-                69.0,
-                Blunt,
-                false,
-                Hide,
-                NoSpecial,
-                Cowardly,
-                Some("club"),
-            ),
-            investigation(
-                &[Graveyard, Crypt, OccupiedHouse],
-                Night,
-                &[GauntHuman],
-                HUMANS,
-                &[EvidenceKind::GraveSoil, EvidenceKind::BootPrints],
-                "They are lightly equipped but likely to flee through prepared routes.",
-            ),
-        ),
-        ThreatId::TownWatch => (
-            "Town watch",
-            &["watchman"],
-            5,
-            5,
-            combat(
-                Humanoid,
-                80,
-                72.0,
-                Spear,
-                false,
-                Armored,
-                AntiArmor,
-                Disciplined,
-                Some("spear"),
-            ),
-            investigation(
-                &[Road, OccupiedHouse],
-                Any,
-                &[ArmedPeople],
-                HUMANS,
-                &[EvidenceKind::HumanSpeech],
-                "Their armor and formation reward anti-armor weapons or withdrawal.",
-            ),
-        ),
-        ThreatId::ArmedRetainer => (
-            "Armed retainer",
-            &["household soldier"],
-            5,
-            5,
-            combat(
-                Humanoid,
-                82,
-                75.0,
-                Spear,
-                false,
-                Armored,
-                AntiArmor,
-                Disciplined,
-                Some("spear"),
-            ),
-            investigation(
-                &[Road, Camp, OccupiedHouse],
-                Any,
-                &[ArmedPeople],
-                HUMANS,
-                &[EvidenceKind::HumanSpeech],
-                "Expect trained, armored opponents working in formation.",
-            ),
-        ),
-        ThreatId::AngryMob => (
-            "Angry townsfolk",
-            &["angry mob"],
-            5,
-            5,
-            combat(
-                Humanoid,
-                76,
-                68.0,
-                Blunt,
-                false,
-                Unarmored,
-                Courage,
-                Aggressive,
-                Some("club"),
-            ),
-            investigation(
-                &[Road, Open, OccupiedHouse],
-                Any,
-                &[ArmedPeople],
-                HUMANS,
-                &[EvidenceKind::HumanSpeech],
-                "Withdrawal is safer than escalating a frightened crowd.",
-            ),
-        ),
-        ThreatId::Wolf => (
-            "Wolf",
-            &["grey wolf"],
-            65,
-            65,
-            combat(
-                Quadruped, 92, 45.0, Bite, false, Hide, NoSpecial, Aggressive, None,
-            ),
-            investigation(
-                &[Open, SparseWoods, DeepWoods],
-                Any,
-                &[DoglikeBeast],
-                DOGS,
-                &[EvidenceKind::Pawprints, EvidenceKind::GnawedBones],
-                "Spears and a tight formation keep the pack at reach.",
-            ),
-        ),
-        ThreatId::Boar => (
-            "Boar",
-            &["wild boar"],
-            50,
-            50,
-            combat(
-                Quadruped, 86, 90.0, Bite, false, Hide, NoSpecial, Aggressive, None,
-            ),
-            investigation(
-                &[Open, SparseWoods, DeepWoods],
-                Day,
-                &[LargeAnimal],
-                &[ThreatId::Bear],
-                &[EvidenceKind::Hoofprints],
-                "Use reach and avoid its initial charge.",
-            ),
-        ),
-        ThreatId::Bear => (
-            "Bear",
-            &["brown bear"],
-            30,
-            45,
-            combat(
-                Quadruped, 80, 260.0, Claw, false, Hide, NoSpecial, Aggressive, None,
-            ),
-            investigation(
-                &[SparseWoods, DeepWoods, Cave],
-                Any,
-                &[LargeAnimal, LargeUprightBeast],
-                UPRIGHT,
-                &[EvidenceKind::ClawMarks, EvidenceKind::Pawprints],
-                "Bring heavy spears and do not fight it alone.",
-            ),
-        ),
-        ThreatId::FeralDog => (
-            "Feral dog",
-            &["stray dog"],
-            45,
-            35,
-            combat(
-                Quadruped, 90, 30.0, Bite, false, Hide, NoSpecial, Aggressive, None,
-            ),
-            investigation(
-                &[Road, Open, OccupiedHouse],
-                Any,
-                &[DoglikeBeast],
-                DOGS,
-                &[EvidenceKind::Pawprints],
-                "A shield and spear blunt a pack's rush.",
-            ),
-        ),
-        ThreatId::TrainedDog => (
-            "Trained attack dog",
-            &["guard dog"],
-            20,
-            30,
-            combat(
-                Quadruped,
-                94,
-                38.0,
-                Bite,
-                false,
-                Hide,
-                NoSpecial,
-                Disciplined,
-                None,
-            ),
-            investigation(
-                &[Road, Camp, OccupiedHouse],
-                Any,
-                &[DoglikeBeast],
-                DOGS,
-                &[EvidenceKind::Pawprints, EvidenceKind::HumanSpeech],
-                "Expect handlers: isolate the dogs instead of chasing them.",
-            ),
-        ),
-        ThreatId::Goblin => (
-            "Goblin",
-            &["goblin raider"],
-            45,
-            65,
-            combat(
-                Humanoid,
-                88,
-                42.0,
-                Bow,
-                true,
-                Hide,
-                NoSpecial,
-                Cowardly,
-                Some("self_bow"),
-            ),
-            investigation(
-                &[Cave, Mine, Ruin, SparseWoods, DeepWoods],
-                Night,
-                &[SmallUprightFigures],
-                &[ThreatId::Kobold],
-                &[EvidenceKind::SmallBareTracks, EvidenceKind::ArrowShafts],
-                "Carry shields and close before their archers can scatter.",
-            ),
-        ),
-        ThreatId::Orc => (
-            "Orc",
-            &["orc raider"],
-            20,
-            50,
-            combat(
-                Humanoid,
-                82,
-                105.0,
-                Blunt,
-                false,
-                Armored,
-                AntiArmor,
-                Aggressive,
-                Some("club"),
-            ),
-            investigation(
-                &[Camp, Ruin, Cave],
-                Any,
-                &[LargeUprightBeast],
-                UPRIGHT,
-                &[EvidenceKind::BootPrints, EvidenceKind::WeaponCuts],
-                "Use anti-armor weapons and avoid trading blows.",
-            ),
-        ),
-        ThreatId::Skeleton => (
-            "Skeleton",
-            &["animated skeleton"],
-            20,
-            60,
-            combat(
-                Humanoid,
-                58,
-                35.0,
-                Blade,
-                false,
-                Bone,
-                ShatteringBlow,
-                Relentless,
-                None,
-            ),
-            investigation(
-                &[Crypt, Graveyard, Ruin, Cave, DeepWoods, OccupiedHouse],
-                Night,
-                &[WalkingDead],
-                UNDEAD,
-                &[EvidenceKind::NoBreath, EvidenceKind::GraveSoil],
-                "Blunt weapons shatter bone; cutting weapons are inefficient.",
-            ),
-        ),
-        ThreatId::Ghoul => (
-            "Ghoul",
-            &["grave eater"],
-            16,
-            55,
-            combat(
-                Humanoid, 74, 55.0, Claw, false, Hide, Fire, Aggressive, None,
-            ),
-            investigation(
-                &[Crypt, Graveyard, Cave],
-                Night,
-                &[GauntHuman, WalkingDead],
-                UNDEAD,
-                &[EvidenceKind::GnawedBones, EvidenceKind::CorpseOdor],
-                "Protect wounds and avoid diseased remains. Fire is an unverified lead, not an autoresolve modifier.",
-            ),
-        ),
-        ThreatId::Revenant => (
-            "Revenant",
-            &["returned dead"],
-            8,
-            35,
-            combat(
-                Humanoid,
-                64,
-                75.0,
-                Blunt,
-                false,
-                Supernatural,
-                Fire,
-                Relentless,
-                None,
-            ),
-            investigation(
-                &[Crypt, Graveyard, Ruin, OccupiedHouse],
-                Night,
-                &[WalkingDead, GauntHuman],
-                UNDEAD,
-                &[EvidenceKind::NoBreath, EvidenceKind::ColdPatch],
-                "Expect supernatural endurance. Fire is an unverified lead, not an autoresolve modifier.",
-            ),
-        ),
-        ThreatId::Werewolf => (
-            "Werewolf",
-            &["therianthrope"],
-            5,
-            40,
-            combat(
-                Humanoid,
-                96,
-                95.0,
-                Claw,
-                false,
-                Supernatural,
-                Silver,
-                Aggressive,
-                None,
-            ),
-            investigation(
-                &[DeepWoods, Cave, OccupiedHouse],
-                Night,
-                &[LargeUprightBeast, DoglikeBeast],
-                UPRIGHT,
-                &[EvidenceKind::BootPrints, EvidenceKind::Pawprints],
-                "Contain it before it reaches isolated victims. Silver is an unverified lead, not an autoresolve modifier.",
-            ),
-        ),
-        ThreatId::Alp => (
-            "Alp",
-            &["night-mare spirit"],
-            3,
-            30,
-            combat(
-                Humanoid,
-                72,
-                55.0,
-                Claw,
-                false,
-                Supernatural,
-                Daylight,
-                Elusive,
-                None,
-            ),
-            investigation(
-                &[OccupiedHouse, Ruin],
-                Night,
-                &[UnseenNightVisitor, GauntHuman],
-                &[ThreatId::Cultist, ThreatId::Nachzehrer],
-                &[EvidenceKind::ColdPatch, EvidenceKind::NoBreath],
-                "Identify its access. Daylight is an investigative lead, not an implemented combat modifier.",
-            ),
-        ),
-        ThreatId::Kobold => (
-            "Kobold",
-            &["house spirit"],
-            7,
-            35,
-            combat(
-                Humanoid, 76, 35.0, Blunt, false, Unarmored, Courage, Elusive, None,
-            ),
-            investigation(
-                &[Mine, OccupiedHouse, Cave],
-                Night,
-                &[SmallUprightFigures, UnseenNightVisitor],
-                &[ThreatId::Goblin],
-                &[EvidenceKind::DisturbedGoods, EvidenceKind::SmallBareTracks],
-                "Once located it is frail; secure exits and distinguish pranks from theft.",
-            ),
-        ),
-        ThreatId::WildMan => (
-            "Wild man",
-            &["woodwose"],
-            8,
-            35,
-            combat(
-                Humanoid,
-                86,
-                95.0,
-                Blunt,
-                false,
-                Hide,
-                NoSpecial,
-                Cautious,
-                Some("club"),
-            ),
-            investigation(
-                &[DeepWoods, Cave, Ruin],
-                Any,
-                &[LargeUprightBeast],
-                UPRIGHT,
-                &[EvidenceKind::BootPrints, EvidenceKind::HumanSpeech],
-                "Approach carefully: it may be reasoned with and knows the terrain.",
-            ),
-        ),
-        ThreatId::SpectralHound => (
-            "Spectral hound",
-            &["black dog"],
-            4,
-            35,
-            combat(
-                Quadruped,
-                100,
-                45.0,
-                Bite,
-                false,
-                Supernatural,
-                Courage,
-                Elusive,
-                None,
-            ),
-            investigation(
-                &[Road, Graveyard, Ruin],
-                Night,
-                &[DoglikeBeast],
-                DOGS,
-                &[EvidenceKind::ColdPatch, EvidenceKind::NoBreath],
-                "Expect an elusive, frightening opponent. Ritual courage is an unverified lead, not an autoresolve modifier.",
-            ),
-        ),
-        ThreatId::Nachzehrer => (
-            "Nachzehrer",
-            &["shroud eater"],
-            3,
-            35,
-            combat(
-                Humanoid,
-                56,
-                70.0,
-                Bite,
-                false,
-                Supernatural,
-                Fire,
-                Relentless,
-                None,
-            ),
-            investigation(
-                &[Crypt, Graveyard, OccupiedHouse],
-                Night,
-                &[WalkingDead, UnseenNightVisitor],
-                UNDEAD,
-                &[EvidenceKind::MissingBlood, EvidenceKind::CorpseOdor],
-                "Locate and contain the corpse. Fire is an unverified lead, not an autoresolve modifier.",
-            ),
-        ),
-        _ => return legacy_profile(ThreatId::Bandit),
-    };
-    if matches!(id, ThreatId::Ghoul | ThreatId::Nachzehrer) {
-        c.disease_risk = 70;
-        c.fear = 45;
-    }
-    if matches!(
-        id,
-        ThreatId::Werewolf | ThreatId::SpectralHound | ThreatId::Revenant | ThreatId::Alp
-    ) {
-        c.fear = 70;
-    }
-    if matches!(id, ThreatId::Goblin | ThreatId::Kobold) {
-        c.encounter_scale_basis_points = 13_000;
-        c.morale = 30;
-    }
-    if matches!(id, ThreatId::Bear | ThreatId::Werewolf | ThreatId::Revenant) {
-        c.encounter_scale_basis_points = 5_000;
-        c.morale = 80;
-    }
-    if matches!(id, ThreatId::Poacher | ThreatId::Smuggler | ThreatId::Alp) {
-        c.stealth = 75;
-    }
-    if matches!(
-        id,
-        ThreatId::Alp | ThreatId::Kobold | ThreatId::SpectralHound
-    ) {
-        i.identification_challenge = true;
-        i.location_challenge = true;
-    }
-    // Replace generic authoring defaults with threat-coherent physical traces.
-    match c.rig {
-        RigTopology::Humanoid => {
-            i.tracks = &[EvidenceKind::BootPrints];
-            i.wounds = &[EvidenceKind::WeaponCuts];
-            i.disturbances = &[EvidenceKind::DisturbedGoods];
-            i.sounds = &["footsteps", "voices"];
-            i.victim_tags = &["travelers", "settlement residents"];
-        }
-        RigTopology::Quadruped => {
-            i.tracks = &[EvidenceKind::Pawprints];
-            i.wounds = &[EvidenceKind::BiteWounds, EvidenceKind::ClawMarks];
-            i.disturbances = &[EvidenceKind::BrokenFoliage];
-            i.sounds = &["growls", "running paws"];
-            i.odors = &[EvidenceKind::AnimalOdor];
-            i.victim_tags = &["livestock", "isolated travelers"];
-        }
-    }
-    match c.attack {
-        AttackStyle::Blunt => i.wounds = &[EvidenceKind::BluntDamage],
-        AttackStyle::Bow => i.wounds = &[EvidenceKind::ArrowShafts],
-        AttackStyle::Bite => i.wounds = &[EvidenceKind::BiteWounds],
-        AttackStyle::Claw => i.wounds = &[EvidenceKind::ClawMarks],
-        AttackStyle::Blade | AttackStyle::Knife | AttackStyle::Spear => {
-            i.wounds = &[EvidenceKind::WeaponCuts]
-        }
-    }
-    match id {
-        ThreatId::Boar => {
-            i.tracks = &[EvidenceKind::Hoofprints];
-            i.wounds = &[EvidenceKind::BiteWounds];
-            i.victim_tags = &["crops", "foresters"];
-        }
-        ThreatId::Bear => {
-            i.tracks = &[EvidenceKind::Pawprints];
-            i.wounds = &[EvidenceKind::ClawMarks, EvidenceKind::BiteWounds];
-            i.victim_tags = &["livestock", "foragers"];
-        }
-        ThreatId::Wolf | ThreatId::FeralDog | ThreatId::TrainedDog => {
-            i.tracks = &[EvidenceKind::Pawprints];
-            i.wounds = &[EvidenceKind::BiteWounds];
-        }
-        ThreatId::Skeleton => {
-            i.tracks = &[EvidenceKind::GraveSoil];
-            i.wounds = &[EvidenceKind::WeaponCuts];
-            i.sounds = &["rattling bone", "scraping metal"];
-            i.odors = &[];
-            i.victim_tags = &["graveyard visitors", "travelers"];
-            i.evidence_visibility = 85;
-        }
-        ThreatId::Ghoul => {
-            i.tracks = &[EvidenceKind::GraveSoil, EvidenceKind::SmallBareTracks];
-            i.wounds = &[EvidenceKind::BiteWounds];
-            i.disturbances = &[EvidenceKind::GnawedBones, EvidenceKind::GraveSoil];
-            i.sounds = &["scratching", "wet chewing"];
-            i.odors = &[EvidenceKind::CorpseOdor];
-            i.victim_tags = &["recently buried dead", "mourners"];
-            i.evidence_visibility = 90;
-            i.countermeasure_hypotheses = &[CountermeasureHypothesis::Fire];
-        }
-        ThreatId::Revenant => {
-            i.tracks = &[EvidenceKind::GraveSoil, EvidenceKind::BootPrints];
-            i.wounds = &[EvidenceKind::BluntDamage];
-            i.disturbances = &[EvidenceKind::ColdPatch];
-            i.sounds = &["slow footsteps"];
-            i.odors = &[EvidenceKind::CorpseOdor];
-            i.victim_tags = &["former associates", "graveyard visitors"];
-            i.countermeasure_hypotheses = &[CountermeasureHypothesis::Fire];
-        }
-        ThreatId::Nachzehrer => {
-            i.tracks = &[EvidenceKind::GraveSoil];
-            i.wounds = &[EvidenceKind::BiteWounds, EvidenceKind::MissingBlood];
-            i.disturbances = &[EvidenceKind::GnawedBones];
-            i.sounds = &["chewing beneath earth"];
-            i.odors = &[EvidenceKind::CorpseOdor];
-            i.victim_tags = &["recently buried dead", "bereaved families"];
-            i.evidence_visibility = 35;
-            i.countermeasure_hypotheses = &[CountermeasureHypothesis::Fire];
-        }
-        ThreatId::Werewolf => {
-            i.tracks = &[EvidenceKind::Pawprints, EvidenceKind::BootPrints];
-            i.wounds = &[EvidenceKind::ClawMarks, EvidenceKind::BiteWounds];
-            i.disturbances = &[EvidenceKind::BrokenFoliage];
-            i.sounds = &["howling", "running paws"];
-            i.odors = &[EvidenceKind::AnimalOdor];
-            i.victim_tags = &["isolated people", "livestock"];
-            i.countermeasure_hypotheses = &[CountermeasureHypothesis::Silver];
-        }
-        ThreatId::SpectralHound => {
-            i.tracks = &[];
-            i.wounds = &[EvidenceKind::BiteWounds];
-            i.disturbances = &[EvidenceKind::ColdPatch];
-            i.sounds = &["distant baying"];
-            i.odors = &[];
-            i.victim_tags = &["night travelers"];
-            i.evidence_visibility = 20;
-            i.countermeasure_hypotheses = &[CountermeasureHypothesis::Courage];
-        }
-        ThreatId::Alp => {
-            i.tracks = &[];
-            i.wounds = &[];
-            i.disturbances = &[EvidenceKind::ColdPatch];
-            i.sounds = &["breathing", "roof noises"];
-            i.odors = &[];
-            i.victim_tags = &["sleepers"];
-            i.evidence_visibility = 15;
-            i.countermeasure_hypotheses = &[CountermeasureHypothesis::Daylight];
-        }
-        ThreatId::Kobold => {
-            i.tracks = &[EvidenceKind::SmallBareTracks];
-            i.wounds = &[];
-            i.disturbances = &[EvidenceKind::DisturbedGoods];
-            i.sounds = &["knocking", "small footsteps"];
-            i.odors = &[];
-            i.victim_tags = &["households", "miners"];
-            i.evidence_visibility = 40;
-        }
-        _ => {}
-    }
-    let (singular_name, plural_name) = display_forms(id, name);
-    ThreatProfile {
-        id,
-        display_name: name,
-        singular_name,
-        plural_name,
-        aliases,
-        base_weight: base,
-        curation_weight: curate,
-        combat: c,
-        investigation: i,
-    }
-}
-
-/// Returns mechanics from the startup-compiled authoring catalog. The legacy
-/// typed profile supplies the closed enum arrays still consumed by tactical
-/// code; scalar combat values and player-facing identity are authoritative in
-/// YAML and use ordinary resistance/padding rather than damage multipliers.
+/// Returns the startup-compiled, YAML-authoritative threat profile.
 pub fn profile(id: ThreatId) -> ThreatProfile {
     static PROFILES: OnceLock<BTreeMap<ThreatId, ThreatProfile>> = OnceLock::new();
     *PROFILES
@@ -1317,7 +461,52 @@ fn compile_profile(
     id: ThreatId,
     authored: &'static crate::quest_catalog::Monster,
 ) -> ThreatProfile {
-    let mut profile = legacy_profile(id);
+    let mut profile = ThreatProfile {
+        id,
+        display_name: authored.name.as_str(),
+        singular_name: authored.singular.as_str(),
+        plural_name: authored.plural.as_str(),
+        aliases: &[],
+        base_weight: authored.base_weight,
+        curation_weight: authored.curation_weight,
+        combat: CombatProfile {
+            rig: RigTopology::Humanoid,
+            speed_m_per_minute: 1,
+            weight_kg: 1.0,
+            attack: AttackStyle::Blade,
+            ranged: false,
+            precision_bonus: 0.0,
+            training_multiplier: 1.0,
+            perception: 0,
+            stealth: 0,
+            morale: 0,
+            protection: Protection::Unarmored,
+            innate_protection: InnateProtection::default(),
+            disease_risk: 0,
+            fear: 0,
+            temperament: Temperament::Cautious,
+            encounter_scale_basis_points: 1,
+            loot_item_id: None,
+        },
+        investigation: InvestigationProfile {
+            habitats: &[],
+            activity: ActivityTime::Any,
+            victim_tags: &[],
+            tracks: &[],
+            wounds: &[],
+            disturbances: &[],
+            sounds: &[],
+            silhouettes: &[],
+            odors: &[],
+            mistaken_for: &[],
+            distinguishing_clues: &[],
+            preparation_advice: "",
+            evidence_visibility: 0,
+            identification_challenge: false,
+            location_challenge: false,
+            countermeasure_hypotheses: &[],
+        },
+    };
     profile.display_name = authored.name.as_str();
     profile.singular_name = authored.singular.as_str();
     profile.plural_name = authored.plural.as_str();
@@ -1446,11 +635,11 @@ fn compile_profile(
             .countermeasure_hypotheses
             .iter()
             .filter_map(|value| match value.as_str() {
+                "shattering_blow" => Some(CountermeasureHypothesis::ShatteringBlow),
                 "fire" => Some(CountermeasureHypothesis::Fire),
                 "silver" => Some(CountermeasureHypothesis::Silver),
                 "daylight" => Some(CountermeasureHypothesis::Daylight),
                 "courage" => Some(CountermeasureHypothesis::Courage),
-                "shattering_blow" => None,
                 _ => unreachable!("validated countermeasure"),
             })
             .collect::<Vec<_>>()
@@ -1481,39 +670,7 @@ fn catalog_habitat(value: &str) -> Habitat {
 }
 
 fn catalog_evidence(value: &str) -> EvidenceKind {
-    match value {
-        "boot_prints" | "large_boot_prints" | "bare_tracks" | "large_bare_tracks" => {
-            EvidenceKind::BootPrints
-        }
-        "small_bare_tracks" => EvidenceKind::SmallBareTracks,
-        "hoofprints" => EvidenceKind::Hoofprints,
-        "pawprints" | "large_pawprints" | "pack_tracks" | "changing_tracks" => {
-            EvidenceKind::Pawprints
-        }
-        "claw_marks" => EvidenceKind::ClawMarks,
-        "gnawed_bones" | "bone_dust" => EvidenceKind::GnawedBones,
-        "grave_soil" | "opened_graves" => EvidenceKind::GraveSoil,
-        "no_breath" => EvidenceKind::NoBreath,
-        "weapon_cuts" | "knife_wounds" | "heavy_weapon_cuts" | "tusk_wounds" => {
-            EvidenceKind::WeaponCuts
-        }
-        "arrow_shafts" => EvidenceKind::ArrowShafts,
-        "corpse_odor" => EvidenceKind::CorpseOdor,
-        "sulfur_odor" => EvidenceKind::SulfurOdor,
-        "cold_patch" => EvidenceKind::ColdPatch,
-        "missing_blood" => EvidenceKind::MissingBlood,
-        "disturbed_goods" | "camp_debris" | "snares" | "contraband" | "ritual_marks"
-        | "tool_marks" | "official_seals" | "heraldry" | "broken_goods" | "rooted_soil"
-        | "human_refuse" | "collar_marks" | "military_kit" | "local_slogans"
-        | "personal_grudge" | "disturbed_bedding" | "moved_goods" | "helpful_mischief"
-        | "woven_branches" | "damaged_shroud" | "eaten_shroud" => EvidenceKind::DisturbedGoods,
-        "human_speech" => EvidenceKind::HumanSpeech,
-        "animal_odor" | "woodsmoke" | "smoke" => EvidenceKind::AnimalOdor,
-        "broken_foliage" => EvidenceKind::BrokenFoliage,
-        "bite_wounds" => EvidenceKind::BiteWounds,
-        "blunt_damage" => EvidenceKind::BluntDamage,
-        _ => EvidenceKind::DisturbedGoods,
-    }
+    EvidenceKind::try_new(value).expect("validated open bestiary evidence ID")
 }
 fn leak_evidence(values: &[String]) -> &'static [EvidenceKind] {
     Box::leak(
@@ -1526,42 +683,6 @@ fn leak_evidence(values: &[String]) -> &'static [EvidenceKind] {
 }
 fn catalog_report(value: &str) -> ReportDescription {
     ReportDescription::try_new(value).expect("validated report description ID")
-}
-
-const fn display_forms(id: ThreatId, fallback: &'static str) -> (&'static str, &'static str) {
-    match id {
-        ThreatId::TownWatch => ("Town watch", "Town watch"),
-        ThreatId::AngryMob => ("Angry townsman", "Angry townsfolk"),
-        ThreatId::WildMan => ("Wild man", "Wild men"),
-        ThreatId::GraveRobber => ("Grave robber", "Grave robbers"),
-        ThreatId::FeralDog => ("Feral dog", "Feral dogs"),
-        ThreatId::TrainedDog => ("Trained attack dog", "Trained attack dogs"),
-        ThreatId::ArmedRetainer => ("Armed retainer", "Armed retainers"),
-        ThreatId::SpectralHound => ("Spectral hound", "Spectral hounds"),
-        ThreatId::Nachzehrer => ("Nachzehrer", "Nachzehrer"),
-        _ => (
-            fallback,
-            match id {
-                ThreatId::Bandit => "Bandits",
-                ThreatId::Deserter => "Deserters",
-                ThreatId::Poacher => "Poachers",
-                ThreatId::Smuggler => "Smugglers",
-                ThreatId::Cultist => "Cultists",
-                ThreatId::Wolf => "Wolves",
-                ThreatId::Boar => "Boars",
-                ThreatId::Bear => "Bears",
-                ThreatId::Goblin => "Goblins",
-                ThreatId::Orc => "Orcs",
-                ThreatId::Skeleton => "Skeletons",
-                ThreatId::Ghoul => "Ghouls",
-                ThreatId::Revenant => "Revenants",
-                ThreatId::Werewolf => "Werewolves",
-                ThreatId::Alp => "Alps",
-                ThreatId::Kobold => "Kobolds",
-                _ => fallback,
-            },
-        ),
-    }
 }
 
 pub(crate) fn habitat_weight(id: ThreatId, habitat: Habitat) -> u16 {

--- a/crates/adventuresim-core/src/bestiary.rs
+++ b/crates/adventuresim-core/src/bestiary.rs
@@ -3,35 +3,12 @@
 
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, sync::OnceLock};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ThreatId {
-    Bandit,
-    Deserter,
-    Poacher,
-    Smuggler,
-    Cultist,
-    GraveRobber,
-    TownWatch,
-    ArmedRetainer,
-    AngryMob,
-    Wolf,
-    Boar,
-    Bear,
-    FeralDog,
-    TrainedDog,
-    Goblin,
-    Orc,
-    Skeleton,
-    Ghoul,
-    Revenant,
-    Werewolf,
-    Alp,
-    Kobold,
-    WildMan,
-    SpectralHound,
-    Nachzehrer,
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ThreatId {
+    len: u8,
+    bytes: [u8; 63],
 }
 
 pub const ALL_THREATS: &[ThreatId] = &[
@@ -62,38 +39,101 @@ pub const ALL_THREATS: &[ThreatId] = &[
     ThreatId::Nachzehrer,
 ];
 
+fn catalog_threats() -> Vec<ThreatId> {
+    crate::quest_catalog::catalog()
+        .monsters()
+        .map(|monster| ThreatId::try_new(&monster.id).expect("validated monster ID"))
+        .collect()
+}
+
 impl ThreatId {
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Bandit => "bandit",
-            Self::Deserter => "deserter",
-            Self::Poacher => "poacher",
-            Self::Smuggler => "smuggler",
-            Self::Cultist => "cultist",
-            Self::GraveRobber => "grave_robber",
-            Self::TownWatch => "town_watch",
-            Self::ArmedRetainer => "armed_retainer",
-            Self::AngryMob => "angry_mob",
-            Self::Wolf => "wolf",
-            Self::Boar => "boar",
-            Self::Bear => "bear",
-            Self::FeralDog => "feral_dog",
-            Self::TrainedDog => "trained_dog",
-            Self::Goblin => "goblin",
-            Self::Orc => "orc",
-            Self::Skeleton => "skeleton",
-            Self::Ghoul => "ghoul",
-            Self::Revenant => "revenant",
-            Self::Werewolf => "werewolf",
-            Self::Alp => "alp",
-            Self::Kobold => "kobold",
-            Self::WildMan => "wild_man",
-            Self::SpectralHound => "spectral_hound",
-            Self::Nachzehrer => "nachzehrer",
+    const fn from_static(value: &str) -> Self {
+        let source = value.as_bytes();
+        let mut bytes = [0; 63];
+        let mut index = 0;
+        while index < source.len() {
+            bytes[index] = source[index];
+            index += 1;
+        }
+        Self {
+            len: source.len() as u8,
+            bytes,
         }
     }
+    pub fn try_new(value: &str) -> Result<Self, UnknownThreatId> {
+        if value.is_empty()
+            || value.len() > 63
+            || !value.bytes().all(|byte| {
+                byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(byte, b'_' | b'-' | b'.' | b':')
+            })
+        {
+            return Err(UnknownThreatId);
+        }
+        let mut bytes = [0; 63];
+        bytes[..value.len()].copy_from_slice(value.as_bytes());
+        Ok(Self {
+            len: value.len() as u8,
+            bytes,
+        })
+    }
+    pub fn as_str(&self) -> &str {
+        core::str::from_utf8(&self.bytes[..usize::from(self.len)]).expect("validated ASCII ID")
+    }
 
-    pub const fn profile(self) -> ThreatProfile {
+    #[allow(non_upper_case_globals)]
+    pub const Bandit: Self = Self::from_static("bandit");
+    #[allow(non_upper_case_globals)]
+    pub const Deserter: Self = Self::from_static("deserter");
+    #[allow(non_upper_case_globals)]
+    pub const Poacher: Self = Self::from_static("poacher");
+    #[allow(non_upper_case_globals)]
+    pub const Smuggler: Self = Self::from_static("smuggler");
+    #[allow(non_upper_case_globals)]
+    pub const Cultist: Self = Self::from_static("cultist");
+    #[allow(non_upper_case_globals)]
+    pub const GraveRobber: Self = Self::from_static("grave_robber");
+    #[allow(non_upper_case_globals)]
+    pub const TownWatch: Self = Self::from_static("town_watch");
+    #[allow(non_upper_case_globals)]
+    pub const ArmedRetainer: Self = Self::from_static("armed_retainer");
+    #[allow(non_upper_case_globals)]
+    pub const AngryMob: Self = Self::from_static("angry_mob");
+    #[allow(non_upper_case_globals)]
+    pub const Wolf: Self = Self::from_static("wolf");
+    #[allow(non_upper_case_globals)]
+    pub const Boar: Self = Self::from_static("boar");
+    #[allow(non_upper_case_globals)]
+    pub const Bear: Self = Self::from_static("bear");
+    #[allow(non_upper_case_globals)]
+    pub const FeralDog: Self = Self::from_static("feral_dog");
+    #[allow(non_upper_case_globals)]
+    pub const TrainedDog: Self = Self::from_static("trained_dog");
+    #[allow(non_upper_case_globals)]
+    pub const Goblin: Self = Self::from_static("goblin");
+    #[allow(non_upper_case_globals)]
+    pub const Orc: Self = Self::from_static("orc");
+    #[allow(non_upper_case_globals)]
+    pub const Skeleton: Self = Self::from_static("skeleton");
+    #[allow(non_upper_case_globals)]
+    pub const Ghoul: Self = Self::from_static("ghoul");
+    #[allow(non_upper_case_globals)]
+    pub const Revenant: Self = Self::from_static("revenant");
+    #[allow(non_upper_case_globals)]
+    pub const Werewolf: Self = Self::from_static("werewolf");
+    #[allow(non_upper_case_globals)]
+    pub const Alp: Self = Self::from_static("alp");
+    #[allow(non_upper_case_globals)]
+    pub const Kobold: Self = Self::from_static("kobold");
+    #[allow(non_upper_case_globals)]
+    pub const WildMan: Self = Self::from_static("wild_man");
+    #[allow(non_upper_case_globals)]
+    pub const SpectralHound: Self = Self::from_static("spectral_hound");
+    #[allow(non_upper_case_globals)]
+    pub const Nachzehrer: Self = Self::from_static("nachzehrer");
+
+    pub fn profile(self) -> ThreatProfile {
         profile(self)
     }
 
@@ -111,11 +151,30 @@ impl ThreatId {
 impl FromStr for ThreatId {
     type Err = UnknownThreatId;
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        ALL_THREATS
-            .iter()
-            .copied()
-            .find(|id| id.as_str() == value)
+        let id = Self::try_new(value)?;
+        crate::quest_catalog::catalog()
+            .monster(value)
+            .map(|_| id)
             .ok_or(UnknownThreatId)
+    }
+}
+
+impl core::fmt::Debug for ThreatId {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+impl Serialize for ThreatId {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+impl<'de> Deserialize<'de> for ThreatId {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = String::deserialize(deserializer)?;
+        value
+            .parse()
+            .map_err(|_| serde::de::Error::custom("unknown threat ID"))
     }
 }
 
@@ -193,17 +252,47 @@ pub enum WitnessCapability {
     Ordinary,
     Trained,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ReportDescription {
-    ArmedPeople,
-    SmallUprightFigures,
-    LargeUprightBeast,
-    GauntHuman,
-    WalkingDead,
-    LargeAnimal,
-    DoglikeBeast,
-    UnseenNightVisitor,
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ReportDescription(ThreatId);
+impl ReportDescription {
+    #[allow(non_upper_case_globals)]
+    pub const ArmedPeople: Self = Self(ThreatId::from_static("armed_people"));
+    #[allow(non_upper_case_globals)]
+    pub const SmallUprightFigures: Self = Self(ThreatId::from_static("small_upright_figures"));
+    #[allow(non_upper_case_globals)]
+    pub const LargeUprightBeast: Self = Self(ThreatId::from_static("large_upright_beast"));
+    #[allow(non_upper_case_globals)]
+    pub const GauntHuman: Self = Self(ThreatId::from_static("gaunt_human"));
+    #[allow(non_upper_case_globals)]
+    pub const WalkingDead: Self = Self(ThreatId::from_static("walking_dead"));
+    #[allow(non_upper_case_globals)]
+    pub const LargeAnimal: Self = Self(ThreatId::from_static("large_animal"));
+    #[allow(non_upper_case_globals)]
+    pub const DoglikeBeast: Self = Self(ThreatId::from_static("doglike_beast"));
+    #[allow(non_upper_case_globals)]
+    pub const UnseenNightVisitor: Self = Self(ThreatId::from_static("unseen_night_visitor"));
+    pub fn try_new(value: &str) -> Result<Self, UnknownThreatId> {
+        ThreatId::try_new(value).map(Self)
+    }
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+impl core::fmt::Debug for ReportDescription {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+impl Serialize for ReportDescription {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+impl<'de> Deserialize<'de> for ReportDescription {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Self::try_new(&String::deserialize(deserializer)?)
+            .map_err(|_| serde::de::Error::custom("invalid description ID"))
+    }
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum EvidenceKind {
@@ -432,13 +521,28 @@ const fn investigation(
     }
 }
 
-pub const fn profile(id: ThreatId) -> ThreatProfile {
+fn legacy_profile(id: ThreatId) -> ThreatProfile {
     use ActivityTime::*;
     use AttackStyle::*;
     use CatalogCountermeasure::*;
     use Habitat::*;
     use Protection::*;
-    use ReportDescription::*;
+    #[allow(non_upper_case_globals)]
+    const ArmedPeople: ReportDescription = ReportDescription::ArmedPeople;
+    #[allow(non_upper_case_globals)]
+    const SmallUprightFigures: ReportDescription = ReportDescription::SmallUprightFigures;
+    #[allow(non_upper_case_globals)]
+    const LargeUprightBeast: ReportDescription = ReportDescription::LargeUprightBeast;
+    #[allow(non_upper_case_globals)]
+    const GauntHuman: ReportDescription = ReportDescription::GauntHuman;
+    #[allow(non_upper_case_globals)]
+    const WalkingDead: ReportDescription = ReportDescription::WalkingDead;
+    #[allow(non_upper_case_globals)]
+    const LargeAnimal: ReportDescription = ReportDescription::LargeAnimal;
+    #[allow(non_upper_case_globals)]
+    const DoglikeBeast: ReportDescription = ReportDescription::DoglikeBeast;
+    #[allow(non_upper_case_globals)]
+    const UnseenNightVisitor: ReportDescription = ReportDescription::UnseenNightVisitor;
     use RigTopology::*;
     use Temperament::*;
     let (name, aliases, base, curate, mut c, mut i): (
@@ -1026,6 +1130,7 @@ pub const fn profile(id: ThreatId) -> ThreatProfile {
                 "Locate and contain the corpse. Fire is an unverified lead, not an autoresolve modifier.",
             ),
         ),
+        _ => return legacy_profile(ThreatId::Bandit),
     };
     if matches!(id, ThreatId::Ghoul | ThreatId::Nachzehrer) {
         c.disease_risk = 70;
@@ -1188,6 +1293,241 @@ pub const fn profile(id: ThreatId) -> ThreatProfile {
     }
 }
 
+/// Returns mechanics from the startup-compiled authoring catalog. The legacy
+/// typed profile supplies the closed enum arrays still consumed by tactical
+/// code; scalar combat values and player-facing identity are authoritative in
+/// YAML and use ordinary resistance/padding rather than damage multipliers.
+pub fn profile(id: ThreatId) -> ThreatProfile {
+    static PROFILES: OnceLock<BTreeMap<ThreatId, ThreatProfile>> = OnceLock::new();
+    *PROFILES
+        .get_or_init(|| {
+            crate::quest_catalog::catalog()
+                .monsters()
+                .map(|monster| {
+                    let id = ThreatId::try_new(&monster.id).expect("validated monster ID");
+                    (id, compile_profile(id, monster))
+                })
+                .collect()
+        })
+        .get(&id)
+        .expect("threat ID was validated against startup catalog")
+}
+
+fn compile_profile(
+    id: ThreatId,
+    authored: &'static crate::quest_catalog::Monster,
+) -> ThreatProfile {
+    let mut profile = legacy_profile(id);
+    profile.display_name = authored.name.as_str();
+    profile.singular_name = authored.singular.as_str();
+    profile.plural_name = authored.plural.as_str();
+    profile.id = id;
+    profile.aliases = Box::leak(
+        authored
+            .aliases
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    profile.base_weight = authored.base_weight;
+    profile.curation_weight = authored.curation_weight;
+    profile.combat.rig = match authored.combat.rig.as_str() {
+        "humanoid" => RigTopology::Humanoid,
+        "quadruped" => RigTopology::Quadruped,
+        _ => unreachable!("validated combat rig"),
+    };
+    profile.combat.speed_m_per_minute = authored.combat.speed_m_per_minute;
+    profile.combat.weight_kg = authored.combat.weight_kg;
+    profile.combat.attack = match authored.combat.attack.as_str() {
+        "blade" => AttackStyle::Blade,
+        "blunt" | "tusk" => AttackStyle::Blunt,
+        "knife" => AttackStyle::Knife,
+        "spear" => AttackStyle::Spear,
+        "bow" => AttackStyle::Bow,
+        "bite" => AttackStyle::Bite,
+        "claw" => AttackStyle::Claw,
+        _ => unreachable!("validated attack style"),
+    };
+    profile.combat.ranged = authored.combat.ranged;
+    profile.combat.precision_bonus = authored.combat.precision_bonus_milli as f32 / 1_000.0;
+    profile.combat.training_multiplier =
+        f32::from(authored.combat.training_multiplier_milli) / 1_000.0;
+    profile.combat.perception = authored.combat.perception;
+    profile.combat.stealth = authored.combat.stealth;
+    profile.combat.morale = authored.combat.morale;
+    profile.combat.protection = match authored.combat.protection.as_str() {
+        "unarmored" => Protection::Unarmored,
+        "hide" => Protection::Hide,
+        "shielded" => Protection::Shielded,
+        "armored" => Protection::Armored,
+        "bone" => Protection::Bone,
+        "supernatural" => Protection::Supernatural,
+        _ => unreachable!("validated protection"),
+    };
+    profile.combat.innate_protection = InnateProtection {
+        resistance_joules: authored.combat.resistance_joules as f32,
+        padding_joules: authored.combat.padding_joules as f32,
+    };
+    profile.combat.disease_risk = authored.combat.disease_risk;
+    profile.combat.fear = authored.combat.fear;
+    profile.combat.temperament = match authored.combat.temperament.as_str() {
+        "cowardly" => Temperament::Cowardly,
+        "cautious" => Temperament::Cautious,
+        "disciplined" => Temperament::Disciplined,
+        "aggressive" => Temperament::Aggressive,
+        "relentless" => Temperament::Relentless,
+        "elusive" => Temperament::Elusive,
+        _ => unreachable!("validated temperament"),
+    };
+    profile.combat.encounter_scale_basis_points = authored.combat.encounter_scale_basis_points;
+    profile.combat.loot_item_id = authored.combat.loot_item_id.as_deref();
+    profile.investigation.preparation_advice = authored.investigation.preparation_advice.as_str();
+    profile.investigation.habitats = Box::leak(
+        authored
+            .investigation
+            .habitats
+            .iter()
+            .map(|value| catalog_habitat(value))
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    profile.investigation.activity = match authored.investigation.activity.as_str() {
+        "day" => ActivityTime::Day,
+        "night" => ActivityTime::Night,
+        "any" => ActivityTime::Any,
+        _ => unreachable!("validated activity"),
+    };
+    profile.investigation.victim_tags = Box::leak(
+        authored
+            .investigation
+            .victim_tags
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    profile.investigation.tracks = leak_evidence(&authored.investigation.tracks);
+    profile.investigation.wounds = leak_evidence(&authored.investigation.wounds);
+    profile.investigation.disturbances = leak_evidence(&authored.investigation.disturbances);
+    profile.investigation.odors = leak_evidence(&authored.investigation.odors);
+    profile.investigation.sounds = Box::leak(
+        authored
+            .investigation
+            .sounds
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    profile.investigation.silhouettes = Box::leak(
+        authored
+            .investigation
+            .silhouettes
+            .iter()
+            .map(|value| catalog_report(value))
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    profile.investigation.mistaken_for = Box::leak(
+        authored
+            .investigation
+            .mistaken_for
+            .iter()
+            .map(|value| ThreatId::try_new(value).expect("validated monster reference"))
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    profile.investigation.distinguishing_clues =
+        leak_evidence(&authored.investigation.distinguishing_clues);
+    profile.investigation.countermeasure_hypotheses = Box::leak(
+        authored
+            .investigation
+            .countermeasure_hypotheses
+            .iter()
+            .filter_map(|value| match value.as_str() {
+                "fire" => Some(CountermeasureHypothesis::Fire),
+                "silver" => Some(CountermeasureHypothesis::Silver),
+                "daylight" => Some(CountermeasureHypothesis::Daylight),
+                "courage" => Some(CountermeasureHypothesis::Courage),
+                "shattering_blow" => None,
+                _ => unreachable!("validated countermeasure"),
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    );
+    profile.investigation.evidence_visibility = authored.investigation.evidence_visibility;
+    profile.investigation.identification_challenge =
+        authored.investigation.identification_challenge;
+    profile.investigation.location_challenge = authored.investigation.location_challenge;
+    profile
+}
+
+fn catalog_habitat(value: &str) -> Habitat {
+    match value {
+        "road" => Habitat::Road,
+        "open" => Habitat::Open,
+        "sparse_woods" => Habitat::SparseWoods,
+        "deep_woods" => Habitat::DeepWoods,
+        "cave" => Habitat::Cave,
+        "crypt" => Habitat::Crypt,
+        "ruin" => Habitat::Ruin,
+        "camp" => Habitat::Camp,
+        "mine" => Habitat::Mine,
+        "graveyard" => Habitat::Graveyard,
+        "occupied_house" => Habitat::OccupiedHouse,
+        _ => unreachable!("validated habitat"),
+    }
+}
+
+fn catalog_evidence(value: &str) -> EvidenceKind {
+    match value {
+        "boot_prints" | "large_boot_prints" | "bare_tracks" | "large_bare_tracks" => {
+            EvidenceKind::BootPrints
+        }
+        "small_bare_tracks" => EvidenceKind::SmallBareTracks,
+        "hoofprints" => EvidenceKind::Hoofprints,
+        "pawprints" | "large_pawprints" | "pack_tracks" | "changing_tracks" => {
+            EvidenceKind::Pawprints
+        }
+        "claw_marks" => EvidenceKind::ClawMarks,
+        "gnawed_bones" | "bone_dust" => EvidenceKind::GnawedBones,
+        "grave_soil" | "opened_graves" => EvidenceKind::GraveSoil,
+        "no_breath" => EvidenceKind::NoBreath,
+        "weapon_cuts" | "knife_wounds" | "heavy_weapon_cuts" | "tusk_wounds" => {
+            EvidenceKind::WeaponCuts
+        }
+        "arrow_shafts" => EvidenceKind::ArrowShafts,
+        "corpse_odor" => EvidenceKind::CorpseOdor,
+        "sulfur_odor" => EvidenceKind::SulfurOdor,
+        "cold_patch" => EvidenceKind::ColdPatch,
+        "missing_blood" => EvidenceKind::MissingBlood,
+        "disturbed_goods" | "camp_debris" | "snares" | "contraband" | "ritual_marks"
+        | "tool_marks" | "official_seals" | "heraldry" | "broken_goods" | "rooted_soil"
+        | "human_refuse" | "collar_marks" | "military_kit" | "local_slogans"
+        | "personal_grudge" | "disturbed_bedding" | "moved_goods" | "helpful_mischief"
+        | "woven_branches" | "damaged_shroud" | "eaten_shroud" => EvidenceKind::DisturbedGoods,
+        "human_speech" => EvidenceKind::HumanSpeech,
+        "animal_odor" | "woodsmoke" | "smoke" => EvidenceKind::AnimalOdor,
+        "broken_foliage" => EvidenceKind::BrokenFoliage,
+        "bite_wounds" => EvidenceKind::BiteWounds,
+        "blunt_damage" => EvidenceKind::BluntDamage,
+        _ => EvidenceKind::DisturbedGoods,
+    }
+}
+fn leak_evidence(values: &[String]) -> &'static [EvidenceKind] {
+    Box::leak(
+        values
+            .iter()
+            .map(|value| catalog_evidence(value))
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+    )
+}
+fn catalog_report(value: &str) -> ReportDescription {
+    ReportDescription::try_new(value).expect("validated report description ID")
+}
+
 const fn display_forms(id: ThreatId, fallback: &'static str) -> (&'static str, &'static str) {
     match id {
         ThreatId::TownWatch => ("Town watch", "Town watch"),
@@ -1224,7 +1564,7 @@ const fn display_forms(id: ThreatId, fallback: &'static str) -> (&'static str, &
     }
 }
 
-pub(crate) const fn habitat_weight(id: ThreatId, habitat: Habitat) -> u16 {
+pub(crate) fn habitat_weight(id: ThreatId, habitat: Habitat) -> u16 {
     let p = profile(id);
     if !contains_habitat(p.investigation.habitats, habitat) {
         return 0;
@@ -1356,59 +1696,25 @@ pub fn report_likelihood(
 }
 
 pub fn description_likelihood(id: ThreatId, report: ReportDescription) -> u32 {
-    use ReportDescription::*;
-    match (id, report) {
-        (ThreatId::Werewolf, LargeUprightBeast) => 95,
-        (ThreatId::WildMan, LargeUprightBeast) => 85,
-        (ThreatId::Orc, LargeUprightBeast) => 70,
-        (ThreatId::Bear, LargeUprightBeast) => 45,
-        (ThreatId::SpectralHound, DoglikeBeast) => 65,
-        (ThreatId::Wolf, DoglikeBeast) => 100,
-        (ThreatId::FeralDog | ThreatId::TrainedDog, DoglikeBeast) => 85,
-        (ThreatId::Werewolf, DoglikeBeast) => 35,
-        (ThreatId::Alp, UnseenNightVisitor) => 100,
-        (ThreatId::Nachzehrer, UnseenNightVisitor) => 45,
-        (ThreatId::Kobold, UnseenNightVisitor) => 55,
-        (ThreatId::Skeleton, WalkingDead) => 100,
-        (ThreatId::Ghoul | ThreatId::Revenant | ThreatId::Nachzehrer, WalkingDead) => 80,
-        (ThreatId::Goblin, SmallUprightFigures) => 100,
-        (ThreatId::Kobold, SmallUprightFigures) => 80,
-        _ if profile(id).investigation.silhouettes.contains(&report) => 60,
-        _ => 0,
-    }
+    crate::quest_catalog::catalog()
+        .relation(&format!("description.{}", report.as_str()))
+        .and_then(|relation| {
+            relation
+                .candidates
+                .iter()
+                .find(|candidate| candidate.id == id.as_str())
+        })
+        .map_or(0, |candidate| candidate.plausibility)
 }
 
-pub const fn regional_prior(id: ThreatId, region: RegionalContext) -> u16 {
+pub fn regional_prior(id: ThreatId, region: RegionalContext) -> u16 {
     if matches!(region, RegionalContext::GenericFantasy) {
         return 100;
     }
-    match id {
-        ThreatId::Bandit
-        | ThreatId::Deserter
-        | ThreatId::Poacher
-        | ThreatId::Smuggler
-        | ThreatId::GraveRobber
-        | ThreatId::TownWatch
-        | ThreatId::ArmedRetainer
-        | ThreatId::AngryMob => 130,
-        ThreatId::Wolf
-        | ThreatId::Boar
-        | ThreatId::Bear
-        | ThreatId::FeralDog
-        | ThreatId::TrainedDog => 140,
-        ThreatId::Alp
-        | ThreatId::Kobold
-        | ThreatId::WildMan
-        | ThreatId::SpectralHound
-        | ThreatId::Nachzehrer => 115,
-        ThreatId::Goblin
-        | ThreatId::Orc
-        | ThreatId::Skeleton
-        | ThreatId::Ghoul
-        | ThreatId::Revenant
-        | ThreatId::Werewolf
-        | ThreatId::Cultist => 70,
-    }
+    crate::quest_catalog::catalog()
+        .monster(id.as_str())
+        .expect("validated threat identity")
+        .northern_germany_prior
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1451,9 +1757,8 @@ pub fn rank_candidates_in_region(
             break;
         }
     }
-    let mut ranked: Vec<_> = ALL_THREATS
-        .iter()
-        .copied()
+    let mut ranked: Vec<_> = catalog_threats()
+        .into_iter()
         .filter_map(|id| {
             let likelihood = report_likelihood(id, report, visibility, distance, capability);
             if likelihood == 0 {
@@ -1509,17 +1814,16 @@ const ALL_HABITATS: &[Habitat] = &[
 ];
 
 pub fn ambiguous_description_cardinality(report: ReportDescription) -> usize {
-    ALL_THREATS
-        .iter()
-        .filter(|id| description_likelihood(**id, report) > 0)
+    catalog_threats()
+        .into_iter()
+        .filter(|id| description_likelihood(*id, report) > 0)
         .count()
 }
 
 pub fn distinguishing_clue_set_count(report: ReportDescription) -> usize {
     let mut sets: Vec<&'static [EvidenceKind]> = Vec::new();
-    for id in ALL_THREATS
-        .iter()
-        .copied()
+    for id in catalog_threats()
+        .into_iter()
         .filter(|id| description_likelihood(*id, report) > 0)
     {
         let clues = profile(id).investigation.distinguishing_clues;
@@ -1585,12 +1889,13 @@ pub struct CatalogDiagnostic {
 
 pub fn validate_catalog() -> Vec<CatalogDiagnostic> {
     let mut errors = Vec::new();
-    if has_duplicates(ALL_THREATS) {
+    let threats = catalog_threats();
+    if has_duplicates(&threats) {
         errors.push(CatalogDiagnostic {
             message: "duplicate stable threat ID".into(),
         });
     }
-    for id in ALL_THREATS {
+    for id in &threats {
         let p = profile(*id);
         if id.as_str().parse::<ThreatId>() != Ok(*id) {
             errors.push(CatalogDiagnostic {

--- a/crates/adventuresim-core/src/bin/questgen-check.rs
+++ b/crates/adventuresim-core/src/bin/questgen-check.rs
@@ -1,5 +1,6 @@
 use adventuresim_core::{
     local_problem::Scope,
+    quest_catalog::{QUEST_CATALOG_DIGEST, catalog},
     quest_generation::{CATALOG_REVISION, GenerationContext, audit, generate, test_witnesses},
 };
 
@@ -29,10 +30,16 @@ fn main() {
     let args = std::env::args().skip(1).collect::<Vec<_>>();
     match args.first().map(String::as_str) {
         Some("validate") => {
+            let catalog = catalog();
             for ordinal in 0..2 {
                 generate(&context(0x187, ordinal)).unwrap_or_else(|e| panic!("{e:?}"));
             }
-            println!("catalog {CATALOG_REVISION}: valid");
+            println!(
+                "catalog {CATALOG_REVISION}: valid ({} monsters, {} documents, digest {})",
+                catalog.monsters().count(),
+                catalog.documents.len(),
+                QUEST_CATALOG_DIGEST
+            );
         }
         Some("explain") => {
             let seed = args

--- a/crates/adventuresim-core/src/encounter.rs
+++ b/crates/adventuresim-core/src/encounter.rs
@@ -59,7 +59,7 @@ impl EncounterArchetype {
         }
     }
 
-    pub const fn enemy_speed_m_per_minute(self) -> u32 {
+    pub fn enemy_speed_m_per_minute(self) -> u32 {
         self.threat_id().profile().combat.speed_m_per_minute
     }
 }
@@ -118,7 +118,7 @@ pub const fn penalty_minutes(terrain: EncounterTerrain, choice: EncounterChoice)
     }
 }
 
-pub const fn run_is_eligible(party_speed: u32, archetype: EncounterArchetype) -> bool {
+pub fn run_is_eligible(party_speed: u32, archetype: EncounterArchetype) -> bool {
     party_speed > archetype.enemy_speed_m_per_minute()
 }
 

--- a/crates/adventuresim-core/src/investigation.rs
+++ b/crates/adventuresim-core/src/investigation.rs
@@ -490,9 +490,10 @@ pub fn infer_threats(mut input: InferenceInput) -> Result<SafeInference, Validat
 mod tests {
     use super::*;
     use crate::bestiary::{
-        ObservationDistance::Medium, ObservationVisibility::Dark,
-        ReportDescription::LargeUprightBeast, WitnessCapability::Ordinary,
+        ObservationDistance::Medium, ObservationVisibility::Dark, ReportDescription,
+        WitnessCapability::Ordinary,
     };
+    const LARGE_UPRIGHT_BEAST: ReportDescription = ReportDescription::LargeUprightBeast;
 
     fn id<T>(make: impl FnOnce(String) -> Result<T, ValidationError>, value: &str) -> T {
         make(value.into()).unwrap()
@@ -711,7 +712,7 @@ mod tests {
     fn inference_has_only_visible_inputs_and_safe_provenance() {
         let base = InferenceInput {
             report: VisibleReport {
-                description: LargeUprightBeast,
+                description: LARGE_UPRIGHT_BEAST,
                 visibility: Dark,
                 distance: Medium,
                 capability: Ordinary,

--- a/crates/adventuresim-core/src/lib.rs
+++ b/crates/adventuresim-core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod npc_adventurer;
 pub mod profession;
 pub mod provisioning;
 pub mod quest_catalog;
+mod quest_catalog_validation;
 pub mod quest_generation;
 pub mod settlement_economy;
 pub mod settlement_population;

--- a/crates/adventuresim-core/src/lib.rs
+++ b/crates/adventuresim-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod morale;
 pub mod npc_adventurer;
 pub mod profession;
 pub mod provisioning;
+pub mod quest_catalog;
 pub mod quest_generation;
 pub mod settlement_economy;
 pub mod settlement_population;

--- a/crates/adventuresim-core/src/local_problem.rs
+++ b/crates/adventuresim-core/src/local_problem.rs
@@ -17,13 +17,28 @@ pub const INCIDENT_INTERVAL_MINUTES: u64 = 2 * 1_440;
 pub const INCIDENT_SEVERITY_STEP_BPS: u32 = 2_500;
 
 pub fn due_incident_count(starts_at: u64, minute: u64) -> u16 {
+    due_incident_count_configured(
+        starts_at,
+        minute,
+        INCIDENT_INTERVAL_MINUTES,
+        MAX_INCIDENTS_PER_PROBLEM,
+    )
+}
+
+pub fn due_incident_count_configured(
+    starts_at: u64,
+    minute: u64,
+    interval_minutes: u64,
+    maximum_incidents: u16,
+) -> u16 {
     if minute < starts_at {
         return 0;
     }
-    let follow_ups = minute.saturating_sub(starts_at) / INCIDENT_INTERVAL_MINUTES;
+    assert!(interval_minutes > 0 && maximum_incidents > 0);
+    let follow_ups = minute.saturating_sub(starts_at) / interval_minutes;
     u16::try_from(follow_ups.saturating_add(1))
         .unwrap_or(u16::MAX)
-        .min(MAX_INCIDENTS_PER_PROBLEM)
+        .min(maximum_incidents)
 }
 
 pub fn incident_severity_bps(incident_count: u16) -> u32 {

--- a/crates/adventuresim-core/src/quest_catalog.rs
+++ b/crates/adventuresim-core/src/quest_catalog.rs
@@ -448,35 +448,43 @@ impl Catalog {
         profession: &str,
         local_role: &str,
     ) -> Option<&WitnessDemographicDefinition> {
-        self.documents
-            .iter()
-            .flat_map(|document| &document.witness_demographics)
-            .flat_map(|demographic| {
-                demographic
-                    .match_rules
-                    .iter()
-                    .map(move |rule| (demographic, rule))
-            })
+        let rules = || {
+            self.documents
+                .iter()
+                .flat_map(|document| &document.witness_demographics)
+                .flat_map(|demographic| {
+                    demographic
+                        .match_rules
+                        .iter()
+                        .map(move |rule| (demographic, rule))
+                })
+        };
+        rules()
             .filter(|(_, rule)| {
-                rule.fallback
-                    || (rule.age_bands.is_empty()
+                !rule.fallback
+                    && (rule.age_bands.is_empty()
                         || rule.age_bands.iter().any(|value| value == age_band))
-                        && (rule.sexes.is_empty() || rule.sexes.iter().any(|value| value == sex))
-                        && (rule.professions.is_empty()
-                            || rule.professions.iter().any(|value| {
-                                crate::quest_catalog_validation::selector_matches_fact(
-                                    value, profession,
-                                )
-                            }))
-                        && (rule.local_roles.is_empty()
-                            || rule.local_roles.iter().any(|value| {
-                                crate::quest_catalog_validation::selector_matches_fact(
-                                    value, local_role,
-                                )
-                            }))
+                    && (rule.sexes.is_empty() || rule.sexes.iter().any(|value| value == sex))
+                    && (rule.professions.is_empty()
+                        || rule.professions.iter().any(|value| {
+                            crate::quest_catalog_validation::selector_matches_fact(
+                                value, profession,
+                            )
+                        }))
+                    && (rule.local_roles.is_empty()
+                        || rule.local_roles.iter().any(|value| {
+                            crate::quest_catalog_validation::selector_matches_fact(
+                                value, local_role,
+                            )
+                        }))
             })
             .max_by_key(|(_, rule)| rule.priority)
             .map(|(demographic, _)| demographic)
+            .or_else(|| {
+                rules()
+                    .find(|(_, rule)| rule.fallback)
+                    .map(|(demographic, _)| demographic)
+            })
     }
     pub fn site(&self, id: &str) -> Option<&SiteDefinition> {
         self.sites.get(id)
@@ -917,6 +925,56 @@ mod tests {
                 .unwrap_err()
                 .contains("matches no authoritative NPC profession")
         );
+    }
+
+    #[test]
+    fn demographic_fallback_never_competes_with_specific_rules() {
+        for fallback_priority in [200, 100, 80] {
+            let (mut raw, files) = raw_catalog();
+            let investigation = raw
+                .iter_mut()
+                .find(|document| document["witness_demographics"].is_array())
+                .unwrap();
+            for demographic in investigation["witness_demographics"]
+                .as_array_mut()
+                .unwrap()
+            {
+                for rule in demographic["match_rules"].as_array_mut().unwrap() {
+                    if rule["fallback"] == serde_json::json!(true) {
+                        rule["priority"] = serde_json::json!(fallback_priority);
+                    }
+                }
+            }
+            crate::quest_catalog_validation::validate_documents(&raw, &files).unwrap();
+            let documents = raw
+                .into_iter()
+                .map(serde_json::from_value)
+                .collect::<Result<Vec<CatalogDocument>, _>>()
+                .unwrap();
+            let catalog = Catalog::compile(documents).unwrap();
+
+            assert_eq!(
+                catalog
+                    .witness_demographic_for("child", "female", "laborer", "resident")
+                    .unwrap()
+                    .id,
+                "child"
+            );
+            assert_eq!(
+                catalog
+                    .witness_demographic_for("adult", "male", "merchant", "market steward")
+                    .unwrap()
+                    .id,
+                "merchant"
+            );
+            assert_eq!(
+                catalog
+                    .witness_demographic_for("adult", "male", "artisan", "resident")
+                    .unwrap()
+                    .id,
+                "laborer"
+            );
+        }
     }
 
     #[test]

--- a/crates/adventuresim-core/src/quest_catalog.rs
+++ b/crates/adventuresim-core/src/quest_catalog.rs
@@ -1,0 +1,521 @@
+//! Startup-compiled, repository-authored quest and bestiary content.
+//!
+//! Files under `content/quests` are sorted, validated, embedded, and hashed by
+//! `build.rs`. Deployment never reads loose data files.
+
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::OnceLock,
+};
+
+include!(concat!(env!("OUT_DIR"), "/quest_catalog.rs"));
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct CatalogDocument {
+    #[serde(default)]
+    pub monsters: Vec<Monster>,
+    #[serde(default)]
+    pub evidence: Vec<EvidenceDefinition>,
+    #[serde(default)]
+    pub witness_demographics: Vec<WitnessDemographicDefinition>,
+    #[serde(default)]
+    pub circumstances: Vec<CircumstanceDefinition>,
+    #[serde(default)]
+    pub sites: Vec<SiteDefinition>,
+    #[serde(default)]
+    pub descriptions: Vec<DescriptionDefinition>,
+    #[serde(default)]
+    pub templates: Vec<TemplateDefinition>,
+    #[serde(default)]
+    pub consequences: Vec<ConsequenceDefinition>,
+    #[serde(default)]
+    pub relations: Vec<WeightedRelation>,
+    #[serde(default)]
+    pub bridges: Vec<BridgeDefinition>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Monster {
+    pub id: String,
+    pub name: String,
+    pub singular: String,
+    pub plural: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub base_weight: u16,
+    pub curation_weight: u16,
+    pub northern_germany_prior: u16,
+    pub combat: MonsterCombat,
+    pub investigation: MonsterInvestigation,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MonsterCombat {
+    pub rig: String,
+    pub speed_m_per_minute: u32,
+    pub weight_kg: f32,
+    pub attack: String,
+    pub ranged: bool,
+    pub precision_bonus_milli: i32,
+    pub training_multiplier_milli: u16,
+    pub perception: u8,
+    pub stealth: u8,
+    pub morale: u8,
+    pub protection: String,
+    pub resistance_joules: u32,
+    pub padding_joules: u32,
+    pub disease_risk: u8,
+    pub fear: u8,
+    pub temperament: String,
+    pub encounter_scale_basis_points: u16,
+    pub loot_item_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MonsterInvestigation {
+    pub habitats: Vec<String>,
+    pub activity: String,
+    pub victim_tags: Vec<String>,
+    pub tracks: Vec<String>,
+    pub wounds: Vec<String>,
+    pub disturbances: Vec<String>,
+    pub sounds: Vec<String>,
+    pub silhouettes: Vec<String>,
+    pub odors: Vec<String>,
+    pub mistaken_for: Vec<String>,
+    pub distinguishing_clues: Vec<String>,
+    pub preparation_advice: String,
+    pub evidence_visibility: u8,
+    pub identification_challenge: bool,
+    pub location_challenge: bool,
+    pub countermeasure_hypotheses: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EvidenceDefinition {
+    pub id: String,
+    pub portrait_label: String,
+    pub portrait_icon: String,
+    pub base_description: String,
+    pub topics: Vec<EvidenceTopicDefinition>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EvidenceTopicDefinition {
+    pub id: String,
+    pub label: String,
+    pub inspection_description: String,
+    pub check: Option<EvidenceCheckDefinition>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct EvidenceCheckDefinition {
+    pub stat: String,
+    pub difficulty_min_milli: u16,
+    pub difficulty_max_milli: u16,
+    pub success_description: String,
+    pub reveals_clue: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct WitnessDemographicDefinition {
+    pub id: String,
+    pub label: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CircumstanceDefinition {
+    pub id: String,
+    pub statement: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SiteDefinition {
+    pub id: String,
+    pub label: String,
+    pub terrain: String,
+    pub habitat: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DescriptionDefinition {
+    pub id: String,
+    pub text: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TemplateDefinition {
+    pub id: String,
+    pub label: String,
+    pub routes: Vec<String>,
+    pub objectives: Vec<String>,
+    pub cause_finales: BTreeMap<String, Vec<String>>,
+    pub consequence_profile: String,
+    pub incident_interval_minutes: u64,
+    pub maximum_incidents: u8,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ConsequenceDefinition {
+    pub id: String,
+    pub family: String,
+    pub causes: Vec<String>,
+    pub symptom: String,
+    pub buy_bps: i32,
+    pub sell_penalty_bps: i32,
+    pub encounter_frequency_bps: u16,
+    pub encounter_archetype: Option<String>,
+    pub disease_intensity: u16,
+    pub public_summary: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct WeightedRelation {
+    pub id: String,
+    pub candidates: Vec<WeightedCandidate>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct WeightedCandidate {
+    pub id: String,
+    pub plausibility: u32,
+    pub curation: u32,
+    pub hard_zero_reason: Option<String>,
+    pub required_bridge: Option<String>,
+    #[serde(default)]
+    pub factors: Vec<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct BridgeDefinition {
+    pub id: String,
+    pub explanation: String,
+    pub lead_summary: String,
+}
+
+#[derive(Debug)]
+pub struct Catalog {
+    pub documents: Vec<CatalogDocument>,
+    monsters: BTreeMap<String, Monster>,
+    evidence: BTreeMap<String, EvidenceDefinition>,
+    sites: BTreeMap<String, SiteDefinition>,
+    descriptions: BTreeMap<String, DescriptionDefinition>,
+    templates: BTreeMap<String, TemplateDefinition>,
+    relations: BTreeMap<String, WeightedRelation>,
+}
+
+impl Catalog {
+    fn compile(documents: Vec<CatalogDocument>) -> Result<Self, String> {
+        let mut monsters = BTreeMap::new();
+        let mut evidence = BTreeMap::new();
+        let mut sites = BTreeMap::new();
+        let mut descriptions = BTreeMap::new();
+        let mut templates = BTreeMap::new();
+        let mut relations = BTreeMap::new();
+        let mut consequence_ids = BTreeSet::new();
+        let mut bridges = BTreeSet::new();
+        let mut monster_ids = BTreeSet::new();
+        for document in &documents {
+            for bridge in &document.bridges {
+                if !bridges.insert(bridge.id.clone()) {
+                    return Err(format!("duplicate bridge {}", bridge.id));
+                }
+            }
+            for monster in &document.monsters {
+                validate_monster(monster)?;
+                monster_ids.insert(monster.id.clone());
+                if monsters
+                    .insert(monster.id.clone(), monster.clone())
+                    .is_some()
+                {
+                    return Err(format!("duplicate monster {}", monster.id));
+                }
+            }
+            for item in &document.evidence {
+                validate_evidence(item)?;
+                if evidence.insert(item.id.clone(), item.clone()).is_some() {
+                    return Err(format!("duplicate evidence {}", item.id));
+                }
+            }
+            for item in &document.sites {
+                if sites.insert(item.id.clone(), item.clone()).is_some() {
+                    return Err(format!("duplicate site {}", item.id));
+                }
+            }
+            for item in &document.descriptions {
+                if descriptions.insert(item.id.clone(), item.clone()).is_some() {
+                    return Err(format!("duplicate description {}", item.id));
+                }
+            }
+            for item in &document.templates {
+                if item.routes.is_empty() || item.objectives.is_empty() {
+                    return Err(format!("template {} has no routes or objectives", item.id));
+                }
+                if item.cause_finales.is_empty()
+                    || item.cause_finales.values().any(|finales| {
+                        finales.is_empty() || finales.iter().any(|id| !item.objectives.contains(id))
+                    })
+                {
+                    return Err(format!(
+                        "template {} has invalid cause/finale coverage",
+                        item.id
+                    ));
+                }
+                if templates.insert(item.id.clone(), item.clone()).is_some() {
+                    return Err(format!("duplicate template {}", item.id));
+                }
+            }
+            for item in &document.consequences {
+                if !consequence_ids.insert(item.id.clone())
+                    || item.causes.is_empty()
+                    || item.public_summary.trim().is_empty()
+                    || item.encounter_frequency_bps > 10_000
+                    || item.disease_intensity > 10_000
+                    || item.buy_bps.unsigned_abs() > 10_000
+                    || item.sell_penalty_bps.unsigned_abs() > 10_000
+                {
+                    return Err(format!("invalid or duplicate consequence {}", item.id));
+                }
+            }
+            for item in &document.relations {
+                if relations.insert(item.id.clone(), item.clone()).is_some() {
+                    return Err(format!("duplicate relation {}", item.id));
+                }
+            }
+        }
+        for monster in monsters.values() {
+            for other in &monster.investigation.mistaken_for {
+                if !monster_ids.contains(other) {
+                    return Err(format!(
+                        "monster {} references missing mistaken_for monster {other}",
+                        monster.id
+                    ));
+                }
+            }
+        }
+        for relation in relations.values() {
+            for candidate in &relation.candidates {
+                if let Some(bridge) = &candidate.required_bridge {
+                    if !bridges.contains(bridge) {
+                        return Err(format!(
+                            "relation {} references missing bridge {bridge}",
+                            relation.id
+                        ));
+                    }
+                }
+            }
+        }
+        for monster in monsters.values() {
+            for description in &monster.investigation.silhouettes {
+                let relation_id = format!("description.{description}");
+                let relation = relations.get(&relation_id).ok_or_else(|| {
+                    format!(
+                        "monster {} has unweighted description {description}",
+                        monster.id
+                    )
+                })?;
+                if !relation
+                    .candidates
+                    .iter()
+                    .any(|candidate| candidate.id == monster.id && candidate.plausibility > 0)
+                {
+                    return Err(format!(
+                        "monster {} description {description} has no positive authored likelihood",
+                        monster.id
+                    ));
+                }
+            }
+        }
+        for relation in relations
+            .values()
+            .filter(|item| item.id.starts_with("description."))
+        {
+            let description = relation.id.trim_start_matches("description.");
+            if !descriptions.contains_key(description) {
+                return Err(format!(
+                    "relation {} references missing description",
+                    relation.id
+                ));
+            }
+            for candidate in &relation.candidates {
+                if !monsters.contains_key(&candidate.id) {
+                    return Err(format!(
+                        "relation {} references missing monster {}",
+                        relation.id, candidate.id
+                    ));
+                }
+            }
+        }
+        Ok(Self {
+            documents,
+            monsters,
+            evidence,
+            sites,
+            descriptions,
+            templates,
+            relations,
+        })
+    }
+
+    pub fn monster(&self, id: &str) -> Option<&Monster> {
+        self.monsters.get(id)
+    }
+    pub fn monsters(&self) -> impl Iterator<Item = &Monster> {
+        self.monsters.values()
+    }
+    pub fn evidence(&self, id: &str) -> Option<&EvidenceDefinition> {
+        self.evidence.get(id)
+    }
+    pub fn circumstance(&self, id: &str) -> Option<&CircumstanceDefinition> {
+        self.documents
+            .iter()
+            .flat_map(|document| &document.circumstances)
+            .find(|item| item.id == id)
+    }
+    pub fn site(&self, id: &str) -> Option<&SiteDefinition> {
+        self.sites.get(id)
+    }
+    pub fn description(&self, id: &str) -> Option<&DescriptionDefinition> {
+        self.descriptions.get(id)
+    }
+    pub fn template(&self, id: &str) -> Option<&TemplateDefinition> {
+        self.templates.get(id)
+    }
+    pub fn relation(&self, id: &str) -> Option<&WeightedRelation> {
+        self.relations.get(id)
+    }
+    pub fn consequence(&self, family: &str, cause: &str) -> Option<&ConsequenceDefinition> {
+        self.documents
+            .iter()
+            .flat_map(|document| &document.consequences)
+            .find(|item| item.family == family && item.causes.iter().any(|id| id == cause))
+            .or_else(|| {
+                self.documents
+                    .iter()
+                    .flat_map(|document| &document.consequences)
+                    .find(|item| item.family == family && item.causes.iter().any(|id| id == "*"))
+            })
+    }
+}
+
+fn validate_monster(monster: &Monster) -> Result<(), String> {
+    if monster.combat.training_multiplier_milli == 0
+        || monster.combat.encounter_scale_basis_points == 0
+        || monster.combat.weight_kg <= 0.0
+        || monster.combat.speed_m_per_minute == 0
+    {
+        return Err(format!("monster {} has invalid combat scalars", monster.id));
+    }
+    if monster.combat.resistance_joules > 20_000 || monster.combat.padding_joules > 20_000 {
+        return Err(format!(
+            "monster {} has implausible innate protection",
+            monster.id
+        ));
+    }
+    if monster.investigation.habitats.is_empty()
+        || monster.investigation.silhouettes.is_empty()
+        || monster.investigation.distinguishing_clues.is_empty()
+    {
+        return Err(format!(
+            "monster {} has incomplete investigation data",
+            monster.id
+        ));
+    }
+    if !matches!(monster.combat.rig.as_str(), "humanoid" | "quadruped")
+        || !matches!(
+            monster.combat.attack.as_str(),
+            "blade" | "blunt" | "knife" | "spear" | "bow" | "bite" | "claw" | "tusk"
+        )
+        || !matches!(
+            monster.combat.protection.as_str(),
+            "unarmored" | "hide" | "shielded" | "armored" | "bone" | "supernatural"
+        )
+        || !matches!(
+            monster.combat.temperament.as_str(),
+            "cowardly" | "cautious" | "disciplined" | "aggressive" | "relentless" | "elusive"
+        )
+    {
+        return Err(format!(
+            "monster {} names an unknown closed mechanic",
+            monster.id
+        ));
+    }
+    if monster.combat.ranged != (monster.combat.attack == "bow") {
+        return Err(format!(
+            "monster {} has inconsistent ranged attack mechanics",
+            monster.id
+        ));
+    }
+    Ok(())
+}
+
+fn validate_evidence(evidence: &EvidenceDefinition) -> Result<(), String> {
+    if evidence.topics.is_empty() {
+        return Err(format!("evidence {} has no inspection topics", evidence.id));
+    }
+    let mut topics = BTreeSet::new();
+    for topic in &evidence.topics {
+        if !topics.insert(&topic.id) {
+            return Err(format!(
+                "evidence {} has duplicate topic {}",
+                evidence.id, topic.id
+            ));
+        }
+        if let Some(check) = &topic.check {
+            if check.difficulty_min_milli > check.difficulty_max_milli
+                || check.difficulty_max_milli > 10_000
+            {
+                return Err(format!(
+                    "evidence {} topic {} has invalid difficulty range",
+                    evidence.id, topic.id
+                ));
+            }
+            if !matches!(
+                check.stat.as_str(),
+                "eyesight" | "intelligence" | "instinct"
+            ) {
+                return Err(format!(
+                    "evidence {} topic {} names unknown check stat {}",
+                    evidence.id, topic.id, check.stat
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn catalog() -> &'static Catalog {
+    static CATALOG: OnceLock<Catalog> = OnceLock::new();
+    CATALOG.get_or_init(|| {
+        let documents: Vec<CatalogDocument> =
+            serde_json::from_str(QUEST_CATALOG_JSON).expect("validated embedded quest catalog");
+        Catalog::compile(documents).expect("validated quest catalog references")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn embedded_catalog_compiles_and_is_sorted_by_lookup_key() {
+        let catalog = catalog();
+        assert!(catalog.monster("skeleton").is_some());
+        assert!(catalog.evidence("footprints").is_some());
+        assert_eq!(catalog.monsters().next().unwrap().id, "alp");
+        assert_eq!(QUEST_CATALOG_DIGEST.len(), 64);
+    }
+
+    #[test]
+    fn every_relation_keeps_plausibility_and_curation_separate() {
+        for document in &catalog().documents {
+            for relation in &document.relations {
+                for candidate in &relation.candidates {
+                    let zero = candidate.plausibility == 0 || candidate.curation == 0;
+                    assert_eq!(zero, candidate.hard_zero_reason.is_some());
+                }
+            }
+        }
+    }
+}

--- a/crates/adventuresim-core/src/quest_catalog.rs
+++ b/crates/adventuresim-core/src/quest_catalog.rs
@@ -12,6 +12,7 @@ use std::{
 include!(concat!(env!("OUT_DIR"), "/quest_catalog.rs"));
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CatalogDocument {
     #[serde(default)]
     pub monsters: Vec<Monster>,
@@ -36,6 +37,7 @@ pub struct CatalogDocument {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Monster {
     pub id: String,
     pub name: String,
@@ -51,6 +53,7 @@ pub struct Monster {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MonsterCombat {
     pub rig: String,
     pub speed_m_per_minute: u32,
@@ -73,6 +76,7 @@ pub struct MonsterCombat {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MonsterInvestigation {
     pub habitats: Vec<String>,
     pub activity: String,
@@ -93,6 +97,7 @@ pub struct MonsterInvestigation {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EvidenceDefinition {
     pub id: String,
     pub portrait_label: String,
@@ -102,6 +107,7 @@ pub struct EvidenceDefinition {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EvidenceTopicDefinition {
     pub id: String,
     pub label: String,
@@ -110,6 +116,7 @@ pub struct EvidenceTopicDefinition {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EvidenceCheckDefinition {
     pub stat: String,
     pub difficulty_min_milli: u16,
@@ -119,18 +126,37 @@ pub struct EvidenceCheckDefinition {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WitnessDemographicDefinition {
     pub id: String,
     pub label: String,
+    pub match_rules: Vec<WitnessMatchRule>,
+}
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WitnessMatchRule {
+    pub priority: i32,
+    #[serde(default)]
+    pub age_bands: Vec<String>,
+    #[serde(default)]
+    pub sexes: Vec<String>,
+    #[serde(default)]
+    pub professions: Vec<String>,
+    #[serde(default)]
+    pub local_roles: Vec<String>,
+    #[serde(default)]
+    pub fallback: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CircumstanceDefinition {
     pub id: String,
     pub statement: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SiteDefinition {
     pub id: String,
     pub label: String,
@@ -139,12 +165,14 @@ pub struct SiteDefinition {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DescriptionDefinition {
     pub id: String,
     pub text: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TemplateDefinition {
     pub id: String,
     pub label: String,
@@ -157,6 +185,7 @@ pub struct TemplateDefinition {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConsequenceDefinition {
     pub id: String,
     pub family: String,
@@ -171,12 +200,14 @@ pub struct ConsequenceDefinition {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WeightedRelation {
     pub id: String,
     pub candidates: Vec<WeightedCandidate>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WeightedCandidate {
     pub id: String,
     pub plausibility: u32,
@@ -188,10 +219,14 @@ pub struct WeightedCandidate {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct BridgeDefinition {
     pub id: String,
     pub explanation: String,
     pub lead_summary: String,
+    pub event_suffix: String,
+    pub evidence_id: String,
+    pub action_ids: BTreeMap<String, String>,
 }
 
 #[derive(Debug)]
@@ -259,6 +294,39 @@ impl Catalog {
                 {
                     return Err(format!(
                         "template {} has invalid cause/finale coverage",
+                        item.id
+                    ));
+                }
+                if item.incident_interval_minutes == 0 || item.maximum_incidents == 0 {
+                    return Err(format!(
+                        "template {} has invalid incident scheduling",
+                        item.id
+                    ));
+                }
+                let (supported_routes, supported_objectives): (&[&str], &[&str]) = match item
+                    .id
+                    .as_str()
+                {
+                    "recurring_depredation" => (
+                        &["physical_trail", "pattern_surveillance", "social_inquiry"],
+                        &["defeat", "drive_off"],
+                    ),
+                    "disappearance_or_loss" => (
+                        &["physical_trail", "social_inquiry"],
+                        &["rescue", "retrieve_return", "expose"],
+                    ),
+                    _ => return Err(format!("template {} has no typed graph assembler", item.id)),
+                };
+                if item.routes.iter().map(String::as_str).collect::<Vec<_>>() != supported_routes
+                    || item
+                        .objectives
+                        .iter()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>()
+                        != supported_objectives
+                {
+                    return Err(format!(
+                        "template {} requests an unsupported typed route/objective graph",
                         item.id
                     ));
                 }
@@ -373,6 +441,41 @@ impl Catalog {
             .flat_map(|document| &document.circumstances)
             .find(|item| item.id == id)
     }
+    pub fn witness_demographic_for(
+        &self,
+        age_band: &str,
+        sex: &str,
+        profession: &str,
+        local_role: &str,
+    ) -> Option<&WitnessDemographicDefinition> {
+        self.documents
+            .iter()
+            .flat_map(|document| &document.witness_demographics)
+            .flat_map(|demographic| {
+                demographic
+                    .match_rules
+                    .iter()
+                    .map(move |rule| (demographic, rule))
+            })
+            .filter(|(_, rule)| {
+                rule.fallback
+                    || (rule.age_bands.is_empty()
+                        || rule.age_bands.iter().any(|value| value == age_band))
+                        && (rule.sexes.is_empty() || rule.sexes.iter().any(|value| value == sex))
+                        && (rule.professions.is_empty()
+                            || rule
+                                .professions
+                                .iter()
+                                .any(|value| profession.contains(value)))
+                        && (rule.local_roles.is_empty()
+                            || rule
+                                .local_roles
+                                .iter()
+                                .any(|value| local_role.contains(value)))
+            })
+            .max_by_key(|(_, rule)| rule.priority)
+            .map(|(demographic, _)| demographic)
+    }
     pub fn site(&self, id: &str) -> Option<&SiteDefinition> {
         self.sites.get(id)
     }
@@ -384,6 +487,12 @@ impl Catalog {
     }
     pub fn relation(&self, id: &str) -> Option<&WeightedRelation> {
         self.relations.get(id)
+    }
+    pub fn bridge(&self, id: &str) -> Option<&BridgeDefinition> {
+        self.documents
+            .iter()
+            .flat_map(|document| &document.bridges)
+            .find(|bridge| bridge.id == id)
     }
     pub fn consequence(&self, family: &str, cause: &str) -> Option<&ConsequenceDefinition> {
         self.documents
@@ -488,8 +597,19 @@ fn validate_evidence(evidence: &EvidenceDefinition) -> Result<(), String> {
 pub fn catalog() -> &'static Catalog {
     static CATALOG: OnceLock<Catalog> = OnceLock::new();
     CATALOG.get_or_init(|| {
-        let documents: Vec<CatalogDocument> =
+        let raw_documents: Vec<serde_json::Value> =
             serde_json::from_str(QUEST_CATALOG_JSON).expect("validated embedded quest catalog");
+        let sources = raw_documents
+            .iter()
+            .enumerate()
+            .map(|(index, _)| format!("embedded.catalog[{index}]"))
+            .collect::<Vec<_>>();
+        crate::quest_catalog_validation::validate_documents(&raw_documents, &sources)
+            .expect("build-validated embedded quest catalog");
+        let documents: Vec<CatalogDocument> = raw_documents
+            .into_iter()
+            .map(|value| serde_json::from_value(value).expect("strict validated catalog schema"))
+            .collect();
         Catalog::compile(documents).expect("validated quest catalog references")
     })
 }
@@ -517,5 +637,221 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn raw_catalog() -> (Vec<serde_json::Value>, Vec<String>) {
+        let documents: Vec<serde_json::Value> = serde_json::from_str(QUEST_CATALOG_JSON).unwrap();
+        let files = (0..documents.len())
+            .map(|index| format!("fixture[{index}]"))
+            .collect();
+        (documents, files)
+    }
+
+    #[test]
+    fn shared_validator_rejects_unknown_fields_oversized_ids_and_layering() {
+        let (documents, files) = raw_catalog();
+        let mut unknown = documents.clone();
+        unknown[0]["monsters"][0]["typo_field"] = serde_json::json!(true);
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&unknown, &files)
+                .unwrap_err()
+                .contains("unknown field")
+        );
+        let mut oversized = documents.clone();
+        oversized[0]["monsters"][0]["id"] = serde_json::json!("x".repeat(64));
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&oversized, &files)
+                .unwrap_err()
+                .contains("bounded catalog ID")
+        );
+        let mut layered = documents;
+        let monster = &mut layered[0]["monsters"][0];
+        monster["combat"]["protection"] = serde_json::json!("armored");
+        monster["combat"]["padding_joules"] = serde_json::json!(1);
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&layered, &files)
+                .unwrap_err()
+                .contains("cannot compose")
+        );
+    }
+
+    #[test]
+    fn shared_validator_rejects_dangling_bridge_and_missing_demographic_fallback() {
+        let (documents, files) = raw_catalog();
+        let mut dangling = documents.clone();
+        let relation_document = dangling
+            .iter_mut()
+            .find(|document| document["relations"].is_array())
+            .unwrap();
+        relation_document["relations"][0]["candidates"][0]["required_bridge"] =
+            serde_json::json!("missing_bridge");
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&dangling, &files)
+                .unwrap_err()
+                .contains("dangling bridge")
+        );
+        let mut no_fallback = documents;
+        let demographic_document = no_fallback
+            .iter_mut()
+            .find(|document| document["witness_demographics"].is_array())
+            .unwrap();
+        for demographic in demographic_document["witness_demographics"]
+            .as_array_mut()
+            .unwrap()
+        {
+            for rule in demographic["match_rules"].as_array_mut().unwrap() {
+                if rule["fallback"] == serde_json::json!(true) {
+                    rule["fallback"] = serde_json::json!(false);
+                    rule["age_bands"] = serde_json::json!(["adult"]);
+                }
+            }
+        }
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&no_fallback, &files)
+                .unwrap_err()
+                .contains("exactly one fallback")
+        );
+    }
+
+    #[test]
+    fn shared_validator_rejects_bad_dcs_graphs_relations_and_demographic_ties() {
+        let (documents, files) = raw_catalog();
+        let mut bad_dc = documents.clone();
+        let investigation = bad_dc
+            .iter_mut()
+            .find(|document| document["evidence"].is_array())
+            .unwrap();
+        investigation["evidence"][0]["topics"][1]["check"]["difficulty_min_milli"] =
+            serde_json::json!(9000);
+        investigation["evidence"][0]["topics"][1]["check"]["difficulty_max_milli"] =
+            serde_json::json!(1000);
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&bad_dc, &files)
+                .unwrap_err()
+                .contains("invalid DC range")
+        );
+
+        let mut bad_graph = documents.clone();
+        let generation = bad_graph
+            .iter_mut()
+            .find(|document| document["templates"].is_array())
+            .unwrap();
+        generation["templates"][0]["routes"] = serde_json::json!(["social_inquiry"]);
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&bad_graph, &files)
+                .unwrap_err()
+                .contains("unsupported route/objective graph")
+        );
+
+        let mut dangling_candidate = documents.clone();
+        let generation = dangling_candidate
+            .iter_mut()
+            .find(|document| document["relations"].is_array())
+            .unwrap();
+        let description = generation["relations"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|relation| relation["id"] == "description.armed_people")
+            .unwrap();
+        description["candidates"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "id":"missing_monster","plausibility":10,"curation":10,
+                "hard_zero_reason":null,"required_bridge":null
+            }));
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&dangling_candidate, &files)
+                .unwrap_err()
+                .contains("dangling candidate")
+        );
+
+        let mut tied_demographics = documents;
+        let investigation = tied_demographics
+            .iter_mut()
+            .find(|document| document["witness_demographics"].is_array())
+            .unwrap();
+        investigation["witness_demographics"][2]["match_rules"][0]["professions"] =
+            serde_json::json!(["cleric"]);
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&tied_demographics, &files)
+                .unwrap_err()
+                .contains("equal-priority demographic rules")
+        );
+    }
+
+    #[test]
+    fn yaml_only_open_ids_validate_without_rust_identity_edits() {
+        let (mut documents, files) = raw_catalog();
+        let monster_document = documents
+            .iter_mut()
+            .find(|document| document["monsters"].is_array())
+            .unwrap();
+        let mut monster = monster_document["monsters"][0].clone();
+        monster["id"] = serde_json::json!("fixture_new_monster");
+        monster["name"] = serde_json::json!("Fixture monster");
+        monster["singular"] = serde_json::json!("Fixture monster");
+        monster["plural"] = serde_json::json!("Fixture monsters");
+        monster["investigation"]["mistaken_for"] = serde_json::json!(["bandit"]);
+        monster_document["monsters"]
+            .as_array_mut()
+            .unwrap()
+            .push(monster);
+        let investigation_document = documents
+            .iter_mut()
+            .find(|document| document["evidence"].is_array())
+            .unwrap();
+        let mut evidence = investigation_document["evidence"][0].clone();
+        evidence["id"] = serde_json::json!("fixture_new_evidence");
+        investigation_document["evidence"]
+            .as_array_mut()
+            .unwrap()
+            .push(evidence);
+        let mut bridge = investigation_document["bridges"][0].clone();
+        bridge["id"] = serde_json::json!("fixture_new_bridge");
+        investigation_document["bridges"]
+            .as_array_mut()
+            .unwrap()
+            .push(bridge);
+        let mut demographic = investigation_document["witness_demographics"][0].clone();
+        demographic["id"] = serde_json::json!("fixture_new_demographic");
+        demographic["match_rules"][0]["age_bands"] = serde_json::json!(["elder"]);
+        demographic["match_rules"][0]["priority"] = serde_json::json!(101);
+        investigation_document["witness_demographics"]
+            .as_array_mut()
+            .unwrap()
+            .push(demographic);
+        let relation_document = documents
+            .iter_mut()
+            .find(|document| document["relations"].is_array())
+            .unwrap();
+        let description_relation = relation_document["relations"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|relation| relation["id"] == "description.armed_people")
+            .unwrap();
+        description_relation["candidates"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "id":"fixture_new_monster","plausibility":60,"curation":100,
+                "hard_zero_reason":null,"required_bridge":"fixture_new_bridge"
+            }));
+        let evidence_relation = relation_document["relations"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|relation| relation["id"] == "evidence.baseline")
+            .unwrap();
+        evidence_relation["candidates"]
+            .as_array_mut()
+            .unwrap()
+            .push(serde_json::json!({
+                "id":"fixture_new_evidence","plausibility":20,"curation":20,
+                "hard_zero_reason":null,"required_bridge":null
+            }));
+        crate::quest_catalog_validation::validate_documents(&documents, &files).unwrap();
     }
 }

--- a/crates/adventuresim-core/src/quest_catalog.rs
+++ b/crates/adventuresim-core/src/quest_catalog.rs
@@ -463,15 +463,17 @@ impl Catalog {
                         || rule.age_bands.iter().any(|value| value == age_band))
                         && (rule.sexes.is_empty() || rule.sexes.iter().any(|value| value == sex))
                         && (rule.professions.is_empty()
-                            || rule
-                                .professions
-                                .iter()
-                                .any(|value| profession.contains(value)))
+                            || rule.professions.iter().any(|value| {
+                                crate::quest_catalog_validation::selector_matches_fact(
+                                    value, profession,
+                                )
+                            }))
                         && (rule.local_roles.is_empty()
-                            || rule
-                                .local_roles
-                                .iter()
-                                .any(|value| local_role.contains(value)))
+                            || rule.local_roles.iter().any(|value| {
+                                crate::quest_catalog_validation::selector_matches_fact(
+                                    value, local_role,
+                                )
+                            }))
             })
             .max_by_key(|(_, rule)| rule.priority)
             .map(|(demographic, _)| demographic)
@@ -778,6 +780,142 @@ mod tests {
             crate::quest_catalog_validation::validate_documents(&tied_demographics, &files)
                 .unwrap_err()
                 .contains("equal-priority demographic rules")
+        );
+    }
+
+    #[test]
+    fn shared_validator_rejects_runtime_type_overflow_optional_and_combat_mismatches() {
+        let (documents, files) = raw_catalog();
+        let validate = |documents: &Vec<serde_json::Value>| {
+            crate::quest_catalog_validation::validate_documents(documents, &files).unwrap_err()
+        };
+
+        let mut priority = documents.clone();
+        let investigation = priority
+            .iter_mut()
+            .find(|document| document["witness_demographics"].is_array())
+            .unwrap();
+        investigation["witness_demographics"][0]["match_rules"][0]["priority"] =
+            serde_json::json!(i64::from(i32::MAX) + 1);
+        assert!(validate(&priority).contains("priority"));
+
+        let mut relation_weight = documents.clone();
+        let generation = relation_weight
+            .iter_mut()
+            .find(|document| document["relations"].is_array())
+            .unwrap();
+        generation["relations"][0]["candidates"][0]["plausibility"] =
+            serde_json::json!(u64::from(u32::MAX) + 1);
+        assert!(validate(&relation_weight).contains("plausibility"));
+
+        let mut typed_scalar = documents.clone();
+        typed_scalar[0]["monsters"][0]["base_weight"] = serde_json::json!(u64::from(u16::MAX) + 1);
+        assert!(validate(&typed_scalar).contains("base_weight"));
+
+        for (field, invalid) in [
+            ("loot_item_id", serde_json::json!(false)),
+            ("loot_item_id", serde_json::json!(17)),
+        ] {
+            let mut optional = documents.clone();
+            optional[0]["monsters"][0]["combat"][field] = invalid;
+            assert!(validate(&optional).contains("string or null"));
+        }
+
+        let mut consequence_optional = documents.clone();
+        let generation = consequence_optional
+            .iter_mut()
+            .find(|document| document["consequences"].is_array())
+            .unwrap();
+        generation["consequences"][0]["encounter_archetype"] = serde_json::json!(false);
+        assert!(validate(&consequence_optional).contains("string or null"));
+
+        let mut relation_optional = documents.clone();
+        let generation = relation_optional
+            .iter_mut()
+            .find(|document| document["relations"].is_array())
+            .unwrap();
+        generation["relations"][0]["candidates"][0]["required_bridge"] = serde_json::json!(false);
+        assert!(validate(&relation_optional).contains("string or null"));
+
+        let mut hard_zero_optional = documents.clone();
+        let generation = hard_zero_optional
+            .iter_mut()
+            .find(|document| document["relations"].is_array())
+            .unwrap();
+        generation["relations"][0]["candidates"][0]["hard_zero_reason"] = serde_json::json!(false);
+        assert!(validate(&hard_zero_optional).contains("string or null"));
+
+        let mut check_optional = documents.clone();
+        let investigation = check_optional
+            .iter_mut()
+            .find(|document| document["evidence"].is_array())
+            .unwrap();
+        investigation["evidence"][0]["topics"][0]["check"] = serde_json::json!(false);
+        assert!(validate(&check_optional).contains("expected object"));
+
+        let mut factors = documents.clone();
+        let generation = factors
+            .iter_mut()
+            .find(|document| document["relations"].is_array())
+            .unwrap();
+        generation["relations"][0]["candidates"][0]["factors"] = serde_json::json!(["valid", 7]);
+        assert!(validate(&factors).contains("expected string"));
+
+        let mut ranged = documents;
+        ranged[0]["monsters"][0]["combat"]["ranged"] = serde_json::json!(true);
+        assert!(validate(&ranged).contains("bow attack and ranged flag"));
+    }
+
+    #[test]
+    fn demographic_selectors_use_exact_or_whole_token_matching() {
+        assert!(crate::quest_catalog_validation::selector_matches_fact(
+            "merchant", "merchant"
+        ));
+        assert!(!crate::quest_catalog_validation::selector_matches_fact(
+            "mer", "merchant"
+        ));
+        assert!(!crate::quest_catalog_validation::selector_matches_fact(
+            "chant", "merchant"
+        ));
+        assert!(crate::quest_catalog_validation::selector_matches_fact(
+            "retainer",
+            "lord's household retainer"
+        ));
+
+        let catalog = catalog();
+        assert_eq!(
+            catalog
+                .witness_demographic_for("adult", "male", "merchant", "resident")
+                .unwrap()
+                .id,
+            "merchant"
+        );
+        assert_eq!(
+            catalog
+                .witness_demographic_for("adult", "male", "mer", "resident")
+                .unwrap()
+                .id,
+            "laborer"
+        );
+        assert_eq!(
+            catalog
+                .witness_demographic_for("adult", "male", "chant", "resident")
+                .unwrap()
+                .id,
+            "laborer"
+        );
+
+        let (mut documents, files) = raw_catalog();
+        let investigation = documents
+            .iter_mut()
+            .find(|document| document["witness_demographics"].is_array())
+            .unwrap();
+        investigation["witness_demographics"][2]["match_rules"][0]["professions"] =
+            serde_json::json!(["mer"]);
+        assert!(
+            crate::quest_catalog_validation::validate_documents(&documents, &files)
+                .unwrap_err()
+                .contains("matches no authoritative NPC profession")
         );
     }
 

--- a/crates/adventuresim-core/src/quest_catalog_validation.rs
+++ b/crates/adventuresim-core/src/quest_catalog_validation.rs
@@ -1,0 +1,1110 @@
+//! Dependency-light validation shared verbatim by `build.rs`, runtime startup,
+//! and the authoring checker.
+
+use serde_json::{Map, Value};
+use std::collections::{BTreeMap, BTreeSet};
+
+const ROOT_KEYS: &[&str] = &[
+    "monsters",
+    "evidence",
+    "witness_demographics",
+    "circumstances",
+    "sites",
+    "descriptions",
+    "templates",
+    "consequences",
+    "relations",
+    "bridges",
+];
+const MONSTER_KEYS: &[&str] = &[
+    "id",
+    "name",
+    "singular",
+    "plural",
+    "aliases",
+    "base_weight",
+    "curation_weight",
+    "northern_germany_prior",
+    "combat",
+    "investigation",
+];
+const COMBAT_KEYS: &[&str] = &[
+    "rig",
+    "speed_m_per_minute",
+    "weight_kg",
+    "attack",
+    "ranged",
+    "precision_bonus_milli",
+    "training_multiplier_milli",
+    "perception",
+    "stealth",
+    "morale",
+    "protection",
+    "resistance_joules",
+    "padding_joules",
+    "disease_risk",
+    "fear",
+    "temperament",
+    "encounter_scale_basis_points",
+    "loot_item_id",
+];
+const INVESTIGATION_KEYS: &[&str] = &[
+    "habitats",
+    "activity",
+    "victim_tags",
+    "tracks",
+    "wounds",
+    "disturbances",
+    "sounds",
+    "silhouettes",
+    "odors",
+    "mistaken_for",
+    "distinguishing_clues",
+    "preparation_advice",
+    "evidence_visibility",
+    "identification_challenge",
+    "location_challenge",
+    "countermeasure_hypotheses",
+];
+const EVIDENCE_KEYS: &[&str] = &[
+    "id",
+    "portrait_label",
+    "portrait_icon",
+    "base_description",
+    "topics",
+];
+const TOPIC_KEYS: &[&str] = &["id", "label", "inspection_description", "check"];
+const CHECK_KEYS: &[&str] = &[
+    "stat",
+    "difficulty_min_milli",
+    "difficulty_max_milli",
+    "success_description",
+    "reveals_clue",
+];
+const DEMOGRAPHIC_KEYS: &[&str] = &["id", "label", "match_rules"];
+const MATCH_RULE_KEYS: &[&str] = &[
+    "priority",
+    "age_bands",
+    "sexes",
+    "professions",
+    "local_roles",
+    "fallback",
+];
+const CIRCUMSTANCE_KEYS: &[&str] = &["id", "statement"];
+const SITE_KEYS: &[&str] = &["id", "label", "terrain", "habitat"];
+const DESCRIPTION_KEYS: &[&str] = &["id", "text"];
+const TEMPLATE_KEYS: &[&str] = &[
+    "id",
+    "label",
+    "routes",
+    "objectives",
+    "cause_finales",
+    "consequence_profile",
+    "incident_interval_minutes",
+    "maximum_incidents",
+];
+const CONSEQUENCE_KEYS: &[&str] = &[
+    "id",
+    "family",
+    "causes",
+    "symptom",
+    "buy_bps",
+    "sell_penalty_bps",
+    "encounter_frequency_bps",
+    "encounter_archetype",
+    "disease_intensity",
+    "public_summary",
+];
+const RELATION_KEYS: &[&str] = &["id", "candidates"];
+const CANDIDATE_KEYS: &[&str] = &[
+    "id",
+    "plausibility",
+    "curation",
+    "hard_zero_reason",
+    "required_bridge",
+    "factors",
+];
+const BRIDGE_KEYS: &[&str] = &[
+    "id",
+    "explanation",
+    "lead_summary",
+    "event_suffix",
+    "evidence_id",
+    "action_ids",
+];
+
+fn object<'a>(value: &'a Value, at: &str) -> Result<&'a Map<String, Value>, String> {
+    value
+        .as_object()
+        .ok_or_else(|| format!("{at}: expected object"))
+}
+fn array<'a>(value: &'a Value, at: &str) -> Result<&'a [Value], String> {
+    value
+        .as_array()
+        .map(Vec::as_slice)
+        .ok_or_else(|| format!("{at}: expected array"))
+}
+fn string<'a>(object: &'a Map<String, Value>, key: &str, at: &str) -> Result<&'a str, String> {
+    object
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{at}.{key}: expected string"))
+}
+fn keys(object: &Map<String, Value>, allowed: &[&str], at: &str) -> Result<(), String> {
+    for key in object.keys() {
+        if !allowed.contains(&key.as_str()) {
+            return Err(format!("{at}.{key}: unknown field"));
+        }
+    }
+    Ok(())
+}
+fn id(value: &str, at: &str) -> Result<(), String> {
+    if value.is_empty()
+        || value.len() > 63
+        || !value.bytes().all(|byte| {
+            byte.is_ascii_lowercase()
+                || byte.is_ascii_digit()
+                || matches!(byte, b'_' | b'-' | b'.' | b':')
+        })
+    {
+        return Err(format!("{at}: invalid bounded catalog ID {value:?}"));
+    }
+    Ok(())
+}
+fn enum_value(value: &str, allowed: &[&str], at: &str) -> Result<(), String> {
+    if allowed.contains(&value) {
+        Ok(())
+    } else {
+        Err(format!("{at}: unknown mechanic {value}"))
+    }
+}
+fn unsigned(
+    object: &Map<String, Value>,
+    key: &str,
+    min: u64,
+    max: u64,
+    at: &str,
+) -> Result<u64, String> {
+    let value = object
+        .get(key)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("{at}.{key}: expected unsigned integer"))?;
+    if !(min..=max).contains(&value) {
+        return Err(format!("{at}.{key}: value {value} outside {min}..={max}"));
+    }
+    Ok(value)
+}
+fn signed(
+    object: &Map<String, Value>,
+    key: &str,
+    min: i64,
+    max: i64,
+    at: &str,
+) -> Result<i64, String> {
+    let value = object
+        .get(key)
+        .and_then(Value::as_i64)
+        .ok_or_else(|| format!("{at}.{key}: expected integer"))?;
+    if !(min..=max).contains(&value) {
+        return Err(format!("{at}.{key}: value {value} outside {min}..={max}"));
+    }
+    Ok(value)
+}
+fn boolean(object: &Map<String, Value>, key: &str, at: &str) -> Result<bool, String> {
+    object
+        .get(key)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| format!("{at}.{key}: expected boolean"))
+}
+fn nonempty_string<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    at: &str,
+) -> Result<&'a str, String> {
+    let value = string(object, key, at)?;
+    if value.trim().is_empty() {
+        Err(format!("{at}.{key}: must not be empty"))
+    } else {
+        Ok(value)
+    }
+}
+fn list_strings(object: &Map<String, Value>, key: &str, at: &str) -> Result<Vec<String>, String> {
+    array(
+        object
+            .get(key)
+            .ok_or_else(|| format!("{at}.{key}: missing"))?,
+        &format!("{at}.{key}"),
+    )?
+    .iter()
+    .enumerate()
+    .map(|(index, value)| {
+        value
+            .as_str()
+            .map(str::to_owned)
+            .ok_or_else(|| format!("{at}.{key}[{index}]: expected string"))
+    })
+    .collect()
+}
+
+#[derive(Clone)]
+struct DemographicRule {
+    demographic: String,
+    at: String,
+    priority: i64,
+    age_bands: Vec<String>,
+    sexes: Vec<String>,
+    professions: Vec<String>,
+    local_roles: Vec<String>,
+    fallback: bool,
+}
+
+fn selectors_overlap(left: &[String], right: &[String]) -> bool {
+    left.is_empty()
+        || right.is_empty()
+        || left.iter().any(|left| {
+            right
+                .iter()
+                .any(|right| left.contains(right) || right.contains(left))
+        })
+}
+
+pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), String> {
+    if documents.len() != files.len() || documents.is_empty() {
+        return Err("catalog: document/source mismatch or empty catalog".into());
+    }
+    let mut namespaces = BTreeMap::<&str, BTreeSet<String>>::new();
+    let mut relations =
+        BTreeMap::<String, Vec<(String, u64, u64, Option<String>, Option<String>)>>::new();
+    let mut monster_refs = Vec::new();
+    let mut description_support = Vec::new();
+    let mut bridge_refs = Vec::new();
+    let mut demographic_rules = Vec::new();
+    let mut template_profiles = Vec::new();
+    let mut consequence_families = BTreeMap::<String, BTreeSet<String>>::new();
+    let mut fallback_demographics = 0usize;
+    for (document_index, document) in documents.iter().enumerate() {
+        let file = &files[document_index];
+        let root = object(document, file)?;
+        keys(root, ROOT_KEYS, file)?;
+        for root_key in ROOT_KEYS {
+            let Some(items) = root.get(*root_key) else {
+                continue;
+            };
+            for (index, item) in array(items, &format!("{file}.{root_key}"))?
+                .iter()
+                .enumerate()
+            {
+                let at = format!("{file}.{root_key}[{index}]");
+                let item = object(item, &at)?;
+                let allowed = match *root_key {
+                    "monsters" => MONSTER_KEYS,
+                    "evidence" => EVIDENCE_KEYS,
+                    "witness_demographics" => DEMOGRAPHIC_KEYS,
+                    "circumstances" => CIRCUMSTANCE_KEYS,
+                    "sites" => SITE_KEYS,
+                    "descriptions" => DESCRIPTION_KEYS,
+                    "templates" => TEMPLATE_KEYS,
+                    "consequences" => CONSEQUENCE_KEYS,
+                    "relations" => RELATION_KEYS,
+                    "bridges" => BRIDGE_KEYS,
+                    _ => unreachable!(),
+                };
+                keys(item, allowed, &at)?;
+                let item_id = string(item, "id", &at)?;
+                id(item_id, &format!("{at}.id"))?;
+                if !namespaces
+                    .entry(root_key)
+                    .or_default()
+                    .insert(item_id.into())
+                {
+                    return Err(format!("{at}.id: duplicate {root_key} ID {item_id}"));
+                }
+                match *root_key {
+                    "monsters" => {
+                        for key in ["name", "singular", "plural"] {
+                            nonempty_string(item, key, &at)?;
+                        }
+                        for alias in list_strings(item, "aliases", &at)? {
+                            if alias.trim().is_empty() {
+                                return Err(format!("{at}.aliases: empty alias"));
+                            }
+                        }
+                        unsigned(item, "base_weight", 1, u16::MAX.into(), &at)?;
+                        unsigned(item, "curation_weight", 1, u16::MAX.into(), &at)?;
+                        unsigned(item, "northern_germany_prior", 1, u16::MAX.into(), &at)?;
+                        let combat = object(
+                            item.get("combat")
+                                .ok_or_else(|| format!("{at}.combat: missing"))?,
+                            &format!("{at}.combat"),
+                        )?;
+                        keys(combat, COMBAT_KEYS, &format!("{at}.combat"))?;
+                        enum_value(
+                            string(combat, "rig", &at)?,
+                            &["humanoid", "quadruped"],
+                            &format!("{at}.combat.rig"),
+                        )?;
+                        enum_value(
+                            string(combat, "attack", &at)?,
+                            &[
+                                "blade", "blunt", "knife", "spear", "bow", "bite", "claw", "tusk",
+                            ],
+                            &format!("{at}.combat.attack"),
+                        )?;
+                        enum_value(
+                            string(combat, "protection", &at)?,
+                            &[
+                                "unarmored",
+                                "hide",
+                                "shielded",
+                                "armored",
+                                "bone",
+                                "supernatural",
+                            ],
+                            &format!("{at}.combat.protection"),
+                        )?;
+                        enum_value(
+                            string(combat, "temperament", &at)?,
+                            &[
+                                "cowardly",
+                                "cautious",
+                                "disciplined",
+                                "aggressive",
+                                "relentless",
+                                "elusive",
+                            ],
+                            &format!("{at}.combat.temperament"),
+                        )?;
+                        unsigned(
+                            combat,
+                            "speed_m_per_minute",
+                            1,
+                            u32::MAX.into(),
+                            &format!("{at}.combat"),
+                        )?;
+                        let weight = combat
+                            .get("weight_kg")
+                            .and_then(Value::as_f64)
+                            .ok_or_else(|| format!("{at}.combat.weight_kg: expected number"))?;
+                        if !weight.is_finite() || weight <= 0.0 {
+                            return Err(format!("{at}.combat.weight_kg: must be positive"));
+                        }
+                        boolean(combat, "ranged", &format!("{at}.combat"))?;
+                        signed(
+                            combat,
+                            "precision_bonus_milli",
+                            i32::MIN.into(),
+                            i32::MAX.into(),
+                            &format!("{at}.combat"),
+                        )?;
+                        unsigned(
+                            combat,
+                            "training_multiplier_milli",
+                            1,
+                            u16::MAX.into(),
+                            &format!("{at}.combat"),
+                        )?;
+                        for key in ["perception", "stealth", "morale", "disease_risk", "fear"] {
+                            unsigned(combat, key, 0, 100, &format!("{at}.combat"))?;
+                        }
+                        let resistance = unsigned(
+                            combat,
+                            "resistance_joules",
+                            0,
+                            20_000,
+                            &format!("{at}.combat"),
+                        )?;
+                        let padding =
+                            unsigned(combat, "padding_joules", 0, 20_000, &format!("{at}.combat"))?;
+                        unsigned(
+                            combat,
+                            "encounter_scale_basis_points",
+                            1,
+                            u16::MAX.into(),
+                            &format!("{at}.combat"),
+                        )?;
+                        if let Some(loot) =
+                            combat.get("loot_item_id").filter(|value| !value.is_null())
+                        {
+                            let loot = loot.as_str().ok_or_else(|| {
+                                format!("{at}.combat.loot_item_id: expected string or null")
+                            })?;
+                            id(loot, &format!("{at}.combat.loot_item_id"))?;
+                        }
+                        if string(combat, "protection", &at)? == "armored"
+                            && (resistance > 0 || padding > 0)
+                        {
+                            return Err(format!(
+                                "{at}.combat: worn armor cannot compose with innate resistance/padding yet"
+                            ));
+                        }
+                        let investigation = object(
+                            item.get("investigation")
+                                .ok_or_else(|| format!("{at}.investigation: missing"))?,
+                            &format!("{at}.investigation"),
+                        )?;
+                        keys(
+                            investigation,
+                            INVESTIGATION_KEYS,
+                            &format!("{at}.investigation"),
+                        )?;
+                        enum_value(
+                            string(investigation, "activity", &at)?,
+                            &["day", "night", "any"],
+                            &format!("{at}.investigation.activity"),
+                        )?;
+                        for habitat in list_strings(investigation, "habitats", &at)? {
+                            enum_value(
+                                &habitat,
+                                &[
+                                    "road",
+                                    "open",
+                                    "sparse_woods",
+                                    "deep_woods",
+                                    "cave",
+                                    "crypt",
+                                    "ruin",
+                                    "camp",
+                                    "mine",
+                                    "graveyard",
+                                    "occupied_house",
+                                ],
+                                &format!("{at}.investigation.habitats"),
+                            )?;
+                        }
+                        for other in list_strings(investigation, "mistaken_for", &at)? {
+                            monster_refs.push((at.clone(), other));
+                        }
+                        for key in [
+                            "tracks",
+                            "wounds",
+                            "disturbances",
+                            "odors",
+                            "distinguishing_clues",
+                        ] {
+                            for evidence_id in list_strings(investigation, key, &at)? {
+                                id(&evidence_id, &format!("{at}.investigation.{key}"))?;
+                            }
+                        }
+                        for description in list_strings(investigation, "silhouettes", &at)? {
+                            description_support.push((item_id.to_owned(), description, at.clone()));
+                        }
+                        for hypothesis in
+                            list_strings(investigation, "countermeasure_hypotheses", &at)?
+                        {
+                            enum_value(
+                                &hypothesis,
+                                &["shattering_blow", "fire", "silver", "daylight", "courage"],
+                                &format!("{at}.investigation.countermeasure_hypotheses"),
+                            )?;
+                        }
+                        for key in ["victim_tags", "sounds"] {
+                            for value in list_strings(investigation, key, &at)? {
+                                if value.trim().is_empty() {
+                                    return Err(format!("{at}.investigation.{key}: empty value"));
+                                }
+                            }
+                        }
+                        nonempty_string(investigation, "preparation_advice", &at)?;
+                        unsigned(
+                            investigation,
+                            "evidence_visibility",
+                            0,
+                            100,
+                            &format!("{at}.investigation"),
+                        )?;
+                        boolean(
+                            investigation,
+                            "identification_challenge",
+                            &format!("{at}.investigation"),
+                        )?;
+                        boolean(
+                            investigation,
+                            "location_challenge",
+                            &format!("{at}.investigation"),
+                        )?;
+                    }
+                    "evidence" => {
+                        for key in ["portrait_label", "portrait_icon", "base_description"] {
+                            nonempty_string(item, key, &at)?;
+                        }
+                        let topics = array(
+                            item.get("topics")
+                                .ok_or_else(|| format!("{at}.topics: missing"))?,
+                            &format!("{at}.topics"),
+                        )?;
+                        if topics.is_empty() {
+                            return Err(format!("{at}.topics: must not be empty"));
+                        }
+                        let mut topic_ids = BTreeSet::new();
+                        for (topic_index, topic) in topics.iter().enumerate() {
+                            let topic_at = format!("{at}.topics[{topic_index}]");
+                            let topic = object(topic, &topic_at)?;
+                            keys(topic, TOPIC_KEYS, &topic_at)?;
+                            let topic_id = string(topic, "id", &topic_at)?;
+                            id(topic_id, &format!("{topic_at}.id"))?;
+                            if !topic_ids.insert(topic_id) {
+                                return Err(format!("{topic_at}.id: duplicate topic"));
+                            }
+                            nonempty_string(topic, "label", &topic_at)?;
+                            nonempty_string(topic, "inspection_description", &topic_at)?;
+                            if let Some(check) = topic.get("check").filter(|value| !value.is_null())
+                            {
+                                let check = object(check, &format!("{topic_at}.check"))?;
+                                keys(check, CHECK_KEYS, &format!("{topic_at}.check"))?;
+                                enum_value(
+                                    string(check, "stat", &topic_at)?,
+                                    &["eyesight", "intelligence", "instinct"],
+                                    &format!("{topic_at}.check.stat"),
+                                )?;
+                                let min = check.get("difficulty_min_milli").and_then(Value::as_u64).ok_or_else(|| format!("{topic_at}.check.difficulty_min_milli: expected integer"))?;
+                                let max = check.get("difficulty_max_milli").and_then(Value::as_u64).ok_or_else(|| format!("{topic_at}.check.difficulty_max_milli: expected integer"))?;
+                                if min > max || max > 10_000 {
+                                    return Err(format!("{topic_at}.check: invalid DC range"));
+                                }
+                                nonempty_string(check, "success_description", &topic_at)?;
+                                boolean(check, "reveals_clue", &format!("{topic_at}.check"))?;
+                            }
+                        }
+                    }
+                    "witness_demographics" => {
+                        nonempty_string(item, "label", &at)?;
+                        let rules = array(
+                            item.get("match_rules")
+                                .ok_or_else(|| format!("{at}.match_rules: missing"))?,
+                            &format!("{at}.match_rules"),
+                        )?;
+                        if rules.is_empty() {
+                            return Err(format!("{at}.match_rules: must not be empty"));
+                        }
+                        for (rule_index, rule) in rules.iter().enumerate() {
+                            let rule_at = format!("{at}.match_rules[{rule_index}]");
+                            let rule = object(rule, &rule_at)?;
+                            keys(rule, MATCH_RULE_KEYS, &rule_at)?;
+                            if rule
+                                .get("fallback")
+                                .and_then(Value::as_bool)
+                                .unwrap_or(false)
+                            {
+                                fallback_demographics += 1;
+                            }
+                            let priority = rule
+                                .get("priority")
+                                .and_then(Value::as_i64)
+                                .ok_or_else(|| format!("{rule_at}.priority: expected integer"))?;
+                            let age_bands = list_strings(rule, "age_bands", &rule_at)?;
+                            let sexes = list_strings(rule, "sexes", &rule_at)?;
+                            let professions = list_strings(rule, "professions", &rule_at)?;
+                            let local_roles = list_strings(rule, "local_roles", &rule_at)?;
+                            for age in &age_bands {
+                                enum_value(
+                                    age,
+                                    &["child", "adolescent", "adult", "elder"],
+                                    &format!("{rule_at}.age_bands"),
+                                )?;
+                            }
+                            for sex in &sexes {
+                                enum_value(sex, &["female", "male"], &format!("{rule_at}.sexes"))?;
+                            }
+                            for (key, values) in
+                                [("professions", &professions), ("local_roles", &local_roles)]
+                            {
+                                for value in values {
+                                    id(value, &format!("{rule_at}.{key}"))?;
+                                }
+                            }
+                            let fallback = rule
+                                .get("fallback")
+                                .and_then(Value::as_bool)
+                                .unwrap_or(false);
+                            if fallback
+                                && (!age_bands.is_empty()
+                                    || !sexes.is_empty()
+                                    || !professions.is_empty()
+                                    || !local_roles.is_empty())
+                            {
+                                return Err(format!(
+                                    "{rule_at}: fallback rule cannot also have selectors"
+                                ));
+                            }
+                            if !fallback
+                                && age_bands.is_empty()
+                                && sexes.is_empty()
+                                && professions.is_empty()
+                                && local_roles.is_empty()
+                            {
+                                return Err(format!(
+                                    "{rule_at}: non-fallback rule needs a selector"
+                                ));
+                            }
+                            demographic_rules.push(DemographicRule {
+                                demographic: item_id.to_owned(),
+                                at: rule_at,
+                                priority,
+                                age_bands,
+                                sexes,
+                                professions,
+                                local_roles,
+                                fallback,
+                            });
+                        }
+                    }
+                    "sites" => {
+                        nonempty_string(item, "label", &at)?;
+                        enum_value(
+                            string(item, "terrain", &at)?,
+                            &["underground", "forest", "settlement", "road"],
+                            &format!("{at}.terrain"),
+                        )?;
+                        enum_value(
+                            string(item, "habitat", &at)?,
+                            &[
+                                "road",
+                                "open",
+                                "sparse_woods",
+                                "deep_woods",
+                                "cave",
+                                "crypt",
+                                "ruin",
+                                "camp",
+                                "mine",
+                                "graveyard",
+                                "occupied_house",
+                            ],
+                            &format!("{at}.habitat"),
+                        )?;
+                    }
+                    "circumstances" => {
+                        nonempty_string(item, "statement", &at)?;
+                    }
+                    "descriptions" => {
+                        nonempty_string(item, "text", &at)?;
+                    }
+                    "templates" => {
+                        nonempty_string(item, "label", &at)?;
+                        let routes = list_strings(item, "routes", &at)?;
+                        let objectives = list_strings(item, "objectives", &at)?;
+                        let (supported_routes, supported_objectives): (&[&str], &[&str]) =
+                            match item_id {
+                                "recurring_depredation" => (
+                                    &["physical_trail", "pattern_surveillance", "social_inquiry"],
+                                    &["defeat", "drive_off"],
+                                ),
+                                "disappearance_or_loss" => (
+                                    &["physical_trail", "social_inquiry"],
+                                    &["rescue", "retrieve_return", "expose"],
+                                ),
+                                _ => return Err(format!("{at}.id: no typed graph assembler")),
+                            };
+                        if routes.iter().map(String::as_str).collect::<Vec<_>>() != supported_routes
+                            || objectives.iter().map(String::as_str).collect::<Vec<_>>()
+                                != supported_objectives
+                        {
+                            return Err(format!("{at}: unsupported route/objective graph"));
+                        }
+                        unsigned(item, "incident_interval_minutes", 1, u64::MAX, &at)?;
+                        unsigned(item, "maximum_incidents", 1, u8::MAX.into(), &at)?;
+                        let plans = object(
+                            item.get("cause_finales")
+                                .ok_or_else(|| format!("{at}.cause_finales: missing"))?,
+                            &format!("{at}.cause_finales"),
+                        )?;
+                        if plans.is_empty() {
+                            return Err(format!("{at}.cause_finales: empty"));
+                        }
+                        let mut parsed_plans = BTreeMap::<String, Vec<String>>::new();
+                        for (cause, finales) in plans {
+                            if cause != "*" {
+                                id(cause, &format!("{at}.cause_finales.{cause}"))?;
+                            }
+                            let mut parsed_finales = Vec::new();
+                            for finale in array(finales, &format!("{at}.cause_finales.{cause}"))? {
+                                let finale = finale.as_str().ok_or_else(|| {
+                                    format!("{at}.cause_finales.{cause}: expected strings")
+                                })?;
+                                if !objectives.iter().any(|value| value == finale) {
+                                    return Err(format!(
+                                        "{at}.cause_finales.{cause}: unknown objective {finale}"
+                                    ));
+                                }
+                                parsed_finales.push(finale.to_owned());
+                            }
+                            parsed_plans.insert(cause.to_owned(), parsed_finales);
+                        }
+                        let expected_plans = match item_id {
+                            "recurring_depredation" => BTreeMap::from([(
+                                "*".to_owned(),
+                                vec!["defeat".to_owned(), "drive_off".to_owned()],
+                            )]),
+                            "disappearance_or_loss" => BTreeMap::from([
+                                ("concealment".to_owned(), vec!["rescue".to_owned()]),
+                                ("fabricated".to_owned(), vec!["expose".to_owned()]),
+                                ("hostile".to_owned(), vec!["rescue".to_owned()]),
+                                (
+                                    "incidental_loss".to_owned(),
+                                    vec!["retrieve_return".to_owned()],
+                                ),
+                            ]),
+                            _ => unreachable!(),
+                        };
+                        if parsed_plans != expected_plans {
+                            return Err(format!(
+                                "{at}.cause_finales: unsupported cause/finale coverage"
+                            ));
+                        }
+                        template_profiles.push((
+                            at.clone(),
+                            item_id.to_owned(),
+                            string(item, "consequence_profile", &at)?.to_owned(),
+                        ));
+                    }
+                    "consequences" => {
+                        enum_value(
+                            string(item, "symptom", &at)?,
+                            &[
+                                "night_screams",
+                                "vanished_livestock",
+                                "missing_caravans",
+                                "empty_stalls",
+                            ],
+                            &format!("{at}.symptom"),
+                        )?;
+                        if let Some(archetype) =
+                            item.get("encounter_archetype").and_then(Value::as_str)
+                        {
+                            enum_value(
+                                archetype,
+                                &["undead", "goblins", "bandits"],
+                                &format!("{at}.encounter_archetype"),
+                            )?;
+                        }
+                        let causes = list_strings(item, "causes", &at)?;
+                        if causes.is_empty() {
+                            return Err(format!("{at}.causes: empty"));
+                        }
+                        let family = string(item, "family", &at)?;
+                        id(family, &format!("{at}.family"))?;
+                        for cause in &causes {
+                            if cause != "*" {
+                                id(cause, &format!("{at}.causes"))?;
+                            }
+                        }
+                        consequence_families
+                            .entry(family.to_owned())
+                            .or_default()
+                            .extend(causes);
+                        signed(item, "buy_bps", -10_000, 10_000, &at)?;
+                        signed(item, "sell_penalty_bps", -10_000, 10_000, &at)?;
+                        unsigned(item, "encounter_frequency_bps", 0, 10_000, &at)?;
+                        unsigned(item, "disease_intensity", 0, 10_000, &at)?;
+                        nonempty_string(item, "public_summary", &at)?;
+                    }
+                    "bridges" => {
+                        for key in ["event_suffix", "evidence_id"] {
+                            id(string(item, key, &at)?, &format!("{at}.{key}"))?;
+                        }
+                        let action_ids = object(
+                            item.get("action_ids")
+                                .ok_or_else(|| format!("{at}.action_ids: missing"))?,
+                            &format!("{at}.action_ids"),
+                        )?;
+                        keys(
+                            action_ids,
+                            &["recurring_depredation", "disappearance_or_loss"],
+                            &format!("{at}.action_ids"),
+                        )?;
+                        for family in ["recurring_depredation", "disappearance_or_loss"] {
+                            let action = string(action_ids, family, &format!("{at}.action_ids"))?;
+                            id(action, &format!("{at}.action_ids.{family}"))?;
+                            let supported = match family {
+                                "recurring_depredation" => &[
+                                    "locate_contact",
+                                    "approach",
+                                    "search",
+                                    "follow",
+                                    "inspect_finale",
+                                    "watch",
+                                    "patrol",
+                                    "reveal_route",
+                                    "ambush",
+                                ][..],
+                                "disappearance_or_loss" => &[
+                                    "inspect_last_known",
+                                    "resolve_physical",
+                                    "follow",
+                                    "locate_contact",
+                                    "approach_social",
+                                    "resolve_social",
+                                ][..],
+                                _ => unreachable!(),
+                            };
+                            if !supported.contains(&action) {
+                                return Err(format!(
+                                    "{at}.action_ids.{family}: action {action} is not emitted by the typed assembler"
+                                ));
+                            }
+                        }
+                        if string(item, "explanation", &at)?.trim().is_empty()
+                            || string(item, "lead_summary", &at)?.trim().is_empty()
+                        {
+                            return Err(format!("{at}: bridge prose must not be empty"));
+                        }
+                    }
+                    "relations" => {
+                        let candidates = array(
+                            item.get("candidates")
+                                .ok_or_else(|| format!("{at}.candidates: missing"))?,
+                            &format!("{at}.candidates"),
+                        )?;
+                        if candidates.is_empty() {
+                            return Err(format!("{at}.candidates: empty"));
+                        }
+                        let mut seen = BTreeSet::new();
+                        let mut parsed = Vec::new();
+                        for (candidate_index, candidate) in candidates.iter().enumerate() {
+                            let candidate_at = format!("{at}.candidates[{candidate_index}]");
+                            let candidate = object(candidate, &candidate_at)?;
+                            keys(candidate, CANDIDATE_KEYS, &candidate_at)?;
+                            let candidate_id = string(candidate, "id", &candidate_at)?;
+                            id(candidate_id, &format!("{candidate_at}.id"))?;
+                            if !seen.insert(candidate_id) {
+                                return Err(format!("{candidate_at}.id: duplicate candidate"));
+                            }
+                            let p = candidate
+                                .get("plausibility")
+                                .and_then(Value::as_u64)
+                                .ok_or_else(|| {
+                                    format!("{candidate_at}.plausibility: expected integer")
+                                })?;
+                            let c = candidate
+                                .get("curation")
+                                .and_then(Value::as_u64)
+                                .ok_or_else(|| {
+                                    format!("{candidate_at}.curation: expected integer")
+                                })?;
+                            let zero_reason = candidate
+                                .get("hard_zero_reason")
+                                .and_then(Value::as_str)
+                                .map(str::to_owned);
+                            if (p == 0 || c == 0) != zero_reason.is_some() {
+                                return Err(format!("{candidate_at}: zero weight/reason mismatch"));
+                            }
+                            let bridge = candidate
+                                .get("required_bridge")
+                                .and_then(Value::as_str)
+                                .map(str::to_owned);
+                            if let Some(value) = &bridge {
+                                bridge_refs.push((candidate_at.clone(), value.clone()));
+                            }
+                            parsed.push((candidate_id.into(), p, c, zero_reason, bridge));
+                        }
+                        relations.insert(item_id.into(), parsed);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    let monsters = namespaces.get("monsters").cloned().unwrap_or_default();
+    let evidence = namespaces.get("evidence").cloned().unwrap_or_default();
+    let demographics = namespaces
+        .get("witness_demographics")
+        .cloned()
+        .unwrap_or_default();
+    let circumstances = namespaces.get("circumstances").cloned().unwrap_or_default();
+    let sites = namespaces.get("sites").cloned().unwrap_or_default();
+    let descriptions = namespaces.get("descriptions").cloned().unwrap_or_default();
+    let templates = namespaces.get("templates").cloned().unwrap_or_default();
+    let bridges = namespaces.get("bridges").cloned().unwrap_or_default();
+    for (at, target) in monster_refs {
+        if !monsters.contains(&target) {
+            return Err(format!("{at}.mistaken_for: dangling monster {target}"));
+        }
+    }
+    for (at, bridge) in bridge_refs {
+        if !bridges.contains(&bridge) {
+            return Err(format!("{at}.required_bridge: dangling bridge {bridge}"));
+        }
+    }
+    for (monster, description, at) in description_support {
+        if !descriptions.contains(&description) {
+            return Err(format!(
+                "{at}.silhouettes: dangling description {description}"
+            ));
+        }
+        let relation = relations
+            .get(&format!("description.{description}"))
+            .ok_or_else(|| format!("{at}.silhouettes: missing description relation"))?;
+        if !relation
+            .iter()
+            .any(|candidate| candidate.0 == monster && candidate.1 > 0 && candidate.2 > 0)
+        {
+            return Err(format!(
+                "{at}.silhouettes: missing positive likelihood for {monster}/{description}"
+            ));
+        }
+    }
+    for (relation_id, candidates) in &relations {
+        let (namespace, context) = relation_id
+            .split_once('.')
+            .map_or((relation_id.as_str(), None), |(left, right)| {
+                (left, Some(right))
+            });
+        let allowed: Option<&BTreeSet<String>> = match namespace {
+            "family" if context.is_none() => Some(&templates),
+            "cause" => {
+                let template = context.ok_or_else(|| {
+                    format!("catalog.relations.{relation_id}: missing template suffix")
+                })?;
+                if !templates.contains(template) {
+                    return Err(format!(
+                        "catalog.relations.{relation_id}: dangling template {template}"
+                    ));
+                }
+                None
+            }
+            "site" => {
+                let monster = context.ok_or_else(|| {
+                    format!("catalog.relations.{relation_id}: missing monster suffix")
+                })?;
+                if !monsters.contains(monster) {
+                    return Err(format!(
+                        "catalog.relations.{relation_id}: dangling monster {monster}"
+                    ));
+                }
+                Some(&sites)
+            }
+            "circumstance" => {
+                let demographic = context.ok_or_else(|| {
+                    format!("catalog.relations.{relation_id}: missing demographic suffix")
+                })?;
+                if !demographics.contains(demographic) {
+                    return Err(format!(
+                        "catalog.relations.{relation_id}: dangling demographic {demographic}"
+                    ));
+                }
+                Some(&circumstances)
+            }
+            "description" => {
+                let description = context.ok_or_else(|| {
+                    format!("catalog.relations.{relation_id}: missing description suffix")
+                })?;
+                if !descriptions.contains(description) {
+                    return Err(format!(
+                        "catalog.relations.{relation_id}: dangling description {description}"
+                    ));
+                }
+                Some(&monsters)
+            }
+            "evidence" => Some(&evidence),
+            "reliability" | "account" | "route" | "pattern" => None,
+            _ => {
+                return Err(format!(
+                    "catalog.relations.{relation_id}: unsupported relation namespace"
+                ));
+            }
+        };
+        for (candidate, _, _, _, _) in candidates {
+            if let Some(allowed) = allowed
+                && !allowed.contains(candidate)
+            {
+                return Err(format!(
+                    "catalog.relations.{relation_id}: dangling candidate {candidate}"
+                ));
+            }
+            let closed = match namespace {
+                "cause" if !monsters.contains(candidate) => {
+                    Some(&["concealment", "incidental_loss", "fabricated"][..])
+                }
+                "reliability" => Some(
+                    &[
+                        "truthful",
+                        "mistaken",
+                        "evasive",
+                        "deceptive",
+                        "partly_truthful",
+                    ][..],
+                ),
+                "account" => Some(&["visual", "heard", "tracks"][..]),
+                "route" => Some(&["direct", "cautious"][..]),
+                "pattern" => Some(&["nightly", "roadside", "victim_specific", "irregular"][..]),
+                _ => None,
+            };
+            if let Some(closed) = closed
+                && !closed.contains(&candidate.as_str())
+            {
+                return Err(format!(
+                    "catalog.relations.{relation_id}: unknown candidate {candidate}"
+                ));
+            }
+        }
+    }
+    if fallback_demographics != 1 {
+        return Err(format!(
+            "catalog.witness_demographics: expected exactly one fallback rule, found {fallback_demographics}"
+        ));
+    }
+    for (index, left) in demographic_rules.iter().enumerate() {
+        for right in demographic_rules.iter().skip(index + 1) {
+            if left.demographic != right.demographic
+                && !left.fallback
+                && !right.fallback
+                && left.priority == right.priority
+                && selectors_overlap(&left.age_bands, &right.age_bands)
+                && selectors_overlap(&left.sexes, &right.sexes)
+                && selectors_overlap(&left.professions, &right.professions)
+                && selectors_overlap(&left.local_roles, &right.local_roles)
+            {
+                return Err(format!(
+                    "{} and {}: equal-priority demographic rules can match the same NPC",
+                    left.at, right.at
+                ));
+            }
+        }
+    }
+    for (at, template_id, profile) in template_profiles {
+        let causes = consequence_families.get(&profile).ok_or_else(|| {
+            format!("{at}.consequence_profile: missing consequence family {profile}")
+        })?;
+        if !causes.contains("*") {
+            let cause_relation = relations
+                .get(&format!("cause.{template_id}"))
+                .ok_or_else(|| format!("{at}: missing cause relation"))?;
+            for (cause, plausibility, curation, _, _) in cause_relation {
+                if *plausibility > 0 && *curation > 0 && !causes.contains(cause) {
+                    return Err(format!(
+                        "{at}.consequence_profile: no consequence for possible cause {cause}"
+                    ));
+                }
+            }
+        }
+    }
+    for required in [
+        "family",
+        "cause.recurring_depredation",
+        "cause.disappearance_or_loss",
+        "reliability.baseline",
+        "account.baseline",
+        "route.recurring_depredation",
+        "route.disappearance_or_loss",
+        "pattern.recurring_depredation",
+        "pattern.disappearance_or_loss",
+        "evidence.baseline",
+    ] {
+        if !relations.contains_key(required) {
+            return Err(format!(
+                "catalog.relations: missing required relation {required}"
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn ids_are_bounded_to_runtime_capacity() {
+        assert!(id(&"a".repeat(63), "fixture").is_ok());
+        assert!(id(&"a".repeat(64), "fixture").is_err());
+    }
+}

--- a/crates/adventuresim-core/src/quest_catalog_validation.rs
+++ b/crates/adventuresim-core/src/quest_catalog_validation.rs
@@ -228,6 +228,17 @@ fn nonempty_string<'a>(
         Ok(value)
     }
 }
+fn optional_string<'a>(
+    object: &'a Map<String, Value>,
+    key: &str,
+    at: &str,
+) -> Result<Option<&'a str>, String> {
+    match object.get(key) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value)),
+        Some(_) => Err(format!("{at}.{key}: expected string or null")),
+    }
+}
 fn list_strings(object: &Map<String, Value>, key: &str, at: &str) -> Result<Vec<String>, String> {
     array(
         object
@@ -245,12 +256,31 @@ fn list_strings(object: &Map<String, Value>, key: &str, at: &str) -> Result<Vec<
     })
     .collect()
 }
+fn optional_list_strings(
+    object: &Map<String, Value>,
+    key: &str,
+    at: &str,
+) -> Result<Vec<String>, String> {
+    match object.get(key) {
+        None => Ok(Vec::new()),
+        Some(value) => array(value, &format!("{at}.{key}"))?
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                value
+                    .as_str()
+                    .map(str::to_owned)
+                    .ok_or_else(|| format!("{at}.{key}[{index}]: expected string"))
+            })
+            .collect(),
+    }
+}
 
 #[derive(Clone)]
 struct DemographicRule {
     demographic: String,
     at: String,
-    priority: i64,
+    priority: i32,
     age_bands: Vec<String>,
     sexes: Vec<String>,
     professions: Vec<String>,
@@ -258,13 +288,58 @@ struct DemographicRule {
     fallback: bool,
 }
 
-fn selectors_overlap(left: &[String], right: &[String]) -> bool {
+pub(crate) fn selector_matches_fact(selector: &str, fact: &str) -> bool {
+    let selector = selector.trim().to_ascii_lowercase();
+    let fact = fact.trim().to_ascii_lowercase();
+    selector == fact
+        || fact
+            .split(|character: char| !character.is_ascii_alphanumeric())
+            .any(|token| !token.is_empty() && token == selector)
+}
+
+const PROFESSION_FACTS: &[&str] = &[
+    "artisan",
+    "householder",
+    "laborer",
+    "retainer",
+    "service provider",
+    "merchant",
+    "weaponsmith",
+    "armourer",
+    "tailor",
+    "herbalist",
+    "innkeeper",
+    "cleric",
+    "guard",
+    "soldier",
+    "noble",
+];
+const LOCAL_ROLE_FACTS: &[&str] = &[
+    "market steward",
+    "master weaponsmith",
+    "master armourer",
+    "master tailor",
+    "local healer",
+    "innkeeper",
+    "parish priest",
+    "customer or visitor",
+    "neighbor",
+    "household representative",
+    "local resident",
+    "resident",
+    "lord's household retainer",
+    "keep servant",
+];
+
+fn selectors_overlap(left: &[String], right: &[String], facts: &[&str]) -> bool {
     left.is_empty()
         || right.is_empty()
-        || left.iter().any(|left| {
-            right
-                .iter()
-                .any(|right| left.contains(right) || right.contains(left))
+        || facts.iter().any(|fact| {
+            left.iter()
+                .any(|selector| selector_matches_fact(selector, fact))
+                && right
+                    .iter()
+                    .any(|selector| selector_matches_fact(selector, fact))
         })
 }
 
@@ -385,10 +460,18 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                             .get("weight_kg")
                             .and_then(Value::as_f64)
                             .ok_or_else(|| format!("{at}.combat.weight_kg: expected number"))?;
-                        if !weight.is_finite() || weight <= 0.0 {
-                            return Err(format!("{at}.combat.weight_kg: must be positive"));
+                        if !weight.is_finite() || weight <= 0.0 || weight > f64::from(f32::MAX) {
+                            return Err(format!(
+                                "{at}.combat.weight_kg: must be a positive finite f32"
+                            ));
                         }
-                        boolean(combat, "ranged", &format!("{at}.combat"))?;
+                        let ranged = boolean(combat, "ranged", &format!("{at}.combat"))?;
+                        let attack = string(combat, "attack", &at)?;
+                        if (attack == "bow") != ranged {
+                            return Err(format!(
+                                "{at}.combat: bow attack and ranged flag must agree"
+                            ));
+                        }
                         signed(
                             combat,
                             "precision_bonus_milli",
@@ -423,11 +506,8 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                             &format!("{at}.combat"),
                         )?;
                         if let Some(loot) =
-                            combat.get("loot_item_id").filter(|value| !value.is_null())
+                            optional_string(combat, "loot_item_id", &format!("{at}.combat"))?
                         {
-                            let loot = loot.as_str().ok_or_else(|| {
-                                format!("{at}.combat.loot_item_id: expected string or null")
-                            })?;
                             id(loot, &format!("{at}.combat.loot_item_id"))?;
                         }
                         if string(combat, "protection", &at)? == "armored"
@@ -452,7 +532,11 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                             &["day", "night", "any"],
                             &format!("{at}.investigation.activity"),
                         )?;
-                        for habitat in list_strings(investigation, "habitats", &at)? {
+                        let habitats = list_strings(investigation, "habitats", &at)?;
+                        if habitats.is_empty() {
+                            return Err(format!("{at}.investigation.habitats: must not be empty"));
+                        }
+                        for habitat in habitats {
                             enum_value(
                                 &habitat,
                                 &[
@@ -485,8 +569,19 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                                 id(&evidence_id, &format!("{at}.investigation.{key}"))?;
                             }
                         }
-                        for description in list_strings(investigation, "silhouettes", &at)? {
+                        let silhouettes = list_strings(investigation, "silhouettes", &at)?;
+                        if silhouettes.is_empty() {
+                            return Err(format!(
+                                "{at}.investigation.silhouettes: must not be empty"
+                            ));
+                        }
+                        for description in silhouettes {
                             description_support.push((item_id.to_owned(), description, at.clone()));
+                        }
+                        if list_strings(investigation, "distinguishing_clues", &at)?.is_empty() {
+                            return Err(format!(
+                                "{at}.investigation.distinguishing_clues: must not be empty"
+                            ));
                         }
                         for hypothesis in
                             list_strings(investigation, "countermeasure_hypotheses", &at)?
@@ -580,17 +675,20 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                             let rule_at = format!("{at}.match_rules[{rule_index}]");
                             let rule = object(rule, &rule_at)?;
                             keys(rule, MATCH_RULE_KEYS, &rule_at)?;
-                            if rule
-                                .get("fallback")
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false)
-                            {
+                            let fallback = match rule.get("fallback") {
+                                None => false,
+                                Some(_) => boolean(rule, "fallback", &rule_at)?,
+                            };
+                            if fallback {
                                 fallback_demographics += 1;
                             }
-                            let priority = rule
-                                .get("priority")
-                                .and_then(Value::as_i64)
-                                .ok_or_else(|| format!("{rule_at}.priority: expected integer"))?;
+                            let priority = signed(
+                                rule,
+                                "priority",
+                                i32::MIN.into(),
+                                i32::MAX.into(),
+                                &rule_at,
+                            )? as i32;
                             let age_bands = list_strings(rule, "age_bands", &rule_at)?;
                             let sexes = list_strings(rule, "sexes", &rule_at)?;
                             let professions = list_strings(rule, "professions", &rule_at)?;
@@ -612,10 +710,26 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                                     id(value, &format!("{rule_at}.{key}"))?;
                                 }
                             }
-                            let fallback = rule
-                                .get("fallback")
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false);
+                            for selector in &professions {
+                                if !PROFESSION_FACTS
+                                    .iter()
+                                    .any(|fact| selector_matches_fact(selector, fact))
+                                {
+                                    return Err(format!(
+                                        "{rule_at}.professions: selector {selector:?} matches no authoritative NPC profession"
+                                    ));
+                                }
+                            }
+                            for selector in &local_roles {
+                                if !LOCAL_ROLE_FACTS
+                                    .iter()
+                                    .any(|fact| selector_matches_fact(selector, fact))
+                                {
+                                    return Err(format!(
+                                        "{rule_at}.local_roles: selector {selector:?} matches no authoritative NPC local role"
+                                    ));
+                                }
+                            }
                             if fallback
                                 && (!age_bands.is_empty()
                                     || !sexes.is_empty()
@@ -768,8 +882,7 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                             ],
                             &format!("{at}.symptom"),
                         )?;
-                        if let Some(archetype) =
-                            item.get("encounter_archetype").and_then(Value::as_str)
+                        if let Some(archetype) = optional_string(item, "encounter_archetype", &at)?
                         {
                             enum_value(
                                 archetype,
@@ -869,31 +982,40 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                             if !seen.insert(candidate_id) {
                                 return Err(format!("{candidate_at}.id: duplicate candidate"));
                             }
-                            let p = candidate
-                                .get("plausibility")
-                                .and_then(Value::as_u64)
-                                .ok_or_else(|| {
-                                    format!("{candidate_at}.plausibility: expected integer")
-                                })?;
-                            let c = candidate
-                                .get("curation")
-                                .and_then(Value::as_u64)
-                                .ok_or_else(|| {
-                                    format!("{candidate_at}.curation: expected integer")
-                                })?;
-                            let zero_reason = candidate
-                                .get("hard_zero_reason")
-                                .and_then(Value::as_str)
-                                .map(str::to_owned);
+                            let p = unsigned(
+                                candidate,
+                                "plausibility",
+                                0,
+                                u32::MAX.into(),
+                                &candidate_at,
+                            )?;
+                            let c =
+                                unsigned(candidate, "curation", 0, u32::MAX.into(), &candidate_at)?;
+                            let zero_reason =
+                                optional_string(candidate, "hard_zero_reason", &candidate_at)?
+                                    .map(str::to_owned);
+                            if zero_reason
+                                .as_ref()
+                                .is_some_and(|reason| reason.trim().is_empty())
+                            {
+                                return Err(format!(
+                                    "{candidate_at}.hard_zero_reason: must not be empty"
+                                ));
+                            }
                             if (p == 0 || c == 0) != zero_reason.is_some() {
                                 return Err(format!("{candidate_at}: zero weight/reason mismatch"));
                             }
-                            let bridge = candidate
-                                .get("required_bridge")
-                                .and_then(Value::as_str)
-                                .map(str::to_owned);
+                            let bridge =
+                                optional_string(candidate, "required_bridge", &candidate_at)?
+                                    .map(str::to_owned);
                             if let Some(value) = &bridge {
+                                id(value, &format!("{candidate_at}.required_bridge"))?;
                                 bridge_refs.push((candidate_at.clone(), value.clone()));
+                            }
+                            for factor in
+                                optional_list_strings(candidate, "factors", &candidate_at)?
+                            {
+                                id(&factor, &format!("{candidate_at}.factors"))?;
                             }
                             parsed.push((candidate_id.into(), p, c, zero_reason, bridge));
                         }
@@ -1003,7 +1125,7 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                 ));
             }
         };
-        for (candidate, _, _, _, _) in candidates {
+        for (candidate, _, _, _, required_bridge) in candidates {
             if let Some(allowed) = allowed
                 && !allowed.contains(candidate)
             {
@@ -1036,6 +1158,11 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                     "catalog.relations.{relation_id}: unknown candidate {candidate}"
                 ));
             }
+            if namespace == "evidence" && required_bridge.is_some() {
+                return Err(format!(
+                    "catalog.relations.{relation_id}: evidence relations cannot require bridges because follow-up evidence selection has no bridge materialization context"
+                ));
+            }
         }
     }
     if fallback_demographics != 1 {
@@ -1049,10 +1176,14 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                 && !left.fallback
                 && !right.fallback
                 && left.priority == right.priority
-                && selectors_overlap(&left.age_bands, &right.age_bands)
-                && selectors_overlap(&left.sexes, &right.sexes)
-                && selectors_overlap(&left.professions, &right.professions)
-                && selectors_overlap(&left.local_roles, &right.local_roles)
+                && selectors_overlap(
+                    &left.age_bands,
+                    &right.age_bands,
+                    &["child", "adolescent", "adult", "elder"],
+                )
+                && selectors_overlap(&left.sexes, &right.sexes, &["female", "male"])
+                && selectors_overlap(&left.professions, &right.professions, PROFESSION_FACTS)
+                && selectors_overlap(&left.local_roles, &right.local_roles, LOCAL_ROLE_FACTS)
             {
                 return Err(format!(
                     "{} and {}: equal-priority demographic rules can match the same NPC",

--- a/crates/adventuresim-core/src/quest_generation.rs
+++ b/crates/adventuresim-core/src/quest_generation.rs
@@ -961,7 +961,7 @@ fn reliability_candidates(
                 id: base.id.as_str(),
                 value,
                 weight: Weight::new(authored.plausibility, authored.curation),
-                bridge: None,
+                bridge: authored.required_bridge.as_deref(),
                 impossible: authored
                     .hard_zero_reason
                     .as_deref()
@@ -1005,7 +1005,7 @@ fn evidence_candidates(cause: CanonicalCause, site: SiteKind) -> Vec<Candidate<E
                 id: authored.id.as_str(),
                 value,
                 weight: Weight::new(selected.plausibility, selected.curation),
-                bridge: None,
+                bridge: selected.required_bridge.as_deref(),
                 impossible: selected
                     .hard_zero_reason
                     .as_deref()
@@ -1172,7 +1172,7 @@ fn account_style_candidates(
                 id: authored.id.as_str(),
                 value,
                 weight: Weight::new(authored.plausibility, authored.curation),
-                bridge: None,
+                bridge: authored.required_bridge.as_deref(),
                 impossible: authored
                     .hard_zero_reason
                     .as_deref()
@@ -1204,16 +1204,22 @@ fn route_variant_candidates(family: TemplateFamily) -> [Candidate<RouteVariant>;
             id: "route.direct",
             value: RouteVariant::Direct,
             weight: Weight::new(direct.plausibility, direct.curation),
-            bridge: None,
-            impossible: None,
+            bridge: direct.required_bridge.as_deref(),
+            impossible: direct
+                .hard_zero_reason
+                .as_deref()
+                .map(|_| "catalog-authored hard zero"),
             factors: vec!["factor.route.direct"],
         },
         Candidate {
             id: "route.cautious",
             value: RouteVariant::Cautious,
             weight: Weight::new(cautious.plausibility, cautious.curation),
-            bridge: None,
-            impossible: None,
+            bridge: cautious.required_bridge.as_deref(),
+            impossible: cautious
+                .hard_zero_reason
+                .as_deref()
+                .map(|_| "catalog-authored hard zero"),
             factors: vec!["factor.route.cautious"],
         },
     ]
@@ -1245,16 +1251,22 @@ fn attack_pattern_candidates(
             id: "pattern.nightly",
             value: AttackPattern::Nightly,
             weight: Weight::new(nightly.plausibility, nightly.curation),
-            bridge: None,
-            impossible: None,
+            bridge: nightly.required_bridge.as_deref(),
+            impossible: nightly
+                .hard_zero_reason
+                .as_deref()
+                .map(|_| "catalog-authored hard zero"),
             factors: vec!["factor.pattern.nightly"],
         },
         Candidate {
             id: "pattern.roadside",
             value: AttackPattern::Roadside,
             weight: Weight::new(roadside.plausibility, roadside.curation),
-            bridge: None,
-            impossible: None,
+            bridge: roadside.required_bridge.as_deref(),
+            impossible: roadside
+                .hard_zero_reason
+                .as_deref()
+                .map(|_| "catalog-authored hard zero"),
             factors: vec!["factor.pattern.roadside"],
         },
         Candidate {
@@ -1268,17 +1280,26 @@ fn attack_pattern_candidates(
                 },
                 victim.curation,
             ),
-            bridge: None,
+            bridge: victim.required_bridge.as_deref(),
             impossible: (!has_victim_target)
-                .then_some("no unused persistent NPC can anchor the victim cohort"),
+                .then_some("no unused persistent NPC can anchor the victim cohort")
+                .or_else(|| {
+                    victim
+                        .hard_zero_reason
+                        .as_deref()
+                        .map(|_| "catalog-authored hard zero")
+                }),
             factors: vec!["factor.pattern.victim", "factor.pattern.persistent_cohort"],
         },
         Candidate {
             id: "pattern.irregular",
             value: AttackPattern::Irregular,
             weight: Weight::new(irregular.plausibility, irregular.curation),
-            bridge: None,
-            impossible: None,
+            bridge: irregular.required_bridge.as_deref(),
+            impossible: irregular
+                .hard_zero_reason
+                .as_deref()
+                .map(|_| "catalog-authored hard zero"),
             factors: vec!["factor.pattern.irregular"],
         },
     ]
@@ -1318,8 +1339,11 @@ struct SolvedVariables {
     demographic: WitnessDemographic,
     circumstance: Circumstance,
     description: ReportDescription,
+    family_bridge: Option<&'static str>,
+    cause_bridge: Option<&'static str>,
     site_bridge: Option<&'static str>,
     circumstance_bridge: Option<&'static str>,
+    description_bridge: Option<&'static str>,
     primary_witness: usize,
     secondary_witness: usize,
 }
@@ -1432,13 +1456,13 @@ fn solve_variables(
                             (
                                 "module.template",
                                 format!("{family:?}"),
-                                None,
+                                families[family_index].bridge,
                                 families[family_index].factors.clone(),
                             ),
                             (
                                 "module.cause",
                                 format!("{cause:?}"),
-                                None,
+                                causes[cause_index].bridge,
                                 causes[cause_index].factors.clone(),
                             ),
                             (
@@ -1462,7 +1486,7 @@ fn solve_variables(
                             (
                                 "module.description",
                                 format!("{:?}", descriptions[description_index].value),
-                                None,
+                                descriptions[description_index].bridge,
                                 descriptions[description_index].factors.clone(),
                             ),
                         ] {
@@ -1486,8 +1510,11 @@ fn solve_variables(
                             demographic: witness.demographic,
                             circumstance,
                             description: descriptions[description_index].value,
+                            family_bridge: families[family_index].bridge,
+                            cause_bridge: causes[cause_index].bridge,
                             site_bridge: sites[site_index].bridge,
                             circumstance_bridge: circumstances[circumstance_index].bridge,
+                            description_bridge: descriptions[description_index].bridge,
                             primary_witness: primary_index,
                             secondary_witness: secondary_index,
                         });
@@ -1532,7 +1559,7 @@ fn family_candidates() -> Vec<Candidate<TemplateFamily>> {
                 _ => unreachable!("startup validation rejects unknown family"),
             },
             weight: Weight::new(candidate.plausibility, candidate.curation),
-            bridge: None,
+            bridge: candidate.required_bridge.as_deref(),
             impossible: candidate
                 .hard_zero_reason
                 .as_deref()
@@ -1567,7 +1594,7 @@ fn cause_candidates(family: TemplateFamily) -> Vec<Candidate<CanonicalCause>> {
                 id: candidate.id.as_str(),
                 value,
                 weight: Weight::new(candidate.plausibility, candidate.curation),
-                bridge: None,
+                bridge: candidate.required_bridge.as_deref(),
                 impossible: candidate
                     .hard_zero_reason
                     .as_deref()
@@ -1710,6 +1737,17 @@ fn description_candidates(cause: CanonicalCause) -> Vec<Candidate<ReportDescript
         .map(|authored| {
             let report =
                 ReportDescription::try_new(&authored.id).expect("validated open description ID");
+            let relation_candidate = match cause {
+                CanonicalCause::Hostile(threat) => crate::quest_catalog::catalog()
+                    .relation(&format!("description.{}", authored.id))
+                    .and_then(|relation| {
+                        relation
+                            .candidates
+                            .iter()
+                            .find(|candidate| candidate.id == threat.as_str())
+                    }),
+                _ => None,
+            };
             let p = match cause {
                 CanonicalCause::Hostile(threat) => description_likelihood(threat, report),
                 CanonicalCause::VoluntaryDisappearance
@@ -1735,9 +1773,18 @@ fn description_candidates(cause: CanonicalCause) -> Vec<Candidate<ReportDescript
             Candidate {
                 id: authored.id.as_str(),
                 value: report,
-                weight: Weight::new(p, 80),
-                bridge: None,
-                impossible: (p == 0).then_some("bestiary forward description likelihood is zero"),
+                weight: Weight::new(
+                    p,
+                    relation_candidate.map_or(80, |candidate| candidate.curation),
+                ),
+                bridge: relation_candidate
+                    .and_then(|candidate| candidate.required_bridge.as_deref()),
+                impossible: relation_candidate
+                    .and_then(|candidate| candidate.hard_zero_reason.as_deref())
+                    .map(|_| "catalog-authored hard zero")
+                    .or_else(|| {
+                        (p == 0).then_some("bestiary forward description likelihood is zero")
+                    }),
                 factors: vec!["factor.description.bestiary_forward_likelihood"],
             }
         })
@@ -2211,15 +2258,18 @@ pub fn generate(context: &GenerationContext) -> Result<GeneratedCase, Generation
         demographic,
         circumstance,
         description,
+        family_bridge,
+        cause_bridge,
         site_bridge,
         circumstance_bridge: circ_bridge,
+        description_bridge,
         primary_witness,
         secondary_witness,
     } = solved;
     let primary = &context.witness_candidates[primary_witness];
     let secondary = &context.witness_candidates[secondary_witness];
     let prefix = observer_scope(context);
-    let (reliability, _) = choose(
+    let (reliability, reliability_bridge) = choose(
         context.seed.rotate_left(5),
         "module.reliability",
         "relation.reliability.context",
@@ -2240,21 +2290,21 @@ pub fn generate(context: &GenerationContext) -> Result<GeneratedCase, Generation
         &secondary_circumstance_candidates(secondary, circumstance),
         &mut trace,
     )?;
-    let (evidence_kind, _) = choose(
+    let (evidence_kind, evidence_bridge) = choose(
         context.seed.rotate_left(17),
         "module.evidence",
         "relation.evidence.cause_site",
         &evidence_candidates(cause, site),
         &mut trace,
     )?;
-    let (account_style, _) = choose(
+    let (account_style, account_bridge) = choose(
         context.seed.rotate_left(23),
         "module.account",
         "relation.account.reliability_circumstance",
         &account_style_candidates(reliability, circumstance),
         &mut trace,
     )?;
-    let (route_variant, _) = choose(
+    let (route_variant, route_bridge) = choose(
         context.seed.rotate_left(31),
         "module.route",
         "relation.route.family",
@@ -2273,7 +2323,7 @@ pub fn generate(context: &GenerationContext) -> Result<GeneratedCase, Generation
             ),
         )
     });
-    let (attack_pattern, _) = choose(
+    let (attack_pattern, pattern_bridge) = choose(
         context.seed.rotate_left(37),
         "module.attack_pattern",
         "relation.pattern.family",
@@ -2761,8 +2811,16 @@ pub fn generate(context: &GenerationContext) -> Result<GeneratedCase, Generation
     );
     let mut bridges = Vec::new();
     for key in [
+        family_bridge,
+        cause_bridge,
         site_bridge,
         circ_bridge,
+        description_bridge,
+        reliability_bridge,
+        evidence_bridge,
+        account_bridge,
+        route_bridge,
+        pattern_bridge,
         secondary_site_bridge,
         secondary_circumstance_bridge,
     ]
@@ -4373,6 +4431,67 @@ mod tests {
         assert_eq!(adult.weight.plausibility, 2);
         assert_eq!(adult.bridge, Some("child_at_adult_venue"));
     }
+
+    #[test]
+    fn selected_yaml_bridge_materializes_complete_reachable_authority() {
+        let generated = generate(&context(44, TemplateFamily::DisappearanceOrLoss)).unwrap();
+        assert!(
+            !generated.bridges.is_empty(),
+            "fixture seed must select a YAML-authored bridge"
+        );
+        validate(&generated).unwrap();
+
+        let mut reachable = generated
+            .actions
+            .iter()
+            .filter(|action| action.active_initially)
+            .map(|action| action.id.clone())
+            .collect::<BTreeSet<_>>();
+        loop {
+            let before = reachable.len();
+            for action in &generated.actions {
+                if action
+                    .prerequisite
+                    .as_ref()
+                    .is_none_or(|required| reachable.contains(required))
+                {
+                    reachable.insert(action.id.clone());
+                }
+            }
+            if reachable.len() == before {
+                break;
+            }
+        }
+
+        for bridge in &generated.bridges {
+            assert!(
+                generated
+                    .canonical_events
+                    .iter()
+                    .any(|event| event.id == bridge.event_id)
+            );
+            assert!(
+                generated
+                    .evidence
+                    .iter()
+                    .any(|evidence| evidence.id == bridge.evidence_id)
+            );
+            assert!(reachable.contains(&bridge.action_id));
+            let action = generated
+                .actions
+                .iter()
+                .find(|action| action.id == bridge.action_id)
+                .unwrap();
+            assert!(action.outputs.iter().any(|output| {
+                matches!(
+                    output,
+                    GeneratedActionOutput::Evidence { evidence_id }
+                        if evidence_id == &bridge.evidence_id
+                )
+            }));
+        }
+    }
+
     #[test]
     fn graph_keeps_both_routes_reachable_from_authored_entries() {
         for family in [

--- a/crates/adventuresim-core/src/quest_generation.rs
+++ b/crates/adventuresim-core/src/quest_generation.rs
@@ -6,7 +6,7 @@
 //! remain private to strategic authority and developer tools.
 
 use crate::{
-    bestiary::{ALL_REPORTS, ReportDescription, ThreatId, description_likelihood},
+    bestiary::{ReportDescription, ThreatId, description_likelihood},
     case::{
         AssetId, Objective, ObjectiveExpression, ObjectiveId, ObjectivePath, ObjectiveRequirement,
         SubjectId,
@@ -18,7 +18,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 
-pub const CATALOG_REVISION: &str = "questgen-2026-07-24.4";
+/// Content-addressed revision of the sorted startup-compiled YAML catalog.
+pub const CATALOG_REVISION: &str = crate::quest_catalog::QUEST_CATALOG_DIGEST;
 pub const MAX_SOLVER_CANDIDATES: usize = 4_096;
 pub const MAX_SOLVER_VISITED_NODES: usize = 16_384;
 pub const MAX_FACTOR_TRACE_RECORDS: usize = 32_768;
@@ -74,18 +75,64 @@ pub enum CanonicalCause {
     FabricatedClaim,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SiteKind {
-    Cave,
-    Crypt,
-    ForestCamp,
-    OccupiedHouse,
-    Riverside,
-    Graveyard,
-    Roadside,
-    AbandonedFarm,
+macro_rules! open_catalog_id {
+    ($name:ident { $($constant:ident => $value:literal),+ $(,)? }) => {
+        #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name { len: u8, bytes: [u8; 63] }
+        impl $name {
+            $(#[allow(non_upper_case_globals)]
+            pub const $constant: Self = Self::from_static($value);)+
+            pub const fn from_static(value: &str) -> Self {
+                let source = value.as_bytes();
+                assert!(!source.is_empty() && source.len() <= 63);
+                let mut bytes = [0; 63];
+                let mut index = 0;
+                while index < source.len() {
+                    bytes[index] = source[index];
+                    index += 1;
+                }
+                Self { len: source.len() as u8, bytes }
+            }
+            pub fn try_new(value: &str) -> Result<Self, &'static str> {
+                if value.is_empty() || value.len() > 63 || !value.bytes().all(|byte|
+                    byte.is_ascii_lowercase() || byte.is_ascii_digit()
+                        || matches!(byte, b'_' | b'-' | b'.' | b':'))
+                {
+                    return Err("invalid open catalog ID");
+                }
+                let mut bytes = [0; 63];
+                bytes[..value.len()].copy_from_slice(value.as_bytes());
+                Ok(Self { len: value.len() as u8, bytes })
+            }
+            pub fn as_str(&self) -> &str {
+                core::str::from_utf8(&self.bytes[..usize::from(self.len)])
+                    .expect("catalog IDs are validated ASCII")
+            }
+        }
+        impl core::fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str(self.as_str())
+            }
+        }
+        impl Serialize for $name {
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                let value = String::deserialize(deserializer)?;
+                Self::try_new(&value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
 }
+
+open_catalog_id!(SiteKind {
+    Cave => "cave", Crypt => "crypt", ForestCamp => "forest_camp",
+    OccupiedHouse => "occupied_house", Riverside => "riverside",
+    Graveyard => "graveyard", Roadside => "roadside", AbandonedFarm => "abandoned_farm"
+});
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -96,27 +143,16 @@ pub enum SiteRole {
     LastKnown,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum WitnessDemographic {
-    Child,
-    Laborer,
-    Merchant,
-    Cleric,
-    Guard,
-    Noble,
-}
+open_catalog_id!(WitnessDemographic {
+    Child => "child", Laborer => "laborer", Merchant => "merchant",
+    Cleric => "cleric", Guard => "guard", Noble => "noble"
+});
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Circumstance {
-    NightWindow,
-    SecretRiversideMeeting,
-    AdultVenue,
-    RoadJourney,
-    GraveDuty,
-    LivestockWatch,
-}
+open_catalog_id!(Circumstance {
+    NightWindow => "night_window", SecretRiversideMeeting => "secret_riverside",
+    AdultVenue => "adult_venue", RoadJourney => "road",
+    GraveDuty => "grave_duty", LivestockWatch => "livestock_watch"
+});
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -128,17 +164,11 @@ pub enum Reliability {
     PartlyTruthful,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum EvidenceKind {
-    Footprints,
-    ClothScrap,
-    BoneDust,
-    BloodlessCorpse,
-    DroppedToken,
-    DragMarks,
-    LedgerEntry,
-}
+open_catalog_id!(EvidenceKind {
+    Footprints => "footprints", ClothScrap => "cloth_scrap", BoneDust => "bone_dust",
+    BloodlessCorpse => "bloodless_corpse", DroppedToken => "dropped_token",
+    DragMarks => "drag_marks", LedgerEntry => "ledger_entry"
+});
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -882,270 +912,161 @@ fn reliability_candidates(
     circumstance: Circumstance,
     cause: CanonicalCause,
 ) -> Vec<Candidate<Reliability>> {
-    [
-        Reliability::Truthful,
-        Reliability::Mistaken,
-        Reliability::Evasive,
-        Reliability::Deceptive,
-        Reliability::PartlyTruthful,
-    ]
-    .into_iter()
-    .map(|value| {
-        let (p, impossible, factor) = match (demographic, circumstance, cause, value) {
-            (WitnessDemographic::Child, _, _, Reliability::Deceptive) => (
-                0,
-                Some("the initial child account is not authored as deliberate fabrication"),
-                "factor.reliability.child_hard_zero",
-            ),
-            (
-                _,
-                Circumstance::SecretRiversideMeeting | Circumstance::AdultVenue,
-                _,
-                Reliability::Evasive,
-            ) => (75, None, "factor.reliability.embarrassing_context"),
-            (_, _, CanonicalCause::FabricatedClaim, Reliability::Deceptive) => {
-                (80, None, "factor.reliability.fabricated_claim")
+    let catalog = crate::quest_catalog::catalog();
+    let baseline = catalog.relation("reliability.baseline").unwrap();
+    baseline
+        .candidates
+        .iter()
+        .map(|base| {
+            let value = match base.id.as_str() {
+                "truthful" => Reliability::Truthful,
+                "mistaken" => Reliability::Mistaken,
+                "evasive" => Reliability::Evasive,
+                "deceptive" => Reliability::Deceptive,
+                "partly_truthful" => Reliability::PartlyTruthful,
+                _ => unreachable!("validated reliability mechanic"),
+            };
+            let contextual = [
+                (
+                    demographic == WitnessDemographic::Child,
+                    "reliability.child",
+                ),
+                (
+                    matches!(
+                        circumstance,
+                        Circumstance::SecretRiversideMeeting | Circumstance::AdultVenue
+                    ),
+                    "reliability.embarrassing_context",
+                ),
+                (
+                    cause == CanonicalCause::FabricatedClaim,
+                    "reliability.fabricated_claim",
+                ),
+                (
+                    circumstance == Circumstance::NightWindow,
+                    "reliability.night_window",
+                ),
+            ]
+            .into_iter()
+            .filter(|(applies, _)| *applies)
+            .filter_map(|(_, id)| catalog.relation(id))
+            .find_map(|relation| relation.candidates.iter().find(|item| item.id == base.id));
+            let authored = contextual.unwrap_or(base);
+            Candidate {
+                id: base.id.as_str(),
+                value,
+                weight: Weight::new(authored.plausibility, authored.curation),
+                bridge: None,
+                impossible: authored
+                    .hard_zero_reason
+                    .as_deref()
+                    .map(|_| "catalog-authored hard zero"),
+                factors: vec!["factor.reliability.catalog"],
             }
-            (_, Circumstance::NightWindow, _, Reliability::Mistaken) => {
-                (70, None, "factor.reliability.darkness")
-            }
-            (_, _, _, Reliability::Truthful) => (65, None, "factor.reliability.baseline"),
-            (_, _, _, Reliability::PartlyTruthful) => (45, None, "factor.reliability.partial"),
-            _ => (25, None, "factor.reliability.possible"),
-        };
-        Candidate {
-            id: match value {
-                Reliability::Truthful => "reliability.truthful",
-                Reliability::Mistaken => "reliability.mistaken",
-                Reliability::Evasive => "reliability.evasive",
-                Reliability::Deceptive => "reliability.deceptive",
-                Reliability::PartlyTruthful => "reliability.partly_truthful",
-            },
-            value,
-            weight: Weight::new(p, 70),
-            bridge: None,
-            impossible,
-            factors: vec![factor],
-        }
-    })
-    .collect()
+        })
+        .collect()
 }
 
 fn evidence_candidates(cause: CanonicalCause, site: SiteKind) -> Vec<Candidate<EvidenceKind>> {
-    [
-        EvidenceKind::Footprints,
-        EvidenceKind::ClothScrap,
-        EvidenceKind::BoneDust,
-        EvidenceKind::BloodlessCorpse,
-        EvidenceKind::DroppedToken,
-        EvidenceKind::DragMarks,
-        EvidenceKind::LedgerEntry,
-    ]
-    .into_iter()
-    .map(|value| {
-        let (p, impossible, factor) = match (cause, site, value) {
-            (CanonicalCause::Hostile(ThreatId::Skeleton), _, EvidenceKind::BoneDust) => {
-                (90, None, "factor.evidence.skeleton")
+    let baseline = crate::quest_catalog::catalog()
+        .relation("evidence.baseline")
+        .expect("validated evidence relation");
+    baseline
+        .candidates
+        .iter()
+        .map(|authored| {
+            let value = evidence_kind_from_catalog(&authored.id);
+            let catalog = crate::quest_catalog::catalog();
+            let relation_ids = [
+                matches!(cause, CanonicalCause::Hostile(threat) if threat == ThreatId::Skeleton)
+                    .then_some("evidence.skeleton"),
+                (cause == CanonicalCause::IncidentalLoss).then_some("evidence.incidental_loss"),
+                (cause == CanonicalCause::FabricatedClaim).then_some("evidence.fabricated_claim"),
+                matches!(site, SiteKind::Roadside | SiteKind::Riverside)
+                    .then_some("evidence.trackable_ground"),
+            ];
+            let selected = relation_ids
+                .into_iter()
+                .flatten()
+                .filter_map(|id| catalog.relation(id))
+                .find_map(|relation| {
+                    relation
+                        .candidates
+                        .iter()
+                        .find(|item| item.id == authored.id)
+                })
+                .unwrap_or(authored);
+            Candidate {
+                id: authored.id.as_str(),
+                value,
+                weight: Weight::new(selected.plausibility, selected.curation),
+                bridge: None,
+                impossible: selected
+                    .hard_zero_reason
+                    .as_deref()
+                    .map(|_| "catalog-authored hard zero"),
+                factors: vec!["factor.evidence.catalog"],
             }
-            (CanonicalCause::IncidentalLoss, _, EvidenceKind::LedgerEntry) => {
-                (70, None, "factor.evidence.asset_record")
-            }
-            (CanonicalCause::FabricatedClaim, _, EvidenceKind::BloodlessCorpse) => (
-                0,
-                Some("a fabricated loss cannot create a canonical corpse clue"),
-                "factor.evidence.fabrication_hard_zero",
-            ),
-            (_, SiteKind::Roadside | SiteKind::Riverside, EvidenceKind::Footprints) => {
-                (75, None, "factor.evidence.trackable_ground")
-            }
-            (_, _, EvidenceKind::DroppedToken | EvidenceKind::ClothScrap) => {
-                (45, None, "factor.evidence.portable")
-            }
-            _ => (25, None, "factor.evidence.possible"),
-        };
-        Candidate {
-            id: match value {
-                EvidenceKind::Footprints => "evidence.footprints",
-                EvidenceKind::ClothScrap => "evidence.cloth",
-                EvidenceKind::BoneDust => "evidence.bone_dust",
-                EvidenceKind::BloodlessCorpse => "evidence.bloodless_corpse",
-                EvidenceKind::DroppedToken => "evidence.token",
-                EvidenceKind::DragMarks => "evidence.drag_marks",
-                EvidenceKind::LedgerEntry => "evidence.ledger",
-            },
-            value,
-            weight: Weight::new(p, 70),
-            bridge: None,
-            impossible,
-            factors: vec![factor],
-        }
-    })
-    .collect()
+        })
+        .collect()
+}
+
+fn evidence_kind_from_catalog(id: &str) -> EvidenceKind {
+    EvidenceKind::try_new(id).expect("validated open evidence ID")
 }
 
 fn evidence_presentation(
     kind: EvidenceKind,
     evidence_id: &EvidenceId,
 ) -> (String, String, String, Vec<EvidenceInspectionTopic>) {
-    let difficulty_milli =
-        1_200 + (crate::settlement_population::stable_hash(&evidence_id.0) % 2_801) as u16;
-    let checked = |id: &str,
-                   label: &str,
-                   inspection_description: &str,
-                   stat: EvidenceCheckStat,
-                   success_description: &str| EvidenceInspectionTopic {
-        id: id.into(),
-        label: label.into(),
-        inspection_description: inspection_description.into(),
-        check: Some(EvidenceInspectionCheck {
-            stat,
-            difficulty_milli,
-            success_description: success_description.into(),
-            reveals_clue: true,
-        }),
-    };
-    let plain = |id: &str, label: &str, description: &str| EvidenceInspectionTopic {
-        id: id.into(),
-        label: label.into(),
-        inspection_description: description.into(),
-        check: None,
-    };
-    match kind {
-        EvidenceKind::Footprints => (
-            "Footprints".into(),
-            "wingfoot".into(),
-            "You see several overlapping footprints impressed into the ground.".into(),
-            vec![
-                plain(
-                    "surrounding-ground",
-                    "surrounding ground",
-                    "The nearby ground is churned by ordinary traffic and weather.",
-                ),
-                checked(
-                    "deepest-impressions",
-                    "deepest impressions",
-                    "You compare the depth, spacing, and edges of the clearest prints.",
-                    EvidenceCheckStat::Eyesight,
-                    "A repeated set of impressions has a distinctive gait and continues away from the others.",
-                ),
-            ],
-        ),
-        EvidenceKind::ClothScrap => (
-            "Torn cloth".into(),
-            "clothes".into(),
-            "You see a torn scrap of cloth caught against a rough edge.".into(),
-            vec![
-                plain(
-                    "dirt",
-                    "dirt on the cloth",
-                    "The dirt is common local soil and says little by itself.",
-                ),
-                checked(
-                    "torn-edge",
-                    "torn edge",
-                    "You study the fibers along the torn edge.",
-                    EvidenceCheckStat::Eyesight,
-                    "Several fibers are cut cleanly while others were pulled apart, suggesting the cloth snagged during a struggle.",
-                ),
-            ],
-        ),
-        EvidenceKind::BoneDust => (
-            "Bone dust".into(),
-            "death-skull".into(),
-            "You see pale dust and small fragments scattered across the surface.".into(),
-            vec![
-                plain(
-                    "loose-fragments",
-                    "loose fragments",
-                    "Most fragments are too damaged to identify.",
-                ),
-                checked(
-                    "dust-pattern",
-                    "pattern of dust",
-                    "You examine where the pale dust has settled and where it is absent.",
-                    EvidenceCheckStat::Intelligence,
-                    "The distribution is too regular for ordinary decay; something repeatedly crossed or disturbed this spot.",
-                ),
-            ],
-        ),
-        EvidenceKind::BloodlessCorpse => (
-            "Bloodless corpse".into(),
-            "bleeding-wound".into(),
-            "You see a corpse whose pallor and lack of visible blood are immediately striking."
-                .into(),
-            vec![
-                plain(
-                    "clothing",
-                    "clothing",
-                    "The clothing is disordered but carries no unique identifying mark.",
-                ),
-                checked(
-                    "wounds",
-                    "wounds",
-                    "You inspect the wounds without disturbing the body further.",
-                    EvidenceCheckStat::Eyesight,
-                    "The smallest wounds account poorly for the amount of blood missing from the body.",
-                ),
-            ],
-        ),
-        EvidenceKind::DroppedToken => (
-            "Dropped token".into(),
-            "coins".into(),
-            "You see a small token lying where it appears to have been dropped.".into(),
-            vec![
-                plain(
-                    "material",
-                    "material",
-                    "It is made from an inexpensive material common in the region.",
-                ),
-                checked(
-                    "worn-markings",
-                    "worn markings",
-                    "You turn the token under the light and compare its worn markings.",
-                    EvidenceCheckStat::Eyesight,
-                    "A partly worn device links the token to a particular trade or household, though not necessarily to the culprit.",
-                ),
-            ],
-        ),
-        EvidenceKind::DragMarks => (
-            "Drag marks".into(),
-            "eye-target".into(),
-            "You see long disturbances where something was pulled across the ground.".into(),
-            vec![
-                plain(
-                    "loose-debris",
-                    "loose debris",
-                    "The loose debris has been disturbed too broadly to preserve a useful shape.",
-                ),
-                checked(
-                    "groove-edges",
-                    "edges of the grooves",
-                    "You compare the interruptions along the edges of the grooves.",
-                    EvidenceCheckStat::Instinct,
-                    "The interruptions show where the burden was lifted briefly, revealing the direction in which it was taken.",
-                ),
-            ],
-        ),
-        EvidenceKind::LedgerEntry => (
-            "Ledger".into(),
-            "open-book".into(),
-            "You see a ledger open near a cluster of recent entries.".into(),
-            vec![
-                plain(
-                    "older-pages",
-                    "older pages",
-                    "The older pages contain routine accounts with no obvious bearing on the trouble.",
-                ),
-                checked(
-                    "recent-entries",
-                    "recent entries",
-                    "You compare the dates, hands, and totals in the recent entries.",
-                    EvidenceCheckStat::Intelligence,
-                    "One entry breaks the surrounding pattern and corroborates when and where the incidents recur.",
-                ),
-            ],
-        ),
-    }
+    let definition = crate::quest_catalog::catalog()
+        .evidence(evidence_catalog_id(kind))
+        .expect("validated evidence catalog covers closed mechanics adapter");
+    let topics = definition
+        .topics
+        .iter()
+        .map(|topic| {
+            let check = topic.check.as_ref().map(|check| {
+                let stat = match check.stat.as_str() {
+                    "eyesight" => EvidenceCheckStat::Eyesight,
+                    "intelligence" => EvidenceCheckStat::Intelligence,
+                    "instinct" => EvidenceCheckStat::Instinct,
+                    _ => unreachable!("startup validation rejects unknown evidence stats"),
+                };
+                let width = u64::from(check.difficulty_max_milli - check.difficulty_min_milli) + 1;
+                EvidenceInspectionCheck {
+                    stat,
+                    difficulty_milli: check.difficulty_min_milli
+                        + (crate::settlement_population::stable_hash(&format!(
+                            "{}:{}",
+                            evidence_id.0, topic.id
+                        )) % width) as u16,
+                    success_description: check.success_description.clone(),
+                    reveals_clue: check.reveals_clue,
+                }
+            });
+            EvidenceInspectionTopic {
+                id: topic.id.clone(),
+                label: topic.label.clone(),
+                inspection_description: topic.inspection_description.clone(),
+                check,
+            }
+        })
+        .collect();
+    (
+        definition.portrait_label.clone(),
+        definition.portrait_icon.clone(),
+        definition.base_description.clone(),
+        topics,
+    )
+}
+
+fn evidence_catalog_id(kind: EvidenceKind) -> &'static str {
+    crate::quest_catalog::catalog()
+        .evidence(kind.as_str())
+        .expect("generated evidence identity exists in catalog")
+        .id
+        .as_str()
 }
 
 fn evidence_reference(kind: EvidenceKind) -> &'static str {
@@ -1157,6 +1078,11 @@ fn evidence_reference(kind: EvidenceKind) -> &'static str {
         EvidenceKind::DroppedToken => "a dropped token",
         EvidenceKind::DragMarks => "some drag marks",
         EvidenceKind::LedgerEntry => "a ledger",
+        _ => crate::quest_catalog::catalog()
+            .evidence(kind.as_str())
+            .expect("generated evidence exists")
+            .portrait_label
+            .as_str(),
     }
 }
 
@@ -1218,55 +1144,61 @@ fn account_style_candidates(
     reliability: Reliability,
     circumstance: Circumstance,
 ) -> Vec<Candidate<AccountStyle>> {
-    [
-        AccountStyle::VisualClaim,
-        AccountStyle::HeardOnly,
-        AccountStyle::TracksAndMovement,
-    ]
-    .into_iter()
-    .map(|value| {
-        let (p, impossible, factor) = match (circumstance, reliability, value) {
-            (Circumstance::NightWindow, _, AccountStyle::HeardOnly) => {
-                (80, None, "factor.account.darkness")
+    let relation = crate::quest_catalog::catalog()
+        .relation(if reliability == Reliability::Mistaken {
+            "account.mistaken"
+        } else if circumstance == Circumstance::NightWindow {
+            "account.night_window"
+        } else {
+            "account.baseline"
+        })
+        .unwrap();
+    relation
+        .candidates
+        .iter()
+        .map(|authored| {
+            let value = match authored.id.as_str() {
+                "visual" => AccountStyle::VisualClaim,
+                "heard" => AccountStyle::HeardOnly,
+                "tracks" => AccountStyle::TracksAndMovement,
+                _ => unreachable!("validated account mechanic"),
+            };
+            Candidate {
+                id: authored.id.as_str(),
+                value,
+                weight: Weight::new(authored.plausibility, authored.curation),
+                bridge: None,
+                impossible: authored
+                    .hard_zero_reason
+                    .as_deref()
+                    .map(|_| "catalog-authored hard zero"),
+                factors: vec!["factor.account.catalog"],
             }
-            (_, Reliability::Mistaken, AccountStyle::TracksAndMovement) => (
-                0,
-                Some("a mistaken eyewitness does not provide the precise track account"),
-                "factor.account.mistaken_hard_zero",
-            ),
-            (_, _, AccountStyle::VisualClaim) => (60, None, "factor.account.visual"),
-            (_, _, AccountStyle::TracksAndMovement) => (45, None, "factor.account.tracks"),
-            _ => (30, None, "factor.account.possible"),
-        };
-        Candidate {
-            id: match value {
-                AccountStyle::VisualClaim => "account.visual",
-                AccountStyle::HeardOnly => "account.heard",
-                AccountStyle::TracksAndMovement => "account.tracks",
-            },
-            value,
-            weight: Weight::new(p, 70),
-            bridge: None,
-            impossible,
-            factors: vec![factor],
-        }
-    })
-    .collect()
+        })
+        .collect()
 }
 
 fn route_variant_candidates(family: TemplateFamily) -> [Candidate<RouteVariant>; 2] {
+    let relation = crate::quest_catalog::catalog()
+        .relation(match family {
+            TemplateFamily::RecurringDepredation => "route.recurring_depredation",
+            TemplateFamily::DisappearanceOrLoss => "route.disappearance_or_loss",
+        })
+        .expect("validated route relation");
+    let authored = |id: &str| {
+        relation
+            .candidates
+            .iter()
+            .find(|item| item.id == id)
+            .unwrap()
+    };
+    let direct = authored("direct");
+    let cautious = authored("cautious");
     [
         Candidate {
             id: "route.direct",
             value: RouteVariant::Direct,
-            weight: Weight::new(
-                if family == TemplateFamily::RecurringDepredation {
-                    70
-                } else {
-                    55
-                },
-                70,
-            ),
+            weight: Weight::new(direct.plausibility, direct.curation),
             bridge: None,
             impossible: None,
             factors: vec!["factor.route.direct"],
@@ -1274,14 +1206,7 @@ fn route_variant_candidates(family: TemplateFamily) -> [Candidate<RouteVariant>;
         Candidate {
             id: "route.cautious",
             value: RouteVariant::Cautious,
-            weight: Weight::new(
-                if family == TemplateFamily::RecurringDepredation {
-                    45
-                } else {
-                    75
-                },
-                70,
-            ),
+            weight: Weight::new(cautious.plausibility, cautious.curation),
             bridge: None,
             impossible: None,
             factors: vec!["factor.route.cautious"],
@@ -1293,11 +1218,28 @@ fn attack_pattern_candidates(
     family: TemplateFamily,
     has_victim_target: bool,
 ) -> [Candidate<AttackPattern>; 4] {
+    let relation = crate::quest_catalog::catalog()
+        .relation(match family {
+            TemplateFamily::RecurringDepredation => "pattern.recurring_depredation",
+            TemplateFamily::DisappearanceOrLoss => "pattern.disappearance_or_loss",
+        })
+        .expect("validated pattern relation");
+    let authored = |id: &str| {
+        relation
+            .candidates
+            .iter()
+            .find(|item| item.id == id)
+            .unwrap()
+    };
+    let nightly = authored("nightly");
+    let roadside = authored("roadside");
+    let victim = authored("victim_specific");
+    let irregular = authored("irregular");
     [
         Candidate {
             id: "pattern.nightly",
             value: AttackPattern::Nightly,
-            weight: Weight::new(60, 70),
+            weight: Weight::new(nightly.plausibility, nightly.curation),
             bridge: None,
             impossible: None,
             factors: vec!["factor.pattern.nightly"],
@@ -1305,7 +1247,7 @@ fn attack_pattern_candidates(
         Candidate {
             id: "pattern.roadside",
             value: AttackPattern::Roadside,
-            weight: Weight::new(55, 70),
+            weight: Weight::new(roadside.plausibility, roadside.curation),
             bridge: None,
             impossible: None,
             factors: vec!["factor.pattern.roadside"],
@@ -1316,12 +1258,10 @@ fn attack_pattern_candidates(
             weight: Weight::new(
                 if !has_victim_target {
                     0
-                } else if family == TemplateFamily::DisappearanceOrLoss {
-                    70
                 } else {
-                    30
+                    victim.plausibility
                 },
-                65,
+                victim.curation,
             ),
             bridge: None,
             impossible: (!has_victim_target)
@@ -1331,7 +1271,7 @@ fn attack_pattern_candidates(
         Candidate {
             id: "pattern.irregular",
             value: AttackPattern::Irregular,
-            weight: Weight::new(35, 55),
+            weight: Weight::new(irregular.plausibility, irregular.curation),
             bridge: None,
             impossible: None,
             factors: vec!["factor.pattern.irregular"],
@@ -1569,143 +1509,133 @@ fn solve_variables(
     })
 }
 
-fn family_candidates() -> [Candidate<TemplateFamily>; 2] {
-    [
-        Candidate {
-            id: "family.recurring_depredation",
-            value: TemplateFamily::RecurringDepredation,
-            weight: Weight::new(100, 100),
+fn family_candidates() -> Vec<Candidate<TemplateFamily>> {
+    crate::quest_catalog::catalog()
+        .relation("family")
+        .expect("validated catalog family relation")
+        .candidates
+        .iter()
+        .map(|candidate| Candidate {
+            id: match candidate.id.as_str() {
+                "recurring_depredation" => "family.recurring_depredation",
+                "disappearance_or_loss" => "family.disappearance_or_loss",
+                _ => unreachable!("startup validation rejects unknown family"),
+            },
+            value: match candidate.id.as_str() {
+                "recurring_depredation" => TemplateFamily::RecurringDepredation,
+                "disappearance_or_loss" => TemplateFamily::DisappearanceOrLoss,
+                _ => unreachable!("startup validation rejects unknown family"),
+            },
+            weight: Weight::new(candidate.plausibility, candidate.curation),
             bridge: None,
-            impossible: None,
+            impossible: candidate
+                .hard_zero_reason
+                .as_deref()
+                .map(|_| "catalog-authored hard zero"),
             factors: vec!["factor.family.rotation"],
-        },
-        Candidate {
-            id: "family.disappearance_or_loss",
-            value: TemplateFamily::DisappearanceOrLoss,
-            weight: Weight::new(100, 100),
-            bridge: None,
-            impossible: None,
-            factors: vec!["factor.family.rotation"],
-        },
-    ]
+        })
+        .collect()
 }
 
 fn cause_candidates(family: TemplateFamily) -> Vec<Candidate<CanonicalCause>> {
-    let loss = family == TemplateFamily::DisappearanceOrLoss;
-    let mut values = vec![
-        (ThreatId::Bandit, 75, 80),
-        (ThreatId::Goblin, if loss { 30 } else { 70 }, 75),
-        (ThreatId::Ghoul, 40, 70),
-        (ThreatId::Skeleton, 35, 70),
-        (ThreatId::Werewolf, if loss { 25 } else { 45 }, 60),
-        (ThreatId::Smuggler, if loss { 60 } else { 25 }, 65),
-        (ThreatId::Wolf, if loss { 20 } else { 65 }, 65),
-    ]
-    .into_iter()
-    .map(|(threat, p, c)| Candidate {
-        id: threat.as_str(),
-        value: CanonicalCause::Hostile(threat),
-        weight: Weight::new(p, c),
-        bridge: None,
-        impossible: None,
-        factors: vec!["factor.cause.bestiary"],
-    })
-    .collect::<Vec<_>>();
-    if loss {
-        values.extend([
+    let relation = match family {
+        TemplateFamily::RecurringDepredation => "cause.recurring_depredation",
+        TemplateFamily::DisappearanceOrLoss => "cause.disappearance_or_loss",
+    };
+    crate::quest_catalog::catalog()
+        .relation(relation)
+        .expect("validated catalog cause relation")
+        .candidates
+        .iter()
+        .map(|candidate| {
+            let value = match candidate.id.as_str() {
+                "concealment" => CanonicalCause::ConcealmentByWitness,
+                "incidental_loss" => CanonicalCause::IncidentalLoss,
+                "fabricated" => CanonicalCause::FabricatedClaim,
+                threat => CanonicalCause::Hostile(
+                    threat
+                        .parse()
+                        .expect("catalog monster has a supported mechanics adapter"),
+                ),
+            };
             Candidate {
-                id: "cause.concealment",
-                value: CanonicalCause::ConcealmentByWitness,
-                weight: Weight::new(35, 75),
+                id: candidate.id.as_str(),
+                value,
+                weight: Weight::new(candidate.plausibility, candidate.curation),
                 bridge: None,
-                impossible: None,
-                factors: vec!["factor.cause.nonhostile"],
-            },
-            Candidate {
-                id: "cause.incidental_loss",
-                value: CanonicalCause::IncidentalLoss,
-                weight: Weight::new(40, 65),
-                bridge: None,
-                impossible: None,
-                factors: vec!["factor.cause.nonhostile"],
-            },
-            Candidate {
-                id: "cause.fabricated",
-                value: CanonicalCause::FabricatedClaim,
-                weight: Weight::new(20, 55),
-                bridge: None,
-                impossible: None,
-                factors: vec!["factor.cause.nonhostile"],
-            },
-        ]);
-    }
-    values
+                impossible: candidate
+                    .hard_zero_reason
+                    .as_deref()
+                    .map(|_| "catalog-authored hard zero"),
+                factors: vec![if matches!(value, CanonicalCause::Hostile(_)) {
+                    "factor.cause.bestiary"
+                } else {
+                    "factor.cause.nonhostile"
+                }],
+            }
+        })
+        .collect()
 }
 
 fn site_candidates(cause: CanonicalCause) -> Vec<Candidate<SiteKind>> {
-    use SiteKind as S;
-    [
-        S::Cave,
-        S::Crypt,
-        S::ForestCamp,
-        S::OccupiedHouse,
-        S::Riverside,
-        S::Graveyard,
-        S::Roadside,
-        S::AbandonedFarm,
-    ]
-    .into_iter()
-    .map(|site| {
-        let (p, bridge, impossible, factor) = match (cause, site) {
-            (CanonicalCause::Hostile(ThreatId::Skeleton), S::Crypt)
-            | (CanonicalCause::Hostile(ThreatId::Ghoul), S::Graveyard) => {
-                (95, None, None, "factor.site.natural_habitat")
+    crate::quest_catalog::catalog()
+        .documents
+        .iter()
+        .flat_map(|document| &document.sites)
+        .map(|authored_site| {
+            let site = SiteKind::try_new(&authored_site.id).expect("validated open site ID");
+            let relation_id = match cause {
+                CanonicalCause::Hostile(threat) => Some(format!("site.{}", threat.as_str())),
+                _ => None,
+            };
+            let relation = relation_id
+                .as_deref()
+                .and_then(|id| crate::quest_catalog::catalog().relation(id))
+                .and_then(|relation| {
+                    relation
+                        .candidates
+                        .iter()
+                        .find(|item| item.id == authored_site.id)
+                });
+            let natural = match cause {
+                CanonicalCause::Hostile(threat) => crate::quest_catalog::catalog()
+                    .monster(threat.as_str())
+                    .is_some_and(|monster| {
+                        monster
+                            .investigation
+                            .habitats
+                            .contains(&authored_site.habitat)
+                    }),
+                _ => false,
+            };
+            let p = relation.map_or(if natural { 80 } else { 20 }, |item| item.plausibility);
+            let curation = relation.map_or(70, |item| item.curation);
+            let impossible = relation
+                .and_then(|item| item.hard_zero_reason.as_deref())
+                .map(|_| "catalog-authored hard zero");
+            let bridge = relation
+                .and_then(|item| item.required_bridge.as_deref())
+                .map(|id| match id {
+                    "skeletons_occupied_house" => "bridge.skeletons_occupied_house",
+                    "child_at_adult_venue" => "bridge.child_at_adult_venue",
+                    _ => unreachable!("validated bridge adapter"),
+                });
+            Candidate {
+                id: authored_site.id.as_str(),
+                value: site,
+                weight: Weight::new(p, curation),
+                bridge,
+                impossible,
+                factors: vec![if relation.is_some() {
+                    "factor.site.catalog_relation"
+                } else if natural {
+                    "factor.site.catalog_habitat"
+                } else {
+                    "factor.site.catalog_baseline"
+                }],
             }
-            (CanonicalCause::Hostile(ThreatId::Bandit), S::ForestCamp)
-            | (CanonicalCause::Hostile(ThreatId::Goblin), S::Cave)
-            | (CanonicalCause::Hostile(ThreatId::Wolf), S::AbandonedFarm) => {
-                (80, None, None, "factor.site.common")
-            }
-            (CanonicalCause::Hostile(ThreatId::Werewolf), S::OccupiedHouse)
-            | (CanonicalCause::Hostile(ThreatId::Smuggler), S::Riverside) => {
-                (90, None, None, "factor.site.concealment")
-            }
-            (CanonicalCause::Hostile(ThreatId::Skeleton), S::OccupiedHouse) => (
-                3,
-                Some("bridge.skeletons_occupied_house"),
-                None,
-                "factor.site.rare_bridge",
-            ),
-            (CanonicalCause::Hostile(ThreatId::Wolf), S::Crypt) => (
-                0,
-                None,
-                Some("quadruped pack cannot maintain a sealed crypt"),
-                "factor.site.impossible",
-            ),
-            (
-                CanonicalCause::VoluntaryDisappearance | CanonicalCause::ConcealmentByWitness,
-                S::OccupiedHouse | S::Riverside,
-            ) => (85, None, None, "factor.site.social"),
-            (CanonicalCause::IncidentalLoss, S::Roadside | S::Riverside) => {
-                (80, None, None, "factor.site.accident")
-            }
-            (CanonicalCause::FabricatedClaim, S::OccupiedHouse) => {
-                (80, None, None, "factor.site.fabrication")
-            }
-            (_, S::OccupiedHouse) => (12, None, None, "factor.site.unusual"),
-            (_, S::Roadside) => (25, None, None, "factor.site.transit"),
-            _ => (20, None, None, "factor.site.possible"),
-        };
-        Candidate {
-            id: site_id(site),
-            value: site,
-            weight: Weight::new(p, 70),
-            bridge,
-            impossible,
-            factors: vec![factor],
-        }
-    })
-    .collect()
+        })
+        .collect()
 }
 
 fn secondary_site_candidates(cause: CanonicalCause, primary: SiteKind) -> Vec<Candidate<SiteKind>> {
@@ -1745,54 +1675,47 @@ fn secondary_circumstance_candidates(
 }
 
 fn circumstance_candidates(demo: WitnessDemographic) -> Vec<Candidate<Circumstance>> {
-    use Circumstance as C;
-    [
-        C::NightWindow,
-        C::SecretRiversideMeeting,
-        C::AdultVenue,
-        C::RoadJourney,
-        C::GraveDuty,
-        C::LivestockWatch,
-    ]
-    .into_iter()
-    .map(|circ| {
-        let (p, bridge, impossible, factor) = match (demo, circ) {
-            (WitnessDemographic::Child, C::AdultVenue) => (
-                2,
-                Some("bridge.child_at_adult_venue"),
-                None,
-                "factor.witness.rare_venue",
-            ),
-            (WitnessDemographic::Cleric, C::AdultVenue) => (
-                0,
-                None,
-                Some("assigned cleric witness is not present in the adult venue"),
-                "factor.witness.impossible_venue",
-            ),
-            (WitnessDemographic::Child, C::NightWindow) => {
-                (90, None, None, "factor.witness.household")
+    let relation_id = format!("circumstance.{}", demo.as_str());
+    let relation = crate::quest_catalog::catalog().relation(&relation_id);
+    crate::quest_catalog::catalog()
+        .documents
+        .iter()
+        .flat_map(|document| &document.circumstances)
+        .map(|authored| {
+            let circ = Circumstance::try_new(&authored.id).expect("validated open circumstance ID");
+            let relation_candidate = relation
+                .and_then(|items| items.candidates.iter().find(|item| item.id == authored.id));
+            let p = relation_candidate.map_or(35, |item| item.plausibility);
+            let curation = relation_candidate.map_or(70, |item| item.curation);
+            let impossible = relation_candidate
+                .and_then(|item| item.hard_zero_reason.as_deref())
+                .map(|_| "catalog-authored hard zero");
+            let bridge = relation_candidate
+                .and_then(|item| item.required_bridge.as_deref())
+                .map(|id| match id {
+                    "child_at_adult_venue" => "bridge.child_at_adult_venue",
+                    _ => unreachable!("validated bridge adapter"),
+                });
+            Candidate {
+                id: authored.id.as_str(),
+                value: circ,
+                weight: Weight::new(p, curation),
+                bridge,
+                impossible,
+                factors: vec!["factor.witness.catalog"],
             }
-            (_, C::RoadJourney) => (55, None, None, "factor.witness.travel"),
-            (_, C::SecretRiversideMeeting) => (25, None, None, "factor.witness.private"),
-            _ => (35, None, None, "factor.witness.general"),
-        };
-        Candidate {
-            id: circumstance_id(circ),
-            value: circ,
-            weight: Weight::new(p, 70),
-            bridge,
-            impossible,
-            factors: vec![factor],
-        }
-    })
-    .collect()
+        })
+        .collect()
 }
 
 fn description_candidates(cause: CanonicalCause) -> Vec<Candidate<ReportDescription>> {
-    ALL_REPORTS
+    crate::quest_catalog::catalog()
+        .documents
         .iter()
-        .copied()
-        .map(|report| {
+        .flat_map(|document| &document.descriptions)
+        .map(|authored| {
+            let report =
+                ReportDescription::try_new(&authored.id).expect("validated open description ID");
             let p = match cause {
                 CanonicalCause::Hostile(threat) => description_likelihood(threat, report),
                 CanonicalCause::VoluntaryDisappearance
@@ -1816,7 +1739,7 @@ fn description_candidates(cause: CanonicalCause) -> Vec<Candidate<ReportDescript
                 }
             };
             Candidate {
-                id: report_id(report),
+                id: authored.id.as_str(),
                 value: report,
                 weight: Weight::new(p, 80),
                 bridge: None,
@@ -1827,52 +1750,23 @@ fn description_candidates(cause: CanonicalCause) -> Vec<Candidate<ReportDescript
         .collect()
 }
 
-fn site_id(site: SiteKind) -> &'static str {
-    match site {
-        SiteKind::Cave => "site.cave",
-        SiteKind::Crypt => "site.crypt",
-        SiteKind::ForestCamp => "site.forest_camp",
-        SiteKind::OccupiedHouse => "site.occupied_house",
-        SiteKind::Riverside => "site.riverside",
-        SiteKind::Graveyard => "site.graveyard",
-        SiteKind::Roadside => "site.roadside",
-        SiteKind::AbandonedFarm => "site.abandoned_farm",
-    }
-}
-fn circumstance_id(v: Circumstance) -> &'static str {
-    match v {
-        Circumstance::NightWindow => "circumstance.night_window",
-        Circumstance::SecretRiversideMeeting => "circumstance.secret_riverside",
-        Circumstance::AdultVenue => "circumstance.adult_venue",
-        Circumstance::RoadJourney => "circumstance.road",
-        Circumstance::GraveDuty => "circumstance.grave_duty",
-        Circumstance::LivestockWatch => "circumstance.livestock_watch",
-    }
-}
 fn report_id(v: ReportDescription) -> &'static str {
-    match v {
-        ReportDescription::ArmedPeople => "description.armed_people",
-        ReportDescription::SmallUprightFigures => "description.small_upright",
-        ReportDescription::LargeUprightBeast => "description.large_upright",
-        ReportDescription::GauntHuman => "description.gaunt_human",
-        ReportDescription::WalkingDead => "description.walking_dead",
-        ReportDescription::LargeAnimal => "description.large_animal",
-        ReportDescription::DoglikeBeast => "description.doglike",
-        ReportDescription::UnseenNightVisitor => "description.unseen",
-    }
+    crate::quest_catalog::catalog()
+        .documents
+        .iter()
+        .flat_map(|document| &document.descriptions)
+        .find(|item| item.id == v.as_str())
+        .expect("generated description exists")
+        .id
+        .as_str()
 }
 
 fn ambiguous_report_description(v: ReportDescription) -> &'static str {
-    match v {
-        ReportDescription::ArmedPeople => "a group of armed figures",
-        ReportDescription::SmallUprightFigures => "several small figures moving upright",
-        ReportDescription::LargeUprightBeast => "a large shape that seemed to stand upright",
-        ReportDescription::GauntHuman => "a gaunt, human-shaped figure",
-        ReportDescription::WalkingDead => "a person moving with a stiff, shambling gait",
-        ReportDescription::LargeAnimal => "the silhouette of a large animal",
-        ReportDescription::DoglikeBeast => "a low, dog-shaped beast",
-        ReportDescription::UnseenNightVisitor => "something hidden in the darkness",
-    }
+    crate::quest_catalog::catalog()
+        .description(report_catalog_id(v))
+        .expect("validated description catalog covers closed mechanics adapter")
+        .text
+        .as_str()
 }
 
 fn ambiguous_visual_claim(v: ReportDescription, place: &str) -> String {
@@ -1883,24 +1777,37 @@ fn ambiguous_visual_claim(v: ReportDescription, place: &str) -> String {
 }
 
 fn terrain(site: SiteKind) -> Terrain {
-    match site {
-        SiteKind::Cave | SiteKind::Crypt => Terrain::Underground,
-        SiteKind::ForestCamp | SiteKind::AbandonedFarm => Terrain::Forest,
-        SiteKind::OccupiedHouse | SiteKind::Graveyard => Terrain::Settlement,
-        SiteKind::Riverside | SiteKind::Roadside => Terrain::Road,
+    match crate::quest_catalog::catalog()
+        .site(site_catalog_id(site))
+        .expect("validated site catalog covers closed mechanics adapter")
+        .terrain
+        .as_str()
+    {
+        "underground" => Terrain::Underground,
+        "forest" => Terrain::Forest,
+        "settlement" => Terrain::Settlement,
+        "road" => Terrain::Road,
+        _ => unreachable!("startup validation rejects unknown terrain"),
     }
 }
 fn label(site: SiteKind) -> &'static str {
-    match site {
-        SiteKind::Cave => "a cave beyond the fields",
-        SiteKind::Crypt => "the old crypt",
-        SiteKind::ForestCamp => "a camp in the woods",
-        SiteKind::OccupiedHouse => "an occupied house",
-        SiteKind::Riverside => "a secluded bend in the river",
-        SiteKind::Graveyard => "the old graveyard",
-        SiteKind::Roadside => "a lonely stretch of road",
-        SiteKind::AbandonedFarm => "an abandoned farm",
-    }
+    crate::quest_catalog::catalog()
+        .site(site_catalog_id(site))
+        .expect("validated site catalog covers closed mechanics adapter")
+        .label
+        .as_str()
+}
+
+fn site_catalog_id(site: SiteKind) -> &'static str {
+    crate::quest_catalog::catalog()
+        .site(site.as_str())
+        .expect("generated site identity exists in catalog")
+        .id
+        .as_str()
+}
+
+fn report_catalog_id(report: ReportDescription) -> &'static str {
+    report_id(report)
 }
 
 fn bridge(id: &str, prefix: &str, family: TemplateFamily, _now: u64) -> CausalBridge {
@@ -1943,62 +1850,41 @@ fn bridge(id: &str, prefix: &str, family: TemplateFamily, _now: u64) -> CausalBr
 }
 
 fn consequence(cause: CanonicalCause, family: TemplateFamily) -> ConsequenceProfile {
-    let (symptom, effects, summary) = match (family, cause) {
-        (
-            TemplateFamily::RecurringDepredation,
-            CanonicalCause::Hostile(ThreatId::Ghoul | ThreatId::Werewolf),
-        ) => (
-            Symptom::NightScreams,
-            Effects {
-                buy_bps: 400,
-                sell_penalty_bps: 200,
-                encounter_frequency_bps: 700,
-                encounter_archetype: Some(EncounterArchetype::Undead),
-                disease_intensity: 180,
-            },
-            "Locals report troubling sounds and disappearances after dark.",
-        ),
-        (
-            TemplateFamily::RecurringDepredation,
-            CanonicalCause::Hostile(ThreatId::Wolf | ThreatId::Goblin),
-        ) => (
-            Symptom::VanishedLivestock,
-            Effects {
-                buy_bps: 700,
-                sell_penalty_bps: 300,
-                encounter_frequency_bps: 1000,
-                encounter_archetype: Some(EncounterArchetype::Goblins),
-                disease_intensity: 0,
-            },
-            "Livestock have been disappearing from nearby holdings.",
-        ),
-        (TemplateFamily::RecurringDepredation, _) => (
-            Symptom::MissingCaravans,
-            Effects {
-                buy_bps: 1200,
-                sell_penalty_bps: 500,
-                encounter_frequency_bps: 1500,
-                encounter_archetype: Some(EncounterArchetype::Bandits),
-                disease_intensity: 0,
-            },
-            "Several expected caravans have not arrived.",
-        ),
-        (TemplateFamily::DisappearanceOrLoss, _) => (
-            Symptom::EmptyStalls,
-            Effects {
-                buy_bps: 900,
-                sell_penalty_bps: 400,
-                encounter_frequency_bps: 500,
-                encounter_archetype: None,
-                disease_intensity: 0,
-            },
-            "A disappearance has disrupted work and trade, but nobody agrees on the cause.",
-        ),
+    let family_id = match family {
+        TemplateFamily::RecurringDepredation => "recurring_depredation",
+        TemplateFamily::DisappearanceOrLoss => "disappearance_or_loss",
     };
+    let cause_id = match cause {
+        CanonicalCause::Hostile(threat) => threat.as_str().to_owned(),
+        CanonicalCause::VoluntaryDisappearance => "voluntary_disappearance".into(),
+        CanonicalCause::ConcealmentByWitness => "concealment".into(),
+        CanonicalCause::IncidentalLoss => "incidental_loss".into(),
+        CanonicalCause::FabricatedClaim => "fabricated".into(),
+    };
+    let authored = crate::quest_catalog::catalog()
+        .consequence(family_id, &cause_id)
+        .expect("validated consequence coverage");
     ConsequenceProfile {
-        symptom,
-        effects,
-        public_summary: summary.into(),
+        symptom: match authored.symptom.as_str() {
+            "night_screams" => Symptom::NightScreams,
+            "vanished_livestock" => Symptom::VanishedLivestock,
+            "missing_caravans" => Symptom::MissingCaravans,
+            "empty_stalls" => Symptom::EmptyStalls,
+            _ => unreachable!("validated consequence symptom"),
+        },
+        effects: Effects {
+            buy_bps: authored.buy_bps,
+            sell_penalty_bps: authored.sell_penalty_bps,
+            encounter_frequency_bps: authored.encounter_frequency_bps,
+            encounter_archetype: authored.encounter_archetype.as_deref().map(|id| match id {
+                "undead" => EncounterArchetype::Undead,
+                "goblins" => EncounterArchetype::Goblins,
+                "bandits" => EncounterArchetype::Bandits,
+                _ => unreachable!("validated encounter archetype"),
+            }),
+            disease_intensity: authored.disease_intensity,
+        },
+        public_summary: authored.public_summary.clone(),
     }
 }
 
@@ -2861,6 +2747,41 @@ pub fn generate(context: &GenerationContext) -> Result<GeneratedCase, Generation
             ),
         },
     };
+    let template_id = match family {
+        TemplateFamily::RecurringDepredation => "recurring_depredation",
+        TemplateFamily::DisappearanceOrLoss => "disappearance_or_loss",
+    };
+    let cause_key = match cause {
+        CanonicalCause::Hostile(_) => "hostile",
+        CanonicalCause::ConcealmentByWitness => "concealment",
+        CanonicalCause::IncidentalLoss => "incidental_loss",
+        CanonicalCause::FabricatedClaim => "fabricated",
+        CanonicalCause::VoluntaryDisappearance => "voluntary_disappearance",
+    };
+    let template = crate::quest_catalog::catalog()
+        .template(template_id)
+        .unwrap();
+    let configured_finales = template
+        .cause_finales
+        .get(cause_key)
+        .or_else(|| template.cause_finales.get("*"))
+        .expect("validated template cause/finale coverage");
+    assert_eq!(
+        finales
+            .iter()
+            .map(|finale| match finale.kind {
+                FinaleKind::Defeat => "defeat",
+                FinaleKind::DriveOff => "drive_off",
+                FinaleKind::Capture => "capture",
+                FinaleKind::Rescue => "rescue",
+                FinaleKind::RetrieveReturn => "retrieve_return",
+                FinaleKind::Expose => "expose",
+                FinaleKind::Negotiate => "negotiate",
+            })
+            .collect::<Vec<_>>(),
+        *configured_finales,
+        "typed objective assembler must implement the YAML finale plan"
+    );
     let mut bridges = Vec::new();
     for key in [
         site_bridge,
@@ -3604,10 +3525,16 @@ mod tests {
 
     #[test]
     fn every_report_description_has_ambiguous_natural_testimony() {
-        assert_eq!(ALL_REPORTS.len(), 8);
-        for report in ALL_REPORTS {
-            let prose = ambiguous_report_description(*report);
-            let claim = ambiguous_visual_claim(*report, "the old bridge");
+        let reports = crate::quest_catalog::catalog()
+            .documents
+            .iter()
+            .flat_map(|document| &document.descriptions)
+            .map(|description| ReportDescription::try_new(&description.id).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(reports.len(), 8);
+        for report in reports {
+            let prose = ambiguous_report_description(report);
+            let claim = ambiguous_visual_claim(report, "the old bridge");
             assert!(!prose.is_empty());
             assert!(
                 !claim.contains(&format!("{report:?}")),
@@ -4441,7 +4368,7 @@ mod tests {
         .unwrap();
         let house = trace
             .iter()
-            .find(|t| t.candidate_id == "site.occupied_house")
+            .find(|t| t.candidate_id == "occupied_house")
             .unwrap();
         assert_eq!(house.plausibility, 3);
         assert_eq!(
@@ -4450,7 +4377,7 @@ mod tests {
         );
         let wolf_crypt = site_candidates(CanonicalCause::Hostile(ThreatId::Wolf))
             .into_iter()
-            .find(|c| c.id == "site.crypt")
+            .find(|c| c.id == "crypt")
             .unwrap();
         assert_eq!(wolf_crypt.weight.plausibility, 0);
         assert!(wolf_crypt.impossible.is_some());

--- a/crates/adventuresim-core/src/quest_generation.rs
+++ b/crates/adventuresim-core/src/quest_generation.rs
@@ -698,6 +698,11 @@ pub struct GeneratedDialogueProducer {
 pub struct GeneratedCase {
     pub catalog_revision: String,
     pub generation_seed: u64,
+    pub template_id: String,
+    pub configured_routes: Vec<String>,
+    pub configured_objectives: Vec<String>,
+    pub incident_interval_minutes: u64,
+    pub maximum_incidents: u16,
     pub family: TemplateFamily,
     pub canonical_case_id: String,
     pub public_case_id: String,
@@ -1613,13 +1618,7 @@ fn site_candidates(cause: CanonicalCause) -> Vec<Candidate<SiteKind>> {
             let impossible = relation
                 .and_then(|item| item.hard_zero_reason.as_deref())
                 .map(|_| "catalog-authored hard zero");
-            let bridge = relation
-                .and_then(|item| item.required_bridge.as_deref())
-                .map(|id| match id {
-                    "skeletons_occupied_house" => "bridge.skeletons_occupied_house",
-                    "child_at_adult_venue" => "bridge.child_at_adult_venue",
-                    _ => unreachable!("validated bridge adapter"),
-                });
+            let bridge = relation.and_then(|item| item.required_bridge.as_deref());
             Candidate {
                 id: authored_site.id.as_str(),
                 value: site,
@@ -1690,12 +1689,7 @@ fn circumstance_candidates(demo: WitnessDemographic) -> Vec<Candidate<Circumstan
             let impossible = relation_candidate
                 .and_then(|item| item.hard_zero_reason.as_deref())
                 .map(|_| "catalog-authored hard zero");
-            let bridge = relation_candidate
-                .and_then(|item| item.required_bridge.as_deref())
-                .map(|id| match id {
-                    "child_at_adult_venue" => "bridge.child_at_adult_venue",
-                    _ => unreachable!("validated bridge adapter"),
-                });
+            let bridge = relation_candidate.and_then(|item| item.required_bridge.as_deref());
             Candidate {
                 id: authored.id.as_str(),
                 value: circ,
@@ -1811,49 +1805,32 @@ fn report_catalog_id(report: ReportDescription) -> &'static str {
 }
 
 fn bridge(id: &str, prefix: &str, family: TemplateFamily, _now: u64) -> CausalBridge {
-    let action_name = match (id, family) {
-        ("bridge.skeletons_occupied_house", TemplateFamily::RecurringDepredation) => "search",
-        ("bridge.skeletons_occupied_house", TemplateFamily::DisappearanceOrLoss) => {
-            "inspect_last_known"
-        }
-        ("bridge.child_at_adult_venue", TemplateFamily::RecurringDepredation) => "watch",
-        ("bridge.child_at_adult_venue", TemplateFamily::DisappearanceOrLoss) => "locate_contact",
-        (_, _) => "approach",
-    };
-    let action_id = ActionId::new(scoped_id(prefix, "action", action_name));
-    match id {
-        "bridge.skeletons_occupied_house" => CausalBridge {
-            id: BridgeId::new(id),
-            explanation: "A graverobber moved animated remains into a shuttered house.".into(),
-            event_id: scoped_id(prefix, "event", "bridge:skeleton_house"),
-            evidence_id: EvidenceId::new(scoped_id(prefix, "evidence", "grave_clay")),
-            action_id,
-            lead_summary: "Grave clay and cart ruts connect the house to the crypt.".into(),
-        },
-        "bridge.child_at_adult_venue" => CausalBridge {
-            id: BridgeId::new(id),
-            explanation: "The child was fetching an adult relative from outside the venue.".into(),
-            event_id: scoped_id(prefix, "event", "bridge:child_venue"),
-            evidence_id: EvidenceId::new(scoped_id(prefix, "evidence", "errand_token")),
-            action_id,
-            lead_summary: "An errand token corroborates why the child waited outside.".into(),
-        },
-        _ => CausalBridge {
-            id: BridgeId::new(id),
-            explanation: "A rare causal link makes the combination possible.".into(),
-            event_id: scoped_id(prefix, "event", "bridge"),
-            evidence_id: EvidenceId::new(scoped_id(prefix, "evidence", "bridge")),
-            action_id,
-            lead_summary: "A corroborating clue explains the unusual combination.".into(),
-        },
-    }
-}
-
-fn consequence(cause: CanonicalCause, family: TemplateFamily) -> ConsequenceProfile {
+    let catalog_id = id.trim_start_matches("bridge.");
+    let authored = crate::quest_catalog::catalog()
+        .bridge(catalog_id)
+        .expect("validated bridge reference");
     let family_id = match family {
         TemplateFamily::RecurringDepredation => "recurring_depredation",
         TemplateFamily::DisappearanceOrLoss => "disappearance_or_loss",
     };
+    let action_id = authored
+        .action_ids
+        .get(family_id)
+        .expect("validated bridge action coverage");
+    CausalBridge {
+        id: BridgeId::new(id),
+        explanation: authored.explanation.clone(),
+        event_id: scoped_id(prefix, "event", &authored.event_suffix),
+        evidence_id: EvidenceId::new(scoped_id(prefix, "evidence", &authored.evidence_id)),
+        action_id: ActionId::new(scoped_id(prefix, "action", action_id)),
+        lead_summary: authored.lead_summary.clone(),
+    }
+}
+
+fn consequence(
+    cause: CanonicalCause,
+    template: &crate::quest_catalog::TemplateDefinition,
+) -> ConsequenceProfile {
     let cause_id = match cause {
         CanonicalCause::Hostile(threat) => threat.as_str().to_owned(),
         CanonicalCause::VoluntaryDisappearance => "voluntary_disappearance".into(),
@@ -1862,7 +1839,7 @@ fn consequence(cause: CanonicalCause, family: TemplateFamily) -> ConsequenceProf
         CanonicalCause::FabricatedClaim => "fabricated".into(),
     };
     let authored = crate::quest_catalog::catalog()
-        .consequence(family_id, &cause_id)
+        .consequence(&template.consequence_profile, &cause_id)
         .expect("validated consequence coverage");
     ConsequenceProfile {
         symptom: match authored.symptom.as_str() {
@@ -2835,7 +2812,7 @@ pub fn generate(context: &GenerationContext) -> Result<GeneratedCase, Generation
         predicate: "caused".into(),
         object: format!(
             "{attack_pattern:?}:{:?}",
-            consequence(cause, family).symptom
+            consequence(cause, template).symptom
         ),
         occurred_at: context.now_minute.saturating_sub(180),
     }]
@@ -2866,13 +2843,18 @@ pub fn generate(context: &GenerationContext) -> Result<GeneratedCase, Generation
     let manifest = GeneratedCase {
         catalog_revision: CATALOG_REVISION.into(),
         generation_seed: context.seed,
+        template_id: template.id.clone(),
+        configured_routes: template.routes.clone(),
+        configured_objectives: template.objectives.clone(),
+        incident_interval_minutes: template.incident_interval_minutes,
+        maximum_incidents: u16::from(template.maximum_incidents),
         family,
         canonical_case_id,
         public_case_id,
         problem_id,
         cause,
         canonical_events,
-        consequence: consequence(cause, family),
+        consequence: consequence(cause, template),
         sites,
         areas: vec![GeneratedArea {
             id: area_id,
@@ -4373,7 +4355,7 @@ mod tests {
         assert_eq!(house.plausibility, 3);
         assert_eq!(
             house.required_bridge.as_ref().unwrap().0,
-            "bridge.skeletons_occupied_house"
+            "skeletons_occupied_house"
         );
         let wolf_crypt = site_candidates(CanonicalCause::Hostile(ThreatId::Wolf))
             .into_iter()
@@ -4389,7 +4371,7 @@ mod tests {
             .find(|c| c.value == Circumstance::AdultVenue)
             .unwrap();
         assert_eq!(adult.weight.plausibility, 2);
-        assert_eq!(adult.bridge, Some("bridge.child_at_adult_venue"));
+        assert_eq!(adult.bridge, Some("child_at_adult_venue"));
     }
     #[test]
     fn graph_keeps_both_routes_reachable_from_authored_entries() {

--- a/crates/adventuresim-stdb-module/src/local_problem.rs
+++ b/crates/adventuresim-stdb-module/src/local_problem.rs
@@ -420,7 +420,12 @@ pub(crate) fn ensure_generated_incidents(
         let Some(validated) = validated_problem_generation(ctx, &problem, settlement_id) else {
             continue;
         };
-        let due = lp::due_incident_count(problem.starts_at, minute);
+        let due = lp::due_incident_count_configured(
+            problem.starts_at,
+            minute,
+            validated.manifest.incident_interval_minutes,
+            validated.manifest.maximum_incidents,
+        );
         if due <= problem.incident_count {
             continue;
         }
@@ -461,7 +466,8 @@ pub(crate) fn ensure_generated_incidents(
             let proposition_id = format!("{id}:proposition");
             let evidence_id = format!("{id}:evidence");
             let occurred_at = problem.starts_at.saturating_add(
-                u64::from(ordinal.saturating_sub(1)).saturating_mul(lp::INCIDENT_INTERVAL_MINUTES),
+                u64::from(ordinal.saturating_sub(1))
+                    .saturating_mul(validated.manifest.incident_interval_minutes),
             );
             let public_summary = follow_up_summary(&problem.symptom).to_owned();
             let witness_account = format!(

--- a/crates/adventuresim-stdb-module/src/local_problem.rs
+++ b/crates/adventuresim-stdb-module/src/local_problem.rs
@@ -372,30 +372,21 @@ pub(crate) fn materialize_generated_problem(
 fn incident_circumstance_label(
     value: adventuresim_core::quest_generation::Circumstance,
 ) -> &'static str {
-    use adventuresim_core::quest_generation::Circumstance;
-    match value {
-        Circumstance::NightWindow => "looking out after dark",
-        Circumstance::SecretRiversideMeeting => "being near the river at night",
-        Circumstance::AdultVenue => "leaving a public house late",
-        Circumstance::RoadJourney => "travelling on the road",
-        Circumstance::GraveDuty => "working near the graves",
-        Circumstance::LivestockWatch => "watching the livestock",
-    }
+    adventuresim_core::quest_catalog::catalog()
+        .circumstance(value.as_str())
+        .expect("generated circumstance exists in startup catalog")
+        .statement
+        .as_str()
 }
 
 fn incident_evidence_description(
     kind: adventuresim_core::quest_generation::EvidenceKind,
 ) -> &'static str {
-    use adventuresim_core::quest_generation::EvidenceKind;
-    match kind {
-        EvidenceKind::Footprints => "a fresh trail of footprints",
-        EvidenceKind::ClothScrap => "a torn scrap of cloth",
-        EvidenceKind::BoneDust => "unusual dust and bone fragments",
-        EvidenceKind::BloodlessCorpse => "a body bearing no obvious wound",
-        EvidenceKind::DroppedToken => "a token dropped during the incident",
-        EvidenceKind::DragMarks => "fresh drag marks",
-        EvidenceKind::LedgerEntry => "a newly relevant ledger entry",
-    }
+    adventuresim_core::quest_catalog::catalog()
+        .evidence(kind.as_str())
+        .expect("generated evidence exists in startup catalog")
+        .base_description
+        .as_str()
 }
 
 fn follow_up_summary(symptom: &str) -> &'static str {

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -71,18 +71,31 @@ fn quest_encounter_archetype(
     enemy_type: &str,
 ) -> Option<adventuresim_core::encounter::EncounterArchetype> {
     use adventuresim_core::{bestiary::ThreatId, encounter::EncounterArchetype};
-    match parse_threat(enemy_type).ok()? {
-        ThreatId::Goblin | ThreatId::Kobold => Some(EncounterArchetype::Goblins),
-        ThreatId::Skeleton | ThreatId::Ghoul | ThreatId::Revenant | ThreatId::Nachzehrer => {
-            Some(EncounterArchetype::Undead)
-        }
-        ThreatId::Bandit
-        | ThreatId::Deserter
-        | ThreatId::Poacher
-        | ThreatId::Smuggler
-        | ThreatId::Cultist
-        | ThreatId::GraveRobber => Some(EncounterArchetype::Bandits),
-        _ => None,
+    let threat = parse_threat(enemy_type).ok()?;
+    if [ThreatId::Goblin, ThreatId::Kobold].contains(&threat) {
+        Some(EncounterArchetype::Goblins)
+    } else if [
+        ThreatId::Skeleton,
+        ThreatId::Ghoul,
+        ThreatId::Revenant,
+        ThreatId::Nachzehrer,
+    ]
+    .contains(&threat)
+    {
+        Some(EncounterArchetype::Undead)
+    } else if [
+        ThreatId::Bandit,
+        ThreatId::Deserter,
+        ThreatId::Poacher,
+        ThreatId::Smuggler,
+        ThreatId::Cultist,
+        ThreatId::GraveRobber,
+    ]
+    .contains(&threat)
+    {
+        Some(EncounterArchetype::Bandits)
+    } else {
+        None
     }
 }
 
@@ -18053,12 +18066,15 @@ pub(crate) fn generated_npc_presence_version(
 }
 
 fn generated_scene_key(kind: adventuresim_core::quest_generation::SiteKind) -> &'static str {
-    use adventuresim_core::quest_generation::SiteKind;
-    match kind {
-        SiteKind::Cave | SiteKind::Crypt => "cave",
-        SiteKind::ForestCamp | SiteKind::AbandonedFarm => "woods",
-        SiteKind::OccupiedHouse | SiteKind::Graveyard => "ruins",
-        SiteKind::Riverside | SiteKind::Roadside => "camp",
+    let site = adventuresim_core::quest_catalog::catalog()
+        .site(kind.as_str())
+        .expect("generated site exists in startup catalog");
+    match site.terrain.as_str() {
+        "underground" => "cave",
+        "forest" => "woods",
+        "settlement" => "ruins",
+        "road" => "camp",
+        _ => unreachable!("catalog validation rejects unknown terrain mechanics"),
     }
 }
 

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -18026,25 +18026,13 @@ fn generated_witness_candidates(
 pub(crate) fn generated_npc_demographic(
     npc: &crate::settlement_population::SettlementNpc,
 ) -> adventuresim_core::quest_generation::WitnessDemographic {
-    use adventuresim_core::quest_generation::WitnessDemographic;
-    match npc.age_band {
-        crate::settlement_population::NpcAgeBand::Child
-        | crate::settlement_population::NpcAgeBand::Adolescent => WitnessDemographic::Child,
-        crate::settlement_population::NpcAgeBand::Adult
-        | crate::settlement_population::NpcAgeBand::Elder => {
-            if npc.profession.contains("merchant") {
-                WitnessDemographic::Merchant
-            } else if npc.profession.contains("cleric") {
-                WitnessDemographic::Cleric
-            } else if npc.profession.contains("guard") || npc.local_role.contains("retainer") {
-                WitnessDemographic::Guard
-            } else if npc.local_role.contains("lord") {
-                WitnessDemographic::Noble
-            } else {
-                WitnessDemographic::Laborer
-            }
-        }
-    }
+    let age_band = format!("{:?}", npc.age_band).to_ascii_lowercase();
+    let sex = format!("{:?}", npc.sex).to_ascii_lowercase();
+    let authored = adventuresim_core::quest_catalog::catalog()
+        .witness_demographic_for(&age_band, &sex, &npc.profession, &npc.local_role)
+        .expect("validated demographic catalog has one fallback");
+    adventuresim_core::quest_generation::WitnessDemographic::try_new(&authored.id)
+        .expect("validated open demographic ID")
 }
 
 pub(crate) fn generated_npc_presence_version(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,12 @@
 # Architecture MVP - Adventure Simulator
 
+Repository-authored dialogue and quest content share a deployment boundary:
+sorted YAML sources are validated and compiled into their crate, then
+deserialized once at startup. Services never interpret loose deployment files.
+Generated quest authority persists the content digest used to create it.
+Canonical truth, hard-zero diagnostics, hidden evidence DCs and factor traces
+remain private; catalog authoring does not broaden observer-safe projections.
+
 Persistent local problems and their privacy boundary are specified in
 [LOCAL_PROBLEMS.md](LOCAL_PROBLEMS.md). Their strategic authority is stored in
 SpacetimeDB; generation and consequence evaluation are pure shared-core logic.

--- a/docs/BESTIARY.md
+++ b/docs/BESTIARY.md
@@ -22,6 +22,10 @@ temperament, encounter scaling, and loot. Investigation covers
 habitat/activity/victims, tracks,
 wounds, disturbances, sounds, silhouettes, odors, mistaken identities,
 distinguishing evidence, visibility, and preparation advice.
+Track, wound, disturbance, odor, and distinguishing-evidence IDs are bounded
+open catalog strings. New physical trace identities therefore do not require a
+Rust enum edit; code changes only when a new executable interpretation is
+needed.
 
 The strategic autoresolver consumes identity, loadout, protection, speed,
 loot, perception/stealth, morale, encounter scaling, and innate protection.
@@ -52,8 +56,8 @@ Zero means impossible and is never raised by curation. A low positive weight
 means rare. The public habitat-selection API validates improbable combinations
 and requires a typed `CausalBridge` with evidence outputs. For
 example, skeletons in an occupied house require a cellar crypt, graveyard
-tunnel, or resident controller. Witness demographics belong to the future case
-model, not this threat-focused catalog.
+tunnel, or resident controller. Causal bridge identities and their event,
+evidence, and action outputs are authored as bounded open IDs.
 
 The MVP northern-Germany regional prior is a small typed authoring context,
 separate from curation; it is not yet derived from imported world geography.

--- a/docs/BESTIARY.md
+++ b/docs/BESTIARY.md
@@ -1,10 +1,17 @@
 # Bestiary authority
 
+Canonical authoring records live in `content/quests/bestiary.yaml`. They are
+sorted, validated, embedded and content-hashed at build time; see
+[Quest generation](QUEST_GENERATION.md). Combat weaknesses use the ordinary
+physical resistance/padding model. Skeleton bone, for example, has edge
+resistance and no innate padding rather than a flat cut/blunt multiplier.
+
 `adventuresim-core::bestiary` is the shared authority for strategic threat
 identity. Persisted `Quest.enemy_type` and `StrategicEncounter.archetype`
-strings are stable `ThreatId` values such as `skeleton` and `grave_robber`.
-Display names and aliases never select behavior, and unknown IDs are rejected
-at strategic combat and loot boundaries instead of becoming a generic enemy.
+strings are bounded, open `ThreatId` values such as `skeleton` and
+`grave_robber`. Display names and aliases never select behavior, and IDs absent
+from the startup catalog are rejected at strategic combat and loot boundaries
+instead of becoming a generic enemy.
 
 ## Profiles and current consumers
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -13,9 +13,10 @@ The build, runtime startup, and checker share one strict catalog validator. It
 reports the source file and structural path for unknown fields, duplicate or
 overlong IDs, dangling references, incomplete relation coverage, ambiguous
 witness-demographic predicates, unknown closed mechanics, invalid evidence DC
-ranges, unsupported template graphs, and zero weights without a hard-zero
-reason. Catalog IDs are at most 63 ASCII identifier bytes. Production embeds
-the validated files; it never reads loose quest YAML.
+ranges, runtime numeric overflows, malformed nullable values, unsupported
+template graphs, and zero weights without a hard-zero reason. It also enforces
+bow/ranged consistency. Catalog IDs are at most 63 ASCII identifier bytes.
+Production embeds the validated files; it never reads loose quest YAML.
 
 Local workflow for running the Adventure Simulator demo.
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -1,5 +1,18 @@
 # Development Workflow
 
+## Quest content
+
+Quest and bestiary content lives in `content/quests/*.yaml` using the same
+strict JSON-compatible YAML convention as dialogue. Validate it with:
+
+```powershell
+cargo run -p adventuresim-core --bin questgen-check -- validate
+```
+
+The build reports the source file and offending ID or relation for duplicate
+IDs, dangling bridge/monster references, unknown mechanics, invalid evidence
+DC ranges, and zero weights without a hard-zero reason.
+
 Local workflow for running the Adventure Simulator demo.
 
 For deterministic multi-year NPC balance experiments and replay commands, see

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -9,9 +9,13 @@ strict JSON-compatible YAML convention as dialogue. Validate it with:
 cargo run -p adventuresim-core --bin questgen-check -- validate
 ```
 
-The build reports the source file and offending ID or relation for duplicate
-IDs, dangling bridge/monster references, unknown mechanics, invalid evidence
-DC ranges, and zero weights without a hard-zero reason.
+The build, runtime startup, and checker share one strict catalog validator. It
+reports the source file and structural path for unknown fields, duplicate or
+overlong IDs, dangling references, incomplete relation coverage, ambiguous
+witness-demographic predicates, unknown closed mechanics, invalid evidence DC
+ranges, unsupported template graphs, and zero weights without a hard-zero
+reason. Catalog IDs are at most 63 ASCII identifier bytes. Production embeds
+the validated files; it never reads loose quest YAML.
 
 Local workflow for running the Adventure Simulator demo.
 

--- a/docs/QUEST_GENERATION.md
+++ b/docs/QUEST_GENERATION.md
@@ -1,5 +1,57 @@
 # Quest generation
 
+## Authoring catalog
+
+Modular quest and bestiary content is authored in the strict JSON-compatible
+subset of YAML under `content/quests/`. Files are read in sorted path order,
+validated during the `adventuresim-core` build, embedded in the executable,
+and parsed into an immutable catalog once at process startup. Production does
+not read loose YAML. The SHA-256 digest of filenames and exact source bytes is
+the generated-case catalog revision, so changing authored content creates a
+new deterministic replay boundary.
+
+`bestiary.yaml` owns current monster names, aliases, combat values,
+loot/loadout identifier, innate resistance and padding, behavior, habitats,
+descriptions, clues, ambiguity links, and preparation text.
+`investigation.yaml` owns evidence portraits, inspection topics and
+creation-time DC ranges, witness demographics and circumstances, descriptions,
+sites, and rare bridges. `generation.yaml` owns templates and separate
+plausibility/curation weights, including explicit hard zeros.
+
+Run `cargo run -p adventuresim-core --bin questgen-check -- validate` after an
+edit. The build rejects duplicate IDs, dangling references, invalid mechanics
+names and malformed weights before the server can start.
+
+### Current typed adapter boundary
+
+Threat, site, witness-demographic, circumstance, ambiguous-description, and
+physical-evidence identities are bounded open string IDs. A new value using
+existing mechanics therefore requires YAML only. Closed Rust enums remain only
+where the engine must execute a finite mechanic: rig topology, attack style,
+protection, temperament, activity period, terrain, evidence check attribute,
+reliability behavior, route/action and objective operation, settlement symptom,
+and encounter archetype. Adding a new value to one of those finite mechanic
+vocabularies requires Rust.
+
+Typed investigation lists, aliases, regional priors and loadout IDs are
+embedded. Tactical materialization currently consumes only one loot item ID;
+it does not support multi-item authored loadouts, ability scripts, bespoke AI
+state machines, or new rig/animation topologies. Behavior currently reaches
+combat through temperament, perception, stealth, morale, movement, attack,
+ranged precision, encounter scale, and physically based innate resistance and
+padding. These are the factual incomplete bestiary surfaces for this change.
+
+The first catalog boundary does not yet interpret arbitrary authored graph
+programs. Reliability semantics (truthful, mistaken, evasive, deceptive),
+account-style behavior, route/action execution, finale/objective execution,
+symptom-to-settlement-effect calculation, and incident construction remain
+closed engine mechanics. Their available IDs and primary selection weights are
+declared in YAML, but adding a new executable semantic requires Rust. Likewise,
+template declarations expose route/objective sets and scheduling metadata for
+authoring and the debug editor, while the two current graph assemblers remain
+typed Rust implementations. This prevents content from becoming executable
+server code and is the principal incomplete quest surface of this PR.
+
 Generated quests are deterministic typed case manifests assembled from shared
 modules rather than scripts with substituted nouns. The initial catalog has
 two families:

--- a/docs/QUEST_GENERATION.md
+++ b/docs/QUEST_GENERATION.md
@@ -19,19 +19,26 @@ sites, and rare bridges. `generation.yaml` owns templates and separate
 plausibility/curation weights, including explicit hard zeros.
 
 Run `cargo run -p adventuresim-core --bin questgen-check -- validate` after an
-edit. The build rejects duplicate IDs, dangling references, invalid mechanics
-names and malformed weights before the server can start.
+edit. Build-time embedding, process startup, and the authoring checker use the
+same exhaustive validator. It rejects unknown fields, duplicate or overlong
+IDs, dangling references, incomplete relation coverage, ambiguous witness
+rules, invalid closed-mechanic names, malformed evidence DCs and weights, and
+unsupported template graphs. Diagnostics include the source file and
+structural path. Open catalog IDs are limited to 63 ASCII identifier bytes.
 
 ### Current typed adapter boundary
 
-Threat, site, witness-demographic, circumstance, ambiguous-description, and
-physical-evidence identities are bounded open string IDs. A new value using
-existing mechanics therefore requires YAML only. Closed Rust enums remain only
+Threat, site, witness-demographic, circumstance, ambiguous-description,
+physical-evidence, bestiary-trace, and causal-bridge identities are bounded
+open string IDs. A new value using existing mechanics therefore requires YAML
+only. Closed Rust enums remain only
 where the engine must execute a finite mechanic: rig topology, attack style,
 protection, temperament, activity period, terrain, evidence check attribute,
 reliability behavior, route/action and objective operation, settlement symptom,
 and encounter archetype. Adding a new value to one of those finite mechanic
 vocabularies requires Rust.
+`shattering_blow` is a preparation hypothesis backed by the existing physical
+resistance/padding model; it does not introduce a damage multiplier.
 
 Typed investigation lists, aliases, regional priors and loadout IDs are
 embedded. Tactical materialization currently consumes only one loot item ID;
@@ -47,10 +54,20 @@ account-style behavior, route/action execution, finale/objective execution,
 symptom-to-settlement-effect calculation, and incident construction remain
 closed engine mechanics. Their available IDs and primary selection weights are
 declared in YAML, but adding a new executable semantic requires Rust. Likewise,
-template declarations expose route/objective sets and scheduling metadata for
-authoring and the debug editor, while the two current graph assemblers remain
-typed Rust implementations. This prevents content from becoming executable
-server code and is the principal incomplete quest surface of this PR.
+template declarations select the route/objective set, cause-to-finale mapping,
+consequence profile, incident interval, and incident ceiling persisted in each
+generated manifest. The two supported route/objective graph shapes still have
+typed Rust assemblers, and startup rejects any other shape. This prevents
+content from becoming executable server code and is the principal incomplete
+quest surface of this PR.
+
+Witness demographic selection is also authored. A match rule may constrain
+the NPC facts `age_band`, `sex`, `profession`, and `local_role`; empty lists are
+wildcards. Age bands are `child`, `adolescent`, `adult`, and `elder`, and sex is
+`female` or `male`. Profession and local-role selectors are lowercase
+identifier fragments matched against the generated NPC strings. Higher
+priority wins. Exactly one selector-free fallback is required, and
+equal-priority rules belonging to different demographics may not overlap.
 
 Generated quests are deterministic typed case manifests assembled from shared
 modules rather than scripts with substituted nouns. The initial catalog has
@@ -74,7 +91,10 @@ curation weights. Authoritative selection uses bounded integer arithmetic,
 stable candidate IDs, and deterministic domain-separated entropy. Zero means
 impossible. Low positive weights remain possible, but sufficiently unusual
 combinations must name a typed causal bridge. A selected bridge materializes a
-canonical event, discoverable evidence, and a playable lead.
+canonical event, discoverable evidence, and a playable lead. Each bridge
+authors the existing action that emits its evidence separately for both
+supported template families; startup rejects missing families or action names
+that their typed assembler does not emit.
 
 The solver uses deterministic weighted candidate order, forward rejection,
 and backtracking under a hard node budget. Its private trace records factors,
@@ -123,14 +143,15 @@ undiscovered evidence, true/decoy status, or hidden coordinates.
 
 The initial manifest remains immutable, but an unresolved generated problem
 may acquire append-only follow-up incidents as authoritative world time
-advances. Every two days, settlement activity materializes the next due
+advances. At the template's authored interval, settlement activity materializes the next due
 incident with a stable `(case, ordinal)` identity, occurrence time, persistent
 NPC witness and victim binding, circumstance, existing case site, canonical
 event, and new physical-evidence authority. Delayed refreshes deterministically
 catch up every missed incident. Fresh evidence is selected through the same
 cause-and-site likelihood table and hard zeros as initial evidence rather than
-an incident-only inverse lookup. The original offence plus four follow-ups is
-the current safety ceiling. Before that ceiling can leave a neglected case
+an incident-only inverse lookup. The template's authored maximum incident
+count is the current safety ceiling (five in both initial templates). Before
+that ceiling can leave a neglected case
 permanently stalled, an available resident NPC adventuring company may
 intervene after the case has aged and accumulated incidents. Recent player
 investigation or physical presence at a case site grants a grace period so the
@@ -160,9 +181,9 @@ and only the first successful discovery records the clue in the journal.
 Each accumulated incident increases the unresolved problem's trade,
 encounter, and disease consequences by 25 percent of their initial values,
 before the existing global safety caps and mitigation are applied. At the
-temporary five-incident ceiling, consequences are twice their initial
-severity. Resolving or fully mitigating the linked problem still suppresses
-all of those effects.
+currently authored five-incident ceiling, consequences are twice their initial
+severity. Resolving or fully mitigating the linked problem still suppresses all
+of those effects.
 
 NPC interventions are deterministic strategic outcomes; they do not create
 tactical tick state. A company chooses a route supported by the case's generated

--- a/docs/QUEST_GENERATION.md
+++ b/docs/QUEST_GENERATION.md
@@ -65,9 +65,12 @@ Witness demographic selection is also authored. A match rule may constrain
 the NPC facts `age_band`, `sex`, `profession`, and `local_role`; empty lists are
 wildcards. Age bands are `child`, `adolescent`, `adult`, and `elder`, and sex is
 `female` or `male`. Profession and local-role selectors are lowercase
-identifier fragments matched against the generated NPC strings. Higher
+identifiers matched against either the complete generated NPC fact or one
+whole alphanumeric token in that fact; arbitrary substrings never match.
+Selectors must match the finite NPC fact vocabulary known at startup. Higher
 priority wins. Exactly one selector-free fallback is required, and
-equal-priority rules belonging to different demographics may not overlap.
+equal-priority rules belonging to different demographics may not overlap under
+the same matching function used at runtime.
 
 Generated quests are deterministic typed case manifests assembled from shared
 modules rather than scripts with substituted nouns. The initial catalog has
@@ -94,7 +97,11 @@ combinations must name a typed causal bridge. A selected bridge materializes a
 canonical event, discoverable evidence, and a playable lead. Each bridge
 authors the existing action that emits its evidence separately for both
 supported template families; startup rejects missing families or action names
-that their typed assembler does not emit.
+that their typed assembler does not emit. A selected bridge from any
+generation relation is carried through to this materialization step. Evidence
+relations are the one explicit exception: startup rejects bridges there
+because the follow-up evidence selector has no case-graph materialization
+context.
 
 The solver uses deterministic weighted candidate order, forward rejection,
 and backtracking under a hard node budget. Its private trace records factors,

--- a/docs/QUEST_GENERATION.md
+++ b/docs/QUEST_GENERATION.md
@@ -70,7 +70,8 @@ whole alphanumeric token in that fact; arbitrary substrings never match.
 Selectors must match the finite NPC fact vocabulary known at startup. Higher
 priority wins. Exactly one selector-free fallback is required, and
 equal-priority rules belonging to different demographics may not overlap under
-the same matching function used at runtime.
+the same matching function used at runtime. Fallback priority is ignored: the
+fallback is consulted only when no non-fallback rule matches.
 
 Generated quests are deterministic typed case manifests assembled from shared
 modules rather than scripts with substituted nouns. The initial catalog has

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (1207)
+## Files (1213)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -33,12 +33,16 @@ development, or wiki document before changing a subsystem.
 - `book.toml` — Tooling or build configuration.
 - `content/dialogue/examples.yaml` — Repository support file.
 - `content/dialogue/services.yaml` — Repository support file.
+- `content/quests/bestiary.yaml` — Repository support file.
+- `content/quests/generation.yaml` — Repository support file.
+- `content/quests/investigation.yaml` — Repository support file.
 - `crates/adventuresim-character-creator/Cargo.lock` — Locked Rust dependency versions.
 - `crates/adventuresim-character-creator/Cargo.toml` — Cargo package/workspace manifest.
 - `crates/adventuresim-character-creator/README.md` — Component overview and usage notes.
 - `crates/adventuresim-character-creator/src/lib.rs` — Rust source module for this component.
 - `crates/adventuresim-character-creator/src/main.rs` — Rust source module for this component.
 - `crates/adventuresim-core/Cargo.toml` — Cargo package/workspace manifest.
+- `crates/adventuresim-core/build.rs` — Rust source module.
 - `crates/adventuresim-core/src/activity.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/alcohol.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/attribute.rs` — Rust source module for this component.
@@ -68,6 +72,8 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-core/src/npc_adventurer.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/profession.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/provisioning.rs` — Rust source module for this component.
+- `crates/adventuresim-core/src/quest_catalog.rs` — Rust source module for this component.
+- `crates/adventuresim-core/src/quest_catalog_validation.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/quest_generation.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/settlement_economy.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/settlement_population.rs` — Rust source module for this component.

--- a/wiki/strategic/Quests.md
+++ b/wiki/strategic/Quests.md
@@ -11,6 +11,11 @@ hostile group, a separate contract, and an independently known case site.
 Combat contributes an authenticated outcome fact; the objective evaluator,
 not tactical code, decides whether the case is resolved.
 
+Quest templates, witnesses, evidence, sites, descriptions, threats and their
+weighted relationships are repository-authored YAML. Its content digest is
+recorded on newly generated cases; existing authority is never silently
+reinterpreted against different content.
+
 A party leader may request one of an NPC company's open roles while both parties occupy the same location and the company's typed recruitment offer remains open and unexpired. The company and offer are generated independently from quests. Acceptance merges the applying party into the destination party: the destination leader retains command, the applying leader fills the selected role, and every other source member becomes an ordinary member. Source recruitment roles and pending applications close, while party-inventory items, reserve value, and each character's absolute stake transfer intact. Generated NPC leaders auto-approve these requests in local development so the complete merge flow can be previewed.
 
 Recruiting NPC companies are discovered at the inn rather than through quest ownership or a global party browser. Their service presentation reveals the company leader and each open role. Role links show exact recommendations on hover and are colored blue for unrestricted roles, green when a member of the viewer's party meets every recommendation, yellow when a member meets some, and red when no member meets any. Selecting a role replaces the side panels with its detailed recommendations, party context, and the request-to-join action.


### PR DESCRIPTION
## Summary

Moves modular quest and bestiary definitions from hardcoded Rust tables into startup-compiled, JSON-compatible YAML under `content/quests/`. The sorted content set is strictly validated, embedded, and SHA-256 revisioned so deterministic generation and replay remain tied to an exact catalog.

This is the first of two stacked PRs. It intentionally contains the catalog/data architecture only; the developer quest editor will be the next PR.

## What is configurable

- All 25 current threat definitions: display forms, aliases, priors, combat scalars, rig/attack/protection/temperament, physical innate resistance and padding, loot ID, behavior, habitats, observations, clues, ambiguity, and preparation hypotheses.
- Physical evidence presentations, portraits, inspection topics, check stats, and hidden DC ranges.
- Witness demographics and deterministic NPC matching predicates, circumstances, descriptions, sites/hideouts, and terrain/habitat mapping.
- Template families, routes, objectives/finales, consequence profiles, incident cadence and ceiling.
- Weighted family/cause/site/circumstance/reliability/account/evidence/route/pattern/description relations with separate plausibility and curation weights, explicit hard zeros, and causal bridges.

Author-facing identities are bounded open string IDs. Finite executable engine mechanics remain typed Rust vocabularies.

## Validation and determinism

- One shared validator runs during build embedding and runtime startup/check tooling.
- Rejects unknown fields, overlong IDs, numeric overflow, invalid optional values, non-finite scalars, dangling references, invalid relation namespaces, malformed weights/hard-zero pairs, unsupported graph shapes, ambiguous demographic rules, incomplete bridge authority, and armored-plus-innate protection.
- Diagnostics retain content file and property-path context.
- Required bridges propagate through every supported generator relation and materialize canonical events, exact evidence, reachable actions, and typed outputs. Unsupported follow-up-evidence bridges are rejected rather than ignored.
- Catalog digest replaces the handwritten revision and participates in existing replay validation.

## Combat model

Monster protection continues to use the existing physically based resistance/padding mechanics. There are no cut/blunt damage multipliers. Skeletons have resistance with zero padding; `shattering_blow` describes the resulting ordinary physical matchup.

## Verification

- `cargo fmt --all`
- `cargo check -p adventuresim-core -p adventuresim-stdb-module -p strategic-web`
- `cargo test -p adventuresim-core` — 331 unit tests and 4 doctests passed
- `cargo test -p adventuresim-stdb-module`
- Focused strict-catalog tests — 9/9 passed
- End-to-end YAML bridge authority fixture passed
- `cargo run -p adventuresim-core --bin questgen-check -- validate` — 25 monsters, 3 documents, digest valid
- Project map and `git diff --check` clean
- Two independent reviews plus targeted remediation reviews; no remaining medium-or-higher finding

## Known limitations / incomplete surfaces

- Only the two current route/objective graph shapes are executable. YAML configures their supported routes, objectives, finales, consequences, and cadence; a genuinely new execution semantic still needs Rust.
- Closed engine vocabularies still require Rust additions: rigs, attacks, protection categories, temperaments, activity/terrain/check mechanics, reliability behavior, route/action/objective operations, symptoms, and strategic encounter archetypes.
- Content is compiled at build/startup and is not hot-loaded from loose files in deployment.
- Tactical behavior and tactical materialization are intentionally untouched. Threat loadouts still expose one loot item ID rather than arbitrary multi-item equipment sets; there are no YAML-authored ability scripts, bespoke AI state machines, new rigs, or animations.
- Fire, silver, daylight, and courage remain investigative hypotheses rather than autoresolve damage modifiers.
- The developer quest-spawn editor is intentionally deferred to the next stacked PR.

## Compatibility

Catalog changes intentionally invalidate existing generated-case replay authority through the digest. Per the pre-launch schema policy, development databases should be recreated/reseeded after catalog changes; no compatibility shim or migration is included.