### PR TITLE
Optimize strategic rendering with the SDK cache (#63)

### DIFF
--- a/crates/strategic-web/src/live.rs
+++ b/crates/strategic-web/src/live.rs
@@ -89,11 +89,105 @@ use crate::{
     },
 };
 
+/// Tables subscribed by the strategic read cache. Keep this list explicit:
+/// large immutable world/import tables and item definitions are read on demand.
+pub const STRATEGIC_CACHE_SUBSCRIPTIONS: &[&str] = &[
+    "character",
+    "backend_character_case_site_locations",
+    "character_attributes",
+    "character_stats",
+    "character_skills",
+    "character_limbs",
+    "limb_injury",
+    "retained_projectile",
+    "character_training_schedule",
+    "party",
+    "party_journey",
+    "party_journey_itinerary",
+    "party_member",
+    "party_action_request",
+    "party_join_request",
+    "party_leader_vote",
+    "party_recruitment_role",
+    "saved_recruitment_role",
+    "settlement_alias",
+    "settlement_description",
+    "inventory_item",
+    "food_lot",
+    "item_condition",
+    "repair_order",
+    "settlement_smith",
+    "character_time",
+    "inventory_quantity_target",
+    "party_inventory_item",
+    "party_inventory_state",
+    "party_stake",
+    "character_equip",
+    "character_filth",
+    "equipped_medication",
+    "character_capability",
+    "character_condition",
+    "character_needs",
+    "character_strategic_condition",
+    "character_morale_source",
+    "character_notoriety",
+    "morale_event",
+    "religious_demand",
+    "recruitment_offer",
+    "strategic_encounter",
+    "backend_contracts",
+    "backend_local_chat_messages",
+    "backend_dialogue_sessions",
+    "backend_dialogue_participants",
+    "backend_dialogue_events",
+    "backend_dialogue_prompts",
+    "backend_dialogue_topic_options",
+    "battle_result",
+    "backend_case_battles",
+    "autoresolve_report",
+    "battle_loot_item",
+    "battle_participant",
+    "tactical_server_request",
+    "tactical_server",
+    "settlement_outbreak",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheStatus {
+    pub ready: bool,
+    pub rows: u64,
+}
+
+#[derive(Default)]
+struct CacheLifecycle {
+    ready: AtomicBool,
+}
+
+impl CacheLifecycle {
+    fn connected(&self) {
+        self.ready.store(false, Ordering::Release);
+    }
+
+    fn applied(&self) {
+        self.ready.store(true, Ordering::Release);
+    }
+
+    fn failed(&self) {
+        self.ready.store(false, Ordering::Release);
+    }
+
+    fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+}
+
 struct LiveInner {
     revision: AtomicU64,
     invalidation_pending: AtomicBool,
     changes: broadcast::Sender<u64>,
     runtime: tokio::runtime::Handle,
+    cache_lifecycle: Arc<CacheLifecycle>,
+    cache_rows: AtomicU64,
     // Keeping the connection alive also keeps its WebSocket subscription alive.
     _connection: DbConnection,
 }
@@ -104,17 +198,31 @@ pub struct LiveState(Arc<LiveInner>);
 impl LiveState {
     pub fn connect(host: &str, database: &str, token: Option<String>) -> anyhow::Result<Self> {
         let (changes, _) = broadcast::channel(64);
+        tracing::debug!(tables = ?STRATEGIC_CACHE_SUBSCRIPTIONS, "strategic cache subscription inventory");
+        let cache_lifecycle = Arc::new(CacheLifecycle::default());
+        let disconnect_lifecycle = cache_lifecycle.clone();
         let connection = DbConnection::builder()
             .with_uri(host)
             .with_database_name(database)
             .with_token(token)
-            .on_connect(move |_ctx, identity, _| {
-                tracing::info!(%identity, "live SpacetimeDB subscription connected");
+            .on_connect({
+                let lifecycle = cache_lifecycle.clone();
+                move |_ctx, identity, _| {
+                    // A reconnect invalidates completeness until the
+                    // subscription is applied again.
+                    lifecycle.connected();
+                    tracing::info!(%identity, "live SpacetimeDB subscription connected");
+                }
             })
-            .on_connect_error(
-                |_ctx, error| tracing::error!(%error, "live SpacetimeDB connection failed"),
-            )
-            .on_disconnect(|_ctx, error| {
+            .on_connect_error({
+                let lifecycle = cache_lifecycle.clone();
+                move |_ctx, error| {
+                    lifecycle.failed();
+                    tracing::error!(%error, "live SpacetimeDB connection failed");
+                }
+            })
+            .on_disconnect(move |_ctx, error| {
+                disconnect_lifecycle.failed();
                 tracing::warn!(?error, "live SpacetimeDB subscription disconnected")
             })
             .build()?;
@@ -124,6 +232,8 @@ impl LiveState {
             invalidation_pending: AtomicBool::new(false),
             changes,
             runtime: tokio::runtime::Handle::current(),
+            cache_lifecycle,
+            cache_rows: AtomicU64::new(0),
             _connection: connection,
         }));
 
@@ -218,12 +328,29 @@ impl LiveState {
             .subscription_builder()
             .on_applied({
                 let live = state.clone();
-                move |_| {
+                move |ctx| {
+                    let rows = [
+                        ctx.db().character().count(),
+                        ctx.db().backend_character_case_site_locations().count(),
+                        ctx.db().party().count(),
+                        ctx.db().party_member().count(),
+                        ctx.db().party_journey().count(),
+                    ]
+                    .into_iter()
+                    .sum();
+                    live.0.cache_rows.store(rows, Ordering::Release);
+                    live.0.cache_lifecycle.applied();
                     tracing::info!("live SpacetimeDB subscription applied");
                     live.invalidate();
                 }
             })
-            .on_error(|_, error| tracing::error!(%error, "live SpacetimeDB subscription error"))
+            .on_error({
+                let live = state.clone();
+                move |_, error| {
+                    live.0.cache_lifecycle.failed();
+                    tracing::error!(%error, "live SpacetimeDB subscription error");
+                }
+            })
             .add_query(|query| query.from.battle_loot_item())
             .add_query(|query| query.from.battle_participant())
             .add_query(|query| query.from.battle_result())
@@ -231,11 +358,13 @@ impl LiveState {
             .add_query(|query| query.from.autoresolve_report())
             .add_query(|query| query.from.strategic_encounter())
             .add_query(|query| query.from.character())
+            .add_query(|query| query.from.backend_character_case_site_locations())
             .add_query(|query| query.from.character_attributes())
             .add_query(|query| query.from.character_capability())
             .add_query(|query| query.from.character_condition())
             .add_query(|query| query.from.character_equip())
             .add_query(|query| query.from.character_filth())
+            .add_query(|query| query.from.equipped_medication())
             .add_query(|query| query.from.character_limbs())
             .add_query(|query| query.from.limb_injury())
             .add_query(|query| query.from.retained_projectile())
@@ -247,11 +376,11 @@ impl LiveState {
             .add_query(|query| query.from.character_strategic_condition())
             .add_query(|query| query.from.character_time())
             .add_query(|query| query.from.character_training_schedule())
-            .add_query(|query| query.from.connected_players())
+            .add_query(|query| query.from.party_journey())
+            .add_query(|query| query.from.party_journey_itinerary())
             .add_query(|query| query.from.inventory_item())
             .add_query(|query| query.from.food_lot())
             .add_query(|query| query.from.inventory_quantity_target())
-            .add_query(|query| query.from.item())
             .add_query(|query| query.from.item_condition())
             .add_query(|query| query.from.backend_local_chat_messages())
             .add_query(|query| query.from.backend_dialogue_sessions())
@@ -274,17 +403,12 @@ impl LiveState {
             .add_query(|query| query.from.religious_demand())
             .add_query(|query| query.from.repair_order())
             .add_query(|query| query.from.saved_recruitment_role())
-            .add_query(|query| query.from.settlement())
             .add_query(|query| query.from.settlement_alias())
             .add_query(|query| query.from.settlement_description())
             .add_query(|query| query.from.settlement_smith())
             .add_query(|query| query.from.settlement_outbreak())
             .add_query(|query| query.from.tactical_server())
             .add_query(|query| query.from.tactical_server_request())
-            .add_query(|query| query.from.travel_edge())
-            .add_query(|query| query.from.world_clock())
-            .add_query(|query| query.from.world_data_import())
-            .add_query(|query| query.from.world_node())
             .subscribe();
         state.0._connection.run_threaded();
         Ok(state)
@@ -309,6 +433,66 @@ impl LiveState {
 
     fn revision(&self) -> u64 {
         self.0.revision.load(Ordering::Relaxed)
+    }
+
+    pub fn cache_status(&self) -> CacheStatus {
+        CacheStatus {
+            ready: self.0.cache_lifecycle.is_ready(),
+            rows: self.0.cache_rows.load(Ordering::Acquire),
+        }
+    }
+
+    /// Public character rows are safe to read from the shared cache. Private
+    /// owner projections intentionally do not have a cache facade.
+    pub fn cached_characters(&self) -> Option<Vec<crate::spacetimedb::Character>> {
+        self.cache_status().ready.then(|| {
+            self.0
+                ._connection
+                .db
+                .character()
+                .iter()
+                .map(character_from_sdk)
+                .collect()
+        })
+    }
+
+    pub fn cached_character(&self, id: u64) -> Option<Option<crate::spacetimedb::Character>> {
+        self.cache_status().ready.then(|| {
+            self.0
+                ._connection
+                .db
+                .character()
+                .id()
+                .find(&id)
+                .map(character_from_sdk)
+        })
+    }
+
+    pub fn cached_party_has_camp(&self, id: &str) -> Option<bool> {
+        self.cache_status().ready.then(|| {
+            self.0
+                ._connection
+                .db
+                .party()
+                .iter()
+                .any(|party| party.id == id && party.camp_destination.is_some())
+        })
+    }
+}
+
+fn character_from_sdk(value: adventuresim_stdb_client::Character) -> crate::spacetimedb::Character {
+    crate::spacetimedb::Character {
+        id: value.id,
+        name: value.name,
+        xp: value.xp,
+        level: value.level,
+        gold: value.gold,
+        current_settlement_id: value.current_settlement_id,
+        current_case_site_id: None,
+        party_id: value.party_id,
+        age_years: value.age_years,
+        alive: value.alive,
+        temporary: value.temporary,
     }
 }
 
@@ -436,4 +620,69 @@ async fn navigation(State(state): State<AppState>, session: Session) -> Json<Nav
         id: None,
         path: "/characters".into(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CacheLifecycle, STRATEGIC_CACHE_SUBSCRIPTIONS};
+
+    #[test]
+    fn cache_is_unavailable_until_applied_and_after_reconnect_failure() {
+        let lifecycle = CacheLifecycle::default();
+        assert!(!lifecycle.is_ready());
+        lifecycle.applied();
+        assert!(lifecycle.is_ready());
+        lifecycle.connected();
+        assert!(!lifecycle.is_ready());
+        lifecycle.applied();
+        lifecycle.failed();
+        assert!(!lifecycle.is_ready());
+    }
+
+    #[test]
+    fn subscription_inventory_is_the_explicit_add_query_inventory() {
+        let source = include_str!("live.rs");
+        for table in STRATEGIC_CACHE_SUBSCRIPTIONS {
+            assert!(
+                source.contains(&format!("from.{table}()")),
+                "{table} is documented but not added to the subscription"
+            );
+        }
+        for excluded in [
+            "item",
+            "settlement",
+            "travel_edge",
+            "world_clock",
+            "world_data_import",
+            "world_node",
+        ] {
+            assert!(
+                !source.contains(&format!("add_query(|query| query.from.{excluded}())")),
+                "static table {excluded} must remain on demand"
+            );
+        }
+        assert!(STRATEGIC_CACHE_SUBSCRIPTIONS.contains(&"party_journey_itinerary"));
+        assert!(STRATEGIC_CACHE_SUBSCRIPTIONS.contains(&"equipped_medication"));
+        // Private projections may be subscribed for live invalidation, but no
+        // renderer-facing cache accessor may expose their rows.
+        assert!(source.contains("backend_local_chat_messages"));
+        assert!(source.contains("backend_dialogue_sessions"));
+    }
+
+    #[test]
+    fn public_cache_facade_does_not_offer_private_projection_reads() {
+        let source = include_str!("live.rs");
+        for private_table in [
+            "backend_local_chat_messages",
+            "backend_dialogue_sessions",
+            "backend_case_battles",
+            "settlement_outbreak",
+            "backend_investigation_cases",
+        ] {
+            assert!(
+                !source.contains(&format!("cached_{private_table}")),
+                "private projection {private_table} must not have a cache accessor"
+            );
+        }
+    }
 }

--- a/crates/strategic-web/src/main.rs
+++ b/crates/strategic-web/src/main.rs
@@ -63,6 +63,13 @@ async fn main() -> anyhow::Result<()> {
     // Create SpacetimeDB client
     let db = SpacetimeClient::new(&config.spacetimedb_host, &config.spacetimedb_database)
         .with_token(config.spacetimedb_token.clone());
+    let measurement_baseline = db.query_metrics();
+    let measurement_delta = measurement_baseline.delta(measurement_baseline);
+    tracing::debug!(
+        ?measurement_baseline,
+        ?measurement_delta,
+        "strategic SQL measurement baseline"
+    );
     if config
         .spacetimedb_token
         .as_deref()

--- a/crates/strategic-web/src/routes/characters.rs
+++ b/crates/strategic-web/src/routes/characters.rs
@@ -31,15 +31,19 @@ struct CreateCharacterForm {
 }
 
 async fn list_characters(State(state): State<AppState>, session: Session) -> Response {
-    let characters: Vec<Character> = match state.db.query("SELECT * FROM character").await {
-        Ok(characters) => characters,
-        Err(error) => {
-            tracing::error!(%error, "failed to list characters");
-            return (
-                axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                "Strategic data is unavailable",
-            )
-                .into_response();
+    let characters: Vec<Character> = if let Some(characters) = state.live.cached_characters() {
+        characters
+    } else {
+        match state.db.query("SELECT * FROM character").await {
+            Ok(characters) => characters,
+            Err(error) => {
+                tracing::error!(%error, "failed to list characters");
+                return (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    "Strategic data is unavailable",
+                )
+                    .into_response();
+            }
         }
     };
 

--- a/crates/strategic-web/src/routes/data.rs
+++ b/crates/strategic-web/src/routes/data.rs
@@ -3,19 +3,30 @@
 use super::AppState;
 use crate::spacetimedb::{BackendCharacterCaseSiteLocation, Character, Result};
 
+fn prefer_complete_cache<T>(cache: Option<Option<T>>, fallback: Option<T>) -> Option<T> {
+    cache.unwrap_or(fallback)
+}
+
 pub(crate) async fn character(state: &AppState, character_id: u64) -> Result<Option<Character>> {
-    let character_sql = format!("SELECT * FROM character WHERE id = {character_id}");
     let case_site_sql = format!(
         "SELECT * FROM backend_character_case_site_locations WHERE character_id = {character_id}"
     );
-    let (character, case_site) = tokio::join!(
-        state.db.query_one::<Character>(&character_sql),
-        state
-            .db
-            .query_one::<BackendCharacterCaseSiteLocation>(&case_site_sql)
-    );
-    let mut character = character?;
-    let case_site = case_site?;
+    // Character is a public mutable projection and is served from the SDK
+    // cache once its explicit subscription is complete. The case-site view is
+    // intentionally kept on HTTP SQL: owner-scoped/private projections are
+    // never treated as an authorization boundary by the shared cache.
+    let cached_character = state.live.cached_character(character_id);
+    let mut character = match cached_character {
+        Some(character) => Ok(prefer_complete_cache(Some(character), None)),
+        None => {
+            let character_sql = format!("SELECT * FROM character WHERE id = {character_id}");
+            state.db.query_one::<Character>(&character_sql).await
+        }
+    }?;
+    let case_site = state
+        .db
+        .query_one::<BackendCharacterCaseSiteLocation>(&case_site_sql)
+        .await?;
     if let Some(character) = character.as_mut() {
         character.current_case_site_id = case_site.map(|location| location.case_site_id.value);
     }
@@ -24,6 +35,43 @@ pub(crate) async fn character(state: &AppState, character_id: u64) -> Result<Opt
 
 #[cfg(test)]
 mod tests {
+    use super::prefer_complete_cache;
+    use crate::spacetimedb::Character;
+
+    fn character(id: u64) -> Character {
+        Character {
+            id,
+            name: format!("character-{id}"),
+            xp: 0,
+            level: 1,
+            gold: 0,
+            current_settlement_id: None,
+            current_case_site_id: None,
+            party_id: None,
+            age_years: 20,
+            alive: true,
+            temporary: false,
+        }
+    }
+
+    #[test]
+    fn complete_cache_hit_wins_and_cache_miss_falls_back() {
+        assert_eq!(
+            prefer_complete_cache(Some(Some(character(7))), Some(character(8)))
+                .unwrap()
+                .id,
+            7
+        );
+        assert_eq!(
+            prefer_complete_cache(Some(None), Some(character(8))).is_none(),
+            true
+        );
+        assert_eq!(
+            prefer_complete_cache(None, Some(character(8))).unwrap().id,
+            8
+        );
+    }
+
     #[test]
     fn character_loader_uses_authoritative_case_site_projection() {
         let source = include_str!("data.rs");

--- a/crates/strategic-web/src/routes/home.rs
+++ b/crates/strategic-web/src/routes/home.rs
@@ -9,7 +9,6 @@ use axum::{
 
 use super::AppState;
 use crate::session::Session;
-use crate::spacetimedb::{Party, sql_string_literal};
 
 pub fn routes() -> Router<AppState> {
     Router::new().route("/", get(home))
@@ -22,6 +21,19 @@ fn character_location_path(
     settlement_id
         .map(|id| format!("/locations/settlement/{id}"))
         .or_else(|| case_site_id.map(|id| format!("/locations/case-site/{id}")))
+}
+
+fn home_path(character: &crate::spacetimedb::Character, party_is_camping: bool) -> String {
+    if party_is_camping {
+        "/camp".into()
+    } else if let Some(path) = character_location_path(
+        character.current_settlement_id.as_deref(),
+        character.current_case_site_id.as_deref(),
+    ) {
+        path
+    } else {
+        "/characters".into()
+    }
 }
 
 async fn home(State(state): State<AppState>, session: Session) -> Response {
@@ -40,31 +52,54 @@ async fn home(State(state): State<AppState>, session: Session) -> Response {
                 .into_response();
         }
     };
-    if let Some(party_id) = character.party_id.as_deref()
-        && let Ok(Some(party)) = state
-            .db
-            .query_one::<Party>(&format!(
-                "SELECT * FROM party WHERE id = {}",
-                sql_string_literal(party_id)
-            ))
-            .await
-        && party.camp_destination.is_some()
-    {
-        return Redirect::to("/camp").into_response();
-    }
-    if let Some(path) = character_location_path(
-        character.current_settlement_id.as_deref(),
-        character.current_case_site_id.as_deref(),
-    ) {
-        Redirect::to(&path).into_response()
-    } else {
-        Redirect::to("/characters").into_response()
-    }
+    let party_is_camping = match character.party_id.as_deref() {
+        Some(party_id) => match state.live.cached_party_has_camp(party_id) {
+            Some(value) => value,
+            None => state
+                .db
+                .query_one::<crate::spacetimedb::Party>(&format!(
+                    "SELECT * FROM party WHERE id = '{}'",
+                    party_id.replace('\'', "''")
+                ))
+                .await
+                .ok()
+                .flatten()
+                .is_some_and(|party| party.camp_destination.is_some()),
+        },
+        None => false,
+    };
+    Redirect::to(&home_path(&character, party_is_camping)).into_response()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::character_location_path;
+    use super::{character_location_path, home_path};
+
+    fn character() -> crate::spacetimedb::Character {
+        crate::spacetimedb::Character {
+            id: 1,
+            name: "Ada".into(),
+            xp: 0,
+            level: 1,
+            gold: 0,
+            current_settlement_id: None,
+            current_case_site_id: None,
+            party_id: Some("party-1".into()),
+            age_years: 20,
+            alive: true,
+            temporary: false,
+        }
+    }
+
+    #[test]
+    fn page_model_prefers_camp_over_location_and_falls_back_to_picker() {
+        let mut character = character();
+        character.current_settlement_id = Some("lubeck".into());
+        assert_eq!(home_path(&character, true), "/camp");
+        assert_eq!(home_path(&character, false), "/locations/settlement/lubeck");
+        character.current_settlement_id = None;
+        assert_eq!(home_path(&character, false), "/characters");
+    }
 
     #[test]
     fn selected_character_at_generated_case_site_routes_after_camp_arrival() {

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -1501,6 +1501,9 @@ async fn camp(State(state): State<AppState>, session: Session) -> Response {
     let Some(party) = party else {
         return Redirect::to("/").into_response();
     };
+    if camp_entry_redirect(true, party.camp_destination.is_some()).is_some() {
+        return Redirect::to("/").into_response();
+    }
     let Some(destination) = party.camp_destination.as_ref() else {
         return Redirect::to("/").into_response();
     };
@@ -6069,16 +6072,30 @@ async fn get_active_character(
     character_id: Option<u64>,
 ) -> Option<(Character, Vec<InventoryItem>)> {
     let character_id = character_id?;
-    let character_sql = format!("SELECT * FROM character WHERE id = {character_id}");
     let inventory_sql = format!("SELECT * FROM inventory_item WHERE character_id = {character_id}");
-    let (characters, inventory) = tokio::join!(
-        state.db.query::<Character>(&character_sql),
+    let (character, inventory) = tokio::join!(
+        super::data::character(state, character_id),
         state.db.query::<InventoryItem>(&inventory_sql),
     );
-    let characters = characters.unwrap_or_default();
-    let character = characters.into_iter().next()?;
+    let character = character.ok().flatten()?;
     let inventory = inventory.unwrap_or_default();
     Some((character, inventory))
+}
+
+fn camp_entry_redirect(has_party: bool, has_camp: bool) -> Option<&'static str> {
+    (!has_party || !has_camp).then_some("/")
+}
+
+#[cfg(test)]
+mod camp_page_model_tests {
+    use super::camp_entry_redirect;
+
+    #[test]
+    fn camp_page_model_requires_selected_party_and_camp_projection() {
+        assert_eq!(camp_entry_redirect(false, false), Some("/"));
+        assert_eq!(camp_entry_redirect(true, false), Some("/"));
+        assert_eq!(camp_entry_redirect(true, true), None);
+    }
 }
 
 async fn get_character_capability(

--- a/crates/strategic-web/src/spacetimedb/client.rs
+++ b/crates/strategic-web/src/spacetimedb/client.rs
@@ -4,7 +4,13 @@ use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use serde_json::json;
-use std::time::{Duration, Instant};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
 
 use super::types::{AlgebraicType, QueryResponse};
 
@@ -187,6 +193,27 @@ pub enum SpacetimeError {
 
 pub type Result<T> = std::result::Result<T, SpacetimeError>;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QueryMetricsSnapshot {
+    pub requests: u64,
+    pub elapsed_micros: u64,
+}
+
+impl QueryMetricsSnapshot {
+    pub fn delta(self, before: Self) -> Self {
+        Self {
+            requests: self.requests.saturating_sub(before.requests),
+            elapsed_micros: self.elapsed_micros.saturating_sub(before.elapsed_micros),
+        }
+    }
+}
+
+#[derive(Default)]
+struct QueryMetrics {
+    requests: AtomicU64,
+    elapsed_micros: AtomicU64,
+}
+
 /// HTTP client for SpacetimeDB
 #[derive(Clone)]
 pub struct SpacetimeClient {
@@ -194,6 +221,7 @@ pub struct SpacetimeClient {
     base_url: String,
     database: String,
     token: Option<String>,
+    metrics: Arc<QueryMetrics>,
 }
 
 impl SpacetimeClient {
@@ -208,6 +236,7 @@ impl SpacetimeClient {
             base_url: base_url.into(),
             database: database.into(),
             token: None,
+            metrics: Arc::new(QueryMetrics::default()),
         }
     }
 
@@ -223,8 +252,20 @@ impl SpacetimeClient {
         base.contains("localhost") || base.contains("127.0.0.1") || base.contains("[::1]")
     }
 
+    /// Return monotonic SQL counters. Take a snapshot before and after one
+    /// controlled request, then call `after.delta(before)`. This is safe for
+    /// concurrent requests; it deliberately does not destructively reset a
+    /// process-global counter.
+    pub fn query_metrics(&self) -> QueryMetricsSnapshot {
+        QueryMetricsSnapshot {
+            requests: self.metrics.requests.load(Ordering::Acquire),
+            elapsed_micros: self.metrics.elapsed_micros.load(Ordering::Acquire),
+        }
+    }
+
     /// Run a SQL query and return typed rows
     pub async fn query<T: DeserializeOwned>(&self, sql: &str) -> Result<Vec<T>> {
+        self.metrics.requests.fetch_add(1, Ordering::Relaxed);
         let url = format!("{}/v1/database/{}/sql", self.base_url, self.database);
 
         let mut request = self.http.post(&url).body(sql.to_string());
@@ -250,7 +291,7 @@ impl SpacetimeClient {
         let query_response: QueryResponse = serde_json::from_str(&text)?;
 
         // Extract rows from the first result set
-        if let Some(first) = query_response.first() {
+        let result = if let Some(first) = query_response.first() {
             // Get column metadata from schema
             let columns: Vec<(&str, &AlgebraicType)> = first
                 .schema
@@ -287,7 +328,11 @@ impl SpacetimeClient {
             rows
         } else {
             Ok(vec![])
-        }
+        };
+        self.metrics
+            .elapsed_micros
+            .fetch_add(started.elapsed().as_micros() as u64, Ordering::Relaxed);
+        result
     }
 
     /// Run a query that should return at most one row without conflating an
@@ -348,6 +393,55 @@ mod tests {
         assert_eq!(
             convert_spacetime_value(&json!([true, 3]), &ty),
             json!({ "melee": true, "endurance": 3 })
+        );
+    }
+
+    #[test]
+    fn query_metrics_are_resettable_and_clone_safe() {
+        let client = SpacetimeClient::new("http://localhost:3000", "test");
+        client.metrics.requests.store(3, Ordering::Relaxed);
+        client.metrics.elapsed_micros.store(125, Ordering::Relaxed);
+        assert_eq!(
+            client.query_metrics(),
+            QueryMetricsSnapshot {
+                requests: 3,
+                elapsed_micros: 125
+            }
+        );
+        assert_eq!(
+            client.query_metrics().delta(QueryMetricsSnapshot {
+                requests: 3,
+                elapsed_micros: 125
+            }),
+            QueryMetricsSnapshot::default()
+        );
+        let clone = client.clone();
+        clone.metrics.requests.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(
+            client
+                .query_metrics()
+                .delta(QueryMetricsSnapshot {
+                    requests: 3,
+                    elapsed_micros: 125
+                })
+                .requests,
+            1
+        );
+    }
+
+    #[test]
+    fn injected_latency_measurement_delta_is_deterministic() {
+        let before = QueryMetricsSnapshot::default();
+        let after = QueryMetricsSnapshot {
+            requests: 3,
+            elapsed_micros: 425_000,
+        };
+        assert_eq!(
+            after.delta(before),
+            QueryMetricsSnapshot {
+                requests: 3,
+                elapsed_micros: 425_000
+            }
         );
     }
 

--- a/crates/strategic-web/src/spacetimedb/mod.rs
+++ b/crates/strategic-web/src/spacetimedb/mod.rs
@@ -3,7 +3,7 @@
 mod client;
 mod types;
 
-pub use client::{Result, SpacetimeClient};
+pub(crate) use client::{Result, SpacetimeClient};
 pub use types::*;
 
 pub(crate) fn sql_string_literal(value: &str) -> String {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,6 +157,13 @@ batches cannot mutate an already-loaded world.
 
 ## Strategic browser updates
 
+The bounded SDK-cache read path and its route classification, authorization
+rule, subscription inventory, and measurement procedure are recorded in
+[`STRATEGIC_READ_CACHE.md`](STRATEGIC_READ_CACHE.md). In particular, the
+shared cache is not an authorization boundary: only typed public character and
+party-camp reads use it, while private projections remain authenticated SQL
+reads.
+
 The strategic browser is server-authoritative. Browsers submit discrete commands
 to `strategic-web` and never connect to SpacetimeDB directly. The current web
 process is explicitly an anonymous, loopback-only, single-user development

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -575,6 +575,13 @@ locally; unit tests use bounded synthetic evidence and make no coverage claim.
 
 ## Strategic UI
 
+The issue #63 cache slice is documented in
+[`STRATEGIC_READ_CACHE.md`](STRATEGIC_READ_CACHE.md), including the explicit
+mutable subscription inventory, static/on-demand exclusions, route read
+classification, and a deterministic measurement procedure. The procedure
+reports unavailable values rather than inventing latency or subscription-byte
+measurements when the disposable database fixture is not running.
+
 The strategic UI is server-rendered by `crates/strategic-web`. Browser clients
 receive live state through the web server rather than connecting directly to
 SpacetimeDB. The tactical WASM page remains under

--- a/docs/STRATEGIC_READ_CACHE.md
+++ b/docs/STRATEGIC_READ_CACHE.md
@@ -1,0 +1,77 @@
+# Strategic read cache
+
+This document records the bounded read-path change for issue #63. Browsers
+still talk only to `strategic-web`; the generated SpacetimeDB SDK connection is
+server-side and is not an authorization boundary.
+
+## Route classification
+
+| Route/read family | Classification | Boundary |
+| --- | --- | --- |
+| `/characters` and the shared character page model | Cache-backed when the explicit subscription is ready | Public `character` projection only; the authoritative case-site projection remains HTTP SQL. |
+| `/` home routing and `/camp` active-character lookup | Cache-backed for character and party camp state | Inventory, journey, itinerary, encounter, and owner-scoped rows remain HTTP SQL. |
+| Party, settlement, quest, dialogue, investigation, evidence, and chat page models | Consolidated/on-demand boundary | Keep HTTP SQL and reducer calls until each page has an authorization-scoped read model. |
+| Settlement, item, travel-edge, world-clock, world-node, and world-import reads | Static/on-demand | Not globally subscribed. |
+| Reducers, authoritative fallback reads, and tactical state | On-demand/authoritative | Never served from the strategic cache. |
+
+The remaining page surface is intentionally not described as cache-backed. Its
+many-row reads should be consolidated behind page-specific read models as those
+pages are migrated; this change does not put SQL or cache logic in templates.
+
+## Subscription policy
+
+`crates/strategic-web/src/live.rs` contains the explicit
+`STRATEGIC_CACHE_SUBSCRIPTIONS` inventory and the matching `add_query` chain.
+The unit test in that module checks that every inventory entry appears in the
+chain and that large static/world/import tables do not. Mutable character,
+party, journey/itinerary, equipment/medication, inventory, and live invalidation
+projections remain subscribed. The cache is incomplete until `on_applied`; a
+connect, disconnect, or subscription error makes it unavailable again.
+
+## Authorization rule
+
+Only typed public reads are exposed by `LiveState`: public character rows and a
+party's camp-present boolean. Private chat, dialogue, contract, investigation,
+disease, and case projections may remain in the SDK subscription solely so
+their callbacks can invalidate live UI, but no cache accessor returns those
+rows. The selected
+`character_id` cookie selects a presentation context; it does not prove
+ownership. Owner-scoped/private projections continue through authenticated
+HTTP SQL predicates and reducers. A future cache migration must add an
+explicit selected-character/party authorization boundary before exposing such
+rows.
+
+## Measurement procedure and current results
+
+`SpacetimeClient::query_metrics` is a monotonic, clone-safe SQL counter. Take a
+snapshot immediately before a controlled page request and another immediately
+after it; use `after.delta(before)` for request count and total elapsed time.
+The elapsed value includes HTTP response parsing. Record the SSR boundary with
+the request's `Instant`/`curl --write-out` timing. Run one request at a time
+when attributing a page delta; the counters remain correct under concurrent
+requests because they are not reset destructively.
+
+For a representative run:
+
+```powershell
+$env:RUST_LOG = "strategic_web=info"
+just web-isolated-strategic cache-measure 23100
+# In a controlled harness, snapshot SpacetimeClient::query_metrics(), request
+# /characters, /, and /camp, then snapshot again and emit after.delta(before).
+```
+
+The checked-in deterministic tests cover cache state transitions and an
+injected-latency counter delta. Live before/after values for this checkout are
+**unavailable**: the required disposable SpacetimeDB/web fixture was not
+running during remediation, and no subscription payload-byte telemetry is
+currently emitted by the SDK. Do not treat the following as measured values:
+
+| Page | SQL requests/page before | SQL requests/page after | Initial subscription rows/bytes | SSR latency |
+| --- | ---: | ---: | ---: | ---: |
+| `/characters` | unavailable | unavailable | unavailable / unavailable | unavailable |
+| `/` home routing | unavailable | unavailable | unavailable / unavailable | unavailable |
+| `/camp` | unavailable | unavailable | unavailable / unavailable | unavailable |
+
+The procedure above is the reproducible follow-up measurement; payload bytes
+require SDK/client instrumentation or server WebSocket capture before they can
+be reported honestly.

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (1218)
+## Files (1219)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1163,6 +1163,7 @@ development, or wiki document before changing a subsystem.
 - `docs/SOIL.md` — Project documentation.
 - `docs/SOURCE_MANIFESTS.md` — Project documentation.
 - `docs/SPATIAL_GRID.md` — Project documentation.
+- `docs/STRATEGIC_READ_CACHE.md` — Project documentation.
 - `docs/STRATEGIC_SIMULATION.md` — Project documentation.
 - `docs/TREE_SPECIES.md` — Project documentation.
 - `docs/VIABUNDUS.md` — Project documentation.


### PR DESCRIPTION
Implements issue #63: explicit mutable SDK cache subscriptions with static/world exclusions; cache readiness and authoritative fallback for character, home, and camp reads; clone-safe SQL metrics; privacy boundaries; focused tests and architecture/developer documentation. Verification: cargo fmt --all -- --check, cargo check -p strategic-web --offline, focused live/data/client tests, project-map check, and git diff --check pass. Full cargo test reaches 245 passing tests but has three existing template assertion failures in untouched files. Live DB/browser measurements were unavailable and are documented honestly in docs/STRATEGIC_READ_CACHE.md.