### PR TITLE
Finish offline quest evaluation harness

### DIFF
--- a/crates/adventuresim-strategic-sim/fixtures/quest-analysis-failure-v3.json
+++ b/crates/adventuresim-strategic-sim/fixtures/quest-analysis-failure-v3.json
@@ -1,0 +1,23 @@
+{
+  "version": 3,
+  "catalog_revision": "22015d9052c8d9b25937a441c32d6409fa7a4d51a26a1fa6c8d6822b5a29897e",
+  "generator_manifest_digest": "c810d69068e2120d320a25c003d11601b786684af0527dd20d844f6866d7866f",
+  "seed": 41,
+  "family": "recurring_depredation",
+  "decisions": [
+    {
+      "version": 3,
+      "choice_id": "choice:eb66c32c53fcd28794778eba",
+      "arguments": {
+        "selection": null
+      }
+    }
+  ],
+  "expected": {
+    "solved": false,
+    "termination": "step_limit",
+    "route": null,
+    "event_count": 1,
+    "semantic_digest": null
+  }
+}

--- a/crates/adventuresim-strategic-sim/src/investigation_eval/environment.rs
+++ b/crates/adventuresim-strategic-sim/src/investigation_eval/environment.rs
@@ -1,8 +1,9 @@
 use super::{
     ArgumentValue, Capability, ChoiceArguments, ChoiceKind, DeveloperCaseAnalysis, DiscoveryView,
     EVAL_FORMAT_VERSION, JournalView, LegalChoice, LocationResolution, PartyView, PlayerFrame,
-    PublicClaim, PublicDialogueLine, PublicEvidence, PublicLocation, PublicQuestTrace,
-    PublicTraceEvent, Termination, WitnessAvailability, WitnessReferral,
+    PolicyClassification, PublicClaim, PublicDialogueLine, PublicEvidence, PublicLocation,
+    PublicQuestTrace, PublicTraceEvent, Termination, TerminationErrorCode, WitnessAvailability,
+    WitnessReferral,
 };
 use adventuresim_core::quest_generation::{
     self as qg, Circumstance, GeneratedActionOutput, GeneratedCase, GeneratedDestinationStage,
@@ -153,8 +154,11 @@ impl InvestigationEnvironment {
         let kind = legal.kind;
         let action_label = legal.label.clone();
         let game_minute = self.frame.game_minute;
+        let action_step = self.frame.step;
+        let pre_observation_digest = semantic_digest(&self.frame)?;
         let waiting_for_witness = matches!(&capability, Capability::WaitForWitness(_));
         let mut learned = Vec::new();
+        let mut learned_claim_ids = Vec::new();
         let mut dialogue = Vec::new();
         let mut corrected_proposition_ids = Vec::new();
         let (result, minutes, cost) = match capability {
@@ -170,8 +174,9 @@ impl InvestigationEnvironment {
                     .generated
                     .witnesses
                     .iter()
-                    .map(|witness| WitnessReferral {
-                        witness_id: witness.id.0.clone(),
+                    .enumerate()
+                    .map(|(index, witness)| WitnessReferral {
+                        witness_id: opaque_handle("witness", index),
                         display_name: witness.display_name.clone(),
                         physical_description: witness.visible_description.clone(),
                         expected_location: witness.expected_location_label.clone(),
@@ -213,14 +218,17 @@ impl InvestigationEnvironment {
                     referral.interviewed = true;
                 }
                 for statement in &witness.testimony {
+                    let claim_id = claim_handle(&self.generated, &statement.proposition_id);
                     self.frame.journal.claims.push(PublicClaim {
-                        proposition_id: statement.proposition_id.clone(),
+                        proposition_id: claim_id.clone(),
                         source: witness.visible_description.clone(),
                         text: statement.spoken_text.clone(),
                     });
+                    learned_claim_ids.push(claim_id);
                     if let Some(corrected) = &statement.corrects_proposition_id {
-                        self.frame.journal.corrections.push(corrected.clone());
-                        corrected_proposition_ids.push(corrected.clone());
+                        let handle = claim_handle(&self.generated, corrected);
+                        self.frame.journal.corrections.push(handle.clone());
+                        corrected_proposition_ids.push(handle);
                     }
                     learned.push(statement.spoken_text.clone());
                     dialogue.push(PublicDialogueLine {
@@ -292,20 +300,22 @@ impl InvestigationEnvironment {
                         }
                         GeneratedActionOutput::Evidence { evidence_id }
                         | GeneratedActionOutput::PatternCondition { evidence_id, .. } => {
-                            if let Some(evidence) = self
+                            if let Some((evidence_index, evidence)) = self
                                 .generated
                                 .evidence
                                 .iter()
-                                .find(|item| &item.id == evidence_id)
+                                .enumerate()
+                                .find(|(_, item)| &item.id == evidence_id)
                             {
                                 self.frame.journal.evidence.push(PublicEvidence {
-                                    evidence_id: evidence.id.0.clone(),
+                                    evidence_id: opaque_handle("evidence", evidence_index),
                                     description: evidence.safe_description.clone(),
                                     discovery_source: action.safe_summary.clone(),
                                 });
                                 if let Some(corrected) = &evidence.corrects_proposition_id {
-                                    self.frame.journal.corrections.push(corrected.clone());
-                                    corrected_proposition_ids.push(corrected.clone());
+                                    let handle = claim_handle(&self.generated, corrected);
+                                    self.frame.journal.corrections.push(handle.clone());
+                                    corrected_proposition_ids.push(handle);
                                 }
                                 learned.push(evidence.safe_description.clone());
                             }
@@ -364,27 +374,40 @@ impl InvestigationEnvironment {
             }
         };
         self.frame.party.supplies = self.frame.party.supplies.saturating_sub(cost);
-        let digest = semantic_digest(&self.frame)?;
+        let preparation_tags = if kind == ChoiceKind::Prepare {
+            learned
+                .iter()
+                .filter_map(|item| item.strip_prefix("Prepared "))
+                .map(|item| item.trim_end_matches('.').to_owned())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        self.frame.step += 1;
+        if !waiting_for_witness {
+            self.frame.game_minute += u64::from(minutes);
+        }
+        self.refresh_choices();
+        let post_observation_digest = semantic_digest(&self.frame)?;
         self.trace.push(PublicTraceEvent {
-            step: self.frame.step,
+            step: action_step,
             game_minute,
             location: self.current_location.clone(),
-            frame_digest: digest,
+            observation_provenance: "offline_projection/player_frame".into(),
+            pre_observation_digest,
+            post_observation_digest,
             choice_id: decision.choice_id.clone(),
             choice_kind: kind,
             action_label,
             dialogue,
             result,
             learned,
+            learned_claim_ids,
             corrected_proposition_ids,
+            preparation_tags,
             game_minutes: minutes,
             resource_cost: cost,
         });
-        self.frame.step += 1;
-        if !waiting_for_witness {
-            self.frame.game_minute += u64::from(minutes);
-        }
-        self.refresh_choices();
         Ok(())
     }
 
@@ -395,7 +418,10 @@ impl InvestigationEnvironment {
     pub fn public_trace(
         &self,
         policy: String,
+        initial_observation_digest: String,
+        initial_classification: PolicyClassification,
         termination: Termination,
+        termination_error: Option<TerminationErrorCode>,
     ) -> Result<PublicQuestTrace, String> {
         let mut trace = PublicQuestTrace {
             version: EVAL_FORMAT_VERSION,
@@ -403,10 +429,13 @@ impl InvestigationEnvironment {
             policy,
             title: format!("Investigation in {}", self.settlement_name),
             problem_summary: self.generated.consequence.public_summary.clone(),
+            initial_observation_digest,
+            initial_classification,
             events: self.trace.clone(),
             solved: self.solved,
             exhausted: self.frame.legal_choices.is_empty(),
             termination,
+            termination_error,
             route: self.route,
             semantic_digest: String::new(),
         };
@@ -709,28 +738,28 @@ fn developer_analysis(case: &GeneratedCase) -> Result<DeveloperCaseAnalysis, Str
         generation_seed: case.generation_seed,
         catalog_revision: case.catalog_revision.clone(),
         true_site,
-        factor_ids: case
-            .factor_trace
-            .iter()
-            .flat_map(|trace| trace.factor_ids.iter().map(|id| id.0.clone()))
-            .collect(),
-        plausibility_factors: case
-            .factor_trace
-            .iter()
-            .map(|trace| trace.plausibility)
-            .collect(),
-        curation_factors: case
-            .factor_trace
-            .iter()
-            .map(|trace| trace.curation)
-            .collect(),
-        bridge_ids: case
-            .bridges
-            .iter()
-            .map(|bridge| bridge.id.0.clone())
-            .collect(),
+        factor_trace: case.factor_trace.clone(),
+        bridges: case.bridges.clone(),
         generator_manifest_digest: private_digest,
     })
+}
+
+fn opaque_handle(kind: &str, index: usize) -> String {
+    format!("{kind}:observed-{}", index + 1)
+}
+
+fn claim_handle(case: &GeneratedCase, proposition_id: &str) -> String {
+    let index = case
+        .witnesses
+        .iter()
+        .flat_map(|witness| &witness.testimony)
+        .position(|statement| statement.proposition_id == proposition_id)
+        .unwrap_or(usize::MAX);
+    if index == usize::MAX {
+        "claim:observed-unknown".into()
+    } else {
+        opaque_handle("claim", index)
+    }
 }
 
 fn generation_context(seed: u64, family: TemplateFamily) -> qg::GenerationContext {

--- a/crates/adventuresim-strategic-sim/src/investigation_eval/policy.rs
+++ b/crates/adventuresim-strategic-sim/src/investigation_eval/policy.rs
@@ -1,12 +1,28 @@
 use super::{
     ChoiceKind, DecisionArguments, EVAL_FORMAT_VERSION, MAX_PROVIDER_RESPONSE_BYTES, PlayerFrame,
-    PolicyDecision,
+    PolicyClassification, PolicyDecision, PolicyRunMetadata,
 };
 use std::time::Instant;
 
 pub trait QuestPolicy {
     fn name(&self) -> &str;
     fn decide(&mut self, frame: &PlayerFrame) -> Result<PolicyDecision, String>;
+    fn classify(&mut self, _frame: &PlayerFrame) -> Result<PolicyClassification, String> {
+        Ok(PolicyClassification::default())
+    }
+    fn run_metadata(&self) -> PolicyRunMetadata {
+        PolicyRunMetadata {
+            policy_name: self.name().into(),
+            policy_kind: "local".into(),
+            provider: None,
+            model: None,
+            prompt_revision: "investigation-policy-v3".into(),
+            requests: 0,
+            estimated_prompt_tokens: 0,
+            estimated_completion_tokens: 0,
+            estimated_cost_microusd: 0,
+        }
+    }
     /// Providers that can block on I/O override this to respect the evaluator's
     /// absolute deadline. Deterministic policies remain immediate.
     fn decide_before(
@@ -67,6 +83,22 @@ impl QuestPolicy for ScriptedPolicy {
             arguments: DecisionArguments::default(),
         })
     }
+
+    fn classify(&mut self, frame: &PlayerFrame) -> Result<PolicyClassification, String> {
+        let summary = frame.discovery.problem_summary.to_ascii_lowercase();
+        let template_guess = if summary.contains("missing") || summary.contains("disappear") {
+            Some("disappearance_or_loss".into())
+        } else if summary.contains("attack") || summary.contains("livestock") {
+            Some("recurring_depredation".into())
+        } else {
+            Some("unknown".into())
+        };
+        Ok(PolicyClassification {
+            template_guess,
+            threat_guess: Some("unknown".into()),
+            confidence_percent: Some(25),
+        })
+    }
 }
 
 /// Credential-free fixture that exercises the exact strict JSON boundary used
@@ -84,6 +116,24 @@ impl QuestPolicy for MockLlmPolicy {
         let intended = baseline.decide(frame)?;
         let fixture_reply = serde_json::to_vec(&intended).map_err(|error| error.to_string())?;
         parse_provider_decision(&fixture_reply)
+    }
+
+    fn classify(&mut self, frame: &PlayerFrame) -> Result<PolicyClassification, String> {
+        ScriptedPolicy::default().classify(frame)
+    }
+
+    fn run_metadata(&self) -> PolicyRunMetadata {
+        PolicyRunMetadata {
+            policy_name: self.name().into(),
+            policy_kind: "mock_provider".into(),
+            provider: Some("strict-json-fixture".into()),
+            model: Some("deterministic-mock".into()),
+            prompt_revision: "investigation-policy-v3".into(),
+            requests: 0,
+            estimated_prompt_tokens: 0,
+            estimated_completion_tokens: 0,
+            estimated_cost_microusd: 0,
+        }
     }
 }
 

--- a/crates/adventuresim-strategic-sim/src/investigation_eval/provider.rs
+++ b/crates/adventuresim-strategic-sim/src/investigation_eval/provider.rs
@@ -1,6 +1,6 @@
 use super::{
-    MAX_PROVIDER_RESPONSE_BYTES, PlayerFrame, PolicyDecision, QuestPolicy, parse_provider_decision,
-    policy_prompt,
+    MAX_PROVIDER_RESPONSE_BYTES, PlayerFrame, PolicyDecision, PolicyRunMetadata, QuestPolicy,
+    parse_provider_decision, policy_prompt,
 };
 use reqwest::{
     StatusCode, Url,
@@ -109,6 +109,8 @@ pub struct OpenAiCompatiblePolicy {
     client: Client,
     requests: u32,
     estimated_cost_microusd: u64,
+    estimated_prompt_tokens: u64,
+    estimated_completion_tokens: u64,
     last_request: Option<Instant>,
 }
 
@@ -127,6 +129,8 @@ impl OpenAiCompatiblePolicy {
             client,
             requests: 0,
             estimated_cost_microusd: 0,
+            estimated_prompt_tokens: 0,
+            estimated_completion_tokens: 0,
             last_request: None,
         })
     }
@@ -183,6 +187,11 @@ impl OpenAiCompatiblePolicy {
                 return Err("provider cost budget exceeded".into());
             }
             self.estimated_cost_microusd = self.estimated_cost_microusd.saturating_add(projected);
+            self.estimated_prompt_tokens =
+                self.estimated_prompt_tokens.saturating_add(prompt_tokens);
+            self.estimated_completion_tokens = self
+                .estimated_completion_tokens
+                .saturating_add(u64::from(self.config.max_completion_tokens));
             self.requests += 1;
             self.last_request = Some(Instant::now());
             let timeout = deadline
@@ -275,6 +284,20 @@ impl QuestPolicy for OpenAiCompatiblePolicy {
         }?;
         check_deadline(Some(deadline))?;
         Ok(decision)
+    }
+
+    fn run_metadata(&self) -> PolicyRunMetadata {
+        PolicyRunMetadata {
+            policy_name: self.name().into(),
+            policy_kind: "remote_provider".into(),
+            provider: Some("openai_compatible".into()),
+            model: Some(self.config.model.clone()),
+            prompt_revision: "investigation-policy-v3".into(),
+            requests: self.requests,
+            estimated_prompt_tokens: self.estimated_prompt_tokens,
+            estimated_completion_tokens: self.estimated_completion_tokens,
+            estimated_cost_microusd: self.estimated_cost_microusd,
+        }
     }
 }
 

--- a/crates/adventuresim-strategic-sim/src/investigation_eval/report.rs
+++ b/crates/adventuresim-strategic-sim/src/investigation_eval/report.rs
@@ -1,8 +1,9 @@
 use super::{
     DeveloperCaseAnalysis, EVAL_FORMAT_VERSION, EvalCaseConfig, InvestigationEnvironment,
-    PolicyDecision, PublicQuestTrace, QuestPolicy, Termination, semantic_digest,
+    PolicyClassification, PolicyDecision, PolicyRunMetadata, PublicQuestTrace, QuestPolicy,
+    Termination, TerminationErrorCode, semantic_digest,
 };
-use adventuresim_core::quest_generation::TemplateFamily;
+use adventuresim_core::quest_generation::{RouteClass, TemplateFamily};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -16,6 +17,9 @@ pub struct EvalLimits {
     pub max_cases: u32,
     pub max_steps_per_case: u32,
     pub max_wall_time_ms: u64,
+    pub max_total_events: u32,
+    pub max_output_bytes: u64,
+    pub max_total_output_bytes: u64,
 }
 
 impl Default for EvalLimits {
@@ -24,6 +28,9 @@ impl Default for EvalLimits {
             max_cases: 64,
             max_steps_per_case: 64,
             max_wall_time_ms: 60_000,
+            max_total_events: 16_384,
+            max_output_bytes: 32 * 1024 * 1024,
+            max_total_output_bytes: 64 * 1024 * 1024,
         }
     }
 }
@@ -33,6 +40,9 @@ impl EvalLimits {
         if !(1..=1_000).contains(&self.max_cases)
             || !(1..=1_000).contains(&self.max_steps_per_case)
             || !(1..=3_600_000).contains(&self.max_wall_time_ms)
+            || !(1..=100_000).contains(&self.max_total_events)
+            || !(1..=100 * 1024 * 1024).contains(&self.max_output_bytes)
+            || !(1..=300 * 1024 * 1024).contains(&self.max_total_output_bytes)
         {
             return Err("quest evaluator bounds are invalid".into());
         }
@@ -53,29 +63,52 @@ pub struct QuestEvalMetrics {
     pub cases: u32,
     pub solved: u32,
     pub solve_rate: f64,
+    pub solve_rate_denominator: u32,
     pub contract_rate: Measurement<f64>,
     pub mean_steps: f64,
     pub mean_game_minutes: f64,
     pub mean_resource_cost: f64,
     pub route_counts: BTreeMap<String, u32>,
+    pub unique_path_fingerprints: u32,
+    pub path_fingerprint_counts: BTreeMap<String, u32>,
+    pub path_diversity_rate: f64,
+    pub dominant_path_share: f64,
+    pub action_kind_counts: BTreeMap<String, u32>,
+    pub action_fingerprint_counts: BTreeMap<String, u32>,
+    pub dominant_action_share: f64,
     pub dominant_route_share: f64,
     pub repeated_policy_choices: u32,
     pub dead_ends: u32,
     pub loops: u32,
     pub false_hypothesis_corrections: u32,
+    pub corrected_case_count: u32,
+    pub mean_false_belief_persistence_steps: Measurement<f64>,
     pub preparation_rate: f64,
+    pub prepared_cases: u32,
+    pub prepared_solve_rate: Measurement<f64>,
+    pub unprepared_solve_rate: Measurement<f64>,
+    pub policy_errors: u32,
+    pub termination_counts: BTreeMap<String, u32>,
     pub accidental_discovery_rate: Measurement<f64>,
-    pub initial_template_classification: Measurement<f64>,
-    pub initial_threat_classification: Measurement<f64>,
+    pub initial_template_classification_coverage: f64,
+    pub initial_threat_classification_coverage: f64,
     pub terrain_benefit: Measurement<f64>,
     pub insight_benefit: Measurement<f64>,
     pub language_benefit: Measurement<f64>,
     pub perception_benefit: Measurement<f64>,
     pub combat_benefit: Measurement<f64>,
     pub counterfactual_fingerprint_rate: Measurement<f64>,
-    pub generator_factor_count: u64,
-    pub generator_bridge_count: u64,
-    pub catalog_revisions: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EvaluationProvenance {
+    pub surface: String,
+    pub authority: String,
+    pub observation_source: String,
+    pub format_revision: u32,
+    pub limits: EvalLimits,
+    pub policy: PolicyRunMetadata,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -83,6 +116,7 @@ pub struct QuestEvalMetrics {
 pub struct PublicEvaluationReport {
     pub version: u32,
     pub policy: String,
+    pub provenance: EvaluationProvenance,
     pub traces: Vec<PublicQuestTrace>,
     pub metrics: QuestEvalMetrics,
     pub semantic_digest: String,
@@ -95,6 +129,9 @@ pub struct DeveloperEvaluationReport {
     pub public_report_digest: String,
     pub cases: Vec<DeveloperCaseAnalysis>,
     pub marginal_audit: MarginalAudit,
+    pub classification_audit: ClassificationAudit,
+    pub counterfactual_audit: CounterfactualAudit,
+    pub privacy_audit: PrivacyAudit,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -105,21 +142,76 @@ pub struct MarginalAudit {
     pub true_site_counts: BTreeMap<String, u32>,
     pub factor_count: u64,
     pub bridge_count: u64,
+    pub catalog_revisions: BTreeSet<String>,
+    pub factor_id_counts: BTreeMap<String, u32>,
+    pub bridge_id_counts: BTreeMap<String, u32>,
+    pub accepted_factor_rows: u64,
+    pub rejected_factor_rows: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClassificationAudit {
+    pub cases: u32,
+    pub template_guesses: u32,
+    pub correct_template_guesses: u32,
+    pub template_accuracy: Measurement<f64>,
+    pub threat_accuracy: Measurement<f64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CounterfactualAudit {
+    pub cases: u32,
+    pub naturally_matched_groups: u32,
+    pub matched_cases: u32,
+    pub comparisons: u32,
+    pub divergent_comparisons: u32,
+    pub fingerprint_divergence_rate: Measurement<f64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrivacyAudit {
+    pub structural_public_private_type_split: bool,
+    pub private_canary_occurrences_in_public_json: u32,
+    pub note: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct EvaluationBundle {
     pub public: PublicEvaluationReport,
     pub developer: DeveloperEvaluationReport,
+    pub artifacts: EvaluationArtifacts,
+}
+
+#[derive(Clone, Debug)]
+pub struct EvaluationArtifacts {
+    pub public_json: Vec<u8>,
+    pub developer_json: Vec<u8>,
+    pub stories_markdown: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReplayCase {
+    pub version: u32,
+    pub catalog_revision: String,
+    pub generator_manifest_digest: String,
     pub seed: u64,
     pub family: TemplateFamily,
     pub decisions: Vec<PolicyDecision>,
-    pub expected_digest: String,
+    pub expected: ReplayExpectations,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReplayExpectations {
+    pub solved: bool,
+    pub termination: Termination,
+    pub route: Option<RouteClass>,
+    pub event_count: u32,
+    pub semantic_digest: Option<String>,
 }
 
 pub const MAX_REPLAY_DECISIONS: usize = 1_000;
@@ -226,6 +318,7 @@ pub fn evaluate_cases(
     let deadline = started + Duration::from_millis(limits.max_wall_time_ms);
     let mut traces = Vec::new();
     let mut private = Vec::new();
+    let mut total_events = 0_u32;
     for config in configs {
         if Instant::now() >= deadline {
             return Err("quest evaluator wall-time budget exceeded".into());
@@ -233,6 +326,9 @@ pub fn evaluate_cases(
         let mut environment = InvestigationEnvironment::generate(config.clone())?;
         private.push(environment.developer_analysis().clone());
         let mut termination = Termination::StepLimit;
+        let mut termination_error = None;
+        let mut initial_classification = PolicyClassification::default();
+        let mut initial_observation_digest = observable_state_digest(environment.frame())?;
         let mut state_visits: BTreeMap<String, u8> = BTreeMap::new();
         for _ in 0..limits.max_steps_per_case {
             if environment.is_solved() {
@@ -262,12 +358,27 @@ pub fn evaluate_cases(
                     } else {
                         Termination::PolicyError
                     };
+                    termination_error = Some(if termination == Termination::BudgetExceeded {
+                        TerminationErrorCode::BudgetExceeded
+                    } else {
+                        TerminationErrorCode::PolicyFailure
+                    });
                     break;
                 }
             };
             if environment.apply(&decision).is_err() {
                 termination = Termination::PolicyError;
+                termination_error = Some(TerminationErrorCode::InvalidDecision);
                 break;
+            }
+            total_events = total_events.saturating_add(1);
+            if total_events > limits.max_total_events {
+                return Err("quest evaluator total event budget exceeded".into());
+            }
+            if environment.frame().step == 1 {
+                initial_observation_digest = observable_state_digest(environment.frame())?;
+                initial_classification = policy.classify(environment.frame())?;
+                initial_classification.validate()?;
             }
             if Instant::now() >= deadline {
                 termination = Termination::BudgetExceeded;
@@ -277,27 +388,69 @@ pub fn evaluate_cases(
         if environment.is_solved() {
             termination = Termination::Solved;
         }
-        traces.push(environment.public_trace(policy.name().into(), termination)?);
+        traces.push(environment.public_trace(
+            policy.name().into(),
+            initial_observation_digest,
+            initial_classification,
+            termination,
+            termination_error,
+        )?);
     }
-    let metrics = metrics(&traces, &private);
+    let metrics = metrics(&traces);
+    let policy_metadata = policy.run_metadata();
     let mut public = PublicEvaluationReport {
         version: EVAL_FORMAT_VERSION,
         policy: policy.name().into(),
+        provenance: EvaluationProvenance {
+            surface: "offline_projection".into(),
+            authority: "generator_content_analysis_only".into(),
+            observation_source: "synthetic_player_frame".into(),
+            format_revision: EVAL_FORMAT_VERSION,
+            limits: limits.clone(),
+            policy: policy_metadata,
+        },
         traces,
         metrics,
         semantic_digest: String::new(),
     };
     public.semantic_digest = semantic_digest(&public)?;
+    let public_json = serde_json::to_vec_pretty(&public).map_err(|error| error.to_string())?;
+    let privacy_audit = privacy_audit(&public_json, &private)?;
     let developer = DeveloperEvaluationReport {
         version: EVAL_FORMAT_VERSION,
         public_report_digest: public.semantic_digest.clone(),
         marginal_audit: marginal_audit(&private),
+        classification_audit: classification_audit(&public.traces, &private),
+        counterfactual_audit: counterfactual_audit(&public.traces, &private),
+        privacy_audit,
         cases: private,
     };
-    Ok(EvaluationBundle { public, developer })
+    let developer_json =
+        serde_json::to_vec_pretty(&developer).map_err(|error| error.to_string())?;
+    let stories_markdown = render_markdown_stories(&public).into_bytes();
+    validate_artifact_sizes(
+        [
+            ("public JSON", public_json.len()),
+            ("developer JSON", developer_json.len()),
+            ("Markdown stories", stories_markdown.len()),
+        ],
+        limits,
+    )?;
+    Ok(EvaluationBundle {
+        public,
+        developer,
+        artifacts: EvaluationArtifacts {
+            public_json,
+            developer_json,
+            stories_markdown,
+        },
+    })
 }
 
 pub fn replay_case(recorded: &ReplayCase) -> Result<PublicQuestTrace, String> {
+    if recorded.version != EVAL_FORMAT_VERSION {
+        return Err("replay fixture schema version mismatch".into());
+    }
     if recorded.decisions.len() > MAX_REPLAY_DECISIONS {
         return Err("recorded action replay exceeds decision cap".into());
     }
@@ -305,6 +458,12 @@ pub fn replay_case(recorded: &ReplayCase) -> Result<PublicQuestTrace, String> {
         recorded.seed,
         recorded.family,
     ))?;
+    if environment.developer_analysis().catalog_revision != recorded.catalog_revision
+        || environment.developer_analysis().generator_manifest_digest
+            != recorded.generator_manifest_digest
+    {
+        return Err("replay fixture generator revision or manifest mismatch".into());
+    }
     for decision in recorded.decisions.iter().take(MAX_REPLAY_DECISIONS) {
         environment.apply(decision)?;
     }
@@ -315,11 +474,80 @@ pub fn replay_case(recorded: &ReplayCase) -> Result<PublicQuestTrace, String> {
     } else {
         Termination::StepLimit
     };
-    let trace = environment.public_trace("recorded-action-replay".into(), termination)?;
-    if trace.semantic_digest != recorded.expected_digest {
-        return Err("recorded action replay digest mismatch".into());
+    let trace = environment.public_trace(
+        "recorded-action-replay".into(),
+        observable_state_digest(environment.frame())?,
+        PolicyClassification::default(),
+        termination,
+        None,
+    )?;
+    if trace.solved != recorded.expected.solved
+        || trace.termination != recorded.expected.termination
+        || trace.route != recorded.expected.route
+        || trace.events.len() as u32 != recorded.expected.event_count
+    {
+        return Err("recorded action replay stable expectation mismatch".into());
+    }
+    if recorded
+        .expected
+        .semantic_digest
+        .as_ref()
+        .is_some_and(|expected| expected != &trace.semantic_digest)
+    {
+        return Err("recorded action replay optional digest mismatch".into());
     }
     Ok(trace)
+}
+
+pub fn promote_replay_candidate(
+    bundle: &EvaluationBundle,
+    case_index: usize,
+) -> Result<ReplayCase, String> {
+    let trace = bundle
+        .public
+        .traces
+        .get(case_index)
+        .ok_or("promotion case index is out of range")?;
+    let developer = bundle
+        .developer
+        .cases
+        .get(case_index)
+        .ok_or("promotion developer join is out of range")?;
+    if trace.solved {
+        return Err("promotion accepts only an observed non-solving case".into());
+    }
+    if !matches!(
+        trace.termination,
+        Termination::StepLimit | Termination::DeadEnd
+    ) {
+        return Err(
+            "promotion accepts only step-limit or dead-end failures reproducible by action replay"
+                .into(),
+        );
+    }
+    Ok(ReplayCase {
+        version: EVAL_FORMAT_VERSION,
+        catalog_revision: developer.catalog_revision.clone(),
+        generator_manifest_digest: developer.generator_manifest_digest.clone(),
+        seed: developer.generation_seed,
+        family: developer.family,
+        decisions: trace
+            .events
+            .iter()
+            .map(|event| PolicyDecision {
+                version: EVAL_FORMAT_VERSION,
+                choice_id: event.choice_id.clone(),
+                arguments: Default::default(),
+            })
+            .collect(),
+        expected: ReplayExpectations {
+            solved: trace.solved,
+            termination: trace.termination,
+            route: trace.route,
+            event_count: trace.events.len() as u32,
+            semantic_digest: None,
+        },
+    })
 }
 
 fn observable_state_digest(frame: &super::PlayerFrame) -> Result<String, String> {
@@ -335,7 +563,29 @@ fn observable_state_digest(frame: &super::PlayerFrame) -> Result<String, String>
     ))
 }
 
-fn metrics(traces: &[PublicQuestTrace], private: &[DeveloperCaseAnalysis]) -> QuestEvalMetrics {
+fn validate_artifact_sizes(
+    artifacts: [(&str, usize); 3],
+    limits: &EvalLimits,
+) -> Result<(), String> {
+    let mut total = 0_u64;
+    for (name, size) in artifacts {
+        let size = size as u64;
+        if size > limits.max_output_bytes {
+            return Err(format!(
+                "quest evaluator {name} exceeds per-artifact byte budget"
+            ));
+        }
+        total = total
+            .checked_add(size)
+            .ok_or("quest evaluator artifact byte count overflow")?;
+    }
+    if total > limits.max_total_output_bytes {
+        return Err("quest evaluator artifacts exceed total output byte budget".into());
+    }
+    Ok(())
+}
+
+fn metrics(traces: &[PublicQuestTrace]) -> QuestEvalMetrics {
     let cases = traces.len() as u32;
     let solved = traces.iter().filter(|trace| trace.solved).count() as u32;
     let total_steps = traces
@@ -357,6 +607,33 @@ fn metrics(traces: &[PublicQuestTrace], private: &[DeveloperCaseAnalysis]) -> Qu
         *route_counts.entry(format!("{route:?}")).or_default() += 1;
     }
     let dominant = route_counts.values().copied().max().unwrap_or(0);
+    let mut path_fingerprint_counts = BTreeMap::new();
+    let mut action_kind_counts = BTreeMap::new();
+    let mut action_fingerprint_counts = BTreeMap::new();
+    for trace in traces {
+        let path = trace
+            .events
+            .iter()
+            .map(observer_safe_action_identity)
+            .collect::<Vec<_>>()
+            .join(">");
+        let fingerprint = blake3::hash(path.as_bytes()).to_hex()[..16].to_string();
+        *path_fingerprint_counts.entry(fingerprint).or_default() += 1;
+        for event in &trace.events {
+            *action_kind_counts
+                .entry(format!("{:?}", event.choice_kind))
+                .or_default() += 1;
+            *action_fingerprint_counts
+                .entry(observer_safe_action_identity(event))
+                .or_default() += 1;
+        }
+    }
+    let dominant_path = path_fingerprint_counts.values().copied().max().unwrap_or(0);
+    let dominant_action = action_fingerprint_counts
+        .values()
+        .copied()
+        .max()
+        .unwrap_or(0);
     let repeated = traces
         .iter()
         .map(|trace| {
@@ -372,6 +649,16 @@ fn metrics(traces: &[PublicQuestTrace], private: &[DeveloperCaseAnalysis]) -> Qu
         .flat_map(|trace| &trace.events)
         .map(|event| event.corrected_proposition_ids.len() as u32)
         .sum();
+    let corrected_case_count = traces
+        .iter()
+        .filter(|trace| {
+            trace
+                .events
+                .iter()
+                .any(|event| !event.corrected_proposition_ids.is_empty())
+        })
+        .count() as u32;
+    let persistence = correction_persistence(traces);
     let prepared = traces
         .iter()
         .filter(|trace| {
@@ -381,10 +668,17 @@ fn metrics(traces: &[PublicQuestTrace], private: &[DeveloperCaseAnalysis]) -> Qu
                 .any(|event| event.choice_kind == super::ChoiceKind::Prepare)
         })
         .count() as u32;
+    let mut termination_counts = BTreeMap::new();
+    for trace in traces {
+        *termination_counts
+            .entry(format!("{:?}", trace.termination))
+            .or_default() += 1;
+    }
     QuestEvalMetrics {
         cases,
         solved,
         solve_rate: ratio(solved, cases),
+        solve_rate_denominator: cases,
         contract_rate: Measurement::NotMeasured(
             "modular #187 cases intentionally have no contract".into(),
         ),
@@ -392,6 +686,13 @@ fn metrics(traces: &[PublicQuestTrace], private: &[DeveloperCaseAnalysis]) -> Qu
         mean_game_minutes: mean(total_minutes, cases),
         mean_resource_cost: mean(total_cost, cases),
         route_counts,
+        unique_path_fingerprints: path_fingerprint_counts.len() as u32,
+        path_diversity_rate: ratio(path_fingerprint_counts.len() as u32, cases),
+        dominant_path_share: ratio(dominant_path, cases),
+        path_fingerprint_counts,
+        dominant_action_share: ratio(dominant_action, total_steps as u32),
+        action_kind_counts,
+        action_fingerprint_counts,
         dominant_route_share: ratio(dominant, solved.max(1)),
         repeated_policy_choices: repeated,
         dead_ends: traces
@@ -403,47 +704,117 @@ fn metrics(traces: &[PublicQuestTrace], private: &[DeveloperCaseAnalysis]) -> Qu
             .filter(|trace| trace.termination == Termination::Loop)
             .count() as u32,
         false_hypothesis_corrections: corrections,
+        corrected_case_count,
+        mean_false_belief_persistence_steps: persistence,
         preparation_rate: ratio(prepared, cases),
+        prepared_cases: prepared,
+        prepared_solve_rate: subgroup_solve_rate(traces, true),
+        unprepared_solve_rate: subgroup_solve_rate(traces, false),
+        policy_errors: traces
+            .iter()
+            .filter(|trace| trace.termination == Termination::PolicyError)
+            .count() as u32,
+        termination_counts,
         accidental_discovery_rate: Measurement::NotMeasured(
             "offline graph has source provenance but no runtime perception roll".into(),
         ),
-        initial_template_classification: Measurement::NotMeasured(
-            "policy decision schema does not ask for a template guess".into(),
+        initial_template_classification_coverage: ratio(
+            traces
+                .iter()
+                .filter(|trace| trace.initial_classification.template_guess.is_some())
+                .count() as u32,
+            cases,
         ),
-        initial_threat_classification: Measurement::NotMeasured(
-            "policy decision schema does not ask for a threat guess".into(),
+        initial_threat_classification_coverage: ratio(
+            traces
+                .iter()
+                .filter(|trace| trace.initial_classification.threat_guess.is_some())
+                .count() as u32,
+            cases,
         ),
-        terrain_benefit: Measurement::NotMeasured("requires a matched skill ablation suite".into()),
-        insight_benefit: Measurement::NotMeasured("requires a matched skill ablation suite".into()),
-        language_benefit: Measurement::NotMeasured("language checks are not in #187 graph".into()),
+        terrain_benefit: Measurement::NotMeasured(
+            "offline projection displays terrain skill but does not apply it causally".into(),
+        ),
+        insight_benefit: Measurement::NotMeasured(
+            "offline projection displays insight but does not apply it causally".into(),
+        ),
+        language_benefit: Measurement::NotMeasured(
+            "language checks are absent from the generated investigation graph".into(),
+        ),
         perception_benefit: Measurement::NotMeasured(
-            "requires a matched skill ablation suite".into(),
+            "offline projection has no causal perception roll".into(),
         ),
         combat_benefit: Measurement::NotMeasured(
             "evaluator does not duplicate tactical combat".into(),
         ),
         counterfactual_fingerprint_rate: Measurement::NotMeasured(
-            "run `quest-eval-suite` with matched policies to populate".into(),
+            "counterfactuals are developer-side and require naturally matched visible prefixes"
+                .into(),
         ),
-        generator_factor_count: private
-            .iter()
-            .map(|case| case.factor_ids.len() as u64)
-            .sum(),
-        generator_bridge_count: private
-            .iter()
-            .map(|case| case.bridge_ids.len() as u64)
-            .sum(),
-        catalog_revisions: private
-            .iter()
-            .map(|case| case.catalog_revision.clone())
-            .collect(),
     }
+}
+
+fn subgroup_solve_rate(traces: &[PublicQuestTrace], prepared: bool) -> Measurement<f64> {
+    let subgroup = traces
+        .iter()
+        .filter(|trace| {
+            trace
+                .events
+                .iter()
+                .any(|event| !event.preparation_tags.is_empty())
+                == prepared
+        })
+        .collect::<Vec<_>>();
+    if subgroup.is_empty() {
+        Measurement::NotMeasured(format!(
+            "no {} cases in this run",
+            if prepared { "prepared" } else { "unprepared" }
+        ))
+    } else {
+        Measurement::Measured(
+            subgroup.iter().filter(|trace| trace.solved).count() as f64 / subgroup.len() as f64,
+        )
+    }
+}
+
+fn correction_persistence(traces: &[PublicQuestTrace]) -> Measurement<f64> {
+    let mut durations = Vec::new();
+    for trace in traces {
+        let mut first_seen = BTreeMap::new();
+        for event in &trace.events {
+            for corrected in &event.corrected_proposition_ids {
+                if let Some(first_step) = first_seen.get(corrected) {
+                    durations.push(event.step.saturating_sub(*first_step));
+                }
+            }
+            for learned in &event.learned_claim_ids {
+                first_seen.entry(learned.clone()).or_insert(event.step);
+            }
+        }
+    }
+    if durations.is_empty() {
+        Measurement::NotMeasured(
+            "no correction had a measurable prior public observation in this run".into(),
+        )
+    } else {
+        Measurement::Measured(
+            durations.iter().map(|value| u64::from(*value)).sum::<u64>() as f64
+                / durations.len() as f64,
+        )
+    }
+}
+
+fn observer_safe_action_identity(event: &super::PublicTraceEvent) -> String {
+    let label_digest = blake3::hash(event.action_label.as_bytes()).to_hex();
+    format!("{:?}:{}", event.choice_kind, &label_digest[..16])
 }
 
 fn marginal_audit(cases: &[DeveloperCaseAnalysis]) -> MarginalAudit {
     let mut family_counts = BTreeMap::new();
     let mut cause_counts = BTreeMap::new();
     let mut true_site_counts = BTreeMap::new();
+    let mut factor_id_counts = BTreeMap::new();
+    let mut bridge_id_counts = BTreeMap::new();
     for case in cases {
         *family_counts
             .entry(format!("{:?}", case.family))
@@ -452,14 +823,171 @@ fn marginal_audit(cases: &[DeveloperCaseAnalysis]) -> MarginalAudit {
             .entry(case.canonical_cause.clone())
             .or_default() += 1;
         *true_site_counts.entry(case.true_site.clone()).or_default() += 1;
+        for row in &case.factor_trace {
+            for factor in &row.factor_ids {
+                *factor_id_counts.entry(factor.0.clone()).or_default() += 1;
+            }
+        }
+        for bridge in &case.bridges {
+            *bridge_id_counts.entry(bridge.id.0.clone()).or_default() += 1;
+        }
     }
     MarginalAudit {
         family_counts,
         cause_counts,
         true_site_counts,
-        factor_count: cases.iter().map(|case| case.factor_ids.len() as u64).sum(),
-        bridge_count: cases.iter().map(|case| case.bridge_ids.len() as u64).sum(),
+        factor_count: cases
+            .iter()
+            .flat_map(|case| &case.factor_trace)
+            .map(|row| row.factor_ids.len() as u64)
+            .sum(),
+        bridge_count: cases.iter().map(|case| case.bridges.len() as u64).sum(),
+        catalog_revisions: cases
+            .iter()
+            .map(|case| case.catalog_revision.clone())
+            .collect(),
+        factor_id_counts,
+        bridge_id_counts,
+        accepted_factor_rows: cases
+            .iter()
+            .flat_map(|case| &case.factor_trace)
+            .filter(|row| row.accepted)
+            .count() as u64,
+        rejected_factor_rows: cases
+            .iter()
+            .flat_map(|case| &case.factor_trace)
+            .filter(|row| !row.accepted)
+            .count() as u64,
     }
+}
+
+fn classification_audit(
+    traces: &[PublicQuestTrace],
+    cases: &[DeveloperCaseAnalysis],
+) -> ClassificationAudit {
+    let mut guesses = 0_u32;
+    let mut correct = 0_u32;
+    for (trace, case) in traces.iter().zip(cases) {
+        if let Some(guess) = &trace.initial_classification.template_guess {
+            guesses += 1;
+            let truth = format!("{:?}", case.family).to_ascii_lowercase();
+            let normalized_guess = guess.replace('_', "").to_ascii_lowercase();
+            if truth == normalized_guess {
+                correct += 1;
+            }
+        }
+    }
+    ClassificationAudit {
+        cases: traces.len() as u32,
+        template_guesses: guesses,
+        correct_template_guesses: correct,
+        template_accuracy: if guesses == 0 {
+            Measurement::NotMeasured("policy emitted no template classifications".into())
+        } else {
+            Measurement::Measured(ratio(correct, guesses))
+        },
+        threat_accuracy: Measurement::NotMeasured(
+            "generated player frame exposes no stable player-facing threat taxonomy".into(),
+        ),
+    }
+}
+
+fn counterfactual_audit(
+    traces: &[PublicQuestTrace],
+    cases: &[DeveloperCaseAnalysis],
+) -> CounterfactualAudit {
+    let mut groups: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    for (index, trace) in traces.iter().enumerate() {
+        groups
+            .entry(trace.initial_observation_digest.as_str())
+            .or_default()
+            .push(index);
+    }
+    let coherent = groups
+        .values()
+        .filter(|indices| {
+            indices.len() > 1
+                && indices.iter().any(|left| {
+                    indices
+                        .iter()
+                        .any(|right| cases[*left].canonical_cause != cases[*right].canonical_cause)
+                })
+        })
+        .collect::<Vec<_>>();
+    let matched_cases = coherent.iter().map(|group| group.len() as u32).sum();
+    let mut comparisons = 0_u32;
+    let mut divergent = 0_u32;
+    for group in &coherent {
+        for (left_position, left_index) in group.iter().enumerate() {
+            for right_index in group.iter().skip(left_position + 1) {
+                if cases[*left_index].canonical_cause == cases[*right_index].canonical_cause {
+                    continue;
+                }
+                comparisons += 1;
+                let left_path = traces[*left_index]
+                    .events
+                    .iter()
+                    .map(observer_safe_action_identity)
+                    .collect::<Vec<_>>();
+                let right_path = traces[*right_index]
+                    .events
+                    .iter()
+                    .map(observer_safe_action_identity)
+                    .collect::<Vec<_>>();
+                if left_path != right_path {
+                    divergent += 1;
+                }
+            }
+        }
+    }
+    CounterfactualAudit {
+        cases: traces.len() as u32,
+        naturally_matched_groups: coherent.len() as u32,
+        matched_cases,
+        comparisons,
+        divergent_comparisons: divergent,
+        fingerprint_divergence_rate: if comparisons == 0 {
+            Measurement::NotMeasured(
+                "no different hidden causes shared an identical player-visible initial prefix"
+                    .into(),
+            )
+        } else {
+            Measurement::Measured(ratio(divergent, comparisons))
+        },
+    }
+}
+
+fn privacy_audit(
+    public_json: &[u8],
+    cases: &[DeveloperCaseAnalysis],
+) -> Result<PrivacyAudit, String> {
+    let public = String::from_utf8_lossy(public_json);
+    let mut occurrences = 0_u32;
+    for case in cases {
+        // Use high-entropy authority values that have no legitimate public
+        // rendering. Factor candidate IDs can intentionally name public
+        // catalog concepts, so treating every candidate as a canary creates
+        // false positives rather than strengthening this heuristic.
+        for private in [
+            case.canonical_case_id.as_str(),
+            case.generator_manifest_digest.as_str(),
+        ] {
+            if !private.is_empty() && public.contains(private) {
+                occurrences = occurrences.saturating_add(1);
+            }
+        }
+    }
+    let structural_public_private_type_split = occurrences == 0;
+    if !structural_public_private_type_split {
+        return Err("private authority canary detected in public evaluation artifact".into());
+    }
+    Ok(PrivacyAudit {
+        structural_public_private_type_split,
+        private_canary_occurrences_in_public_json: occurrences,
+        note:
+            "Heuristic canary scan plus separate serialization types; not a formal privacy proof."
+                .into(),
+    })
 }
 
 fn ratio(numerator: u32, denominator: u32) -> f64 {
@@ -590,6 +1118,38 @@ mod tests {
             assert!(!public.contains(&case.canonical_case_id));
             assert!(!public.contains(&case.generator_manifest_digest));
         }
+        assert_eq!(
+            bundle
+                .developer
+                .privacy_audit
+                .private_canary_occurrences_in_public_json,
+            0
+        );
+        assert!(!public.contains("catalog_revision"));
+        assert!(!public.contains("factor_trace"));
+        assert!(!public.contains("\"bridges\""));
+    }
+
+    #[test]
+    fn player_frames_use_run_local_handles_not_generator_ids() {
+        let mut environment = InvestigationEnvironment::generate(EvalCaseConfig::fixture(
+            11,
+            TemplateFamily::DisappearanceOrLoss,
+        ))
+        .unwrap();
+        let enter = environment.frame().legal_choices[0].choice_id.clone();
+        environment
+            .apply(&PolicyDecision {
+                version: EVAL_FORMAT_VERSION,
+                choice_id: enter,
+                arguments: Default::default(),
+            })
+            .unwrap();
+        let public = serde_json::to_string(environment.frame()).unwrap();
+        assert!(public.contains("witness:observed-"));
+        for factor in &environment.developer_analysis().factor_trace {
+            assert!(!public.contains(&factor.candidate_id));
+        }
     }
 
     #[test]
@@ -600,11 +1160,15 @@ mod tests {
             policy: "fixture".into(),
             title: "Fixture investigation".into(),
             problem_summary: "Something happened.".into(),
+            initial_observation_digest: "initial".into(),
+            initial_classification: PolicyClassification::default(),
             events: vec![super::super::PublicTraceEvent {
                 step: 0,
                 game_minute: 0,
                 location: "the market".into(),
-                frame_digest: "digest".into(),
+                observation_provenance: "offline_projection/player_frame".into(),
+                pre_observation_digest: "pre".into(),
+                post_observation_digest: "post".into(),
                 choice_id: "choice:fixture".into(),
                 choice_kind: super::super::ChoiceKind::InterviewWitness,
                 action_label: "Speak with Marta.".into(),
@@ -614,17 +1178,44 @@ mod tests {
                 }],
                 result: "ordinary testimony".into(),
                 learned: vec!["no correction wording here".into()],
+                learned_claim_ids: vec!["claim:wrong".into()],
                 corrected_proposition_ids: vec!["claim:wrong".into()],
+                preparation_tags: Vec::new(),
                 game_minutes: 1,
                 resource_cost: 0,
             }],
             solved: false,
             exhausted: false,
             termination: Termination::StepLimit,
+            termination_error: None,
             route: None,
             semantic_digest: "fixture".into(),
         };
-        assert_eq!(metrics(&[trace], &[]).false_hypothesis_corrections, 1);
+        let measured = metrics(&[trace]);
+        assert_eq!(measured.false_hypothesis_corrections, 1);
+        assert!(matches!(
+            measured.mean_false_belief_persistence_steps,
+            Measurement::NotMeasured(_)
+        ));
+    }
+
+    #[test]
+    fn fingerprints_distinguish_same_kind_actions_by_visible_identity() {
+        let bundle = evaluate_cases(
+            &golden_suite(5, 1),
+            &mut ScriptedPolicy::default(),
+            &EvalLimits::default(),
+        )
+        .unwrap();
+        let mut left = bundle.public.traces[0].clone();
+        let mut right = left.clone();
+        left.events[0].choice_kind = super::super::ChoiceKind::Investigate;
+        right.events[0].choice_kind = super::super::ChoiceKind::Investigate;
+        left.events[0].action_label = "Inspect the eastern tracks.".into();
+        right.events[0].action_label = "Inspect the western tracks.".into();
+        let measured = metrics(&[left, right]);
+        assert_eq!(measured.unique_path_fingerprints, 2);
+        assert!(measured.action_fingerprint_counts.len() >= 2);
     }
 
     #[test]
@@ -655,6 +1246,9 @@ mod tests {
     #[test]
     fn replay_rejects_unbounded_decision_lists_before_execution() {
         let recorded = ReplayCase {
+            version: EVAL_FORMAT_VERSION,
+            catalog_revision: "fixture".into(),
+            generator_manifest_digest: "fixture".into(),
             seed: 1,
             family: TemplateFamily::RecurringDepredation,
             decisions: vec![
@@ -665,8 +1259,204 @@ mod tests {
                 };
                 MAX_REPLAY_DECISIONS + 1
             ],
-            expected_digest: "unused".into(),
+            expected: ReplayExpectations {
+                solved: false,
+                termination: Termination::StepLimit,
+                route: None,
+                event_count: 0,
+                semantic_digest: None,
+            },
         };
         assert!(replay_case(&recorded).is_err());
+    }
+
+    #[test]
+    fn promoted_failure_replays_against_stable_expectations() {
+        let limits = EvalLimits {
+            max_cases: 1,
+            max_steps_per_case: 1,
+            ..EvalLimits::default()
+        };
+        let bundle = evaluate_cases(
+            &[EvalCaseConfig::fixture(
+                41,
+                TemplateFamily::RecurringDepredation,
+            )],
+            &mut MockLlmPolicy,
+            &limits,
+        )
+        .unwrap();
+        let fixture = promote_replay_candidate(&bundle, 0).unwrap();
+        assert!(!fixture.expected.solved);
+        let first = replay_case(&fixture).unwrap();
+        let second = replay_case(&fixture).unwrap();
+        assert_eq!(first.termination, fixture.expected.termination);
+        assert_eq!(first.semantic_digest, second.semantic_digest);
+
+        for termination in [
+            Termination::Loop,
+            Termination::PolicyError,
+            Termination::BudgetExceeded,
+        ] {
+            let mut rejected = bundle.clone();
+            rejected.public.traces[0].termination = termination;
+            assert!(promote_replay_candidate(&rejected, 0).is_err());
+        }
+    }
+
+    #[test]
+    fn checked_in_failure_fixture_replays_deterministically() {
+        let fixture: ReplayCase = serde_json::from_str(include_str!(
+            "../../fixtures/quest-analysis-failure-v3.json"
+        ))
+        .unwrap();
+        let first = replay_case(&fixture).unwrap();
+        let second = replay_case(&fixture).unwrap();
+        assert!(!first.solved);
+        assert_eq!(first.termination, Termination::StepLimit);
+        assert_eq!(first.semantic_digest, second.semantic_digest);
+    }
+
+    #[test]
+    fn counterfactual_pairs_are_complete_and_order_invariant() {
+        let bundle = evaluate_cases(
+            &golden_suite(71, 2),
+            &mut ScriptedPolicy::default(),
+            &EvalLimits::default(),
+        )
+        .unwrap();
+        let mut traces = bundle.public.traces[..3].to_vec();
+        let mut cases = bundle.developer.cases[..3].to_vec();
+        for (index, trace) in traces.iter_mut().enumerate() {
+            trace.initial_observation_digest = "shared-visible-prefix".into();
+            trace.events[0].action_label = format!("Visible action {index}");
+            cases[index].canonical_cause = format!("private-cause-{index}");
+        }
+        let forward = counterfactual_audit(&traces, &cases);
+        traces.reverse();
+        cases.reverse();
+        let reversed = counterfactual_audit(&traces, &cases);
+        assert_eq!(forward.comparisons, 3);
+        assert_eq!(forward.divergent_comparisons, 3);
+        assert_eq!(forward.comparisons, reversed.comparisons);
+        assert_eq!(
+            forward.fingerprint_divergence_rate,
+            reversed.fingerprint_divergence_rate
+        );
+    }
+
+    #[test]
+    fn artifact_byte_budgets_cover_pretty_json_and_markdown() {
+        let limits = EvalLimits {
+            max_cases: 2,
+            max_output_bytes: 64,
+            max_total_output_bytes: 192,
+            ..EvalLimits::default()
+        };
+        assert!(
+            evaluate_cases(&golden_suite(5, 1), &mut ScriptedPolicy::default(), &limits)
+                .unwrap_err()
+                .contains("per-artifact")
+        );
+
+        let limits = EvalLimits {
+            max_cases: 2,
+            max_output_bytes: 100 * 1024 * 1024,
+            max_total_output_bytes: 128,
+            ..EvalLimits::default()
+        };
+        assert!(
+            evaluate_cases(&golden_suite(5, 1), &mut ScriptedPolicy::default(), &limits)
+                .unwrap_err()
+                .contains("total output")
+        );
+    }
+
+    #[test]
+    fn privacy_canaries_fail_closed() {
+        let bundle = evaluate_cases(
+            &golden_suite(5, 1),
+            &mut ScriptedPolicy::default(),
+            &EvalLimits::default(),
+        )
+        .unwrap();
+        let leaked = format!(
+            "{{\"secret\":\"{}\"}}",
+            bundle.developer.cases[0].canonical_case_id
+        );
+        assert!(privacy_audit(leaked.as_bytes(), &bundle.developer.cases).is_err());
+    }
+
+    struct SecretErrorPolicy;
+
+    impl QuestPolicy for SecretErrorPolicy {
+        fn name(&self) -> &str {
+            "secret-error-fixture"
+        }
+
+        fn decide(&mut self, _frame: &super::super::PlayerFrame) -> Result<PolicyDecision, String> {
+            Err("provider failed at https://secret.internal.example/v1?token=CANARY".into())
+        }
+    }
+
+    #[test]
+    fn public_policy_errors_are_typed_and_do_not_echo_provider_details() {
+        let bundle = evaluate_cases(
+            &golden_suite(5, 1),
+            &mut SecretErrorPolicy,
+            &EvalLimits::default(),
+        )
+        .unwrap();
+        let public = String::from_utf8(bundle.artifacts.public_json).unwrap();
+        assert!(!public.contains("secret.internal"));
+        assert!(!public.contains("CANARY"));
+        assert_eq!(
+            bundle.public.traces[0].termination_error,
+            Some(TerminationErrorCode::PolicyFailure)
+        );
+    }
+
+    struct InvalidClassificationPolicy;
+
+    impl QuestPolicy for InvalidClassificationPolicy {
+        fn name(&self) -> &str {
+            "invalid-classification-fixture"
+        }
+
+        fn decide(&mut self, frame: &super::super::PlayerFrame) -> Result<PolicyDecision, String> {
+            ScriptedPolicy::default().decide(frame)
+        }
+
+        fn classify(
+            &mut self,
+            _frame: &super::super::PlayerFrame,
+        ) -> Result<PolicyClassification, String> {
+            Ok(PolicyClassification {
+                template_guess: Some("X".repeat(65)),
+                threat_guess: None,
+                confidence_percent: Some(101),
+            })
+        }
+    }
+
+    #[test]
+    fn invalid_classifications_fail_before_publication() {
+        assert!(
+            evaluate_cases(
+                &golden_suite(5, 1),
+                &mut InvalidClassificationPolicy,
+                &EvalLimits::default()
+            )
+            .is_err()
+        );
+        assert!(
+            PolicyClassification {
+                template_guess: Some("ValidButUppercase".into()),
+                threat_guess: None,
+                confidence_percent: Some(50),
+            }
+            .validate()
+            .is_err()
+        );
     }
 }

--- a/crates/adventuresim-strategic-sim/src/investigation_eval/types.rs
+++ b/crates/adventuresim-strategic-sim/src/investigation_eval/types.rs
@@ -1,10 +1,10 @@
 use adventuresim_core::{
     investigation_action::InvestigationActionKind,
-    quest_generation::{RouteClass, TemplateFamily},
+    quest_generation::{CausalBridge, FactorTrace, RouteClass, TemplateFamily},
 };
 use serde::{Deserialize, Serialize};
 
-pub const EVAL_FORMAT_VERSION: u32 = 2;
+pub const EVAL_FORMAT_VERSION: u32 = 3;
 pub const MAX_PROVIDER_RESPONSE_BYTES: usize = 64 * 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -144,6 +144,59 @@ pub struct PolicyDecision {
     pub arguments: DecisionArguments,
 }
 
+/// A bounded, player-facing classification probe. This records an answer, not
+/// hidden reasoning or chain-of-thought.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyClassification {
+    pub template_guess: Option<String>,
+    pub threat_guess: Option<String>,
+    pub confidence_percent: Option<u8>,
+}
+
+impl PolicyClassification {
+    pub fn validate(&self) -> Result<(), String> {
+        for value in [&self.template_guess, &self.threat_guess]
+            .into_iter()
+            .flatten()
+        {
+            if value.is_empty()
+                || value.len() > 64
+                || !value.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'_' | b'-')
+                })
+            {
+                return Err(
+                    "policy classification contains an invalid bounded taxonomy value".into(),
+                );
+            }
+        }
+        if self
+            .confidence_percent
+            .is_some_and(|confidence| confidence > 100)
+        {
+            return Err("policy classification confidence exceeds 100".into());
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyRunMetadata {
+    pub policy_name: String,
+    pub policy_kind: String,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+    pub prompt_revision: String,
+    pub requests: u32,
+    pub estimated_prompt_tokens: u64,
+    pub estimated_completion_tokens: u64,
+    pub estimated_cost_microusd: u64,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DecisionArguments {
@@ -164,7 +217,9 @@ pub struct PublicTraceEvent {
     /// Player-visible in-world time at which this action began.
     pub game_minute: u64,
     pub location: String,
-    pub frame_digest: String,
+    pub observation_provenance: String,
+    pub pre_observation_digest: String,
+    pub post_observation_digest: String,
     pub choice_id: String,
     pub choice_kind: ChoiceKind,
     /// Exact label presented to the policy when it chose this action.
@@ -173,8 +228,10 @@ pub struct PublicTraceEvent {
     pub dialogue: Vec<PublicDialogueLine>,
     pub result: String,
     pub learned: Vec<String>,
+    pub learned_claim_ids: Vec<String>,
     /// Structured correction provenance; metrics must not infer it from prose.
     pub corrected_proposition_ids: Vec<String>,
+    pub preparation_tags: Vec<String>,
     pub game_minutes: u32,
     pub resource_cost: u16,
 }
@@ -187,10 +244,13 @@ pub struct PublicQuestTrace {
     pub policy: String,
     pub title: String,
     pub problem_summary: String,
+    pub initial_observation_digest: String,
+    pub initial_classification: PolicyClassification,
     pub events: Vec<PublicTraceEvent>,
     pub solved: bool,
     pub exhausted: bool,
     pub termination: Termination,
+    pub termination_error: Option<TerminationErrorCode>,
     pub route: Option<RouteClass>,
     pub semantic_digest: String,
 }
@@ -206,6 +266,14 @@ pub enum Termination {
     BudgetExceeded,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminationErrorCode {
+    BudgetExceeded,
+    PolicyFailure,
+    InvalidDecision,
+}
+
 /// This type must never be passed to a policy or serialized into public trace.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -216,10 +284,8 @@ pub struct DeveloperCaseAnalysis {
     pub generation_seed: u64,
     pub catalog_revision: String,
     pub true_site: String,
-    pub factor_ids: Vec<String>,
-    pub plausibility_factors: Vec<u32>,
-    pub curation_factors: Vec<u32>,
-    pub bridge_ids: Vec<String>,
+    pub factor_trace: Vec<FactorTrace>,
+    pub bridges: Vec<CausalBridge>,
     pub generator_manifest_digest: String,
 }
 

--- a/crates/adventuresim-strategic-sim/src/main.rs
+++ b/crates/adventuresim-strategic-sim/src/main.rs
@@ -15,6 +15,51 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
+    /// Analyze generated quest content through an offline observer-safe projection.
+    QuestAnalyze {
+        #[arg(long, value_enum, default_value_t = EvalPolicyArg::Mock)]
+        policy: EvalPolicyArg,
+        #[arg(long, default_value_t = 41)]
+        seed: u64,
+        #[arg(long, default_value_t = 4)]
+        cases_per_template: u32,
+        #[arg(long)]
+        public_output: PathBuf,
+        #[arg(long)]
+        developer_output: PathBuf,
+        #[arg(long)]
+        stories_output: PathBuf,
+        #[arg(long, default_value_t = false)]
+        overwrite: bool,
+        #[arg(long)]
+        endpoint: Option<String>,
+        #[arg(long, default_value = "gpt-4.1-nano")]
+        model: String,
+        #[arg(long, default_value = "OPENAI_API_KEY")]
+        api_key_env: String,
+        #[arg(long, default_value_t = false)]
+        allow_network: bool,
+    },
+    /// Replay a review-approved deterministic quest-analysis fixture.
+    QuestAnalyzeReplay {
+        #[arg(long)]
+        fixture: PathBuf,
+        #[arg(long)]
+        output: Option<PathBuf>,
+    },
+    /// Emit a reviewable fixture candidate from a bounded non-solving run.
+    QuestAnalyzePromote {
+        #[arg(long, default_value_t = 41)]
+        seed: u64,
+        #[arg(long, value_enum, default_value_t = EvalFamilyArg::RecurringDepredation)]
+        family: EvalFamilyArg,
+        #[arg(long, default_value_t = 1)]
+        max_steps: u32,
+        #[arg(long)]
+        output: PathBuf,
+        #[arg(long, default_value_t = false)]
+        overwrite: bool,
+    },
     /// Generate profiles and run canonical settlement downtime.
     Run {
         #[arg(long)]
@@ -89,9 +134,137 @@ enum NpcStrategyPolicyArg {
     Openai,
 }
 
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum EvalPolicyArg {
+    Scripted,
+    Mock,
+    Openai,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum EvalFamilyArg {
+    RecurringDepredation,
+    DisappearanceOrLoss,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
-    let command = cli.command;
+    let command = match cli.command {
+        Command::QuestAnalyze {
+            policy,
+            seed,
+            cases_per_template,
+            public_output,
+            developer_output,
+            stories_output,
+            overwrite,
+            endpoint,
+            model,
+            api_key_env,
+            allow_network,
+        } => {
+            validate_distinct_output_paths(&[&public_output, &developer_output, &stories_output])?;
+            if !overwrite
+                && [&public_output, &developer_output, &stories_output]
+                    .iter()
+                    .any(|path| path.exists())
+            {
+                return Err(
+                    "one or more quest analysis outputs already exist; pass --overwrite explicitly"
+                        .into(),
+                );
+            }
+            let mut policy: Box<dyn QuestPolicy> = match policy {
+                EvalPolicyArg::Scripted => Box::new(ScriptedPolicy::default()),
+                EvalPolicyArg::Mock => Box::new(MockLlmPolicy),
+                EvalPolicyArg::Openai => Box::new(OpenAiCompatiblePolicy::new(ProviderConfig {
+                    endpoint: endpoint.unwrap_or_else(|| ProviderConfig::default().endpoint),
+                    model,
+                    api_key_env,
+                    allow_network,
+                    ..ProviderConfig::default()
+                })?),
+            };
+            let case_count = cases_per_template
+                .checked_mul(2)
+                .ok_or("case count overflow")?;
+            let limits = EvalLimits {
+                max_cases: case_count,
+                ..EvalLimits::default()
+            };
+            let bundle = evaluate_cases(
+                &golden_suite(seed, cases_per_template),
+                policy.as_mut(),
+                &limits,
+            )?;
+            write_output(&public_output, &bundle.artifacts.public_json, overwrite)?;
+            write_output(
+                &developer_output,
+                &bundle.artifacts.developer_json,
+                overwrite,
+            )?;
+            write_output(
+                &stories_output,
+                &bundle.artifacts.stories_markdown,
+                overwrite,
+            )?;
+            eprintln!(
+                "offline quest content analysis: {}/{} solved; public={} developer={} stories={}",
+                bundle.public.metrics.solved,
+                bundle.public.metrics.cases,
+                public_output.display(),
+                developer_output.display(),
+                stories_output.display()
+            );
+            return Ok(());
+        }
+        Command::QuestAnalyzeReplay { fixture, output } => {
+            let recorded: ReplayCase = serde_json::from_slice(&read_bounded(&fixture)?)?;
+            let trace = replay_case(&recorded)?;
+            let json = serde_json::to_vec_pretty(&trace)?;
+            if let Some(path) = output {
+                write_output(&path, &json, false)?;
+            } else {
+                println!("{}", String::from_utf8(json)?);
+            }
+            return Ok(());
+        }
+        Command::QuestAnalyzePromote {
+            seed,
+            family,
+            max_steps,
+            output,
+            overwrite,
+        } => {
+            let family = match family {
+                EvalFamilyArg::RecurringDepredation => {
+                    adventuresim_core::quest_generation::TemplateFamily::RecurringDepredation
+                }
+                EvalFamilyArg::DisappearanceOrLoss => {
+                    adventuresim_core::quest_generation::TemplateFamily::DisappearanceOrLoss
+                }
+            };
+            let limits = EvalLimits {
+                max_cases: 1,
+                max_steps_per_case: max_steps,
+                ..EvalLimits::default()
+            };
+            let mut policy = MockLlmPolicy;
+            let bundle = evaluate_cases(
+                &[EvalCaseConfig::fixture(seed, family)],
+                &mut policy,
+                &limits,
+            )?;
+            let fixture = promote_replay_candidate(&bundle, 0)?;
+            write_output(&output, &serde_json::to_vec_pretty(&fixture)?, overwrite)?;
+            eprintln!(
+                "reviewable replay candidate written to {}; verify before committing",
+                output.display()
+            );
+            return Ok(());
+        }
+        command => command,
+    };
     if let Command::CoreLoop {
         host,
         database,
@@ -221,9 +394,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
             emit(run_profiles(config, vec![a, b])?, output)?
         }
-        Command::CoreLoop { .. } => unreachable!(),
+        Command::CoreLoop { .. }
+        | Command::QuestAnalyze { .. }
+        | Command::QuestAnalyzeReplay { .. }
+        | Command::QuestAnalyzePromote { .. } => unreachable!(),
     };
     eprintln!("{}", human_summary(&report));
+    Ok(())
+}
+
+fn write_output(
+    path: &Path,
+    bytes: &[u8],
+    overwrite: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs::OpenOptions;
+    let mut options = OpenOptions::new();
+    options.write(true);
+    if overwrite {
+        options.create(true).truncate(true);
+    } else {
+        options.create_new(true);
+    }
+    std::io::Write::write_all(&mut options.open(path)?, bytes)?;
     Ok(())
 }
 
@@ -234,14 +427,15 @@ fn validate_distinct_output_paths(paths: &[&Path]) -> Result<(), Box<dyn std::er
         } else {
             std::env::current_dir()?.join(path)
         };
-        // `canonicalize` cannot normalize a not-yet-created output. Collapse
-        // `.` and `..` lexically first, then resolve existing aliases/symlinks.
         let lexical = lexical_normalize(&absolute);
-        if lexical.exists() {
-            Ok(lexical_normalize(&fs::canonicalize(lexical)?))
-        } else {
-            Ok(lexical)
-        }
+        let existing = lexical
+            .ancestors()
+            .find(|candidate| candidate.exists())
+            .ok_or("output path has no existing ancestor")?;
+        let missing_tail = lexical.strip_prefix(existing)?;
+        Ok(lexical_normalize(
+            &fs::canonicalize(existing)?.join(missing_tail),
+        ))
     };
     let normalized = paths
         .iter()
@@ -328,5 +522,22 @@ mod tests {
         let stories = PathBuf::from("npc-adventurer-stories.md");
         assert!(validate_distinct_output_paths(&[&report, &stories]).is_ok());
         assert!(validate_distinct_output_paths(&[&stories, &stories]).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nonexistent_leaves_under_symlinked_parents_are_aliases() {
+        use std::os::unix::fs::symlink;
+
+        let root =
+            std::env::temp_dir().join(format!("adventuresim-output-alias-{}", std::process::id()));
+        let real = root.join("real");
+        let alias = root.join("alias");
+        fs::create_dir_all(&real).unwrap();
+        symlink(&real, &alias).unwrap();
+        let direct = real.join("future.json");
+        let through_alias = alias.join("future.json");
+        assert!(validate_distinct_output_paths(&[&direct, &through_alias]).is_err());
+        fs::remove_dir_all(&root).unwrap();
     }
 }

--- a/docs/STRATEGIC_SIMULATION.md
+++ b/docs/STRATEGIC_SIMULATION.md
@@ -167,7 +167,71 @@ just strategic-sim-core-loop 42 8 20 30 2
 
 ## Quest evaluators
 
-There are two evaluator surfaces, with deliberately different boundaries.
+There are two gameplay evaluator surfaces and one offline content-analysis
+surface, with deliberately different boundaries.
+
+### Offline generated-content analyzer
+
+`quest-analyze` projects deterministic generated investigations into an
+observer-safe, in-memory `PlayerFrame`. It is useful for generator regression,
+route diversity, policy fingerprints, dead ends, loops, correction persistence,
+and separate public/developer audit artifacts. It does **not** call
+SpacetimeDB reducers, exercise the browser, perform tactical combat, or prove
+production gameplay behavior.
+
+The default recipe is credential-free and the mock policy round-trips through
+the same strict JSON response parser used by an OpenAI-compatible provider:
+
+```powershell
+just quest-analyze-mock 41 4
+```
+
+This creates `quest-analysis-public.json`, `quest-analysis-developer.json`, and
+`quest-analysis-stories.md` as distinct artifacts and refuses to overwrite
+them unless direct invocation passes `--overwrite`. The public report contains
+only player-visible traces, bounded run provenance, classifications, and
+aggregate behavior. Seeds, catalog revisions, canonical truth, structured
+factor traces, bridge IDs, generator marginals, and truth-joined
+classification/counterfactual audits remain in the developer report. Their
+digest join is one-way.
+
+All three artifacts are rendered in memory first. Per-artifact and combined
+byte budgets are checked against the exact pretty JSON and Markdown bytes
+before any output file is created. Existing-ancestor canonicalization also
+prevents distinct-looking paths through symlinked or junction parents from
+collapsing public and developer output onto the same file.
+
+Each trace records pre/post observation digests, opaque legal choices, exact
+dialogue, public discoveries and corrections, preparation, costs, exhaustion,
+and termination. Classifications are bounded answers, never chain-of-thought.
+Prepared/unprepared solve rates are descriptive quality slices, not causal
+skill or equipment-benefit estimates.
+Counterfactual comparisons are made only when different hidden cases naturally
+share an identical player-visible initial prefix; absence of such a group is
+reported as `not_measured`.
+
+Contract completion, language benefit, tactical combat benefit, causal skill
+benefit, and accidental perception discovery are also explicitly
+`not_measured` because this projection does not implement those mechanics.
+No proxy number should be treated as evidence for them. The privacy audit is a
+structural type boundary plus canary scan, not a formal proof.
+
+An observed non-solving run can be promoted into a reviewable deterministic
+fixture candidate:
+
+```powershell
+just quest-analyze-promote 41 recurring-depredation
+cargo run -p adventuresim-strategic-sim -- quest-analyze-replay `
+  --fixture quest-analysis-replay-candidate.json
+# Replay the reviewed checked-in regression:
+just quest-analyze-replay-fixture
+```
+
+The versioned fixture joins catalog revision and generator manifest, records
+opaque decisions, and checks stable outcome fields. Promotion never silently
+commits or approves a fixture. Only step-limit and dead-end failures can be
+promoted; provider failures, loop detection, and exhausted runtime budgets
+cannot be reproduced from an opaque action list alone.
 
 ### Server-simulated NPC adventurers
 

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (1248)
+## Files (1249)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -748,6 +748,7 @@ development, or wiki document before changing a subsystem.
 - `crates/adventuresim-stdb-module/src/time.rs` — Rust source module for this component.
 - `crates/adventuresim-stdb-module/static/tactical.html` — Browser UI page.
 - `crates/adventuresim-strategic-sim/Cargo.toml` — Cargo package/workspace manifest.
+- `crates/adventuresim-strategic-sim/fixtures/quest-analysis-failure-v3.json` — Repository support file.
 - `crates/adventuresim-strategic-sim/src/analysis.rs` — Rust source module for this component.
 - `crates/adventuresim-strategic-sim/src/config.rs` — Rust source module for this component.
 - `crates/adventuresim-strategic-sim/src/investigation_eval/environment.rs` — Rust source module.

--- a/justfile
+++ b/justfile
@@ -325,6 +325,21 @@ test-dev-stack:
 strategic-sim seed="42" population="100" days="1095":
     @cargo run -p adventuresim-strategic-sim -- run --seed {{ seed }} --population {{ population }} --days {{ days }}
 
+# Credential-free offline generator/content analysis. These artifacts are not
+# reducer-authoritative gameplay evidence.
+quest-analyze seed="41" cases_per_template="4":
+    @cargo run -p adventuresim-strategic-sim -- quest-analyze --policy scripted --seed {{ seed }} --cases-per-template {{ cases_per_template }} --public-output quest-analysis-public.json --developer-output quest-analysis-developer.json --stories-output quest-analysis-stories.md
+
+quest-analyze-mock seed="41" cases_per_template="4":
+    @cargo run -p adventuresim-strategic-sim -- quest-analyze --policy mock --seed {{ seed }} --cases-per-template {{ cases_per_template }} --public-output quest-analysis-public.json --developer-output quest-analysis-developer.json --stories-output quest-analysis-stories.md
+
+# Intentionally use a short run to create a non-solving, reviewable replay candidate.
+quest-analyze-promote seed="41" family="recurring-depredation":
+    @cargo run -p adventuresim-strategic-sim -- quest-analyze-promote --seed {{ seed }} --family {{ family }} --max-steps 1 --output quest-analysis-replay-candidate.json
+
+quest-analyze-replay-fixture:
+    @cargo run -p adventuresim-strategic-sim -- quest-analyze-replay --fixture crates/adventuresim-strategic-sim/fixtures/quest-analysis-failure-v3.json
+
 test-strategic-sim:
     @cargo test -p adventuresim-strategic-sim
 

--- a/wiki/strategic/Quests.md
+++ b/wiki/strategic/Quests.md
@@ -118,7 +118,7 @@ later receive a dry journal notice about the result.
 
 ### Automated investigation evaluation
 
-There are two evaluation paths. The server-side strategic simulator exercises
+There are two gameplay evaluation paths. The server-side strategic simulator exercises
 the real NPC adventuring companies described above. Scripted decisions are the
 default; an optional LLM can choose only among observer-safe strategies offered
 by the server, while the server remains the sole outcome authority. Every run
@@ -132,6 +132,15 @@ plays through the same web interface as a person. It produces a screenshot
 timeline rather than a Markdown story. It receives no canonical cause, true
 destination, generation weights, reducer names, or hidden case identifiers.
 Since you know what enemies you will face at the destination and can estimate what enemies you'll possibly face on the journey, you should plan a party in advance to account for this. For now this is mainly a question of whether you expect to encounter armored enemies (and therefore need hammers/rondels), hordes of weak enemies (therefore want a cleaving sword/axe/hammer and heavy armor), large enemies (therefore want a polearm), and enemies with projectiles (therefore want armor/full-plate). You will also want to account for difficult terrain or the need for stealth/detection during [travel](Travel.md) in your party composition, the latter is important if you're traveling through an area with enemies that are too dangerous for your party to fight against.
+
+A third developer tool, `quest-analyze`, is an offline generator/content
+analyzer. It uses a synthetic observer-safe projection and can run with a
+scripted policy or a credential-free strict-JSON mock. It produces separate
+public traces/stories and developer-only truth/factor audits. It is useful for
+finding generator dead ends, loops, route dominance, correction persistence,
+and policy fingerprints, but it is not reducer-authoritative gameplay or
+browser evidence. Unsupported contract, language, tactical-combat, perception,
+and causal skill-benefit measures remain explicitly unavailable.
 ### Mixed-Level
 Quests are not balanced around the assumption that all members of a party have a similar power level, in fact its generally the case that you *want* a mixed-strength party. When you set out to clear out a vampire crypt, you need a very skilled armored duelist or two to fight the vampire. But you'll also be encountering plenty of zombies and skeletons, which can be efficiently dealt with by a small group of decent semi-armored combatants with clubs and axes. 
 ## Reward


### PR DESCRIPTION
## Summary

- expose the existing offline investigation projection as a bounded quest-content analysis CLI with scripted, keyless mock, and guarded provider policies
- emit separate public traces, developer audits, and Markdown stories with versioned provenance, privacy checks, aggregate metrics, and explicit unsupported measurements
- add observer-safe fingerprints, natural visible-prefix counterfactual audits, and deterministic failure promotion/replay
- document the boundary between the authoritative server evaluator, browser evaluator, and offline generator analyzer

## Design decisions

- This is explicitly generator/content analysis, not reducer-authoritative gameplay evidence.
- Contract, language, tactical-combat, accidental-perception, and causal skill-benefit metrics remain `not_measured` until those mechanics exist.
- Counterfactuals compare only naturally matched player-visible prefixes; the report states when no coherent pairs exist.
- Public artifacts fail closed on private-canary detection and never contain raw provider diagnostics or generator authority identifiers.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p adventuresim-strategic-sim` (44 library, 3 CLI, and 16 simulation tests passed; 1 explicitly gated live test ignored)
- `cargo test -p adventuresim-core quest_generation` (36 passed)
- `cargo run -p adventuresim-core --bin questgen-check -- validate`
- `python scripts/update_project_map.py --check`
- `git diff --check`
- keyless mock demo: 4/4 cases solved across 4 path fingerprints; zero private canaries
- checked-in failure fixture replayed deterministically

Closes #188
