### PR TITLE
Defer settlement activity during world import

### DIFF
--- a/crates/adventuresim-stdb-client/src/quest_generation_authority_type.rs
+++ b/crates/adventuresim-stdb-client/src/quest_generation_authority_type.rs
@@ -67,6 +67,7 @@ pub struct QuestGenerationAuthorityIxCols {
     pub case_id: __sdk::__query_builder::IxCol<QuestGenerationAuthority, String>,
     pub public_case_id: __sdk::__query_builder::IxCol<QuestGenerationAuthority, String>,
     pub seed: __sdk::__query_builder::IxCol<QuestGenerationAuthority, u64>,
+    pub settlement_id: __sdk::__query_builder::IxCol<QuestGenerationAuthority, String>,
 }
 
 impl __sdk::__query_builder::HasIxCols for QuestGenerationAuthority {
@@ -76,6 +77,7 @@ impl __sdk::__query_builder::HasIxCols for QuestGenerationAuthority {
             case_id: __sdk::__query_builder::IxCol::new(table_name, "case_id"),
             public_case_id: __sdk::__query_builder::IxCol::new(table_name, "public_case_id"),
             seed: __sdk::__query_builder::IxCol::new(table_name, "seed"),
+            settlement_id: __sdk::__query_builder::IxCol::new(table_name, "settlement_id"),
         }
     }
 }

--- a/crates/adventuresim-stdb-module/src/npc_adventurer.rs
+++ b/crates/adventuresim-stdb-module/src/npc_adventurer.rs
@@ -314,12 +314,15 @@ pub(crate) fn ensure_npc_case_interventions(
     let mut authorities = ctx
         .db
         .quest_generation_authority()
-        .iter()
-        .filter(|authority| authority.settlement_id == settlement_id)
+        .settlement_id()
+        .filter(&settlement_id.to_string())
         .collect::<Vec<_>>();
     authorities.sort_by(|left, right| left.case_id.cmp(&right.case_id));
     for authority in authorities {
         let validated = validate_quest_generation_authority(&authority)?;
+        if validated.context.settlement_id != settlement_id {
+            continue;
+        }
         let Some(case) = ctx.db.case_authority().id().find(&authority.case_id) else {
             continue;
         };
@@ -927,6 +930,22 @@ mod tests {
         assert!(!reducer.contains("apply_outcome("));
         assert!(!reducer.contains("resolve_generated_case("));
         assert!(source.contains("let decision = decide_after_supported_approach("));
+    }
+
+    #[test]
+    fn npc_interventions_use_the_settlement_authority_index() {
+        let source = include_str!("npc_adventurer.rs").replace('\r', "");
+        let activity = source
+            .split("pub(crate) fn ensure_npc_case_interventions")
+            .nth(1)
+            .and_then(|tail| tail.split("fn ensure_npc_adventuring_party").next())
+            .expect("NPC intervention activity");
+        assert!(activity.contains("quest_generation_authority()"));
+        assert!(activity.contains(".settlement_id()"));
+        assert!(activity.contains(".filter(&settlement_id.to_string())"));
+        assert!(!activity.contains("quest_generation_authority()\n        .iter()"));
+        assert!(activity.contains("validate_quest_generation_authority"));
+        assert!(activity.contains("validated.context.settlement_id != settlement_id"));
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -2005,21 +2005,25 @@ mod healing_tests {
 
     #[test]
     fn generated_activity_is_contract_free_and_counted_by_open_case_authority() {
-        let source = include_str!("strategic.rs");
+        let source = include_str!("strategic.rs").replace('\r', "");
         let generation = source
-            .split("fn generate_quest_for_settlement")
-            .nth(1)
+            .rsplit("fn generate_quest_for_settlement")
+            .next()
             .and_then(|tail| tail.split("#[reducer]").next())
             .expect("generated quest materialization");
         assert!(!generation.contains("contract_authority().insert"));
         assert!(!generation.contains("Contract {"));
         let activity = source
-            .split("fn ensure_settlement_activity_inner")
-            .nth(1)
+            .rsplit("fn ensure_settlement_activity_inner")
+            .next()
             .and_then(|tail| tail.split("fn ensure_npc_recruiting_parties").next())
             .expect("settlement activity");
         assert!(activity.contains("active_generated_cases"));
         assert!(activity.contains("quest_generation_authority()"));
+        assert!(activity.contains(".settlement_id()"));
+        assert!(activity.contains(".filter(&settlement_id.to_string())"));
+        assert!(!activity.contains("quest_generation_authority()\n            .iter()"));
+        assert!(activity.contains("validated.context.settlement_id != settlement_id"));
         assert!(activity.contains("CaseResolutionStatus::Open"));
         let resolution = source
             .split("pub(crate) fn ingest_case_outcome_fact")
@@ -2027,6 +2031,56 @@ mod healing_tests {
             .and_then(|tail| tail.split("fn select_case_finale").next())
             .expect("case resolution");
         assert!(resolution.contains("ensure_settlement_activity_inner"));
+    }
+
+    #[test]
+    fn world_import_persists_settlement_facts_without_activating_gameplay() {
+        let source = include_str!("strategic.rs").replace('\r', "");
+        let authority = source
+            .split("pub struct QuestGenerationAuthority")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("pub(crate) struct ValidatedQuestGenerationAuthority")
+                    .next()
+            })
+            .expect("quest generation authority schema");
+        assert!(authority.contains("#[index(btree)]\n    pub settlement_id: String"));
+
+        let import = source
+            .rsplit("pub fn import_settlements")
+            .next()
+            .and_then(|tail| tail.split("fn validate_travel_edge_endpoints").next())
+            .expect("settlement import reducer");
+        for forbidden in [
+            "ensure_settlement_activity_inner",
+            "ensure_settlement_smith",
+            "ensure_settlement_herbalist",
+            "ensure_settlement_population",
+        ] {
+            assert!(
+                !import.contains(forbidden),
+                "world import must not {forbidden}"
+            );
+        }
+
+        let activity = source
+            .split("fn ensure_settlement_activity_inner")
+            .nth(1)
+            .and_then(|tail| tail.split("fn ensure_npc_recruiting_parties").next())
+            .expect("settlement activity");
+        assert!(activity.contains("ensure_settlement_smith"));
+        assert!(activity.contains("ensure_settlement_herbalist"));
+
+        for consumer in [
+            "fn generate_quest_for_settlement",
+            "pub fn spawn_developer_quest",
+        ] {
+            let body = source
+                .rsplit(consumer)
+                .next()
+                .expect("quest ordinal consumer");
+            assert!(body.contains("validated.context.settlement_id == settlement_id"));
+        }
     }
 
     #[test]
@@ -2752,15 +2806,11 @@ pub fn import_settlements(
             source_node_id: Some(settlement.source_node_id),
             sources: settlement.sources,
         };
-        let settlement_id = row.id.clone();
         if ctx.db.settlement().id().find(&row.id).is_some() {
             ctx.db.settlement().id().update(row);
         } else {
             ctx.db.settlement().insert(row);
         }
-        ensure_settlement_activity_inner(ctx, &settlement_id)?;
-        crate::repair::ensure_settlement_smith(ctx, &settlement_id);
-        crate::disease::ensure_settlement_herbalist(ctx, &settlement_id);
     }
     Ok(())
 }
@@ -3239,6 +3289,7 @@ pub struct QuestGenerationAuthority {
     pub case_id: String,
     #[index(btree)]
     pub public_case_id: String,
+    #[index(btree)]
     pub settlement_id: String,
     pub settlement_name: String,
     #[index(btree)]
@@ -17793,6 +17844,10 @@ fn ensure_settlement_activity_inner(
     ctx: &ReducerContext,
     settlement_id: &str,
 ) -> Result<(), String> {
+    // World import writes only canonical settlement facts. These derived
+    // service rows are instead materialized when settlement activity is used.
+    crate::repair::ensure_settlement_smith(ctx, settlement_id);
+    crate::disease::ensure_settlement_herbalist(ctx, settlement_id);
     crate::settlement_population::ensure_settlement_population(ctx, settlement_id)?;
     let official_minute = crate::time::refresh_clock(ctx)?;
     for mut contract in ctx
@@ -17835,27 +17890,29 @@ fn ensure_settlement_activity_inner(
                 && tracked_quests.contains(&quest.id))
         })
         .count();
-    let active_generated_cases =
-        ctx.db
-            .quest_generation_authority()
-            .iter()
-            .try_fold(0usize, |count, authority| {
-                let validated = validate_quest_generation_authority(&authority)?;
-                Ok::<_, String>(
-                    count
-                        + usize::from(
-                            validated.context.settlement_id == settlement_id
-                                && ctx
-                                    .db
-                                    .case_authority()
-                                    .id()
-                                    .find(&authority.case_id)
-                                    .is_some_and(|case| {
-                                        case.resolution_status == CaseResolutionStatus::Open
-                                    }),
-                        ),
-                )
-            })?;
+    let active_generated_cases = ctx
+        .db
+        .quest_generation_authority()
+        .settlement_id()
+        .filter(&settlement_id.to_string())
+        .try_fold(0usize, |count, authority| {
+            let validated = validate_quest_generation_authority(&authority)?;
+            if validated.context.settlement_id != settlement_id {
+                return Ok(count);
+            }
+            Ok::<_, String>(
+                count
+                    + usize::from(
+                        ctx.db
+                            .case_authority()
+                            .id()
+                            .find(&authority.case_id)
+                            .is_some_and(|case| {
+                                case.resolution_status == CaseResolutionStatus::Open
+                            }),
+                    ),
+            )
+        })?;
     let active = active_contracts.saturating_add(active_generated_cases);
     for _ in active..settlement_activity_target(settlement_id) {
         generate_quest_for_settlement(ctx, settlement_id)?;
@@ -18110,7 +18167,8 @@ fn generate_quest_for_settlement(ctx: &ReducerContext, settlement_id: &str) -> R
     let ordinal = ctx
         .db
         .quest_generation_authority()
-        .iter()
+        .settlement_id()
+        .filter(&settlement_id.to_string())
         .try_fold(0u16, |count, row| {
             let validated = validate_quest_generation_authority(&row)?;
             Ok::<_, String>(count + u16::from(validated.context.settlement_id == settlement_id))
@@ -18370,7 +18428,8 @@ pub fn spawn_developer_quest(
     let ordinal = ctx
         .db
         .quest_generation_authority()
-        .iter()
+        .settlement_id()
+        .filter(&settlement_id.to_string())
         .try_fold(0u16, |count, row| {
             let validated = validate_quest_generation_authority(&row)?;
             Ok::<_, String>(count + u16::from(validated.context.settlement_id == settlement_id))

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -148,6 +148,26 @@ mod building_query_tests {
         assert_eq!(merchant_service_location("herbalist"), None);
         assert_eq!(merchant_service_location("../inn"), None);
     }
+
+    #[test]
+    fn settlement_entry_activates_activity_without_a_local_server_bypass() {
+        let source = include_str!("settlements.rs").replace('\r', "");
+        let entry = source
+            .rsplit("async fn show_settlement_location")
+            .next()
+            .and_then(|tail| tail.split("async fn settlement_map").next())
+            .expect("settlement entry route");
+        assert!(entry.contains(".call("));
+        assert!(entry.contains("\"ensure_settlement_activity\""));
+        assert!(!entry.contains("is_local()"));
+
+        let offers = source
+            .split("async fn service_quest_offers")
+            .nth(1)
+            .and_then(|tail| tail.split("fn service_quest_greeting").next())
+            .expect("service quest offers route");
+        assert!(!offers.contains("ensure_settlement_activity"));
+    }
 }
 
 use super::AppState;
@@ -998,26 +1018,36 @@ async fn show_settlement_location(
     session: Session,
 ) -> Html<String> {
     let settlement_literal = sql_string_literal(&id);
+    let settlement = state
+        .db
+        .query_one::<Settlement>(&format!(
+            "SELECT * FROM settlement WHERE id = {settlement_literal}"
+        ))
+        .await;
+    let settlement = match settlement {
+        Ok(Some(settlement)) => settlement,
+        Ok(None) => return Html("<h1>Settlement not found</h1>".to_string()),
+        Err(error) => {
+            tracing::error!(%error, settlement_id = %id, "failed to load settlement");
+            return Html("<h1>Settlement data unavailable</h1>".to_string());
+        }
+    };
+    if let Err(error) = state
+        .db
+        .call("ensure_settlement_activity", &[json!(id.clone())])
+        .await
+    {
+        tracing::warn!(%error, settlement_id = %id, "failed to activate settlement activity");
+    }
     let alias_sql =
         format!("SELECT * FROM settlement_alias WHERE settlement_id = {settlement_literal}");
     let description_sql =
         format!("SELECT * FROM settlement_description WHERE settlement_id = {settlement_literal}");
-    let (settlements, aliases, descriptions, active_character) = tokio::join!(
-        state.db.query::<Settlement>("SELECT * FROM settlement"),
+    let (aliases, descriptions, active_character) = tokio::join!(
         state.db.query::<SettlementAlias>(&alias_sql),
         state.db.query::<SettlementDescription>(&description_sql),
         get_active_character(&state, session.character_id_u64()),
     );
-    let settlements = match settlements {
-        Ok(settlements) => settlements,
-        Err(error) => {
-            tracing::error!(%error, settlement_id = %id, "failed to load settlements");
-            return Html("<h1>Settlement data unavailable</h1>".to_string());
-        }
-    };
-    let Some(settlement) = settlements.iter().find(|settlement| settlement.id == id) else {
-        return Html("<h1>Settlement not found</h1>".to_string());
-    };
     let party_members = get_active_party_members(
         &state,
         active_character.as_ref().map(|(character, _)| character),
@@ -1046,7 +1076,7 @@ async fn show_settlement_location(
     descriptions.sort_by(|left, right| left.id.cmp(&right.id));
     Html(
         settlement_overview_page(
-            settlement,
+            &settlement,
             &aliases,
             &descriptions,
             active_character.as_ref().map(|(character, _)| character),
@@ -2271,12 +2301,6 @@ async fn service_quest_offers(
     Path(id): Path<String>,
     session: Session,
 ) -> Json<ServiceActivityResponse> {
-    if state.db.is_local() {
-        let _ = state
-            .db
-            .call("ensure_settlement_activity", &[json!(id.clone())])
-            .await;
-    }
     let settlements: Vec<Settlement> = state
         .db
         .query("SELECT * FROM settlement")

--- a/crates/strategic-web/src/spacetimedb/client.rs
+++ b/crates/strategic-web/src/spacetimedb/client.rs
@@ -246,12 +246,6 @@ impl SpacetimeClient {
         self
     }
 
-    /// Whether this client points at the local development database.
-    pub fn is_local(&self) -> bool {
-        let base = self.base_url.to_ascii_lowercase();
-        base.contains("localhost") || base.contains("127.0.0.1") || base.contains("[::1]")
-    }
-
     /// Return monotonic SQL counters. Take a snapshot before and after one
     /// controlled request, then call `after.delta(before)`. This is safe for
     /// concurrent requests; it deliberately does not destructively reset a

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -448,6 +448,11 @@ pinned approximately 60 MiB runtime archive when its files are absent, then
 sends `target/world-1544.json` in bounded batches to a published local module.
 The same archive installs the AVIF map and final terrain-routing package, so a
 fresh checkout does not need the 26 GiB source bundle or a geospatial rebuild.
+World loading persists canonical map and settlement facts only; it deliberately
+does not pre-generate settlement populations, services, quests, incidents, or
+recruitment. The first player-facing visit to a settlement materializes that
+settlement's derived activity and service state, so complete `just load-world`
+before serving the browser rather than competing with normal gameplay queries.
 Run it after
 `just publish-reset`, without `_seed-world`, when using the historical world.
 Interrupted loads can be resumed without recompiling by loading the identical


### PR DESCRIPTION
## Summary

- Keep historical world imports limited to canonical settlement facts.
- Materialize settlement activity and services when a player opens a settlement.
- Add and use a settlement-id B-tree index for quest-generation authorities.

## Why

Loading the full world previously generated population, services, quests, incidents, and recruitment for every imported settlement. This competed with normal strategic queries and made settlement loading slow while imports ran.

## Impact

World loads now avoid derived gameplay work. A player-facing settlement visit activates only that settlement, including smith and herbalist services. Per-settlement quest authority reads no longer scan all authority rows.

## Validation

- `just verify-db-client`
- `cargo fmt --all -- --check`
- `cargo test -p adventuresim-stdb-module`
- `cargo test -p strategic-web routes::settlements::building_query_tests::settlement_entry_activates_activity_without_a_local_server_bypass`
- `python scripts/update_project_map.py --check`
- `git diff --check`

The full strategic-web suite retains one pre-existing failure in `templates::layout::tests::strategic_shell_loads_the_location_preserving_journal_tab`; the identical test also fails at the base commit.
