### PR TITLE
Fix forage skill action modal

### DIFF
--- a/crates/strategic-web/src/routes/foraging.rs
+++ b/crates/strategic-web/src/routes/foraging.rs
@@ -4,7 +4,7 @@ use axum::{
     response::{Html, IntoResponse, Response},
     routing::{get, post},
 };
-use maud::{DOCTYPE, html};
+use maud::{DOCTYPE, Markup, html};
 use serde::Deserialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
@@ -318,6 +318,70 @@ async fn environment(
         "cultivated": environment.cultivated,
     });
     Ok((environment, attestation))
+}
+
+pub(crate) async fn activity_dialog(
+    state: &AppState,
+    character: &Character,
+    return_to: &str,
+) -> Markup {
+    let outcome = environment(state, character).await;
+    let (environment, unavailable) = match outcome {
+        Ok((environment, _)) => (Some(environment), None),
+        Err(error) => (None, Some(error)),
+    };
+    let resources = environment
+        .as_ref()
+        .map(|environment| {
+            adventuresim_core::foraging::FORAGE_RESOURCES
+                .iter()
+                .filter(|resource| adventuresim_core::foraging::available(resource, *environment))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let illegal =
+        environment.is_some_and(|environment| environment.settlement || environment.cultivated);
+    html! {
+        div class="character-action-overlay" data-character-action-dialog data-initial-focus="#forage-targets" {
+            a class="character-action-backdrop" href=(return_to) aria-label="Close foraging dialog" {}
+            section class="character-action-dialog forage-dialog" role="dialog" aria-modal="true"
+                aria-labelledby="forage-title" aria-describedby="forage-description" tabindex="-1" {
+                header class="character-action-dialog-header" {
+                    h2 id="forage-title" { "Forage nearby" }
+                    a class="character-action-dialog-close" href=(return_to) aria-label="Close foraging dialog" { "×" }
+                }
+                p id="forage-description" { "Search only the character's immediate vicinity. Multiple targets share the selected time." }
+                @if let Some(reason) = unavailable {
+                    p role="alert" class="badge badge-danger" { (reason) }
+                } @else {
+                    @if illegal {
+                        p role="alert" class="badge badge-warning" { "Foraging here is illegal. One Stealth check is made when the search completes; failure costs 1 Virtue." }
+                    }
+                    form method="post" action="/forage" {
+                        input type="hidden" name="return_to" value=(return_to);
+                        p id="forage-target-limit" class="text-muted small-copy" { "Choose at most eight targets. Every selected target shares the same search time." }
+                        fieldset id="forage-targets" aria-describedby="forage-target-limit" {
+                            legend { "Targets" }
+                            @for resource in resources {
+                                label class="inventory-row" {
+                                    input type="checkbox" name="target" value=(resource.item_id);
+                                    span { (resource.name) " · " (format!("{:?}", resource.rarity)) }
+                                }
+                            }
+                        }
+                        label for="forage-hours" { "Search plan" }
+                        input id="forage-hours" name="hours" type="range" min="1" max="24" value="4"
+                            oninput="this.nextElementSibling.value=this.value + ' hours'";
+                        output { "4 hours" }
+                        div class="modal-actions" {
+                            button class="btn btn-primary" type="submit" { "Begin search" }
+                            a class="btn btn-secondary character-action-dialog-close" href=(return_to) { "Cancel" }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 async fn menu(

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -42,6 +42,7 @@ const BUILDINGS: &[&str] = &[
 struct BuildingQuery {
     building: Option<String>,
     cook: Option<bool>,
+    forage: Option<bool>,
     social_feedback: Option<String>,
 }
 
@@ -2773,6 +2774,19 @@ async fn render_party_personal(
         .query::<ItemDefinition>("SELECT * FROM item")
         .await
         .unwrap_or_default();
+    let foraging_dialog = if building.forage.unwrap_or(false) {
+        Some(
+            crate::routes::foraging::activity_dialog(
+                state,
+                &active_character,
+                &location
+                    .preserve_building(format!("{}/party/{character_id}", location.base_path(),)),
+            )
+            .await,
+        )
+    } else {
+        None
+    };
     Html(
         party_personal_page(
             &location,
@@ -2804,6 +2818,7 @@ async fn render_party_personal(
             dialog,
             surgery_open,
             social_open,
+            foraging_dialog,
         )
         .into_string(),
     )

--- a/crates/strategic-web/src/templates/settlement/character_details.rs
+++ b/crates/strategic-web/src/templates/settlement/character_details.rs
@@ -75,7 +75,7 @@ pub(crate) struct CharacterSheetView<'a> {
     pub combat_profile: CombatTrainingProfile,
     pub religion_id: Option<&'a str>,
     pub training_religion_id: Option<&'a str>,
-    pub notoriety: f32,
+    pub virtue: f32,
     pub attributes_title: &'a str,
     pub skills_title: &'a str,
     pub description: &'a str,
@@ -129,7 +129,7 @@ pub(crate) fn character_sheet_markup(view: CharacterSheetView<'_>) -> Markup {
             (character_bio_rail(
                 view.character,
                 view.religion_id,
-                view.notoriety,
+                view.virtue,
                 view.personality,
                 view.can_renounce,
                 view.location_path,
@@ -175,7 +175,7 @@ pub fn party_personal_page(
     combat_profile: CombatTrainingProfile,
     activity_preview: ActivityPreviewRates,
     religious_demand: Option<&crate::spacetimedb::ReligiousDemand>,
-    notoriety: f32,
+    virtue: f32,
     personality: Option<&crate::spacetimedb::CharacterPersonality>,
     medical: &MedicalPresentation,
     _can_examine: bool,
@@ -189,6 +189,7 @@ pub fn party_personal_page(
     character_action_dialog: Option<Markup>,
     surgery_open: Option<&str>,
     social_open: bool,
+    foraging_dialog: Option<Markup>,
 ) -> Markup {
     let cooking_href = location.preserve_building(format!(
         "{}/party/{}?cook=true",
@@ -202,7 +203,10 @@ pub fn party_personal_page(
         active_character.id
     ));
     let location_path = location.base_path();
-    let foraging_href = format!("/forage?return_to={location_path}");
+    let foraging_href = location.preserve_building(format!(
+        "{location_path}/party/{}?forage=true",
+        active_character.id,
+    ));
     let schedule_action = format!("{location_path}/party/{}/schedule", active_character.id);
     let social_path = location.preserve_building(format!(
         "{location_path}/party/{}/social",
@@ -228,10 +232,13 @@ pub fn party_personal_page(
         false,
     );
     let center_after = settlement_chat_area(&active_character.name, Some(active_character));
+    let foraging_open = foraging_dialog.is_some();
     let after = html! {
         (physiology_dialog(medical, "physiology-chart-dialog", &active_character.name))
         @if cooking_open {
             (cooking_activity_dialog(location, active_character, inventory, food_lots, item_definitions))
+        } @else if let Some(dialog) = foraging_dialog {
+            (dialog)
         } @else {
             @if let Some(dialog) = character_action_dialog { (dialog) }
         }
@@ -247,7 +254,7 @@ pub fn party_personal_page(
         combat_profile,
         religion_id,
         training_religion_id: religion_id.or(location.religion_id.as_deref()),
-        notoriety,
+        virtue,
         attributes_title: "Your attributes",
         skills_title: "Your skills",
         description: "Your identity, condition, and capabilities",
@@ -265,7 +272,7 @@ pub fn party_personal_page(
             cooking_href: Some(&cooking_href),
             cooking_open,
             foraging_href: Some(&foraging_href),
-            foraging_open: false,
+            foraging_open,
         },
         location_path: &location_path,
         center_before: html! {},
@@ -293,7 +300,7 @@ pub fn party_stats_page(
     religion_id: Option<&str>,
     active_party: Option<&Party>,
     selected_party: Option<&Party>,
-    notoriety: f32,
+    virtue: f32,
     personality: Option<&crate::spacetimedb::CharacterPersonality>,
     medical: &MedicalPresentation,
     _can_examine: bool,
@@ -368,7 +375,7 @@ pub fn party_stats_page(
         combat_profile,
         religion_id,
         training_religion_id: religion_id.or(location.religion_id.as_deref()),
-        notoriety,
+        virtue,
         attributes_title: &selected_attributes_title,
         skills_title: &selected_skills_title,
         description: "Party member identity and capabilities",
@@ -413,16 +420,11 @@ pub(super) fn religion_name(religion_id: Option<&str>) -> &'static str {
 fn character_bio_rail(
     character: &Character,
     religion_id: Option<&str>,
-    notoriety: f32,
+    virtue: f32,
     personality: Option<&crate::spacetimedb::CharacterPersonality>,
     can_renounce: bool,
     location_path: &str,
 ) -> Markup {
-    let virtue = if notoriety.abs() < 0.0005 {
-        0.0
-    } else {
-        -notoriety
-    };
     html! {
         (sidebar_section("Bio", html! {
             dl class="character-bio" {

--- a/crates/strategic-web/src/templates/settlement/character_skills.rs
+++ b/crates/strategic-web/src/templates/settlement/character_skills.rs
@@ -533,7 +533,13 @@ fn terrain_skill_rows(
         / 4.0;
     html! {
         tr class="party-skill-row terrain-primary-row" data-terrain-primary {
-            th scope="row" class="party-skill-name party-skill-icon-cell" { (stat_icon("Terrain", "terrain", "terrain", false)) }
+            th scope="row" class="party-skill-name party-skill-icon-cell" {
+                @if let Some(action) = action {
+                    (skill_action_icon("Terrain", "terrain", action, false))
+                } @else {
+                    (stat_icon("Terrain", "terrain", "terrain", false))
+                }
+            }
             td class="party-skill-meter" colspan=[schedule_context.then_some("7")] {
                 (skill_rank_bar_with_tooltip(
                     rank,
@@ -548,9 +554,6 @@ fn terrain_skill_rows(
                 ))
             }
             td class="religion-expand-cell" {
-                @if let Some(action) = action {
-                    (skill_action_icon("Terrain", "terrain", action, false))
-                }
                 button type="button" class="religion-expand-button" data-terrain-expand aria-expanded="false" aria-label="Expand Terrain skills" title="Expand Terrain" {
                     span class="religion-expand-chevron" aria-hidden="true" { "›" }
                 }
@@ -1733,6 +1736,28 @@ mod tests {
         assert!(!allocation.contains("data-schedule-step"));
         assert!(!allocation.contains("type=\"range\""));
         assert!(!allocation.contains("schedule-handle"));
+    }
+
+    #[test]
+    fn forage_action_replaces_the_terrain_skill_icon_not_the_expand_control() {
+        let rendered = terrain_skill_rows(
+            &CharacterSkills::default(),
+            1.0,
+            false,
+            Some(SkillAction::Get {
+                href: "/forage",
+                label: "Forage in the immediate vicinity",
+                open: false,
+            }),
+        )
+        .into_string();
+        let primary = rendered.find("data-terrain-primary").unwrap();
+        let action = rendered.find("href=\"/forage\"").unwrap();
+        let expand = rendered.find("data-terrain-expand").unwrap();
+
+        assert!(primary < action && action < expand);
+        assert!(rendered.contains("class=\"religion-expand-cell\"><button"));
+        assert!(!rendered.contains("class=\"religion-expand-cell\"><a"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Move the forage action onto the Terrain skill icon.
- Render the forage workflow in the party-page dialog overlay.
- Pass the current Virtue value through the character sheet without the legacy notoriety inversion.

## Why

The action was rendered in the sticky Terrain expansion cell and navigated to a standalone, unstyled forage page.

## Validation

- `cargo check -p strategic-web`
- `cargo test -p strategic-web forage_action_replaces_the_terrain_skill_icon_not_the_expand_control`
- Verified the local party page opens the forage dialog from the Terrain skill action.