### PR TITLE
Make strategic navigation feel instantaneous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8669,6 +8669,7 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/strategic-web/Cargo.toml
+++ b/crates/strategic-web/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2.workspace = true
 tower-http = { version = "0.6", features = ["fs", "compression-br", "compression-gzip"] }
+tower = { version = "0.5", features = ["util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { workspace = true }

--- a/crates/strategic-web/src/live.rs
+++ b/crates/strategic-web/src/live.rs
@@ -667,6 +667,14 @@ mod tests {
     }
 
     #[test]
+    fn live_navigation_uses_the_canonical_case_site_contract() {
+        let source = include_str!("live.rs");
+        assert!(source.contains("kind: Some(\"case_site\")"));
+        assert!(source.contains("path: format!(\"/locations/case-site/{id}\")"));
+        assert!(!source.contains("kind: Some(\"quest\")"));
+    }
+
+    #[test]
     fn public_cache_facade_does_not_offer_private_projection_reads() {
         let source = include_str!("live.rs");
         for private_table in [

--- a/crates/strategic-web/src/main.rs
+++ b/crates/strategic-web/src/main.rs
@@ -12,18 +12,21 @@ mod spacetimedb;
 mod strategic_map;
 mod templates;
 
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use axum::{
-    extract::Request,
-    http::{HeaderName, HeaderValue},
+    body::{Body, to_bytes},
+    extract::{Request, State},
+    http::{HeaderName, HeaderValue, Method, StatusCode, Uri, header},
     middleware::Next,
     response::Response,
 };
 use clap::Parser;
+use tower::ServiceExt;
 use tower_http::{compression::CompressionLayer, services::ServeDir};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -132,7 +135,11 @@ async fn main() -> anyhow::Result<()> {
         terrain,
     };
 
-    // Build router
+    // Keep a middleware-free clone for rendering authoritative POST
+    // destinations without issuing a second browser request.
+    let navigation = StrategicNavigationMiddleware {
+        renderer: build_router(state.clone()),
+    };
     let app = build_router(state);
 
     // Add static file serving
@@ -145,6 +152,10 @@ async fn main() -> anyhow::Result<()> {
     let app = app.route("/health", axum::routing::get(health_check));
 
     let app = app
+        .layer(axum::middleware::from_fn_with_state(
+            navigation,
+            strategic_navigation_metadata,
+        ))
         .layer(CompressionLayer::new())
         .layer(axum::middleware::from_fn(log_http_request));
 
@@ -164,6 +175,323 @@ async fn main() -> anyhow::Result<()> {
 
 async fn health_check() -> &'static str {
     "OK"
+}
+
+#[derive(Clone)]
+struct StrategicNavigationMiddleware {
+    renderer: axum::Router,
+}
+
+async fn strategic_navigation_metadata(
+    State(navigation): State<StrategicNavigationMiddleware>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let method = request.method().clone();
+    let negotiated = request
+        .headers()
+        .get("x-strategic-navigation")
+        .is_some_and(|value| value == "true");
+    let canonical = request.uri().to_string();
+    let current_url = request
+        .headers()
+        .get("x-strategic-current-url")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| value.starts_with('/') && !value.starts_with("//") && !value.contains('\\'))
+        .map(str::to_owned);
+    let cookie = request.headers().get(header::COOKIE).cloned();
+    let response = apply_strategic_navigation_metadata(
+        &method,
+        &canonical,
+        negotiated,
+        next.run(request).await,
+    );
+    if negotiated && method == Method::GET {
+        strategic_root_fragment(response).await
+    } else if negotiated && method == Method::POST && response.status().is_success() {
+        negotiated_post_root(navigation, response, current_url.as_deref(), cookie).await
+    } else {
+        response
+    }
+}
+
+fn strategic_hard_boundary(path: &str) -> bool {
+    path.starts_with("/characters")
+        || path.starts_with("/missions")
+        || path.starts_with("/tactical")
+        || path == "/map/data-license"
+}
+
+fn local_redirect_path(value: &str) -> Option<String> {
+    (value.starts_with('/') && !value.starts_with("//") && !value.contains('\\'))
+        .then(|| value.to_owned())
+}
+
+fn valid_hard_navigation_target(target: &str) -> bool {
+    local_redirect_path(target).is_some()
+        || target
+            .parse::<reqwest::Url>()
+            .is_ok_and(|url| matches!(url.scheme(), "http" | "https"))
+}
+
+fn hard_navigation_response(target: &str, set_cookies: &[HeaderValue]) -> Response {
+    if !valid_hard_navigation_target(target) {
+        let mut response = Response::new(Body::from("Unsafe navigation target."));
+        *response.status_mut() = StatusCode::BAD_REQUEST;
+        append_set_cookies(&mut response, set_cookies);
+        return response;
+    }
+    let mut response = Response::new(Body::empty());
+    *response.status_mut() = StatusCode::NO_CONTENT;
+    if let Ok(value) = HeaderValue::from_str(target) {
+        response.headers_mut().insert(
+            HeaderName::from_static("x-strategic-hard-navigation"),
+            value,
+        );
+    }
+    append_set_cookies(&mut response, set_cookies);
+    response
+}
+
+fn response_set_cookies(response: &Response) -> Vec<HeaderValue> {
+    response
+        .headers()
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .cloned()
+        .collect()
+}
+
+fn append_set_cookies(response: &mut Response, cookies: &[HeaderValue]) {
+    for cookie in cookies {
+        response
+            .headers_mut()
+            .append(header::SET_COOKIE, cookie.clone());
+    }
+}
+
+fn update_cookie_header(
+    cookie: Option<HeaderValue>,
+    set_cookies: &[HeaderValue],
+) -> Option<HeaderValue> {
+    let mut values = BTreeMap::<String, String>::new();
+    if let Some(cookie) = cookie.and_then(|value| value.to_str().ok().map(str::to_owned)) {
+        for pair in cookie.split(';') {
+            if let Some((name, value)) = pair.trim().split_once('=') {
+                values.insert(name.trim().to_owned(), value.trim().to_owned());
+            }
+        }
+    }
+    for set_cookie in set_cookies {
+        let Ok(set_cookie) = set_cookie.to_str() else {
+            continue;
+        };
+        let (pair, attributes) = set_cookie.split_once(';').unwrap_or((set_cookie, ""));
+        let Some((name, value)) = pair.trim().split_once('=') else {
+            continue;
+        };
+        let clears = value.is_empty()
+            || attributes
+                .to_ascii_lowercase()
+                .split(';')
+                .any(|attribute| attribute.trim() == "max-age=0");
+        if clears {
+            values.remove(name.trim());
+        } else {
+            values.insert(name.trim().to_owned(), value.trim().to_owned());
+        }
+    }
+    HeaderValue::from_str(
+        &values
+            .into_iter()
+            .map(|(name, value)| format!("{name}={value}"))
+            .collect::<Vec<_>>()
+            .join("; "),
+    )
+    .ok()
+    .filter(|value| !value.is_empty())
+}
+
+async fn negotiated_post_root(
+    navigation: StrategicNavigationMiddleware,
+    response: Response,
+    current_url: Option<&str>,
+    cookie: Option<HeaderValue>,
+) -> Response {
+    let mut set_cookies = response_set_cookies(&response);
+    let mut cookie = update_cookie_header(cookie, &set_cookies);
+    let redirected = response
+        .headers()
+        .get("x-strategic-redirected")
+        .is_some_and(|value| value == "true");
+    let target = if redirected {
+        let raw = response
+            .headers()
+            .get("x-strategic-canonical-url")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        match raw {
+            Some(raw) => match local_redirect_path(&raw) {
+                Some(local) => Some(local),
+                None => return hard_navigation_response(&raw, &set_cookies),
+            },
+            None => None,
+        }
+    } else {
+        current_url.and_then(local_redirect_path)
+    };
+    let Some(mut target) = target else {
+        return response;
+    };
+
+    for _ in 0..5 {
+        if strategic_hard_boundary(target.split(['?', '#']).next().unwrap_or(target.as_str())) {
+            return hard_navigation_response(&target, &set_cookies);
+        }
+        let request_target = target.split('#').next().unwrap_or(target.as_str());
+        let Ok(uri) = request_target.parse::<Uri>() else {
+            return hard_navigation_response(&target, &set_cookies);
+        };
+        let mut request = Request::builder()
+            .method(Method::GET)
+            .uri(uri)
+            .header("x-strategic-navigation-internal", "true");
+        if let Some(cookie) = cookie.as_ref() {
+            request = request.header(header::COOKIE, cookie.clone());
+        }
+        let rendered = navigation
+            .renderer
+            .clone()
+            .oneshot(request.body(Body::empty()).expect("valid internal request"))
+            .await
+            .expect("router service is infallible");
+        let next_set_cookies = response_set_cookies(&rendered);
+        cookie = update_cookie_header(cookie, &next_set_cookies);
+        set_cookies.extend(next_set_cookies);
+        if rendered.status().is_redirection() {
+            let Some(next) = rendered
+                .headers()
+                .get(header::LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .and_then(local_redirect_path)
+            else {
+                return hard_navigation_response(&target, &set_cookies);
+            };
+            target = next;
+            continue;
+        }
+        let mut rendered = strategic_root_fragment(rendered).await;
+        if !rendered.status().is_success()
+            || !rendered
+                .headers()
+                .get("x-strategic-response")
+                .is_some_and(|value| value == "root")
+        {
+            let mut error = Response::new(Body::from(
+                "The updated strategic page could not be rendered.",
+            ));
+            *error.status_mut() = StatusCode::BAD_GATEWAY;
+            append_set_cookies(&mut error, &set_cookies);
+            return error;
+        }
+        *rendered.status_mut() = StatusCode::OK;
+        rendered.headers_mut().insert(
+            HeaderName::from_static("x-strategic-canonical-url"),
+            HeaderValue::from_str(&target).expect("validated local target is a header"),
+        );
+        rendered.headers_mut().insert(
+            HeaderName::from_static("x-strategic-response"),
+            HeaderValue::from_static("root"),
+        );
+        if redirected {
+            rendered.headers_mut().insert(
+                HeaderName::from_static("x-strategic-redirected"),
+                HeaderValue::from_static("true"),
+            );
+        }
+        rendered.headers_mut().remove(header::SET_COOKIE);
+        append_set_cookies(&mut rendered, &set_cookies);
+        return rendered;
+    }
+    hard_navigation_response(&target, &set_cookies)
+}
+
+fn apply_strategic_navigation_metadata(
+    method: &Method,
+    canonical: &str,
+    negotiated: bool,
+    mut response: Response,
+) -> Response {
+    if negotiated {
+        let mut response_kind =
+            (*method == Method::POST && response.status().is_success()).then_some("mutation");
+        if *method == Method::POST && response.status().is_redirection() {
+            let location = response
+                .headers()
+                .get(header::LOCATION)
+                .cloned()
+                .unwrap_or_else(|| {
+                    HeaderValue::from_str(&canonical).expect("request URI is valid")
+                });
+            *response.status_mut() = StatusCode::NO_CONTENT;
+            response.headers_mut().remove(header::LOCATION);
+            response.headers_mut().insert(
+                HeaderName::from_static("x-strategic-canonical-url"),
+                location,
+            );
+            response.headers_mut().insert(
+                HeaderName::from_static("x-strategic-redirected"),
+                HeaderValue::from_static("true"),
+            );
+            response_kind = Some("mutation");
+        } else {
+            response.headers_mut().insert(
+                HeaderName::from_static("x-strategic-canonical-url"),
+                HeaderValue::from_str(&canonical).expect("request URI is a valid header value"),
+            );
+        }
+        if let Some(response_kind) = response_kind {
+            response.headers_mut().insert(
+                HeaderName::from_static("x-strategic-response"),
+                HeaderValue::from_static(response_kind),
+            );
+        }
+    }
+    response
+}
+
+async fn strategic_root_fragment(response: Response) -> Response {
+    const START: &str = "<!-- strategic-page-start -->";
+    const END: &str = "<!-- strategic-page-end -->";
+    let (mut parts, body) = response.into_parts();
+    let Ok(bytes) = to_bytes(body, 16 * 1024 * 1024).await else {
+        return Response::from_parts(parts, Body::empty());
+    };
+    let Ok(document) = String::from_utf8(bytes.to_vec()) else {
+        return Response::from_parts(parts, Body::from(bytes));
+    };
+    let Some(start) = document.find(START).map(|index| index + START.len()) else {
+        return Response::from_parts(parts, Body::from(document));
+    };
+    let Some(end) = document[start..].find(END).map(|index| start + index) else {
+        return Response::from_parts(parts, Body::from(document));
+    };
+    let fragment = &document[start..end];
+    let profile = ["strategic", "live", "entry"]
+        .into_iter()
+        .find(|profile| fragment.contains(&format!("data-script-profile=\"{profile}\"")));
+    parts.headers.remove(header::CONTENT_LENGTH);
+    parts.headers.insert(
+        HeaderName::from_static("x-strategic-response"),
+        HeaderValue::from_static("root"),
+    );
+    if let Some(profile) = profile {
+        parts.headers.insert(
+            HeaderName::from_static("x-strategic-script-profile"),
+            HeaderValue::from_static(profile),
+        );
+    }
+    Response::from_parts(parts, Body::from(fragment.to_owned()))
 }
 
 static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
@@ -202,6 +530,272 @@ struct HttpRequestLog {
     uri: String,
     started: Instant,
     finished: bool,
+}
+
+#[cfg(test)]
+mod strategic_navigation_contract_tests {
+    use axum::{
+        Router,
+        body::Body,
+        http::{HeaderMap, HeaderValue, Method, Response, StatusCode, header},
+        response::Html,
+        routing::get,
+    };
+
+    use super::{
+        StrategicNavigationMiddleware, apply_strategic_navigation_metadata, local_redirect_path,
+        negotiated_post_root, strategic_hard_boundary, strategic_root_fragment,
+        update_cookie_header, valid_hard_navigation_target,
+    };
+
+    #[test]
+    fn negotiated_posts_are_terminal_instead_of_redirecting_to_a_get() {
+        let redirect = Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(header::LOCATION, "/camp?from=travel#party")
+            .body(Body::empty())
+            .unwrap();
+        let response =
+            apply_strategic_navigation_metadata(&Method::POST, "/camp/continue", true, redirect);
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert!(!response.headers().contains_key(header::LOCATION));
+        assert_eq!(
+            response.headers()["x-strategic-canonical-url"],
+            "/camp?from=travel#party"
+        );
+        assert_eq!(response.headers()["x-strategic-response"], "mutation");
+        assert_eq!(response.headers()["x-strategic-redirected"], "true");
+    }
+
+    #[test]
+    fn ordinary_gets_are_not_marked_as_negotiated_fragments() {
+        let response = Response::new(Body::empty());
+        let response = apply_strategic_navigation_metadata(
+            &Method::GET,
+            "/locations/settlement/lubeck",
+            false,
+            response,
+        );
+        assert!(!response.headers().contains_key("x-strategic-response"));
+        assert!(!response.headers().contains_key("x-strategic-canonical-url"));
+    }
+
+    #[test]
+    fn negotiated_gets_include_canonical_metadata_before_body_rendering() {
+        let response = apply_strategic_navigation_metadata(
+            &Method::GET,
+            "/locations/settlement/lubeck?building=inn",
+            true,
+            Response::new(Body::empty()),
+        );
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers()["x-strategic-canonical-url"],
+            "/locations/settlement/lubeck?building=inn"
+        );
+        assert!(
+            !response
+                .headers()
+                .contains_key("x-strategic-script-profile")
+        );
+        assert!(!response.headers().contains_key("x-strategic-response"));
+    }
+
+    #[tokio::test]
+    async fn negotiated_get_body_contains_only_the_stable_root() {
+        let document = concat!(
+            "<!doctype html><head><title>Camp</title></head><body>",
+            "<div id=\"strategic-live-stream\"></div>",
+            "<!-- strategic-page-start --><div id=\"strategic-page\" ",
+            "data-page-title=\"Camp\" data-script-profile=\"strategic\">Camp</div>",
+            "<!-- strategic-page-end --></body>",
+        );
+        let response = strategic_root_fragment(Response::new(Body::from(document))).await;
+        assert_eq!(response.headers()["x-strategic-response"], "root");
+        assert_eq!(
+            response.headers()["x-strategic-script-profile"],
+            "strategic"
+        );
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let body = std::str::from_utf8(&body).unwrap();
+        assert!(body.starts_with("<div id=\"strategic-page\""));
+        assert!(!body.contains("<!doctype"));
+        assert!(!body.contains("strategic-live-stream"));
+    }
+
+    #[test]
+    fn redirected_entry_and_tactical_targets_are_hard_boundaries() {
+        for path in [
+            "/characters",
+            "/characters/new",
+            "/missions/mission-1",
+            "/tactical/tactical.html",
+            "/map/data-license",
+        ] {
+            assert!(strategic_hard_boundary(path), "{path}");
+        }
+        assert!(!strategic_hard_boundary("/locations/settlement/lubeck"));
+        assert_eq!(
+            local_redirect_path("/camp?from=travel"),
+            Some("/camp?from=travel".into())
+        );
+        assert_eq!(local_redirect_path("//example.test/steal"), None);
+        assert_eq!(local_redirect_path("https://example.test/steal"), None);
+    }
+
+    #[tokio::test]
+    async fn negotiated_post_renders_redirect_destination_in_the_same_response() {
+        let renderer = Router::new().route(
+            "/camp",
+            get(|| async {
+                Html(concat!(
+                    "<!doctype html><body><!-- strategic-page-start -->",
+                    "<div id=\"strategic-page\" data-page-title=\"Camp\" ",
+                    "data-script-profile=\"strategic\">Fresh camp</div>",
+                    "<!-- strategic-page-end --></body>",
+                ))
+            }),
+        );
+        let redirect = Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(header::LOCATION, "/camp")
+            .body(Body::empty())
+            .unwrap();
+        let negotiated =
+            apply_strategic_navigation_metadata(&Method::POST, "/camp/continue", true, redirect);
+        let response = negotiated_post_root(
+            StrategicNavigationMiddleware { renderer },
+            negotiated,
+            Some("/camp"),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["x-strategic-response"], "root");
+        assert_eq!(
+            response.headers()["x-strategic-script-profile"],
+            "strategic"
+        );
+        assert_eq!(response.headers()["x-strategic-canonical-url"], "/camp");
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        assert!(std::str::from_utf8(&body).unwrap().contains("Fresh camp"));
+    }
+
+    #[tokio::test]
+    async fn negotiated_post_keeps_entry_redirect_as_a_hard_boundary() {
+        let redirect = Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(header::LOCATION, "/characters")
+            .body(Body::empty())
+            .unwrap();
+        let negotiated =
+            apply_strategic_navigation_metadata(&Method::POST, "/quests/accept", true, redirect);
+        let response = negotiated_post_root(
+            StrategicNavigationMiddleware {
+                renderer: Router::new(),
+            },
+            negotiated,
+            Some("/quests"),
+            None,
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(
+            response.headers()["x-strategic-hard-navigation"],
+            "/characters"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_selected_character_clear_reaches_internal_render_and_browser() {
+        let renderer = Router::new().route(
+            "/camp",
+            get(|headers: HeaderMap| async move {
+                let cookie = headers
+                    .get(header::COOKIE)
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or("");
+                assert!(!cookie.contains("character_id="));
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header(header::SET_COOKIE, "session=fresh; Path=/; HttpOnly")
+                    .body(Body::from(concat!(
+                        "<!doctype html><body><!-- strategic-page-start -->",
+                        "<div id=\"strategic-page\" data-page-title=\"Camp\" ",
+                        "data-script-profile=\"strategic\">Fresh camp</div>",
+                        "<!-- strategic-page-end --></body>",
+                    )))
+                    .unwrap()
+            }),
+        );
+        let redirect = Response::builder()
+            .status(StatusCode::SEE_OTHER)
+            .header(header::LOCATION, "/camp")
+            .header(
+                header::SET_COOKIE,
+                "character_id=; Max-Age=0; Path=/; HttpOnly",
+            )
+            .body(Body::empty())
+            .unwrap();
+        let negotiated =
+            apply_strategic_navigation_metadata(&Method::POST, "/camp/continue", true, redirect);
+        let response = negotiated_post_root(
+            StrategicNavigationMiddleware { renderer },
+            negotiated,
+            Some("/camp"),
+            Some(HeaderValue::from_static("character_id=stale; session=old")),
+        )
+        .await;
+        let set_cookies = response
+            .headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .filter_map(|value| value.to_str().ok())
+            .collect::<Vec<_>>();
+        assert_eq!(set_cookies.len(), 2);
+        assert!(
+            set_cookies
+                .iter()
+                .any(|value| value.starts_with("character_id=;"))
+        );
+        assert!(
+            set_cookies
+                .iter()
+                .any(|value| value.starts_with("session=fresh;"))
+        );
+    }
+
+    #[test]
+    fn cookie_replacements_and_hard_navigation_schemes_fail_closed() {
+        let cookie = update_cookie_header(
+            Some(HeaderValue::from_static("character_id=stale; session=old")),
+            &[
+                HeaderValue::from_static("character_id=; Max-Age=0; Path=/"),
+                HeaderValue::from_static("session=fresh; Path=/"),
+            ],
+        )
+        .unwrap();
+        assert_eq!(cookie, "session=fresh");
+        for target in [
+            "/characters",
+            "https://example.test/",
+            "http://example.test/",
+        ] {
+            assert!(valid_hard_navigation_target(target), "{target}");
+        }
+        for target in [
+            "javascript:alert(1)",
+            "data:text/html,boom",
+            "file:///tmp/secret",
+            "//example.test/scheme-relative",
+        ] {
+            assert!(!valid_hard_navigation_target(target), "{target}");
+        }
+    }
 }
 
 impl Drop for HttpRequestLog {

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -2565,14 +2565,14 @@ async fn resolve_location(state: &AppState, kind: &str, id: &str) -> LocationLoo
                     )
                 })
             }),
-        LocationKind::Quest => state
+        LocationKind::CaseSite => state
             .db
-            .query_one::<ContractPresentation>(&format!(
-                "SELECT * FROM backend_contracts WHERE id = {}",
+            .query_one::<BackendCaseSitePin>(&format!(
+                "SELECT * FROM backend_case_site_pins WHERE case_site_id = {}",
                 sql_string_literal(id)
             ))
             .await
-            .map(|row| row.map(|quest| (quest.title, None, None))),
+            .map(|row| row.map(|site| (site.display_title, None, None))),
     };
     let (name, category, religion_id) = match location {
         Ok(Some(location)) => location,
@@ -2597,7 +2597,7 @@ fn character_is_at_location(character: &Character, location: &LocationView) -> b
         LocationKind::Settlement => {
             character.current_settlement_id.as_deref() == Some(location.id.as_str())
         }
-        LocationKind::Quest => {
+        LocationKind::CaseSite => {
             character.current_case_site_id.as_deref() == Some(location.id.as_str())
         }
     }

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -38,7 +38,7 @@ pub fn journal_layout(content: Markup, logged_in_as: Option<&str>) -> Markup {
         "Journal",
         entry_top_bar_with_session(logged_in_as),
         content,
-        ScriptProfile::Live,
+        ScriptProfile::Strategic,
     )
 }
 
@@ -183,6 +183,8 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/live-regions.js?v=persistent-rest-refresh-2" defer {}
                 }
                 @if scripts == ScriptProfile::Strategic {
+                    script src="/static/strategic-navigation.js?v=soft-navigation-1" defer {}
+                    script src="/static/strategic-mutations.js?v=single-transaction-1" defer {}
                     script src="/static/journal-tab.js?v=journal-tab-1" defer {}
                     script src="/static/numeric-editor.js?v=shared-numeric-editor-2" defer {}
                     script src="/static/inventory-browser.js?v=coin-currencies-3-alcohol-targets-1-food-lots-4-infinite-catalog" defer {}
@@ -211,13 +213,16 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                         span id="strategic-live-revision" data-live-revision="0" hidden {}
                     }
                 }
-                div class="app" {
+                (maud::PreEscaped("<!-- strategic-page-start -->"))
+                div class="app" id="strategic-page" data-page-title=(title)
+                    data-script-profile=(match scripts { ScriptProfile::Entry => "entry", ScriptProfile::Live => "live", ScriptProfile::Strategic => "strategic" }) {
                     (header)
 
                     div class="main-grid" {
                         (content)
                     }
                 }
+                (maud::PreEscaped("<!-- strategic-page-end -->"))
             }
         }
     }
@@ -701,8 +706,8 @@ pub fn sidebar_section(title: &str, content: Markup) -> Markup {
 mod tests {
     use super::{
         HorizonVariant, ScriptProfile, WildernessVariant, building_tier, building_tint,
-        entry_layout, horizon_variant, page_shell, quest_location_top_bar, religion_icon_path,
-        settlement_layout_with_session, settlement_top_bar, wilderness_variant,
+        entry_layout, horizon_variant, journal_layout, page_shell, quest_location_top_bar,
+        religion_icon_path, settlement_layout_with_session, settlement_top_bar, wilderness_variant,
     };
     use crate::spacetimedb::SettlementCategory;
     use maud::html;
@@ -713,7 +718,20 @@ mod tests {
         assert!(markup.contains("/static/local-chat.js?v=local-chat-location-authority-1"));
         assert!(!markup.contains("local-chat.js?v=herbalist-private-1"));
         assert!(markup.contains("/static/live-regions.js?v=persistent-rest-refresh-2"));
+        assert!(markup.contains("id=\"strategic-page\""));
+        assert!(markup.contains("/static/strategic-navigation.js"));
+        assert!(markup.contains("/static/strategic-mutations.js"));
+        assert_eq!(markup.matches("id=\"strategic-live-stream\"").count(), 1);
+        assert!(markup.find("id=\"strategic-live-stream\"") < markup.find("id=\"strategic-page\""));
         assert!(!markup.contains("live-regions.js?v=floating-time-editor-1"));
+    }
+
+    #[test]
+    fn direct_journal_uses_the_persistent_strategic_profile() {
+        let markup = journal_layout(html! {}, Some("Ada")).into_string();
+        assert!(markup.contains("data-script-profile=\"strategic\""));
+        assert!(markup.contains("/static/strategic-navigation.js"));
+        assert_eq!(markup.matches("id=\"strategic-live-stream\"").count(), 1);
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/character_skills.rs
+++ b/crates/strategic-web/src/templates/settlement/character_skills.rs
@@ -2253,7 +2253,9 @@ mod tests {
         assert!(!schedule.contains("scheduleDrag"));
         assert!(!schedule.contains("travel_"));
         assert!(equipment.contains("'/api/equipment'"));
-        assert!(equipment.contains("window.location.reload()"));
+        assert!(equipment.contains("strategicSubmitMutation"));
+        assert!(!equipment.contains("window.location.reload()"));
+        assert!(!equipment.contains("strategic-live-refresh-requested"));
         assert!(live_regions.contains("const scrollOffsets = (selector)"));
         assert!(live_regions.contains("region.scrollTop = offsets.top"));
         assert!(live_regions.contains("replaced.includes(\"left-sidebar\")"));

--- a/crates/strategic-web/src/templates/settlement/context.rs
+++ b/crates/strategic-web/src/templates/settlement/context.rs
@@ -17,14 +17,14 @@ pub struct LocationView {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LocationKind {
     Settlement,
-    Quest,
+    CaseSite,
 }
 
 impl LocationKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Settlement => "settlement",
-            Self::Quest => "quest",
+            Self::CaseSite => "case-site",
         }
     }
 }
@@ -40,7 +40,7 @@ impl FromStr for LocationKind {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "settlement" => Ok(Self::Settlement),
-            "quest" => Ok(Self::Quest),
+            "case-site" => Ok(Self::CaseSite),
             _ => Err(()),
         }
     }
@@ -101,7 +101,8 @@ mod tests {
 
     #[test]
     fn location_kind_rejects_unknown_path_segments() {
-        assert_eq!("quest".parse(), Ok(LocationKind::Quest));
+        assert_eq!("case-site".parse(), Ok(LocationKind::CaseSite));
+        assert!("quest".parse::<LocationKind>().is_err());
         assert!("merchant".parse::<LocationKind>().is_err());
     }
 }

--- a/crates/strategic-web/static/background-fetch.js
+++ b/crates/strategic-web/static/background-fetch.js
@@ -46,9 +46,8 @@
     }
   };
 
-  const abortAll = () => {
-    if (leavingPage) return;
-    leavingPage = true;
+  const abortAll = ({ permanent = false } = {}) => {
+    if (permanent) leavingPage = true;
     active.forEach((controller) => controller.abort());
     active.clear();
   };
@@ -74,6 +73,11 @@
     return result;
   };
 
-  document.addEventListener("strategic-navigation-start", abortAll);
-  window.addEventListener("pagehide", abortAll, { once: true });
+  document.addEventListener("strategic-page-unmounting", () => abortAll());
+  document.addEventListener("strategic-page-mounted", () => {
+    leavingPage = false;
+    initialQueue = Promise.resolve();
+    window.strategicApplyReturnNavigation();
+  });
+  window.addEventListener("pagehide", () => abortAll({ permanent: true }), { once: true });
 })();

--- a/crates/strategic-web/static/building-state.js
+++ b/crates/strategic-web/static/building-state.js
@@ -1,50 +1,44 @@
 (() => {
   const services = new Set(["", "residences", "keep", "map", "merchants", "weapons", "armor", "clothing", "herbalist", "inn", "religion"]);
-  const nav = document.querySelector("[data-settlement-id]");
-  if (!nav) return;
-  const current = new URL(window.location.href);
-  const requested = current.searchParams.get("building");
-  const serverActive = nav.querySelector(".nav-tab.active")?.dataset.serviceId;
-  const partyInspection = current.pathname.startsWith("/locations/") && current.pathname.includes("/party");
-  const building = partyInspection && services.has(requested)
-    ? requested
-    : (services.has(serverActive) ? serverActive : "map");
-  if (requested && (!services.has(requested) || !partyInspection)) {
-    current.searchParams.delete("building");
-    history.replaceState(null, "", current);
-  }
-  nav.querySelectorAll("[data-service-id]").forEach((tab) => {
-    const selected = tab.dataset.serviceId === building;
-    tab.classList.toggle("active", selected);
-    tab.setAttribute("aria-current", selected ? "page" : "false");
-    if (selected) document.documentElement.style.setProperty("--active-building-tint", tab.style.getPropertyValue("--building-tint"));
-  });
-  const syncPartyLinks = (root = document) => {
-    root.querySelectorAll("a[href], form[action]").forEach((node) => {
+  let observer;
+  const mount = () => {
+    observer?.disconnect();
+    const page = document.querySelector("#strategic-page");
+    const nav = page?.querySelector("[data-settlement-id]");
+    if (!nav) return;
+    const current = new URL(location.href);
+    const requested = current.searchParams.get("building");
+    const serverActive = nav.querySelector(".nav-tab.active")?.dataset.serviceId;
+    const partyInspection = current.pathname.startsWith("/locations/") && current.pathname.includes("/party");
+    const building = partyInspection && services.has(requested)
+      ? requested : (services.has(serverActive) ? serverActive : "map");
+    if (requested && (!services.has(requested) || !partyInspection)) {
+      current.searchParams.delete("building");
+      history.replaceState(history.state, "", current);
+    }
+    nav.querySelectorAll("[data-service-id]").forEach((tab) => {
+      const selected = tab.dataset.serviceId === building;
+      tab.classList.toggle("active", selected);
+      tab.setAttribute("aria-current", selected ? "page" : "false");
+      if (selected) document.documentElement.style.setProperty("--active-building-tint", tab.style.getPropertyValue("--building-tint"));
+    });
+    const syncPartyLinks = (root = page) => root.querySelectorAll?.("a[href], form[action]").forEach((node) => {
       const attribute = node.matches("form") ? "action" : "href";
       const raw = node.getAttribute(attribute);
       if (!raw || !raw.startsWith("/locations/")) return;
-      const url = new URL(raw, window.location.origin);
+      const url = new URL(raw, location.origin);
       if (!url.pathname.includes("/party")) return;
       if (building) url.searchParams.set("building", building);
       else url.searchParams.delete("building");
       node.setAttribute(attribute, `${url.pathname}${url.search}${url.hash}`);
     });
+    syncPartyLinks();
+    observer = new MutationObserver((mutations) => mutations.forEach((mutation) =>
+      mutation.addedNodes.forEach((node) => node.nodeType === Node.ELEMENT_NODE && syncPartyLinks(node.matches("a[href], form[action]") ? node.parentElement : node)),
+    ));
+    observer.observe(page, { childList: true, subtree: true });
   };
-  syncPartyLinks();
-
-  // Live regions replace party controls after this deferred script runs. Keep
-  // the active building on links introduced by those server-driven updates.
-  new MutationObserver((mutations) => {
-    mutations.forEach((mutation) => {
-      mutation.addedNodes.forEach((node) => {
-        if (node.nodeType !== Node.ELEMENT_NODE) return;
-        if (node.matches("a[href], form[action]")) {
-          syncPartyLinks(node.parentElement || node);
-        } else {
-          syncPartyLinks(node);
-        }
-      });
-    });
-  }).observe(document.body, { childList: true, subtree: true });
+  mount();
+  document.addEventListener("strategic-page-mounted", mount);
+  document.addEventListener("strategic-page-unmounting", () => observer?.disconnect());
 })();

--- a/crates/strategic-web/static/character-action-dialog.js
+++ b/crates/strategic-web/static/character-action-dialog.js
@@ -14,7 +14,8 @@
     if (!backwards && current === length - 1) return 0;
     return current + (backwards ? -1 : 1);
   };
-  const dialogOwnsBodyLock = (hasCharacterDialog) => hasCharacterDialog;
+  const dialogOwnsBodyLock = (hasCharacterDialog, hasRemoteDialog = false) =>
+    hasCharacterDialog || hasRemoteDialog;
   const openerIdentity = (opener) => opener?.dataset?.dialogOpener || opener?.getAttribute?.("aria-label") || null;
   const submitAutomaticChatToggle = (input) => {
     if (!input?.matches?.("[data-automatic-social-chat]") || !input.form?.requestSubmit) return false;
@@ -43,44 +44,61 @@
     submitAutomaticChatToggle(event.target);
   });
 
-  const overlays = [...document.querySelectorAll("[data-character-action-dialog]")];
-  const overlay = overlays[0];
-  overlays.slice(1).forEach((extra) => { extra.hidden = true; });
-  if (!overlay) {
+  let lifecycle;
+  const unmount = () => {
+    lifecycle?.abort();
+    lifecycle = null;
     document.body.classList.remove("character-action-dialog-open");
-    if (sessionStorage.getItem(`${restoreKey}-pending`) === "true") {
-      sessionStorage.removeItem(`${restoreKey}-pending`);
-      const identity = sessionStorage.getItem(restoreKey);
-      if (identity) {
-        requestAnimationFrame(() => [...document.querySelectorAll("[aria-haspopup='dialog']")]
-          .find((element) => openerIdentity(element) === identity)?.focus());
+  };
+  const mount = () => {
+    unmount();
+    lifecycle = new AbortController();
+    const { signal } = lifecycle;
+    const overlays = [...document.querySelectorAll("#strategic-page [data-character-action-dialog]")];
+    const overlay = overlays[0];
+    overlays.slice(1).forEach((extra) => { extra.hidden = true; });
+    document.body.classList.toggle(
+      "character-action-dialog-open",
+      dialogOwnsBodyLock(Boolean(overlay), Boolean(document.querySelector("dialog[open]"))),
+    );
+    if (!overlay) {
+      if (sessionStorage.getItem(`${restoreKey}-pending`) === "true") {
+        sessionStorage.removeItem(`${restoreKey}-pending`);
+        const identity = sessionStorage.getItem(restoreKey);
+        if (identity) {
+          requestAnimationFrame(() => [...document.querySelectorAll("[aria-haspopup='dialog']")]
+            .find((element) => openerIdentity(element) === identity)?.focus());
+        }
       }
-    }
-    return;
-  }
-
-  document.body.classList.add("character-action-dialog-open");
-  const dialog = overlay.querySelector("[role='dialog']");
-  const close = overlay.querySelector(".character-action-dialog-close");
-  requestAnimationFrame(() => {
-    const preferred = overlay.dataset.initialFocus && dialog.querySelector(overlay.dataset.initialFocus);
-    (preferred || visible(dialog)[0] || dialog).focus?.();
-  });
-
-  overlay.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && close) {
-      event.preventDefault();
-      sessionStorage.setItem(`${restoreKey}-pending`, "true");
-      close.click();
       return;
     }
-    if (event.key !== "Tab") return;
-    const focusables = visible(dialog);
-    const current = focusables.indexOf(document.activeElement);
-    const next = wrappedFocusIndex(focusables.length, current, event.shiftKey);
-    if (next >= 0 && (current < 0 || next !== current + (event.shiftKey ? -1 : 1))) {
-      event.preventDefault();
-      focusables[next].focus();
-    }
-  });
+
+    const dialog = overlay.querySelector("[role='dialog']");
+    const close = overlay.querySelector(".character-action-dialog-close");
+    requestAnimationFrame(() => {
+      if (signal.aborted || !dialog?.isConnected) return;
+      const preferred = overlay.dataset.initialFocus && dialog.querySelector(overlay.dataset.initialFocus);
+      (preferred || visible(dialog)[0] || dialog).focus?.();
+    });
+
+    overlay.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && close) {
+        event.preventDefault();
+        sessionStorage.setItem(`${restoreKey}-pending`, "true");
+        close.click();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const focusables = visible(dialog);
+      const current = focusables.indexOf(document.activeElement);
+      const next = wrappedFocusIndex(focusables.length, current, event.shiftKey);
+      if (next >= 0 && (current < 0 || next !== current + (event.shiftKey ? -1 : 1))) {
+        event.preventDefault();
+        focusables[next].focus();
+      }
+    }, { signal });
+  };
+  mount();
+  document.addEventListener("strategic-page-unmounting", unmount);
+  document.addEventListener("strategic-page-mounted", mount);
 })();

--- a/crates/strategic-web/static/chat-resize.js
+++ b/crates/strategic-web/static/chat-resize.js
@@ -2,72 +2,71 @@
   const STORAGE_KEY = "adventuresim.chat-height";
   const DESKTOP_MIN_HEIGHT = 128;
   const MOBILE_MIN_HEIGHT = 160;
-  // Preserve room for the party tray, centered counterparty description, and
-  // the counterparty tray attached to the moving top edge of the chat.
   const MIN_STAGE_HEIGHT = 260;
   const CHAT_BOTTOM_GAP = 5;
   const KEYBOARD_STEP = 24;
-
-  const chat = document.querySelector(".settlement-chat");
-  const handle = chat?.querySelector(".settlement-chat-resize");
-  const container = chat?.closest(".settlement-main");
-  if (!chat || !handle || !container) return;
-
-  const minimumHeight = () => window.matchMedia("(max-width: 768px)").matches ? MOBILE_MIN_HEIGHT : DESKTOP_MIN_HEIGHT;
-  const maximumHeight = () => Math.max(minimumHeight(), container.clientHeight - MIN_STAGE_HEIGHT - CHAT_BOTTOM_GAP);
-  const clampHeight = (height) => Math.min(maximumHeight(), Math.max(minimumHeight(), height));
-
-  const setHeight = (height, persist = true) => {
-    const next = Math.round(clampHeight(height));
-    chat.style.setProperty("--chat-height", `${next}px`);
-    // The quest combat controls share this stage with the floating chat. Keep
-    // their reserved space in lockstep with a user-resized chat panel.
-    container.style.setProperty("--chat-panel-height", `${next}px`);
-    handle.setAttribute("aria-valuemin", String(minimumHeight()));
-    handle.setAttribute("aria-valuenow", String(next));
-    handle.setAttribute("aria-valuemax", String(Math.round(maximumHeight())));
-    if (persist) localStorage.setItem(STORAGE_KEY, String(next));
-  };
-
-  const savedHeight = Number.parseInt(localStorage.getItem(STORAGE_KEY) || "", 10);
-  if (Number.isFinite(savedHeight)) setHeight(savedHeight, false);
-  else setHeight(chat.getBoundingClientRect().height, false);
-
-  let startY = 0;
-  let startHeight = 0;
-
-  handle.addEventListener("pointerdown", (event) => {
-    if (event.button !== 0) return;
-    startY = event.clientY;
-    startHeight = chat.getBoundingClientRect().height;
-    handle.setPointerCapture(event.pointerId);
-    handle.classList.add("is-resizing");
-    document.body.classList.add("chat-resizing");
-    event.preventDefault();
-  });
-
-  handle.addEventListener("pointermove", (event) => {
-    if (!handle.hasPointerCapture(event.pointerId)) return;
-    setHeight(startHeight + startY - event.clientY, false);
-  });
-
-  const finishResize = (event) => {
-    if (!handle.hasPointerCapture(event.pointerId)) return;
-    handle.releasePointerCapture(event.pointerId);
-    handle.classList.remove("is-resizing");
+  let lifecycle;
+  let activeHandle;
+  const unmount = () => {
+    lifecycle?.abort();
+    activeHandle?.classList.remove("is-resizing");
     document.body.classList.remove("chat-resizing");
-    setHeight(chat.getBoundingClientRect().height);
+    activeHandle = null;
   };
-
-  handle.addEventListener("pointerup", finishResize);
-  handle.addEventListener("pointercancel", finishResize);
-
-  handle.addEventListener("keydown", (event) => {
-    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return;
-    const direction = event.key === "ArrowUp" ? 1 : -1;
-    setHeight(chat.getBoundingClientRect().height + direction * KEYBOARD_STEP);
-    event.preventDefault();
-  });
-
-  window.addEventListener("resize", () => setHeight(chat.getBoundingClientRect().height, false));
+  const mount = () => {
+    unmount();
+    lifecycle = new AbortController();
+    const { signal } = lifecycle;
+    const chat = document.querySelector("#strategic-page .settlement-chat");
+    const handle = chat?.querySelector(".settlement-chat-resize");
+    const container = chat?.closest(".settlement-main");
+    if (!chat || !handle || !container) return;
+    activeHandle = handle;
+    const minimum = () => matchMedia("(max-width: 768px)").matches ? MOBILE_MIN_HEIGHT : DESKTOP_MIN_HEIGHT;
+    const maximum = () => Math.max(minimum(), container.clientHeight - MIN_STAGE_HEIGHT - CHAT_BOTTOM_GAP);
+    const setHeight = (height, persist = true) => {
+      const value = Math.round(Math.max(minimum(), Math.min(maximum(), height)));
+      chat.style.setProperty("--chat-height", `${value}px`);
+      container.style.setProperty("--chat-panel-height", `${value}px`);
+      handle.setAttribute("aria-valuemin", String(minimum()));
+      handle.setAttribute("aria-valuenow", String(value));
+      handle.setAttribute("aria-valuemax", String(Math.round(maximum())));
+      if (persist) localStorage.setItem(STORAGE_KEY, String(value));
+    };
+    setHeight(Number(localStorage.getItem(STORAGE_KEY)) || chat.getBoundingClientRect().height, false);
+    let startY = 0;
+    let startHeight = 0;
+    const finish = (event) => {
+      if (!handle.hasPointerCapture?.(event.pointerId)) return;
+      handle.releasePointerCapture(event.pointerId);
+      handle.classList.remove("is-resizing");
+      document.body.classList.remove("chat-resizing");
+      setHeight(chat.getBoundingClientRect().height);
+    };
+    handle.addEventListener("pointerdown", (event) => {
+      if (event.button !== 0) return;
+      startY = event.clientY;
+      startHeight = chat.getBoundingClientRect().height;
+      handle.setPointerCapture(event.pointerId);
+      handle.classList.add("is-resizing");
+      document.body.classList.add("chat-resizing");
+      event.preventDefault();
+    }, { signal });
+    handle.addEventListener("pointermove", (event) => {
+      if (handle.hasPointerCapture(event.pointerId)) setHeight(startHeight + startY - event.clientY, false);
+    }, { signal });
+    handle.addEventListener("pointerup", finish, { signal });
+    handle.addEventListener("pointercancel", finish, { signal });
+    handle.addEventListener("keydown", (event) => {
+      if (!["ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) return;
+      event.preventDefault();
+      const current = chat.getBoundingClientRect().height;
+      setHeight(event.key === "Home" ? minimum() : event.key === "End" ? maximum() :
+        current + (event.key === "ArrowUp" ? KEYBOARD_STEP : -KEYBOARD_STEP));
+    }, { signal });
+    addEventListener("resize", () => setHeight(chat.getBoundingClientRect().height, false), { signal });
+  };
+  mount();
+  document.addEventListener("strategic-page-mounted", mount);
+  document.addEventListener("strategic-page-unmounting", unmount);
 })();

--- a/crates/strategic-web/static/cooking.js
+++ b/crates/strategic-web/static/cooking.js
@@ -183,5 +183,6 @@
 
   window.addEventListener("DOMContentLoaded", () => mount());
   window.addEventListener("strategic-live-regions-refreshed", () => mount());
+  document.addEventListener("strategic-page-mounted", () => mount());
   window.strategicCooking = { mount };
 })();

--- a/crates/strategic-web/static/dialogue-client.js
+++ b/crates/strategic-web/static/dialogue-client.js
@@ -62,6 +62,11 @@
   }
   if (typeof document === "undefined") return;
 
+  let lifecycle;
+  const mount = () => {
+  lifecycle?.abort();
+  lifecycle = new AbortController();
+  const { signal } = lifecycle;
   const chat = document.querySelector("[data-local-chat-subject][data-dialogue-catalog-revision]");
   if (!chat) return;
   const messages = chat.querySelector(".settlement-chat-messages");
@@ -213,7 +218,7 @@
     return true;
   };
 
-  input?.addEventListener("input", refreshCompletion);
+  input?.addEventListener("input", refreshCompletion, { signal });
   input?.addEventListener("keydown", (event) => {
     if (event.key === "Tab" && input.dataset.dialogueSuggestion) {
       event.preventDefault();
@@ -225,14 +230,14 @@
       event.preventDefault();
       event.stopImmediatePropagation();
     }
-  }, true);
+  }, { capture: true, signal });
   send?.addEventListener("click", (event) => {
     if (!submitTypedAction()) return;
     event.preventDefault();
     event.stopImmediatePropagation();
-  }, true);
-  document.addEventListener("click", (event) => { const topic = event.target.closest("[data-dialogue-topic]"); if (!topic || event.target.closest(".dialogue-source-link")) return; event.preventDefault(); chooseTopic({ sessionId: topic.dataset.dialogueSession, topicId: topic.dataset.dialogueTopic, revision: Number(topic.dataset.dialogueRevision), selectionGeneration: Number(topic.dataset.dialogueGeneration), npcId: topic.dataset.dialogueNpc }); });
-  document.addEventListener("submit", (event) => { const form = event.target.closest("[data-dialogue-prompt]"); if (!form) return; event.preventDefault(); const submitter = event.submitter; const choices = submitter?.name === "choice" ? [submitter.value] : Array.from(new FormData(form).getAll("choice"), String); answerPrompt(choices); });
+  }, { capture: true, signal });
+  document.addEventListener("click", (event) => { const topic = event.target.closest("[data-dialogue-topic]"); if (!topic || event.target.closest(".dialogue-source-link")) return; event.preventDefault(); chooseTopic({ sessionId: topic.dataset.dialogueSession, topicId: topic.dataset.dialogueTopic, revision: Number(topic.dataset.dialogueRevision), selectionGeneration: Number(topic.dataset.dialogueGeneration), npcId: topic.dataset.dialogueNpc }); }, { signal });
+  document.addEventListener("submit", (event) => { const form = event.target.closest("[data-dialogue-prompt]"); if (!form) return; event.preventDefault(); const submitter = event.submitter; const choices = submitter?.name === "choice" ? [submitter.value] : Array.from(new FormData(form).getAll("choice"), String); answerPrompt(choices); }, { signal });
   const begin = () => {
     if (!chat.dataset.localChatSubject) return;
     const generation = selectionGeneration;
@@ -288,4 +293,8 @@
     selectNpc(people[defaultIndex], buttons[defaultIndex]);
   };
   loadPeople().catch((error) => window.reportStrategicError(error, "load settlement NPCs"));
+  };
+  mount();
+  document.addEventListener("strategic-page-mounted", mount);
+  document.addEventListener("strategic-page-unmounting", () => lifecycle?.abort());
 })();

--- a/crates/strategic-web/static/equipment-toggle.js
+++ b/crates/strategic-web/static/equipment-toggle.js
@@ -5,14 +5,13 @@
     const previous = !checkbox.checked;
     checkbox.disabled = true;
     try {
-      await window.strategicFetch('/api/equipment', {
-        method: 'POST',
+      await window.strategicSubmitMutation('/api/equipment', {
         body: new URLSearchParams({
           inventory_item_id: checkbox.dataset.inventoryItemId,
           equipped: String(checkbox.checked),
         }),
+        originPage: checkbox.closest('#strategic-page'),
       });
-      window.location.reload();
     } catch (_error) {
       checkbox.checked = previous;
       checkbox.disabled = false;

--- a/crates/strategic-web/static/inventory-browser.js
+++ b/crates/strategic-web/static/inventory-browser.js
@@ -616,5 +616,9 @@
   const api = { parsePanelState, serializePanelState, compareValues, normalizeSortValue, rowValue, groupCurrencyRows, groupFoodRows, mountAll, refresh, syncPanelWidth };
   global.strategicInventoryBrowser = api;
   if (typeof module !== "undefined") module.exports = api;
-  if (global.document) { global.addEventListener("DOMContentLoaded", () => mountAll()); global.addEventListener("popstate", () => mountAll()); }
+  if (global.document) {
+    global.addEventListener("DOMContentLoaded", () => mountAll());
+    global.addEventListener("popstate", () => mountAll());
+    global.document.addEventListener("strategic-page-mounted", () => mountAll());
+  }
 })(typeof window === "undefined" ? globalThis : window);

--- a/crates/strategic-web/static/journal-tab.js
+++ b/crates/strategic-web/static/journal-tab.js
@@ -1,89 +1,98 @@
 (() => {
-  const button = document.querySelector("[data-journal-tab]");
-  const grid = document.querySelector(".main-grid");
-  if (!button || !grid) return;
+  let state = null;
+  let generation = 0;
 
-  let originalLeft = null;
-  let originalRight = null;
-  let journalLeft = null;
-  let journalRight = null;
-  let loading = false;
-
+  const close = ({ restoreFocus = true } = {}) => {
+    if (!state) return;
+    if (state.loading) {
+      state.controller?.abort();
+      state = null;
+      return;
+    }
+    const { journalLeft, journalRight, originalLeft, originalRight } = state;
+    state.controller?.abort();
+    journalLeft.replaceWith(originalLeft);
+    journalRight.replaceWith(originalRight);
+    state.button.classList.remove("active");
+    state.button.setAttribute("aria-pressed", "false");
+    state.button.setAttribute("aria-label", "Open journal");
+    if (restoreFocus) state.button.focus();
+    state = null;
+  };
   const selectCase = (caseId) => {
-    journalLeft?.querySelectorAll("[data-journal-case-select]").forEach((tab) => {
+    state?.journalLeft.querySelectorAll("[data-journal-case-select]").forEach((tab) => {
       const selected = tab.dataset.journalCaseSelect === caseId;
       tab.classList.toggle("active", selected);
       tab.setAttribute("aria-selected", String(selected));
     });
-    journalRight?.querySelectorAll("[data-journal-case-panel]").forEach((panel) => {
+    state?.journalRight.querySelectorAll("[data-journal-case-panel]").forEach((panel) => {
       panel.hidden = panel.dataset.journalCasePanel !== caseId;
     });
   };
-
-  const wireCaseTabs = () => {
-    journalLeft?.querySelectorAll("[data-journal-case-select]").forEach((tab) => {
-      tab.addEventListener("click", () => selectCase(tab.dataset.journalCaseSelect));
-    });
-  };
-
-  const closeJournal = ({ restoreFocus = true } = {}) => {
-    if (!originalLeft || !originalRight || !journalLeft || !journalRight) return;
-    journalLeft.replaceWith(originalLeft);
-    journalRight.replaceWith(originalRight);
-    journalLeft = null;
-    journalRight = null;
-    button.classList.remove("active");
-    button.setAttribute("aria-pressed", "false");
-    button.setAttribute("aria-label", "Open journal");
-    if (restoreFocus) button.focus();
-  };
-
-  const openJournal = async () => {
-    if (loading) return;
-    loading = true;
+  const open = async (button) => {
+    if (state?.loading) return;
+    const mine = generation;
+    const grid = button.closest("#strategic-page")?.querySelector(".main-grid");
+    if (!grid) return;
+    const controller = new AbortController();
+    state = { button, grid, loading: true, controller };
     button.setAttribute("aria-busy", "true");
     try {
       const response = await window.strategicFetch("/quests", {
         headers: { Accept: "text/html" },
+        signal: controller.signal,
       });
-      if (!response.ok) throw new Error(`Could not open journal (${response.status})`);
+      if (mine !== generation) return;
       const responseDocument = new DOMParser().parseFromString(await response.text(), "text/html");
       const nextLeft = responseDocument.querySelector("[data-journal-case-index]");
       const nextRight = responseDocument.querySelector("[data-journal-case-log]");
-      if (!nextLeft || !nextRight) {
-        throw new Error("The journal response did not contain both journal rails.");
+      const originalLeft = grid.querySelector(":scope > .left-sidebar");
+      const originalRight = grid.querySelector(":scope > .right-sidebar");
+      if (!nextLeft || !nextRight || !originalLeft || !originalRight) {
+        throw new Error("The journal response did not contain replaceable rails.");
       }
-
-      originalLeft = grid.querySelector(":scope > .left-sidebar");
-      originalRight = grid.querySelector(":scope > .right-sidebar");
-      if (!originalLeft || !originalRight) {
-        throw new Error("The current location does not contain replaceable side rails.");
-      }
-
-      journalLeft = document.importNode(nextLeft, true);
-      journalRight = document.importNode(nextRight, true);
+      const journalLeft = document.importNode(nextLeft, true);
+      const journalRight = document.importNode(nextRight, true);
+      Object.assign(state, {
+        originalLeft, originalRight,
+        journalLeft,
+        journalRight,
+        loading: false,
+      });
       originalLeft.replaceWith(journalLeft);
       originalRight.replaceWith(journalRight);
-      wireCaseTabs();
       button.classList.add("active");
       button.setAttribute("aria-pressed", "true");
       button.setAttribute("aria-label", "Close journal");
-      journalLeft.querySelector("[data-journal-case-select]")?.focus();
+      state.journalLeft.querySelector("[data-journal-case-select]")?.focus();
     } catch (error) {
+      if (mine === generation) state = null;
       window.reportStrategicError?.(error, "open journal");
     } finally {
-      loading = false;
       button.removeAttribute("aria-busy");
     }
   };
 
-  button.addEventListener("click", (event) => {
+  document.addEventListener("click", (event) => {
+    const currentButton = document.querySelector("[data-journal-tab]");
+    const caseTab = event.target.closest("[data-journal-case-select]");
+    if (caseTab && state) {
+      event.preventDefault();
+      selectCase(caseTab.dataset.journalCaseSelect);
+      return;
+    }
+    const button = event.target.closest("[data-journal-tab]");
+    if (button !== currentButton) return;
+    if (!button) return;
     event.preventDefault();
-    if (journalLeft) closeJournal();
-    else openJournal();
+    if (state) close();
+    else open(button);
   });
-
   document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && journalLeft) closeJournal();
+    if (event.key === "Escape" && state) close();
+  });
+  document.addEventListener("strategic-page-unmounting", () => {
+    generation += 1;
+    close({ restoreFocus: false });
   });
 })();

--- a/crates/strategic-web/static/live-regions.js
+++ b/crates/strategic-web/static/live-regions.js
@@ -168,6 +168,16 @@
     window.clearTimeout(refreshTimer);
     dirtyRetry.reset();
   });
+  document.addEventListener("strategic-page-unmounting", () => {
+    navigating = true;
+    generation += 1;
+    window.clearTimeout(refreshTimer);
+    dirtyRetry.reset();
+  });
+  document.addEventListener("strategic-page-mounted", () => {
+    navigating = false;
+    generation += 1;
+  });
 
   document.addEventListener("strategic-live-update", scheduleRefresh);
   document.addEventListener("strategic-live-refresh-requested", scheduleRefresh);

--- a/crates/strategic-web/static/live-state.js
+++ b/crates/strategic-web/static/live-state.js
@@ -21,7 +21,7 @@
     if (kind === "camp") return location.pathname === "/camp";
     if (!kind || !id) return location.pathname === "/characters";
     const encoded = encodeURIComponent(id);
-    if (kind === "quest") return location.pathname.startsWith(`/locations/quest/${encoded}`);
+    if (kind === "case_site") return location.pathname.startsWith(`/locations/case-site/${encoded}`);
     return location.pathname.startsWith(`/locations/settlement/${encoded}`)
       || location.pathname.startsWith(`/settlements/${encoded}`);
   };
@@ -74,6 +74,10 @@
     if (destination.origin === location.origin && destination.href !== location.href) {
       beginNavigation();
     }
+  });
+  document.addEventListener("strategic-page-mounted", () => {
+    navigating = false;
+    synchronizationPending = false;
   });
 
   new MutationObserver(() => {

--- a/crates/strategic-web/static/local-chat.js
+++ b/crates/strategic-web/static/local-chat.js
@@ -102,6 +102,11 @@
 
   window.strategicChat = Object.freeze({ appendChannelRow, appendInfo, createChannelRow });
 
+  let lifecycle;
+  const mount = () => {
+  lifecycle?.abort();
+  lifecycle = new AbortController();
+  const { signal } = lifecycle;
   document.querySelectorAll(".settlement-chat").forEach((panel) => {
     const messages = panel.querySelector(".settlement-chat-messages");
     const filters = [...panel.querySelectorAll("[data-chat-filter]")];
@@ -114,8 +119,10 @@
       const rows = [...messages.querySelectorAll("[data-chat-channel]")];
       applyChannelVisibility(rows, visibleChannels);
     };
-    filters.forEach((filter) => filter.addEventListener("change", applyFilters));
-    new MutationObserver(applyFilters).observe(messages, { childList: true, subtree: true });
+    filters.forEach((filter) => filter.addEventListener("change", applyFilters, { signal }));
+    const observer = new MutationObserver(applyFilters);
+    observer.observe(messages, { childList: true, subtree: true });
+    signal.addEventListener("abort", () => observer.disconnect(), { once: true });
     applyFilters();
   });
 
@@ -131,7 +138,7 @@
     incomingHost.replaceChildren(...players.map((player) => {
       const link = document.createElement("a");
       link.className = "local-chat-incoming-portrait";
-      const match = location.pathname.match(/^\/locations\/(settlement|quest)\/[^/]+/);
+      const match = location.pathname.match(/^\/locations\/(settlement|case-site)\/[^/]+/);
       link.href = `${match?.[0] || ""}/players/${player.id}`;
       link.title = `Talk to ${player.name}`;
       link.textContent = player.name.charAt(0) || "?";
@@ -139,7 +146,7 @@
     }));
   };
   window.queueStrategicInitialLoad(refreshIncoming);
-  document.addEventListener("strategic-live-update", refreshIncoming);
+  document.addEventListener("strategic-live-update", refreshIncoming, { signal });
 
   const chat = document.querySelector(".settlement-chat[data-local-chat-kind][data-local-chat-subject]");
   if (!chat) return;
@@ -231,13 +238,17 @@
     const response = await window.strategicFetch(endpoint, { method: "POST", headers: { "Content-Type": "application/x-www-form-urlencoded" }, body: form });
     if (response.ok) { input.value = ""; await refresh(); }
   };
-  send?.addEventListener("click", submit);
-  input?.addEventListener("keydown", (event) => { if (event.key === "Enter") { event.preventDefault(); submit(); } });
+  send?.addEventListener("click", submit, { signal });
+  input?.addEventListener("keydown", (event) => { if (event.key === "Enter") { event.preventDefault(); submit(); } }, { signal });
   window.queueStrategicInitialLoad(refresh).finally(() => {
     chat.dataset.localChatReady = "true";
     chat.dispatchEvent(new Event("local-chat-ready"));
   });
-  document.addEventListener("strategic-live-update", refresh);
-  chat.addEventListener("local-chat-subject-changed", () => { lastSignature = ""; refresh(); });
+  document.addEventListener("strategic-live-update", refresh, { signal });
+  chat.addEventListener("local-chat-subject-changed", () => { lastSignature = ""; refresh(); }, { signal });
 
+  };
+  mount();
+  document.addEventListener("strategic-page-mounted", mount);
+  document.addEventListener("strategic-page-unmounting", () => lifecycle?.abort());
 })();

--- a/crates/strategic-web/static/party-notifications.js
+++ b/crates/strategic-web/static/party-notifications.js
@@ -1,5 +1,5 @@
 (() => {
-  const baseTitle = document.title.replace(/^\(\d+\)\s*/, "");
+  let baseTitle = document.title.replace(/^\(\d+\)\s*/, "");
 
   const gameIcon = (name) => {
     const icon = document.createElement("span");
@@ -116,6 +116,10 @@
     window.setTimeout(() => notice.remove(), 3000);
   }
   document.addEventListener("strategic-live-update", refreshPartyNotifications);
+  document.addEventListener("strategic-page-mounted", () => {
+    baseTitle = document.title.replace(/^\(\d+\)\s*/, "");
+    refreshPartyNotifications();
+  });
   document.addEventListener("strategic-live-regions-refreshed", (event) => {
     if (event.detail?.regions?.includes("party-portraits")) refreshPartyNotifications();
   });

--- a/crates/strategic-web/static/party-recruitment.js
+++ b/crates/strategic-web/static/party-recruitment.js
@@ -323,6 +323,10 @@
 
   window.queueStrategicInitialLoad(loadRecruitment).catch((error) => window.reportStrategicError(error, "party recruitment"));
   document.addEventListener("strategic-live-update", () => loadRecruitment().catch((error) => window.reportStrategicError(error, "party recruitment")));
+  document.addEventListener("strategic-page-mounted", () => {
+    recruitmentSignature = "";
+    loadRecruitment().catch((error) => window.reportStrategicError(error, "party recruitment"));
+  });
   document.addEventListener("strategic-live-regions-refreshed", () => {
     recruitmentSignature = "";
     loadRecruitment().catch((error) => window.reportStrategicError(error, "party recruitment"));

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -647,3 +647,8 @@ if (document.readyState === "loading") {
   mountInventoryBulkControls();
 }
 document.addEventListener("strategic-live-regions-refreshed", () => refreshInventoryPanel(document));
+document.addEventListener("strategic-page-mounted", () => {
+  initializeProvisioningDraft();
+  mountInventoryBulkControls();
+  refreshInventoryPanel(document);
+});

--- a/crates/strategic-web/static/physical-evidence.js
+++ b/crates/strategic-web/static/physical-evidence.js
@@ -1,6 +1,11 @@
 (() => {
   "use strict";
 
+  let lifecycle;
+  const mount = () => {
+  lifecycle?.abort();
+  lifecycle = new AbortController();
+  const { signal } = lifecycle;
   const strip = document.querySelector("[data-evidence-strip]");
   if (!strip) return;
   const stage = document.querySelector("[data-evidence-description]");
@@ -211,7 +216,7 @@
     } catch (error) {
       window.reportStrategicError(error, "inspect physical evidence");
     }
-  });
+  }, { signal });
 
   // Physical evidence has clickable inspection topics rather than free-form
   // speech. Keep the ordinary chat composer visibly unavailable.
@@ -221,4 +226,8 @@
   }
   if (send) send.disabled = true;
   load().catch((error) => window.reportStrategicError(error, "load physical evidence"));
+  };
+  mount();
+  document.addEventListener("strategic-page-mounted", mount);
+  document.addEventListener("strategic-page-unmounting", () => lifecycle?.abort());
 })();

--- a/crates/strategic-web/static/rest-duration.js
+++ b/crates/strategic-web/static/rest-duration.js
@@ -222,6 +222,7 @@
 
   window.strategicRestDuration = { isDirty, mountAll };
   mountAll();
+  document.addEventListener("strategic-page-mounted", () => mountAll());
   document.addEventListener("strategic-time-ready", (event) => {
     mountAll();
     syncTime(document, event.detail.characterMinutes);

--- a/crates/strategic-web/static/service-quests.js
+++ b/crates/strategic-web/static/service-quests.js
@@ -9,11 +9,12 @@ if (typeof module !== "undefined") module.exports = { serviceQuestTabState };
 
 (() => {
   if (typeof document === "undefined") return;
-  const services = document.querySelector("[data-settlement-id]");
-  if (!services) return;
-  const settlementId = services.dataset.settlementId;
-  const chat = document.querySelector("[data-service-quest-id]");
-  const refreshServiceQuests = () => window.strategicBackgroundFetch(
+  const refreshServiceQuests = () => {
+    const services = document.querySelector("#strategic-page [data-settlement-id]");
+    if (!services) return Promise.resolve();
+    const settlementId = services.dataset.settlementId;
+    const chat = document.querySelector("#strategic-page [data-service-quest-id]");
+    return window.strategicBackgroundFetch(
     "service-quests", `/api/settlements/${encodeURIComponent(settlementId)}/service-quests`,
     { headers: { Accept: "application/json" } },
   ).then((response) => (response.ok ? response.json() : { quests: [], recruitment: [] }))
@@ -64,6 +65,8 @@ if (typeof module !== "undefined") module.exports = { serviceQuestTabState };
         right.prepend(section);
       }
     }).catch((error) => window.reportStrategicError(error, "service quests"));
+  };
   window.queueStrategicInitialLoad(refreshServiceQuests);
   document.addEventListener("strategic-live-update", refreshServiceQuests);
+  document.addEventListener("strategic-page-mounted", refreshServiceQuests);
 })();

--- a/crates/strategic-web/static/strategic-map.js
+++ b/crates/strategic-web/static/strategic-map.js
@@ -325,5 +325,6 @@
   const initializeStrategicMaps = (root = document) => root.querySelectorAll("[data-strategic-map]").forEach((map) => initializeMap(map));
   globalThis.StrategicMap = { boxesOverlap, hitTargetRadius, initializeMap, labelPriorityThreshold, layoutLabels, layoutSettlementPins, parentTileFallback, parseViewBox, pannedView, populationLevelThreshold, renderTiles, resizedView, scaleHitTargets, tileZoom, viewForElement, visibleTileRange, zoomedView };
   initializeStrategicMaps();
+  document.addEventListener("strategic-page-mounted", () => initializeStrategicMaps());
   document.addEventListener("strategic-live-regions-refreshed", () => initializeStrategicMaps());
 })();

--- a/crates/strategic-web/static/strategic-mutations.js
+++ b/crates/strategic-web/static/strategic-mutations.js
@@ -1,0 +1,115 @@
+(() => {
+  let generation = 0;
+  let pending;
+
+  const hardBoundary = (form, url) =>
+    form.target && form.target.toLowerCase() !== "_self" ||
+    form.dataset.hardNavigation !== undefined ||
+    url.origin !== location.origin ||
+    window.strategicBoundaryUrl?.(url);
+
+  const notice = (message) => {
+    let region = document.querySelector("[data-strategic-mutation-status]");
+    if (!region) {
+      region = document.createElement("div");
+      region.dataset.strategicMutationStatus = "true";
+      region.className = "strategic-notice";
+      region.setAttribute("role", "alert");
+      document.querySelector("#strategic-page main")?.prepend(region);
+    }
+    region.textContent = message;
+  };
+
+  const submitMutation = async (url, { body, originPage = document.querySelector("#strategic-page") } = {}) => {
+    const mine = ++generation;
+    const restore = {
+      strategicScroll: [scrollX, scrollY],
+      strategicFocus: window.strategicFocusKey?.(document.activeElement) || null,
+    };
+    pending?.abort();
+    pending = new AbortController();
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "X-Strategic-Navigation": "true",
+        "X-Strategic-Current-Url": `${location.pathname}${location.search}${location.hash}`,
+      },
+      body,
+      credentials: "same-origin",
+      redirect: "error",
+      signal: pending.signal,
+    });
+    if (mine !== generation || originPage !== document.querySelector("#strategic-page")) return false;
+    const hardTarget = response.headers.get("X-Strategic-Hard-Navigation");
+    if (hardTarget) {
+      const target = new URL(hardTarget, location.href);
+      if (target.origin !== location.origin && !["http:", "https:"].includes(target.protocol)) {
+        throw new Error("The server returned an unsafe navigation target.");
+      }
+      location.assign(target);
+      return true;
+    }
+    if (!response.ok) {
+      throw new Error(response.status === 409
+        ? "The world changed before that action completed. Review the page and try again."
+        : "The action could not be completed.");
+    }
+    const text = await response.text();
+    if (mine !== generation || originPage !== document.querySelector("#strategic-page")) return false;
+    const parsed = new DOMParser().parseFromString(text, "text/html");
+    const replacement = parsed.querySelector("#strategic-page");
+    const profile = response.headers.get("X-Strategic-Script-Profile");
+    const canonical = new URL(
+      response.headers.get("X-Strategic-Canonical-Url") || location.href,
+      location.href,
+    );
+    if (window.strategicBoundaryUrl?.(canonical) ||
+        profile !== "strategic" || replacement?.dataset.scriptProfile !== "strategic") {
+      location.assign(canonical);
+      return true;
+    }
+    if (response.headers.get("X-Strategic-Response") !== "root" || !replacement) {
+      throw new Error("The server did not return the negotiated mutation root.");
+    }
+    window.strategicCommitPage({
+      replacement,
+      title: `${replacement.dataset.pageTitle} - Adventure Simulator`,
+      finalUrl: canonical,
+      historyMode: response.headers.get("X-Strategic-Redirected") === "true" ? "push" : "replace",
+      restore: response.headers.get("X-Strategic-Redirected") === "true" ? null : restore,
+    });
+    document.dispatchEvent(new CustomEvent("strategic-mutation-complete", {
+      detail: { canonicalUrl: canonical.href, status: response.status },
+    }));
+    return true;
+  };
+
+  document.addEventListener("submit", async (event) => {
+    const form = event.target.closest?.("#strategic-page form[method='post' i]");
+    if (!form || event.defaultPrevented) return;
+    const submitter = event.submitter;
+    const url = new URL(submitter?.formAction || form.action, location.href);
+    if (hardBoundary(form, url)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if (form.dataset.strategicSubmitting) return;
+    form.dataset.strategicSubmitting = "true";
+    const body = new URLSearchParams(new FormData(form));
+    if (submitter?.name) body.append(submitter.name, submitter.value);
+    try {
+      await submitMutation(url, { body, originPage: form.closest("#strategic-page") });
+    } catch (error) {
+      if (error.name !== "AbortError") {
+        notice(error.message || "The action could not be completed.");
+        window.reportStrategicError?.(error, "strategic action");
+      }
+    } finally {
+      delete form.dataset.strategicSubmitting;
+    }
+  }, true);
+  document.addEventListener("strategic-page-unmounting", () => {
+    generation += 1;
+    pending?.abort();
+  });
+  window.strategicSubmitMutation = submitMutation;
+})();

--- a/crates/strategic-web/static/strategic-navigation.js
+++ b/crates/strategic-web/static/strategic-navigation.js
@@ -1,0 +1,189 @@
+(() => {
+  const HEADER = "X-Strategic-Navigation";
+  let generation = 0;
+  let pending;
+  let announced;
+
+  const page = () => document.querySelector("#strategic-page");
+  const boundaryUrl = (url) => url.origin !== location.origin ||
+    url.pathname.startsWith("/characters") || url.pathname === "/map/data-license" ||
+    url.pathname.startsWith("/missions/") || url.pathname.startsWith("/tactical/");
+  const focusKey = (element) => {
+    if (!element || element === document.body) return null;
+    if (element.id) return { kind: "id", value: element.id };
+    const service = element.closest?.("[data-service-id]");
+    if (service) return { kind: "service", value: service.dataset.serviceId || "" };
+    const equipment = element.closest?.("[data-equipment-toggle]");
+    if (equipment) return { kind: "equipment", value: equipment.dataset.inventoryItemId || "" };
+    const control = element.closest?.("button,input,select,textarea");
+    if (control?.name) {
+      const formUrl = control.form ? new URL(control.form.action, location.href) : null;
+      return {
+        kind: "control",
+        name: control.name,
+        tag: control.tagName,
+        form: formUrl && formUrl.origin === location.origin ? formUrl.pathname : "",
+      };
+    }
+    const link = element.closest?.("a[href]");
+    if (link) {
+      const url = new URL(link.href, location.href);
+      if (url.origin === location.origin) return { kind: "href", value: `${url.pathname}${url.search}${url.hash}` };
+    }
+    return null;
+  };
+  const restoreFocus = (root, key) => {
+    let target = null;
+    if (key?.kind === "id") target = document.getElementById(key.value);
+    if (key?.kind === "service") {
+      target = [...root.querySelectorAll("[data-service-id]")]
+        .find((element) => (element.dataset.serviceId || "") === key.value);
+    }
+    if (key?.kind === "href") {
+      target = [...root.querySelectorAll("a[href]")].find((link) => {
+        const url = new URL(link.href, location.href);
+        return `${url.pathname}${url.search}${url.hash}` === key.value;
+      });
+    }
+    if (key?.kind === "equipment") {
+      target = [...root.querySelectorAll("[data-equipment-toggle]")]
+        .find((element) => (element.dataset.inventoryItemId || "") === key.value);
+    }
+    if (key?.kind === "control") {
+      target = [...root.querySelectorAll("button,input,select,textarea")].find((element) => {
+        const formUrl = element.form ? new URL(element.form.action, location.href) : null;
+        return element.name === key.name && element.tagName === key.tag &&
+          (formUrl?.pathname || "") === key.form;
+      });
+    }
+    target ||= root.querySelector("main h1, main h2");
+    if (target) {
+      if (target.matches("h1,h2") && !target.hasAttribute("tabindex")) target.tabIndex = -1;
+      target.focus({ preventScroll: true });
+    }
+  };
+  const announce = (message) => {
+    if (!announced) {
+      announced = document.createElement("div");
+      announced.className = "sr-only";
+      announced.setAttribute("aria-live", "polite");
+      document.body.append(announced);
+    }
+    announced.textContent = message;
+  };
+  const saveScroll = () => history.replaceState(
+    {
+      ...(history.state || {}),
+      strategicScroll: [scrollX, scrollY],
+      strategicFocus: focusKey(document.activeElement),
+    }, "", location.href,
+  );
+  const hardBoundary = (link, url) =>
+    link.hasAttribute("download") || link.dataset.hardNavigation !== undefined ||
+    link.target && link.target.toLowerCase() !== "_self" ||
+    url.pathname === "/live" || boundaryUrl(url);
+
+  const commitPage = ({ replacement, title, finalUrl, historyMode = "push", restore = null, alreadyUnmounted = false }) => {
+    const current = page();
+    if (!current) return false;
+    if (!alreadyUnmounted) document.dispatchEvent(new CustomEvent("strategic-page-unmounting"));
+    current.replaceWith(replacement);
+    document.title = title || `${replacement.dataset.pageTitle} - Adventure Simulator`;
+    if (historyMode === "push") history.pushState({ strategicScroll: [0, 0] }, "", finalUrl);
+    else if (historyMode === "replace") history.replaceState({ strategicScroll: [0, 0] }, "", finalUrl);
+    document.dispatchEvent(new CustomEvent("strategic-page-mounted"));
+    if (restore) {
+      scrollTo(...(restore.strategicScroll || [0, 0]));
+      restoreFocus(replacement, restore.strategicFocus);
+    } else {
+      const fragmentTarget = finalUrl.hash && document.getElementById(decodeURIComponent(finalUrl.hash.slice(1)));
+      if (fragmentTarget) fragmentTarget.scrollIntoView();
+      else scrollTo(0, 0);
+      restoreFocus(replacement, null);
+    }
+    return true;
+  };
+
+  async function navigate(url, { historyMode = "push", restore = null } = {}) {
+    const current = page();
+    if (!current) return location.assign(url);
+    const mine = ++generation;
+    pending?.abort();
+    pending = new AbortController();
+    saveScroll();
+    current.setAttribute("aria-busy", "true");
+    document.dispatchEvent(new CustomEvent("strategic-soft-navigation-start"));
+    document.dispatchEvent(new CustomEvent("strategic-page-unmounting"));
+    announce("Loading");
+    try {
+      const response = await fetch(url, {
+        headers: { [HEADER]: "true", Accept: "text/html" },
+        credentials: "same-origin",
+        signal: pending.signal,
+        redirect: "follow",
+      });
+      if (mine !== generation) return;
+      const text = await response.text();
+      const parsed = new DOMParser().parseFromString(text, "text/html");
+      const replacement = parsed.querySelector("#strategic-page");
+      if (!response.ok || !replacement) {
+        const safe = current.cloneNode(false);
+        safe.innerHTML = `<main class="center-content strategic-notice-main"><section class="strategic-notice" role="alert"><h2>Unable to open this page</h2><p></p><a class="btn btn-primary" href="/">Return</a></section></main>`;
+        safe.querySelector("p").textContent = response.status === 404
+          ? "That destination is no longer available."
+          : "The destination could not be loaded. Your current session is still active.";
+        current.replaceWith(safe);
+        document.dispatchEvent(new CustomEvent("strategic-page-mounted"));
+        announce("Unable to open page");
+        return;
+      }
+      const profile = response.headers.get("X-Strategic-Script-Profile");
+      if (response.headers.get("X-Strategic-Response") !== "root" ||
+          profile !== "strategic" || replacement.dataset.scriptProfile !== "strategic") {
+        location.assign(response.url || url);
+        return;
+      }
+      const finalUrl = new URL(
+        response.headers.get("X-Strategic-Canonical-Url") || response.url || url,
+        location.href,
+      );
+      if (boundaryUrl(finalUrl)) {
+        location.assign(finalUrl);
+        return;
+      }
+      if (finalUrl.origin !== new URL(response.url || url, location.href).origin) {
+        throw new Error("The server did not return the negotiated strategic contract");
+      }
+      const requestedHash = new URL(response.url || url, location.href).hash || new URL(url, location.href).hash;
+      if (!finalUrl.hash && requestedHash) finalUrl.hash = requestedHash;
+      commitPage({ replacement, title: parsed.title, finalUrl, historyMode, restore, alreadyUnmounted: true });
+      document.dispatchEvent(new CustomEvent("strategic-soft-navigation-complete"));
+      announce("Page loaded");
+    } catch (error) {
+      if (error.name === "AbortError") return;
+      location.assign(url);
+    }
+  }
+
+  document.addEventListener("click", (event) => {
+    if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey ||
+        event.shiftKey || event.altKey) return;
+    const link = event.target.closest("a[href]");
+    if (!link) return;
+    const raw = link.getAttribute("href");
+    if (!raw || raw.startsWith("#")) return;
+    const url = new URL(link.href, location.href);
+    if (hardBoundary(link, url)) return;
+    event.preventDefault();
+    navigate(url.href);
+  });
+  addEventListener("popstate", (event) => navigate(location.href, {
+    historyMode: "none", restore: event.state || { strategicScroll: [0, 0] },
+  }));
+  addEventListener("pagehide", () => pending?.abort(), { once: true });
+  if (!history.state?.strategicScroll) history.replaceState({ strategicScroll: [scrollX, scrollY] }, "");
+  window.strategicNavigate = navigate;
+  window.strategicCommitPage = commitPage;
+  window.strategicBoundaryUrl = boundaryUrl;
+  window.strategicFocusKey = focusKey;
+})();

--- a/crates/strategic-web/static/strategic-time.js
+++ b/crates/strategic-web/static/strategic-time.js
@@ -77,7 +77,7 @@
   window.strategicTimeLighting = lighting;
   window.strategicTimeApplyLighting = applyLighting;
 
-  window.queueStrategicInitialLoad(() => window.strategicBackgroundFetch("strategic-time", "/time"))
+  const refreshTime = () => window.queueStrategicInitialLoad(() => window.strategicBackgroundFetch("strategic-time", "/time"))
     .then((response) => response.json())
     .then(({ character_minutes: characterMinutes, official_minutes: officialMinutes }) => {
       window.strategicCharacterMinutes = characterMinutes;
@@ -91,4 +91,6 @@
       }));
     })
     .catch((error) => window.reportStrategicError(error, "strategic time"));
+  refreshTime();
+  document.addEventListener("strategic-page-mounted", refreshTime);
 })();

--- a/crates/strategic-web/static/training-schedule.js
+++ b/crates/strategic-web/static/training-schedule.js
@@ -378,6 +378,7 @@
   }
 
   mountSchedules();
+  document.addEventListener('strategic-page-mounted', () => mountSchedules());
   document.addEventListener('strategic-live-regions-refreshed', (event) => {
     if (!event.detail?.regions || event.detail.regions.includes('left-sidebar')) mountSchedules();
   });

--- a/crates/strategic-web/static/travel-planner.js
+++ b/crates/strategic-web/static/travel-planner.js
@@ -534,5 +534,6 @@
   };
 
   initializeTravelPlanner();
+  document.addEventListener("strategic-page-mounted", initializeTravelPlanner);
   document.addEventListener("strategic-live-regions-refreshed", (event) => { if (event.detail?.regions?.includes("right-sidebar")) initializeTravelPlanner(); });
 })();

--- a/crates/strategic-web/tests/icon-rendering.test.cjs
+++ b/crates/strategic-web/tests/icon-rendering.test.cjs
@@ -110,7 +110,7 @@ test("merchant provisioning initializes only once the Party tab DOM exists", () 
   const layout = fs.readFileSync(path.join(staticRoot, "src", "templates", "layout.rs"), "utf8");
   assert.match(layout, /party-trade\.js[^\n]+defer/);
   assert.match(trade, /DOMContentLoaded", initializeProvisioningDraft, \{ once: true \}/);
-  assert.match(trade, /partyTab\.click\(\)/);
+  assert.match(trade, /selectMerchantInventoryScope\(partyTab\)/);
   assert.match(trade, /\["travel_ration", parseQuantity\("provision_rations"\)\]/);
   assert.match(trade, /\["waterskin", parseQuantity\("provision_waterskins"\)\]/);
 });

--- a/crates/strategic-web/tests/strategic-navigation.test.cjs
+++ b/crates/strategic-web/tests/strategic-navigation.test.cjs
@@ -1,0 +1,76 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const vm = require("node:vm");
+
+test("soft navigation declares the negotiated, lifecycle, history, and cancellation contract", () => {
+  const source = fs.readFileSync("crates/strategic-web/static/strategic-navigation.js", "utf8");
+  for (const token of [
+    "X-Strategic-Navigation", "strategic-page-unmounting", "strategic-page-mounted",
+    "strategic-soft-navigation-start", "strategic-soft-navigation-complete",
+    "AbortController", "popstate", "strategicScroll", "aria-busy", "response.url",
+  ]) assert.ok(source.includes(token), token);
+});
+
+test("hard navigation boundaries and native anchor affordances remain explicit", () => {
+  const source = fs.readFileSync("crates/strategic-web/static/strategic-navigation.js", "utf8");
+  for (const token of [
+    "download", "hardNavigation", "_self", "/characters", "/map/data-license",
+    "/missions/", "/tactical/", "event.metaKey", "event.ctrlKey", "raw.startsWith(\"#\")",
+  ]) assert.ok(source.includes(token), token);
+});
+
+test("page lifecycle resets permanent services and remounts idempotent modules", () => {
+  const read = (name) => fs.readFileSync(`crates/strategic-web/static/${name}.js`, "utf8");
+  for (const name of [
+    "background-fetch", "building-state", "cooking", "dialogue-client",
+    "inventory-browser", "live-regions", "local-chat",
+    "party-notifications", "party-recruitment", "physical-evidence",
+    "rest-duration", "service-quests", "strategic-map", "strategic-time",
+    "training-schedule", "travel-planner", "chat-resize",
+  ]) {
+    assert.match(read(name), /strategic-page-mounted/, `${name} remount`);
+  }
+  assert.match(read("background-fetch"), /leavingPage = false/);
+  assert.match(read("live-regions"), /navigating = false/);
+  assert.match(read("building-state"), /observer\?\.disconnect/);
+  assert.match(read("local-chat"), /lifecycle\?\.abort/);
+  assert.match(read("journal-tab"), /strategic-page-unmounting/);
+  assert.match(read("character-action-dialog"), /const mount = \(\) =>/);
+  assert.match(read("character-action-dialog"), /const unmount = \(\) =>/);
+  assert.match(read("character-action-dialog"), /strategic-page-mounted/);
+  assert.match(read("character-action-dialog"), /\{ signal \}/);
+  const resize = read("chat-resize");
+  for (const token of [
+    "--chat-height", "--chat-panel-height", "CHAT_BOTTOM_GAP",
+    "chat-resizing", "is-resizing", "setPointerCapture",
+  ]) assert.ok(resize.includes(token), `chat resize ${token}`);
+});
+
+test("negotiated mutations cannot follow a redirect with a hidden GET", () => {
+  const source = fs.readFileSync("crates/strategic-web/static/strategic-mutations.js", "utf8");
+  assert.match(source, /method: "POST"/);
+  assert.match(source, /"X-Strategic-Navigation": "true"/);
+  assert.match(source, /redirect: "error"/);
+  assert.match(source, /strategicCommitPage/);
+  assert.match(source, /X-Strategic-Hard-Navigation/);
+  assert.match(source, /\["http:", "https:"\]\.includes\(target\.protocol\)/);
+  assert.match(source, /target\.origin !== location\.origin/);
+  assert.match(source, /unsafe navigation target/);
+  assert.match(source, /originPage !== document\.querySelector/);
+  assert.doesNotMatch(source, /strategic-live-refresh-requested/);
+});
+
+test("negotiated navigation validates root metadata and never evaluates scripts", () => {
+  const source = fs.readFileSync("crates/strategic-web/static/strategic-navigation.js", "utf8");
+  assert.match(source, /X-Strategic-Response/);
+  assert.match(source, /dataset\.scriptProfile/);
+  assert.match(source, /querySelector\("#strategic-page"\)/);
+  assert.doesNotMatch(source, /\beval\(|new Function|createElement\(["']script/);
+  assert.match(source, /profile !== "strategic"/);
+  assert.match(source, /strategicBoundaryUrl/);
+  assert.match(source, /kind: "service"/);
+  assert.match(source, /kind: "control"/);
+  assert.match(source, /kind: "equipment"/);
+  assert.match(source, /restoreFocus\(replacement, restore\.strategicFocus\)/);
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -692,3 +692,25 @@ The final terrain pack is also the single authority for exact 1 km cultivated
 state. Strategic-web may attest a bounded current-location sample through its
 authenticated digest-pinned gateway; reducers re-derive location and reject
 direct, stale, or mismatched attestations.
+### Strategic document shell
+
+Strategic pages render as complete server-authoritative HTML documents for direct
+requests and no-JavaScript clients. In an active strategic session, one
+document-scoped `/live` stream remains outside the stable `#strategic-page`
+morph root. Eligible same-origin links are progressively enhanced with a
+negotiated GET (`X-Strategic-Navigation: true`); the returned server markup
+replaces that root while retaining native `href` fallbacks. Page scripts use
+`strategic-page-unmounting` and `strategic-page-mounted` for per-page cleanup
+and setup. Character selection, licences, and tactical transitions remain hard
+document navigations.
+
+Strategic POST forms are also progressively enhanced. The browser marks the
+request with the same negotiation header. Negotiated GETs contain only the
+stable root plus its title/profile metadata; ordinary GETs remain complete
+documents. An authoritative reducer still performs the mutation. The gateway
+then renders the reducer's local redirect destination through a middleware-free
+internal router and returns that strategic root in the original POST response,
+so the browser performs no follow-up GET and never commits a new URL over old
+page chrome. Entry, licence, mission, tactical, external, and non-strategic
+destinations remain deliberate hard navigations. Direct form submissions retain
+their ordinary `303` and complete HTML fallback.

--- a/docs/llm/PROJECT_MAP.md
+++ b/docs/llm/PROJECT_MAP.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or wiki document before changing a subsystem.
 
-## Files (1256)
+## Files (1259)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1102,6 +1102,8 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/static/service-quests.js` — Repository support file.
 - `crates/strategic-web/static/strategic-condition.js` — Repository support file.
 - `crates/strategic-web/static/strategic-map.js` — Repository support file.
+- `crates/strategic-web/static/strategic-mutations.js` — Repository support file.
+- `crates/strategic-web/static/strategic-navigation.js` — Repository support file.
 - `crates/strategic-web/static/strategic-time.js` — Repository support file.
 - `crates/strategic-web/static/styles/timber-framed/background/city/coastal.png` — Binary game or UI asset.
 - `crates/strategic-web/static/styles/timber-framed/background/city/inland.png` — Binary game or UI asset.
@@ -1170,6 +1172,7 @@ development, or wiki document before changing a subsystem.
 - `crates/strategic-web/tests/rest-duration.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/service-quests.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/strategic-map-behavior.test.cjs` — Repository support file.
+- `crates/strategic-web/tests/strategic-navigation.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/tooltips.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/training-schedule.test.cjs` — Repository support file.
 - `crates/strategic-web/tests/travel-planner-behavior.test.cjs` — Repository support file.


### PR DESCRIPTION
Closes #243

## Summary
- add negotiated, history-aware soft navigation for the strategic web shell while preserving ordinary full-document and no-JavaScript behavior
- keep one stable `/live` stream outside the replaceable page root and remount page scripts through an idempotent lifecycle
- complete negotiated POST mutations in one external HTTP transaction, including redirect rendering, cookie propagation, hard-boundary handling, cancellation, and focus/scroll restoration
- correct the case-site live-query mismatch and document the navigation boundary

## Review
- independent correctness review completed; all high/medium findings remediated
- independent security review completed; cookie propagation and hard-target scheme validation remediated with regression coverage

## Verification
- `cargo test -p strategic-web --quiet` — 274 passed
- focused Node navigation/lifecycle tests — 13 passed
- `python scripts/update_project_map.py --check`
- `git diff --check`
- generated SpacetimeDB client bindings unchanged

## Live demo
Verified in a disposable isolated profile at `127.0.0.1:24301` with cached world data loaded (1,228 nodes, 1,745 edges, 714 settlements). Settlement → residences → browser back/forward → journal retained one `#strategic-page` and one `#strategic-live-stream`, updated URL/title/content, completed a developer-mode POST in place, and produced no browser warnings/errors.

The full-world import loaded the geography but its final consistency check rejected the profile's pre-seeded Riverdale demo industry graph; this remained confined to the disposable profile and did not affect navigation verification.