### PR TITLE
Audit and rebalance strategic gameplay

### DIFF
--- a/crates/adventuresim-core/src/capability.rs
+++ b/crates/adventuresim-core/src/capability.rs
@@ -335,7 +335,7 @@ pub fn evaluate_capabilities(
         anatomy,
         knife,
         tailoring,
-        surgery: (anatomy + knife + tailoring) / 3.0,
+        surgery: ((anatomy + knife) * 0.5).min((anatomy + tailoring) * 0.5),
         command: skills
             .skill_check_by_parts(
                 Skill::Command,
@@ -508,6 +508,16 @@ mod tests {
         let current = [2.0, 4.0, 3.0];
         assert!((aggregate_party_check(current) - (4.0 + 1.5 + 2.0 / 3.0)).abs() < 0.001);
         assert!((aggregate_party_contribution(&current, 5.0) - 7.0 / 3.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn surgery_coverage_requires_both_procedure_pairs() {
+        let coverage = |anatomy: f32, knife: f32, tailoring: f32| {
+            ((anatomy + knife) * 0.5).min((anatomy + tailoring) * 0.5)
+        };
+        assert_eq!(coverage(0.0, 5.0, 5.0), 2.5);
+        assert_eq!(coverage(5.0, 5.0, 0.0), 2.5);
+        assert_eq!(coverage(4.0, 4.0, 4.0), 4.0);
     }
 
     #[test]

--- a/crates/adventuresim-core/src/food.rs
+++ b/crates/adventuresim-core/src/food.rs
@@ -269,6 +269,49 @@ pub fn cooking_duration_minutes(
     setup.checked_add(slowest)?.checked_add(batch)
 }
 
+/// Expertise shortens setup and batch handling, never the ingredient safety
+/// interval. Rank five removes at most thirty percent of overhead.
+pub fn cooking_duration_minutes_for_check(
+    method: CookingMethod,
+    safety_minutes: &[u32],
+    total_mass_kg: f32,
+    cooking_check: f32,
+) -> Option<u32> {
+    let baseline = cooking_duration_minutes(method, safety_minutes, total_mass_kg)?;
+    let safety = safety_minutes.iter().copied().max()?;
+    let overhead = baseline.saturating_sub(safety);
+    let check = if cooking_check.is_finite() {
+        cooking_check.clamp(0.0, 5.0)
+    } else {
+        0.0
+    };
+    safety.checked_add((overhead as f32 * (1.0 - 0.06 * check)).ceil() as u32)
+}
+
+pub fn cooked_nutrition_retention(cooking_check: f32) -> f32 {
+    let check = if cooking_check.is_finite() {
+        cooking_check.clamp(0.0, 5.0)
+    } else {
+        0.0
+    };
+    0.95 + 0.008 * check
+}
+
+pub fn cooked_quality_multiplier(cooking_check: f32) -> f32 {
+    let check = if cooking_check.is_finite() {
+        cooking_check.clamp(0.0, 5.0)
+    } else {
+        0.0
+    };
+    0.95 + 0.03 * check
+}
+
+/// Cooked output is terminal preparation state. Allowing it back into the
+/// ingredient pipeline would repeatedly multiply retained value and nutrition.
+pub fn is_cookable_ingredient(item_id: &str) -> bool {
+    item_id != "cooked_meal"
+}
+
 pub fn travel_consumption(deficit_kcal: f32, available_kcal: f32) -> f32 {
     if !deficit_kcal.is_finite() || !available_kcal.is_finite() {
         return 0.0;
@@ -339,6 +382,30 @@ mod tests {
             cooking_duration_minutes(CookingMethod::Roast, &[5], 4.0)
                 > cooking_duration_minutes(CookingMethod::Roast, &[5], 0.5)
         );
+    }
+    #[test]
+    fn cooking_skill_only_reduces_overhead_and_bounds_quality() {
+        let safety = [22];
+        let novice =
+            cooking_duration_minutes_for_check(CookingMethod::Roast, &safety, 4.0, 0.0).unwrap();
+        let master =
+            cooking_duration_minutes_for_check(CookingMethod::Roast, &safety, 4.0, 5.0).unwrap();
+        assert!(master < novice);
+        assert!(master >= 22);
+        assert_eq!(cooked_nutrition_retention(-1.0), 0.95);
+        assert!((cooked_nutrition_retention(5.0) - 0.99).abs() < f32::EPSILON);
+        assert_eq!(cooked_quality_multiplier(f32::NAN), 0.95);
+        assert!((cooked_quality_multiplier(5.0) - 1.10).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn cooked_output_cannot_reenter_the_value_multiplier() {
+        assert!(is_cookable_ingredient("hazelnuts"));
+        assert!(!is_cookable_ingredient("cooked_meal"));
+        let ingredient_value = 100.0;
+        let once = ingredient_value * cooked_quality_multiplier(5.0);
+        assert_eq!(once, 110.0);
+        assert!(!is_cookable_ingredient("cooked_meal"));
     }
     #[test]
     fn travel_never_creates_surplus_but_meals_can() {

--- a/crates/adventuresim-core/src/foraging.rs
+++ b/crates/adventuresim-core/src/foraging.rs
@@ -13,6 +13,9 @@ pub const CULTIVATED_STEALTH_DC_MILLIRANK: u16 = 1_750;
 pub const SETTLEMENT_STEALTH_DC_MILLIRANK: u16 = 2_500;
 pub const DURATION_STEALTH_DC_PER_HOUR: u16 = 75;
 pub const MAX_TARGETS: usize = 8;
+/// Food searches are calibrated so an eight-hour low-skill search in an ideal
+/// habitat can approximately replace that interval's metabolic expenditure.
+pub const FOOD_DISCOVERY_RATE_PERMILLE: u64 = 1_750;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -208,13 +211,23 @@ pub fn resource(item_id: &str) -> Option<&'static ForageResource> {
 }
 
 pub fn available(resource: &ForageResource, environment: ForageEnvironment) -> bool {
-    resource.biomes.iter().any(|biome| match biome {
-        Plains => environment.terrain.plains > 0,
-        Forest => environment.terrain.forest > 0,
-        Hills => environment.terrain.hills > 0,
-        RiverWetGround => environment.river_or_wet_ground,
-        SeaCoast => environment.sea_or_coast,
-    })
+    habitat_share_permille(resource, environment) > 0
+}
+
+pub fn habitat_share_permille(resource: &ForageResource, environment: ForageEnvironment) -> u16 {
+    resource
+        .biomes
+        .iter()
+        .map(|biome| match biome {
+            Plains => environment.terrain.plains,
+            Forest => environment.terrain.forest,
+            Hills => environment.terrain.hills,
+            RiverWetGround if environment.river_or_wet_ground => 1_000,
+            SeaCoast if environment.sea_or_coast => 1_000,
+            _ => 0,
+        })
+        .fold(0_u16, u16::saturating_add)
+        .min(1_000)
 }
 
 pub fn stealth_dc_millirank(environment: ForageEnvironment, minutes: u64) -> Option<u16> {
@@ -273,10 +286,18 @@ pub fn resolve(
     let target_count = targets.len() as u64;
     let mut yields = Vec::new();
     for (index, target) in targets.into_iter().enumerate() {
+        let habitat = u64::from(habitat_share_permille(target, environment));
+        let food_rate = if crate::food::definition(target.item_id).is_some() {
+            FOOD_DISCOVERY_RATE_PERMILLE
+        } else {
+            1_000
+        };
         let expected_permille = u64::from(target.rarity.discoveries_per_eight_hours_permille())
             * minutes
             * u64::from(skill_bonus_permille)
-            / (8 * 60 * 1_000 * target_count);
+            * habitat
+            * food_rate
+            / (8 * 60 * 1_000 * 1_000 * 1_000 * target_count);
         let guaranteed = expected_permille / 1_000;
         let remainder = expected_permille % 1_000;
         let discovered =
@@ -293,7 +314,7 @@ pub fn resolve(
             / 1_000;
         yields.push(ForageYield {
             item_id: target.item_id,
-            quantity: u16::try_from(quantity.max(1)).unwrap_or(u16::MAX),
+            quantity: u16::try_from(quantity).unwrap_or(u16::MAX),
         });
     }
     let (dc, stealth_succeeded) =
@@ -436,5 +457,81 @@ mod tests {
     fn training_is_conserved_across_leaf_skills() {
         let gains = training_hours(legal().terrain, 120);
         assert!((gains.iter().sum::<f32>() - 2.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn habitat_share_scales_mixed_biome_resources() {
+        assert_eq!(
+            habitat_share_permille(resource("hazelnuts").unwrap(), legal()),
+            500
+        );
+        assert_eq!(
+            habitat_share_permille(resource("wild_berries").unwrap(), legal()),
+            1_000
+        );
+    }
+
+    #[test]
+    fn ideal_food_search_is_near_subsistence_and_skill_is_monotonic() {
+        let forest = ForageEnvironment {
+            terrain: LocalTerrainMixture {
+                plains: 0,
+                forest: 1_000,
+                hills: 0,
+            },
+            ..Default::default()
+        };
+        let calories = |check| {
+            (0..256_u64)
+                .map(|seed| {
+                    resolve(seed, forest, &["hazelnuts".into()], 8 * 60, check, 0)
+                        .unwrap()
+                        .yields
+                        .iter()
+                        .map(|row| f32::from(row.quantity) * 630.0)
+                        .sum::<f32>()
+                })
+                .sum::<f32>()
+                / 256.0
+        };
+        let novice = calories(0);
+        let expert = calories(5_000);
+        assert!((1_400.0..=2_600.0).contains(&novice), "{novice}");
+        assert!(expert > novice);
+    }
+
+    #[test]
+    fn half_habitat_has_about_half_the_ideal_expected_output() {
+        let environment = |forest| ForageEnvironment {
+            terrain: LocalTerrainMixture {
+                plains: 1_000 - forest,
+                forest,
+                hills: 0,
+            },
+            ..Default::default()
+        };
+        let average = |forest| {
+            (0..4_096_u64)
+                .map(|seed| {
+                    resolve(
+                        seed,
+                        environment(forest),
+                        &["hazelnuts".into()],
+                        8 * 60,
+                        0,
+                        0,
+                    )
+                    .unwrap()
+                    .yields
+                    .iter()
+                    .map(|row| f32::from(row.quantity))
+                    .sum::<f32>()
+                })
+                .sum::<f32>()
+                / 4_096.0
+        };
+        let ideal = average(1_000);
+        let half = average(500);
+        assert!((0.45..=0.55).contains(&(half / ideal)), "{half}/{ideal}");
     }
 }

--- a/crates/adventuresim-core/src/skill.rs
+++ b/crates/adventuresim-core/src/skill.rs
@@ -380,6 +380,70 @@ mod tests {
         assert_eq!(bulk_hours, chunked_hours);
         assert!((bulk_morale - chunked_morale).abs() < 0.0001);
     }
+
+    #[test]
+    fn ordinary_correlations_are_one_pass_and_direct_gated() {
+        struct Hours {
+            cooking: f32,
+            knife: f32,
+            sword: f32,
+        }
+        impl PlayerSkills for Hours {
+            fn skill_hours_trained(&self, skill: Skill) -> f32 {
+                match skill {
+                    Skill::Cooking => self.cooking,
+                    Skill::Knife => self.knife,
+                    Skill::Sword => self.sword,
+                    _ => 0.0,
+                }
+            }
+        }
+        let practiced = Hours {
+            cooking: 100.0,
+            knife: 1_000.0,
+            sword: 2_000.0,
+        };
+        assert_eq!(practiced.effective_skill_hours(Skill::Cooking), 200.0);
+        assert_eq!(practiced.effective_skill_hours(Skill::Sword), 2_200.0);
+        assert_eq!(practiced.effective_skill_hours(Skill::Knife), 1_415.0);
+        assert_eq!(
+            Hours {
+                cooking: 0.0,
+                ..practiced
+            }
+            .effective_skill_hours(Skill::Cooking),
+            0.0
+        );
+        let epsilon = Hours {
+            cooking: 0.01,
+            knife: 30_000.0,
+            sword: 0.0,
+        };
+        assert!((epsilon.effective_skill_hours(Skill::Cooking) - 0.02).abs() < f32::EPSILON);
+        let threshold = Hours {
+            cooking: 1_000.0,
+            knife: 2_000.0,
+            sword: 0.0,
+        };
+        assert_eq!(threshold.effective_skill_hours(Skill::Cooking), 1_300.0);
+    }
+
+    #[test]
+    fn terrain_and_defense_correlations_are_conservative() {
+        struct Hours;
+        impl PlayerSkills for Hours {
+            fn skill_hours_trained(&self, skill: Skill) -> f32 {
+                match skill {
+                    Skill::TerrainForest => 1_000.0,
+                    Skill::TerrainHills => 500.0,
+                    Skill::Balance => 2_000.0,
+                    _ => 0.0,
+                }
+            }
+        }
+        assert_eq!(Hours.effective_skill_hours(Skill::TerrainPlains), 300.0);
+        assert_eq!(Hours.effective_skill_hours(Skill::Dodge), 400.0);
+    }
 }
 
 impl Skill {
@@ -554,6 +618,39 @@ impl Skill {
                 | Skill::Smithing
         )
     }
+
+    /// Sparse, symmetric transfer relationships for ordinary skills. These
+    /// coefficients are projected from direct source hours in one pass.
+    pub const fn ordinary_correlations(self) -> &'static [(Skill, f32)] {
+        match self {
+            Self::Cooking => &[(Self::Knife, 0.15)],
+            Self::Knife => &[(Self::Cooking, 0.15), (Self::Sword, 0.20)],
+            Self::Sword => &[(Self::Knife, 0.20)],
+            Self::Dodge => &[(Self::Balance, 0.20)],
+            Self::Balance => &[(Self::Dodge, 0.20)],
+            Self::TerrainPlains => &[
+                (Self::TerrainForest, 0.20),
+                (Self::TerrainHills, 0.20),
+                (Self::TerrainUrban, 0.20),
+            ],
+            Self::TerrainForest => &[
+                (Self::TerrainPlains, 0.20),
+                (Self::TerrainHills, 0.20),
+                (Self::TerrainUrban, 0.20),
+            ],
+            Self::TerrainHills => &[
+                (Self::TerrainPlains, 0.20),
+                (Self::TerrainForest, 0.20),
+                (Self::TerrainUrban, 0.20),
+            ],
+            Self::TerrainUrban => &[
+                (Self::TerrainPlains, 0.20),
+                (Self::TerrainForest, 0.20),
+                (Self::TerrainHills, 0.20),
+            ],
+            _ => &[],
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -662,6 +759,30 @@ pub enum SkillKind {
 pub trait PlayerSkills {
     fn skill_hours_trained(&self, skill: Skill) -> f32;
 
+    /// One nonrecursive transfer pass over direct skill hours. The projection
+    /// is never persisted and therefore cannot amplify itself.
+    fn effective_skill_hours(&self, skill: Skill) -> f32 {
+        let direct = self.skill_hours_trained(skill).max(0.0);
+        if skill.is_trained() && direct <= 0.0 {
+            return 0.0;
+        }
+        let transferred = skill
+            .ordinary_correlations()
+            .iter()
+            .map(|(source, coefficient)| self.skill_hours_trained(*source).max(0.0) * coefficient)
+            .sum::<f32>()
+            .max(0.0);
+        // A tiny direct investment must not unlock an arbitrarily large
+        // lifetime transfer into an ordinary trained skill. Intuitive skills
+        // remain able to benefit from related experience before direct study.
+        let transferred = if skill.is_trained() {
+            transferred.min(direct)
+        } else {
+            transferred
+        };
+        direct + transferred
+    }
+
     fn bestiary_hours_for(&self, _category: adventuresim_world_schema::BestiaryCategory) -> f32 {
         self.skill_hours_trained(Skill::Bestiary)
     }
@@ -675,7 +796,7 @@ pub trait PlayerSkills {
         equipment: &impl PlayerEquipment,
         weights: LimbWeights,
     ) -> f32 {
-        let hours_trained = self.skill_hours_trained(skill);
+        let hours_trained = self.effective_skill_hours(skill);
         let mut check = skill.capped_training_rank(hours_trained, attr);
         // Injury remains an explicit performance penalty. Aptitude itself is
         // healthy/raw and contributes nothing to the final check value.

--- a/crates/adventuresim-core/src/social.rs
+++ b/crates/adventuresim-core/src/social.rs
@@ -286,7 +286,7 @@ pub fn choose_automatic_social_action(
                 .total_cmp(&right_score)
                 .then_with(|| left.2.total_cmp(&right.2))
                 .then_with(|| left.1.total_cmp(&right.1))
-                .then_with(|| left.0.risk().total_cmp(&right.0.risk()))
+                .then_with(|| right.0.risk().total_cmp(&left.0.risk()))
         })
         .map(|(action, _, _)| action)
 }
@@ -609,6 +609,20 @@ mod tests {
                 [
                     (SocialActionKind::Flirt, 5.0, 2.0),
                     (SocialActionKind::Listen, 1.0, 0.0),
+                ],
+            ),
+            Some(SocialActionKind::Listen)
+        );
+    }
+
+    #[test]
+    fn automatic_action_exact_ties_prefer_lower_risk() {
+        assert_eq!(
+            choose_automatic_social_action(
+                SocialTopic::Defeat,
+                [
+                    (SocialActionKind::Rally, 3.0, 0.0),
+                    (SocialActionKind::Listen, 3.0, 0.0),
                 ],
             ),
             Some(SocialActionKind::Listen)

--- a/crates/adventuresim-core/src/strategic_schedule.rs
+++ b/crates/adventuresim-core/src/strategic_schedule.rs
@@ -4,7 +4,10 @@ use crate::attribute::PlayerAttributes;
 use crate::equipment::WeaponSkillDistribution;
 use crate::profession::ProfessionId;
 use crate::skill::{Skill, apply_direct_training};
-use crate::{activity::*, strategic_time::training_hours_increment};
+use crate::{
+    activity::*,
+    strategic_time::{MINUTES_PER_DAY, training_hours_increment},
+};
 use adventuresim_world_schema::{BestiaryHours, OfficialReligion, ReligionHours};
 
 /// Stable order used by reports and schedule arrays.
@@ -135,6 +138,25 @@ impl DailySchedule {
         .map(u64::from)
         .sum()
     }
+}
+
+/// Deterministically projects the unallocated share of a repeating daily
+/// schedule onto an absolute interval. Cumulative integer arithmetic makes
+/// adjacent chunks telescope exactly without persisting a fractional remainder.
+pub fn restorative_leisure_minutes(
+    schedule: DailySchedule,
+    interval_start_minute: u64,
+    elapsed_minutes: u64,
+) -> u64 {
+    let leisure = MINUTES_PER_DAY.saturating_sub(schedule.allocated_minutes());
+    let cumulative = |minute: u64| {
+        minute
+            .saturating_mul(leisure)
+            .checked_div(MINUTES_PER_DAY)
+            .unwrap_or(0)
+    };
+    cumulative(interval_start_minute.saturating_add(elapsed_minutes))
+        .saturating_sub(cumulative(interval_start_minute))
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -533,12 +555,34 @@ mod tests {
             + skills.block
             + skills.will
             + skills.balance;
-        assert!((combat_total - 6.0).abs() < 0.001);
+        // The dedicated combat budget is six hours; physician training adds
+        // its separately conserved one-sixth share to Knife.
+        assert!((combat_total - (6.0 + 1.0 / 3.0)).abs() < 0.001);
         assert!((skills.humor - 1.0).abs() < 0.001);
         assert!((skills.physiology - 1.0).abs() < 0.001);
         assert!((skills.anatomy - 1.0 / 3.0).abs() < 0.001);
         assert!((skills.knife - 1.0 / 3.0).abs() < 0.001);
         assert!((skills.tailoring - 1.0 / 3.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn restorative_leisure_is_proportional_and_chunk_invariant() {
+        let none = DailySchedule::default();
+        assert_eq!(restorative_leisure_minutes(none, 0, 1_440), 1_440);
+        let full = DailySchedule {
+            labor: 1_440,
+            ..Default::default()
+        };
+        assert_eq!(restorative_leisure_minutes(full, 0, 1_440), 0);
+        let half = DailySchedule {
+            labor: 720,
+            ..Default::default()
+        };
+        assert_eq!(restorative_leisure_minutes(half, 0, 1_440), 720);
+        let bulk = restorative_leisure_minutes(half, 17, 1_000);
+        let first = restorative_leisure_minutes(half, 17, 333);
+        let second = restorative_leisure_minutes(half, 350, 667);
+        assert_eq!(bulk, first + second);
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/condition.rs
+++ b/crates/adventuresim-stdb-module/src/condition.rs
@@ -1926,6 +1926,7 @@ pub fn set_character_religion(
     character_id: u64,
     religion_id: String,
 ) -> Result<(), String> {
+    crate::strategic::require_strategic_character_authority(ctx, character_id)?;
     crate::character::require_living_character(ctx, character_id)?;
     initialize_character_condition(ctx, character_id)?;
     let religion_id = religion_id.trim();

--- a/crates/adventuresim-stdb-module/src/food.rs
+++ b/crates/adventuresim-stdb-module/src/food.rs
@@ -3,11 +3,12 @@
 use adventuresim_core::{
     disease::{self, DiseaseId},
     food,
+    prelude::{PlayerSkills, Skill},
 };
 use spacetimedb::{ReducerContext, SpacetimeType, Table, reducer, table};
 
 use crate::{
-    character::{character, character_attributes, character_skills},
+    character::{character, character_attributes, character_limbs, character_skills},
     condition::{character_needs, initialize_character_condition},
     disease::{InfectionEpisodeRow, infection_episode},
     inventory_item,
@@ -492,6 +493,31 @@ fn equipment_reason(
     }
 }
 
+fn cooking_check(ctx: &ReducerContext, character_id: u64) -> Result<f32, String> {
+    let attributes = ctx
+        .db
+        .character_attributes()
+        .character_id()
+        .find(character_id)
+        .ok_or("Character attributes not found")?;
+    let limbs = ctx
+        .db
+        .character_limbs()
+        .character_id()
+        .find(character_id)
+        .ok_or("Character limbs not found")?;
+    let skills = ctx
+        .db
+        .character_skills()
+        .character_id()
+        .find(character_id)
+        .ok_or("Character skills not found")?;
+    Ok(Skill::Cooking.capped_rank_for_aptitude(
+        skills.effective_skill_hours(Skill::Cooking),
+        Skill::Cooking.governing_aptitude(&attributes),
+    ) * limbs.head_health.clamp(0.0, 1.0))
+}
+
 pub fn preview_cooking(
     ctx: &ReducerContext,
     character_id: u64,
@@ -524,14 +550,22 @@ pub fn preview_cooking(
         if inventory.character_id != character_id || quantity > inventory.quantity {
             return Err("Ingredient is not available in that quantity".into());
         }
+        if !food::is_cookable_ingredient(&inventory.item_id) {
+            return Err("A cooked meal cannot be cooked again".into());
+        }
         let lot = lot_for_inventory(ctx, id)?;
         safety.push(
             food::definition(&inventory.item_id).map_or(5, |definition| definition.cooking_minutes),
         );
         mass += lot.mass_kg * quantity as f32 / inventory.quantity as f32;
     }
-    food::cooking_duration_minutes(method.core(), &safety, mass)
-        .ok_or("Cooking duration could not be calculated".into())
+    food::cooking_duration_minutes_for_check(
+        method.core(),
+        &safety,
+        mass,
+        cooking_check(ctx, character_id)?,
+    )
+    .ok_or("Cooking duration could not be calculated".into())
 }
 
 fn expose_to_dysentery(
@@ -764,6 +798,7 @@ pub fn cook_food(
         return Err("Cooking is unavailable during a tactical encounter".into());
     }
     let duration = preview_cooking(ctx, character_id, method, &inventory_item_ids, &quantities)?;
+    let cooking_check = cooking_check(ctx, character_id)?;
     initialize_character_condition(ctx, character_id)?;
     let needs = ctx
         .db
@@ -870,8 +905,8 @@ pub fn cook_food(
         ingredient_item_ids: ingredients,
         ingredient_quantities,
         mass_kg: mass,
-        nutrition_kcal: kcal * 0.97,
-        total_value: value,
+        nutrition_kcal: kcal * food::cooked_nutrition_retention(cooking_check),
+        total_value: value * food::cooked_quality_multiplier(cooking_check),
         created_at_minute: out_minute,
     });
     let weighted = if mass > 0.0 {
@@ -920,5 +955,17 @@ mod tests {
     #[test]
     fn method_mapping_is_stable() {
         assert_eq!(CookingMethod::Roast.core(), food::CookingMethod::Roast);
+    }
+
+    #[test]
+    fn authoritative_preview_rejects_cooked_output_as_an_ingredient() {
+        let source = include_str!("food.rs");
+        let preview = source
+            .split("pub fn preview_cooking")
+            .nth(1)
+            .and_then(|tail| tail.split("fn expose_to_dysentery").next())
+            .expect("preview cooking implementation");
+        assert!(preview.contains("food::is_cookable_ingredient(&inventory.item_id)"));
+        assert!(preview.contains("A cooked meal cannot be cooked again"));
     }
 }

--- a/crates/adventuresim-stdb-module/src/foraging.rs
+++ b/crates/adventuresim-stdb-module/src/foraging.rs
@@ -2,13 +2,17 @@
 
 use adventuresim_core::{
     foraging::{self, ForageEnvironment, ILLEGAL_FORAGE_VIRTUE_LOSS, LocalTerrainMixture},
-    prelude::Skill,
+    prelude::*,
 };
 use sha2::{Digest, Sha256};
 use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, reducer, table, view};
 
 use crate::{
-    character::{character, character_attributes, character_limbs, character_skills},
+    capability::StrategicEquipment,
+    character::{
+        character, character_attributes, character_equip, character_limbs, character_skills,
+        character_stats,
+    },
     investigation::{character_case_site_id, exact_case_site_for_observer},
     strategic::{
         party_authority, party_journey_authority, party_journey_route_authority,
@@ -276,23 +280,36 @@ fn acting_checks(
         .character_id()
         .find(character_id)
         .ok_or("Character skills not found")?;
-    let head = limbs.head_health.clamp(0.0, 1.0);
-    let mental = ((attributes.instinct + attributes.intelligence) * 0.5 * head).clamp(0.0, 5.0);
-    let terrain_training = Skill::TerrainPlains.training_rank(skills.terrain_plains_hours)
-        * f32::from(mixture.plains)
-        / 1_000.0
-        + Skill::TerrainForest.training_rank(skills.terrain_forest_hours)
-            * f32::from(mixture.forest)
-            / 1_000.0
-        + Skill::TerrainHills.training_rank(skills.terrain_hills_hours) * f32::from(mixture.hills)
-            / 1_000.0;
-    let arms = ((limbs.left_arm_health + limbs.right_arm_health) * 0.5).clamp(0.0, 1.0);
-    let agility =
-        ((attributes.left_arm_agility + attributes.right_arm_agility) * 0.5 * arms).clamp(0.0, 5.0);
-    let stealth_training = Skill::Stealth.training_rank(skills.stealth_hours);
+    let stats = ctx
+        .db
+        .character_stats()
+        .character_id()
+        .find(character_id)
+        .ok_or("Character stats not found")?;
+    let equip = ctx
+        .db
+        .character_equip()
+        .character_id()
+        .find(character_id)
+        .ok_or("Character equipment not found")?;
+    let equipment = StrategicEquipment::load(ctx, character_id, &equip);
+    let check = |skill| {
+        skills.skill_check_by_parts(
+            skill,
+            &attributes,
+            &limbs,
+            &stats,
+            &equipment,
+            LimbWeights::all_equal(),
+        )
+    };
+    let terrain_training = check(Skill::TerrainPlains) * f32::from(mixture.plains) / 1_000.0
+        + check(Skill::TerrainForest) * f32::from(mixture.forest) / 1_000.0
+        + check(Skill::TerrainHills) * f32::from(mixture.hills) / 1_000.0;
+    let stealth_training = check(Skill::Stealth);
     Ok((
-        (((terrain_training + mental) * 0.5).clamp(0.0, 5.0) * 1_000.0).round() as u16,
-        (((stealth_training + agility) * 0.5).clamp(0.0, 5.0) * 1_000.0).round() as u16,
+        (terrain_training.clamp(0.0, 5.0) * 1_000.0).round() as u16,
+        (stealth_training.clamp(0.0, 5.0) * 1_000.0).round() as u16,
     ))
 }
 
@@ -375,13 +392,40 @@ pub fn forage_current_vicinity(
         && let Some(mut skills) = ctx.db.character_skills().character_id().find(character_id)
     {
         let gains = foraging::training_hours(environment.terrain, elapsed);
-        skills.terrain_plains_hours =
-            (skills.terrain_plains_hours + gains[0]).min(Skill::TerrainPlains.max_hours());
-        skills.terrain_forest_hours =
-            (skills.terrain_forest_hours + gains[1]).min(Skill::TerrainForest.max_hours());
-        skills.terrain_hills_hours =
-            (skills.terrain_hills_hours + gains[2]).min(Skill::TerrainHills.max_hours());
+        let attributes = ctx
+            .db
+            .character_attributes()
+            .character_id()
+            .find(character_id)
+            .ok_or("Character attributes not found")?;
+        let mut excess = 0.0;
+        for (stored, skill, real_hours) in [
+            (
+                &mut skills.terrain_plains_hours,
+                Skill::TerrainPlains,
+                gains[0],
+            ),
+            (
+                &mut skills.terrain_forest_hours,
+                Skill::TerrainForest,
+                gains[1],
+            ),
+            (
+                &mut skills.terrain_hills_hours,
+                Skill::TerrainHills,
+                gains[2],
+            ),
+        ] {
+            excess += adventuresim_core::skill::apply_direct_training(
+                skill,
+                stored,
+                real_hours,
+                &attributes,
+            )
+            .excess_effective_hours;
+        }
         ctx.db.character_skills().character_id().update(skills);
+        crate::condition::record_mastery_training_morale(ctx, character_id, elapsed, excess);
     }
     let interrupted = !completed || elapsed < requested_minutes;
     let mut resolution = (!interrupted).then_some(planned);

--- a/crates/adventuresim-stdb-module/src/item.rs
+++ b/crates/adventuresim-stdb-module/src/item.rs
@@ -625,8 +625,8 @@ const WEAPONS: &[EquipmentDefinition] = &[
 const SHIELDS: &[EquipmentDefinition] = &[
     shield("buckler", 1.0, 5, 1.5),
     shield("targe", 2.5, 8, 2.5),
-    shield("heater_shield", 3.0, 10, 3.0),
-    shield("round_shield", 3.5, 10, 3.0),
+    shield("round_shield", 3.0, 10, 3.0),
+    shield("heater_shield", 3.5, 12, 3.5),
     shield("pavise", 8.0, 20, 5.0),
 ];
 
@@ -1788,6 +1788,22 @@ mod tests {
                 _ => unreachable!("equipment catalog contains a non-equipment item"),
             }
         }
+    }
+
+    #[test]
+    fn round_and_heater_shields_have_a_weight_block_tradeoff() {
+        let round = SHIELDS
+            .iter()
+            .find(|item| item.id == "round_shield")
+            .unwrap();
+        let heater = SHIELDS
+            .iter()
+            .find(|item| item.id == "heater_shield")
+            .unwrap();
+        assert!(round.weight < heater.weight);
+        assert!(round.block < heater.block);
+        assert!(!(round.weight <= heater.weight && round.block >= heater.block));
+        assert!(!(heater.weight <= round.weight && heater.block >= round.block));
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -315,16 +315,19 @@ mod healing_tests {
         FinaleKind, FinaleStatus, HostileGroupAuthority, HostileGroupDisposition,
         HostileResolutionKind, IncidentStatus, LocalChatMessage, MissionApproachCapability,
         MissionAttemptStatus, MissionAuthority, MissionOutcomeCandidate, QuestGenerationAuthority,
-        RecruitmentOfferStatus, activity_incident_source_id, autoresolve_drop,
+        RecruitmentOffer, RecruitmentOfferBindingFields, RecruitmentOfferId,
+        RecruitmentOfferStatus, RecruitmentSourceId, activity_incident_source_id, autoresolve_drop,
         case_refs_have_exact_dialogue_provenance, generated_case_site_combat_eligible,
         generated_dialogue_action_matches, generated_dialogue_producer_recipient,
         generated_scene_key, generated_witness_visible_description, hostile_group_authority_row,
         hostile_resolution_for_objective, incident_group_matches, merchant_storefront,
         mission_candidate_from_capability, npc_conversation_authority_matches,
         player_participant_ids, project_local_chat_message, quest_encounter_archetype,
-        quest_generation_context_commitment, refreshed_recruitment_offer_status,
-        sample_mission_candidate, unique_default_merchant_provider,
-        validate_quest_generation_authority, validated_generated_dialogue_manifest,
+        quest_generation_context_commitment, recruitment_offer_binding_fields_are_live,
+        refreshed_recruitment_offer_status, renewed_recruitment_offer_expiry,
+        sample_mission_candidate, sanitized_encounter_body_weight,
+        unique_default_merchant_provider, validate_quest_generation_authority,
+        validated_generated_dialogue_manifest,
     };
     use adventuresim_core::encounter::EncounterArchetype;
     use std::collections::HashSet;
@@ -835,6 +838,193 @@ mod healing_tests {
             refreshed_recruitment_offer_status(RecruitmentOfferStatus::Open, 10, 20, false),
             RecruitmentOfferStatus::Closed
         );
+        assert_eq!(
+            refreshed_recruitment_offer_status(RecruitmentOfferStatus::Open, 20, 20, false),
+            RecruitmentOfferStatus::Closed
+        );
+        let first = renewed_recruitment_offer_expiry(20);
+        let second = renewed_recruitment_offer_expiry(first);
+        assert!(first > 20);
+        assert!(second > first);
+    }
+
+    #[test]
+    fn recruitment_offer_requires_every_authoritative_location_binding() {
+        let offer = RecruitmentOffer {
+            id_key: "offer".into(),
+            id: RecruitmentOfferId {
+                value: "offer".into(),
+            },
+            source_id: RecruitmentSourceId {
+                value: "source".into(),
+            },
+            recruiting_party_id: "party".into(),
+            settlement_id: "lubeck".into(),
+            settlement_npc_id: "npc".into(),
+            location_id: "inn".into(),
+            leader_id: 7,
+            status: RecruitmentOfferStatus::Open,
+            created_at_minute: 0,
+            expires_at_minute: 10,
+        };
+        let live = RecruitmentOfferBindingFields {
+            party_leader_id: 7,
+            party_settlement_id: Some("lubeck"),
+            leader_alive: true,
+            leader_party_id: Some("party"),
+            leader_settlement_id: Some("lubeck"),
+            npc_home_settlement_id: Some("lubeck"),
+            presence_settlement_id: Some("lubeck"),
+            presence_location_id: Some("inn"),
+            presence_is_current: true,
+        };
+        assert!(recruitment_offer_binding_fields_are_live(&offer, live));
+        for stale in [
+            RecruitmentOfferBindingFields {
+                party_settlement_id: Some("hamburg"),
+                ..live
+            },
+            RecruitmentOfferBindingFields {
+                leader_settlement_id: Some("hamburg"),
+                ..live
+            },
+            RecruitmentOfferBindingFields {
+                npc_home_settlement_id: Some("hamburg"),
+                ..live
+            },
+            RecruitmentOfferBindingFields {
+                presence_location_id: Some("market"),
+                ..live
+            },
+            RecruitmentOfferBindingFields {
+                leader_alive: false,
+                ..live
+            },
+            RecruitmentOfferBindingFields {
+                leader_party_id: Some("other-party"),
+                ..live
+            },
+            RecruitmentOfferBindingFields {
+                presence_is_current: false,
+                ..live
+            },
+        ] {
+            assert!(!recruitment_offer_binding_fields_are_live(&offer, stale));
+        }
+        let source = include_str!("strategic.rs");
+        assert_eq!(
+            source
+                .matches("recruitment_offer_bindings_are_live(ctx, &offer, now)")
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn all_dead_party_teardown_clears_only_strategic_ghost_state() {
+        let source = include_str!("strategic.rs");
+        let teardown = source
+            .split("pub(crate) fn teardown_all_dead_strategic_party")
+            .nth(1)
+            .and_then(|tail| tail.split("/// Lazily backfills").next())
+            .expect("all-dead teardown");
+        for required in [
+            "party.camp_destination = None",
+            "party.camp_remaining_minutes = 0",
+            "finish_party_journey(ctx, party_id)",
+            "strategic_encounter()",
+            "party_action_request_authority()",
+            "party_leader_vote()",
+            "party_join_request()",
+            "party_recruitment_role()",
+            "delete_recruitment_role_authority(ctx, role.id)",
+        ] {
+            assert!(teardown.contains(required), "missing {required}");
+        }
+        for preserved in [
+            "mission_authority()",
+            "tactical_server_authority()",
+            "party_inventory_item()",
+            "party_authority().id().delete",
+        ] {
+            assert!(!teardown.contains(preserved), "must preserve {preserved}");
+        }
+
+        let time = include_str!("time.rs");
+        let camp = time
+            .split("pub fn rest_at_camp")
+            .nth(1)
+            .and_then(|tail| tail.split("fn party_fatigue_summary").next())
+            .expect("camp rest reducer");
+        let empty = camp.find("if living_after.is_empty()").unwrap();
+        assert!(empty < camp.find("record_party_camp_rest").unwrap());
+        assert!(empty < camp.find("refresh_party_journey_forecast").unwrap());
+    }
+
+    #[test]
+    fn join_entry_points_reject_an_all_dead_target_before_creating_state() {
+        let source = include_str!("strategic.rs");
+        let guard = source
+            .split("fn require_living_recruitment_target")
+            .nth(1)
+            .and_then(|tail| tail.split("#[reducer]").next())
+            .expect("living recruitment target guard");
+        assert!(guard.contains("!leader.alive"));
+        assert!(guard.contains("living_party_member_ids"));
+
+        let specific = source
+            .split("pub fn request_to_join_party")
+            .nth(1)
+            .and_then(|tail| tail.split("#[reducer]").next())
+            .expect("specific join request");
+        assert!(
+            specific.find("require_living_recruitment_target").unwrap()
+                < specific.find("party_join_request().insert").unwrap()
+        );
+
+        let general = source
+            .split("pub fn request_general_party_join")
+            .nth(1)
+            .and_then(|tail| tail.split("#[reducer]").next())
+            .expect("general join request");
+        assert!(
+            general.find("require_living_recruitment_target").unwrap()
+                < general.find(".insert(PartyRecruitmentRole").unwrap()
+        );
+    }
+
+    #[test]
+    fn contract_and_religion_lifecycle_guards_are_explicit() {
+        let strategic = include_str!("strategic.rs");
+        let disband = strategic
+            .split("pub fn disband_party")
+            .nth(1)
+            .and_then(|tail| tail.split("#[reducer]").next())
+            .expect("disband reducer");
+        assert!(disband.contains("ContractStatus::ReadyToReport"));
+        let normalize = strategic
+            .split("fn normalize_and_elect_party_leader")
+            .nth(1)
+            .and_then(|tail| tail.split("#[reducer]").next())
+            .expect("leadership normalization");
+        assert!(normalize.contains("ContractStatus::Accepted | ContractStatus::ReadyToReport"));
+        assert!(!normalize.contains("ContractStatus::Paid"));
+
+        let condition = include_str!("condition.rs");
+        let religion = condition
+            .split("pub fn set_character_religion")
+            .nth(1)
+            .and_then(|tail| tail.split("#[reducer]").next())
+            .expect("religion reducer");
+        assert!(religion.contains("require_strategic_character_authority"));
+    }
+
+    #[test]
+    fn encounter_body_weight_is_authoritative_but_sanitized() {
+        assert_eq!(sanitized_encounter_body_weight(55.0), 55.0);
+        assert_eq!(sanitized_encounter_body_weight(300.0), 300.0);
+        assert_eq!(sanitized_encounter_body_weight(0.0), 70.0);
+        assert_eq!(sanitized_encounter_body_weight(f32::NAN), 70.0);
     }
 
     #[test]
@@ -8265,6 +8455,94 @@ fn put_leader_vote(ctx: &ReducerContext, party_id: &str, voter_id: u64, candidat
     }
 }
 
+/// Retire only strategic party state that can otherwise keep an all-dead
+/// company travelling or accepting input. Tactical mission/server authority
+/// and pooled party assets intentionally remain untouched.
+pub(crate) fn teardown_all_dead_strategic_party(
+    ctx: &ReducerContext,
+    party_id: &str,
+) -> Result<(), String> {
+    if !living_party_member_ids(ctx, party_id).is_empty() {
+        return Err("Cannot retire strategic state for a party with living members".into());
+    }
+    let party_key = party_id.to_string();
+    let mut party = ctx
+        .db
+        .party_authority()
+        .id()
+        .find(&party_key)
+        .ok_or("Party not found")?;
+    party.camp_destination = None;
+    party.camp_remaining_minutes = 0;
+    ctx.db.party_authority().id().update(party);
+
+    finish_party_journey(ctx, party_id);
+    if ctx
+        .db
+        .strategic_encounter()
+        .party_id()
+        .find(&party_key)
+        .is_some()
+    {
+        ctx.db.strategic_encounter().party_id().delete(&party_key);
+    }
+    for row in ctx
+        .db
+        .party_action_request_authority()
+        .party_id()
+        .filter(party_id)
+        .collect::<Vec<_>>()
+    {
+        ctx.db.party_action_request_authority().id().delete(row.id);
+    }
+    for row in ctx
+        .db
+        .party_leader_vote()
+        .party_id()
+        .filter(party_id)
+        .collect::<Vec<_>>()
+    {
+        ctx.db.party_leader_vote().id().delete(&row.id);
+    }
+    let member_ids: HashSet<_> = ctx
+        .db
+        .party_member()
+        .party_id()
+        .filter(party_id)
+        .map(|member| member.character_id)
+        .collect();
+    for role in ctx
+        .db
+        .party_recruitment_role()
+        .party_id()
+        .filter(party_id)
+        .collect::<Vec<_>>()
+    {
+        delete_recruitment_role_authority(ctx, role.id);
+    }
+    for row in ctx
+        .db
+        .party_join_request()
+        .iter()
+        .filter(|request| {
+            request.party_id == party_id || member_ids.contains(&request.character_id)
+        })
+        .collect::<Vec<_>>()
+    {
+        ctx.db.party_join_request().id().delete(row.id);
+    }
+    if let Some(mut offer) = ctx
+        .db
+        .recruitment_offer()
+        .recruiting_party_id()
+        .find(&party_key)
+    {
+        offer.status = RecruitmentOfferStatus::Closed;
+        ctx.db.recruitment_offer().id_key().update(offer);
+    }
+    Ok(())
+}
+
 /// Lazily backfills standing votes and discards stale legacy succession rows.
 /// This is intentionally safe to call after every membership or life-state
 /// transition, preserving non-destructive compatibility with existing parties.
@@ -8279,6 +8557,22 @@ pub(crate) fn normalize_and_elect_party_leader(
         .find(&party_id.to_string())
         .ok_or("Party not found")?;
     let living = living_party_member_ids(ctx, party_id);
+    if living.is_empty() {
+        if let Some(contract_id) = party.active_contract_id.take()
+            && let Some(mut contract) = ctx.db.contract_authority().id().find(&contract_id)
+            && matches!(
+                contract.status,
+                ContractStatus::Accepted | ContractStatus::ReadyToReport
+            )
+        {
+            contract.status = ContractStatus::Withdrawn;
+            ctx.db.contract_authority().id().update(contract);
+        }
+        party.current_case_site_id = None;
+        ctx.db.party_authority().id().update(party);
+        teardown_all_dead_strategic_party(ctx, party_id)?;
+        return Ok(());
+    }
     let living_set: std::collections::HashSet<_> = living.iter().copied().collect();
     for vote in ctx
         .db
@@ -8804,6 +9098,11 @@ pub fn delete_recruitment_role(
     if role.party_id != party_id {
         return Err("Cannot delete another party's role".into());
     }
+    delete_recruitment_role_authority(ctx, role_id);
+    Ok(())
+}
+
+fn delete_recruitment_role_authority(ctx: &ReducerContext, role_id: u64) {
     for request in ctx
         .db
         .party_join_request()
@@ -8825,7 +9124,6 @@ pub fn delete_recruitment_role(
         ctx.db.party_member().id().update(member);
     }
     ctx.db.party_recruitment_role().id().delete(role_id);
-    Ok(())
 }
 
 #[reducer]
@@ -8983,6 +9281,74 @@ fn role_requirements(
     requirements
 }
 
+#[derive(Clone, Copy)]
+struct RecruitmentOfferBindingFields<'a> {
+    party_leader_id: u64,
+    party_settlement_id: Option<&'a str>,
+    leader_alive: bool,
+    leader_party_id: Option<&'a str>,
+    leader_settlement_id: Option<&'a str>,
+    npc_home_settlement_id: Option<&'a str>,
+    presence_settlement_id: Option<&'a str>,
+    presence_location_id: Option<&'a str>,
+    presence_is_current: bool,
+}
+
+fn recruitment_offer_binding_fields_are_live(
+    offer: &RecruitmentOffer,
+    fields: RecruitmentOfferBindingFields<'_>,
+) -> bool {
+    offer.leader_id == fields.party_leader_id
+        && fields.leader_alive
+        && fields.leader_party_id == Some(offer.recruiting_party_id.as_str())
+        && fields.party_settlement_id == Some(offer.settlement_id.as_str())
+        && fields.leader_settlement_id == Some(offer.settlement_id.as_str())
+        && fields.npc_home_settlement_id == Some(offer.settlement_id.as_str())
+        && fields.presence_settlement_id == Some(offer.settlement_id.as_str())
+        && fields.presence_location_id == Some(offer.location_id.as_str())
+        && fields.presence_is_current
+}
+
+fn recruitment_offer_bindings_are_live(
+    ctx: &ReducerContext,
+    offer: &RecruitmentOffer,
+    now: u64,
+) -> bool {
+    let Some(party) = ctx
+        .db
+        .party_authority()
+        .id()
+        .find(&offer.recruiting_party_id)
+    else {
+        return false;
+    };
+    let Some(leader) = ctx.db.character().id().find(offer.leader_id) else {
+        return false;
+    };
+    let npc = ctx.db.settlement_npc().id().find(&offer.settlement_npc_id);
+    let presence = ctx
+        .db
+        .settlement_npc_presence()
+        .npc_id()
+        .find(&offer.settlement_npc_id);
+    recruitment_offer_binding_fields_are_live(
+        offer,
+        RecruitmentOfferBindingFields {
+            party_leader_id: party.leader_id,
+            party_settlement_id: party.current_settlement_id.as_deref(),
+            leader_alive: leader.alive,
+            leader_party_id: leader.party_id.as_deref(),
+            leader_settlement_id: leader.current_settlement_id.as_deref(),
+            npc_home_settlement_id: npc.as_ref().map(|row| row.home_settlement_id.as_str()),
+            presence_settlement_id: presence.as_ref().map(|row| row.settlement_id.as_str()),
+            presence_location_id: presence.as_ref().map(|row| row.location_id.as_str()),
+            presence_is_current: presence
+                .as_ref()
+                .is_some_and(|row| crate::settlement_population::npc_is_present(row, now)),
+        },
+    )
+}
+
 fn require_open_recruitment_offer(
     ctx: &ReducerContext,
     party: &Party,
@@ -9006,22 +9372,7 @@ fn require_open_recruitment_offer(
     if offer.status != RecruitmentOfferStatus::Open {
         return Err("This recruitment offer is no longer open".into());
     }
-    let npc = ctx.db.settlement_npc().id().find(&offer.settlement_npc_id);
-    let presence = ctx
-        .db
-        .settlement_npc_presence()
-        .npc_id()
-        .find(&offer.settlement_npc_id);
-    let bindings_are_live = offer.leader_id == party.leader_id
-        && leader.party_id.as_deref() == Some(party.id.as_str())
-        && party.current_settlement_id.as_deref() == Some(offer.settlement_id.as_str())
-        && leader.current_settlement_id.as_deref() == Some(offer.settlement_id.as_str())
-        && npc.is_some_and(|npc| npc.home_settlement_id == offer.settlement_id)
-        && presence.is_some_and(|presence| {
-            presence.settlement_id == offer.settlement_id
-                && presence.location_id == offer.location_id
-                && crate::settlement_population::npc_is_present(&presence, now)
-        });
+    let bindings_are_live = recruitment_offer_bindings_are_live(ctx, &offer, now);
     let refreshed = refreshed_recruitment_offer_status(
         offer.status,
         now,
@@ -9029,8 +9380,13 @@ fn require_open_recruitment_offer(
         bindings_are_live,
     );
     if refreshed != RecruitmentOfferStatus::Open {
-        offer.status = refreshed;
-        ctx.db.recruitment_offer().id_key().update(offer);
+        // A valid generated offer remains Open-but-expired until settlement
+        // activity renews it in place. Persisting Expired here would strand
+        // its unique NPC/party identity and prevent that renewal.
+        if refreshed == RecruitmentOfferStatus::Closed {
+            offer.status = refreshed;
+            ctx.db.recruitment_offer().id_key().update(offer);
+        }
         return Err(if refreshed == RecruitmentOfferStatus::Expired {
             "This recruitment offer has expired".into()
         } else {
@@ -9048,13 +9404,29 @@ fn refreshed_recruitment_offer_status(
 ) -> RecruitmentOfferStatus {
     if current != RecruitmentOfferStatus::Open {
         current
-    } else if now >= expires_at {
-        RecruitmentOfferStatus::Expired
     } else if !bindings_are_live {
         RecruitmentOfferStatus::Closed
+    } else if now >= expires_at {
+        RecruitmentOfferStatus::Expired
     } else {
         RecruitmentOfferStatus::Open
     }
+}
+
+fn require_living_recruitment_target(ctx: &ReducerContext, party: &Party) -> Result<(), String> {
+    let leader = ctx
+        .db
+        .character()
+        .id()
+        .find(party.leader_id)
+        .ok_or("Recruiting party leader not found")?;
+    if !leader.alive
+        || leader.party_id.as_deref() != Some(party.id.as_str())
+        || !living_party_member_ids(ctx, &party.id).contains(&party.leader_id)
+    {
+        return Err("Cannot join a party without a living leader".into());
+    }
+    Ok(())
 }
 
 #[reducer]
@@ -9094,6 +9466,7 @@ pub fn request_to_join_party(
     if current_party_id == party_id {
         return Err("Cannot join your own party".into());
     }
+    require_living_recruitment_target(ctx, &party)?;
     require_open_recruitment_offer(ctx, &party)?;
     if !crate::simulation::same_simulation_scope(ctx, character_id, party.leader_id) {
         return Err("Simulation and ordinary parties cannot merge".into());
@@ -9133,6 +9506,13 @@ pub fn request_general_party_join(
     target_party_id: String,
 ) -> Result<(), String> {
     require_strategic_character_authority(ctx, character_id)?;
+    let target_party = ctx
+        .db
+        .party_authority()
+        .id()
+        .find(&target_party_id)
+        .ok_or("Party not found")?;
+    require_living_recruitment_target(ctx, &target_party)?;
     let role = ctx
         .db
         .party_recruitment_role()
@@ -11524,6 +11904,19 @@ pub fn disband_party(ctx: &ReducerContext, leader_id: u64, party_id: String) -> 
     if party.leader_id != leader_id {
         return Err("Only the party leader can disband the party".into());
     }
+    if party
+        .active_contract_id
+        .as_ref()
+        .is_some_and(|contract_id| {
+            ctx.db
+                .contract_authority()
+                .id()
+                .find(contract_id)
+                .is_some_and(|contract| contract.status == ContractStatus::ReadyToReport)
+        })
+    {
+        return Err("Report the completed contract before disbanding the party".into());
+    }
     if party.current_case_site_id.is_some() {
         return Err("Travel to a settlement before disbanding the party".into());
     }
@@ -13557,12 +13950,31 @@ fn party_encumbrance_remaining_basis_points(
             adventuresim_core::equipment::encumbrance_capacity_kg(adjusted_leg_strength)
         })
         .sum();
-    let body_burden = member_ids.len() as f32 * 70.0;
+    let body_burden: f32 = member_ids
+        .iter()
+        .map(|member_id| {
+            ctx.db
+                .character_condition()
+                .character_id()
+                .find(*member_id)
+                .map_or(70.0, |condition| {
+                    sanitized_encounter_body_weight(condition.body_weight_kg)
+                })
+        })
+        .sum();
     let remaining = adventuresim_core::equipment::encumbrance_remaining_multiplier(
         body_burden + personal_burden + party_burden,
         capacity,
     );
     (remaining.clamp(0.0, 1.0) * 10_000.0).round() as u32
+}
+
+fn sanitized_encounter_body_weight(weight_kg: f32) -> f32 {
+    if weight_kg.is_finite() && (20.0..=300.0).contains(&weight_kg) {
+        weight_kg
+    } else {
+        70.0
+    }
 }
 
 fn current_party_fatigue_percent(ctx: &ReducerContext, member_ids: &[u64]) -> u8 {
@@ -18055,7 +18467,14 @@ fn ensure_npc_recruiting_parties(ctx: &ReducerContext, settlement_id: &str) -> R
     let now = crate::time::refresh_clock(ctx)?;
     for mut offer in ctx.db.recruitment_offer().iter().collect::<Vec<_>>() {
         if offer.status == RecruitmentOfferStatus::Open && now >= offer.expires_at_minute {
-            offer.status = RecruitmentOfferStatus::Expired;
+            if recruitment_offer_bindings_are_live(ctx, &offer, now) {
+                // Reuse the canonical offer identity instead of allowing
+                // historical rows to exhaust the finite NPC population.
+                offer.created_at_minute = now;
+                offer.expires_at_minute = renewed_recruitment_offer_expiry(now);
+            } else {
+                offer.status = RecruitmentOfferStatus::Closed;
+            }
             ctx.db.recruitment_offer().id_key().update(offer);
         }
     }
@@ -18072,6 +18491,7 @@ fn ensure_npc_recruiting_parties(ctx: &ReducerContext, settlement_id: &str) -> R
             .recruitment_offer()
             .settlement_id()
             .filter(&settlement_id.to_string())
+            .filter(|offer| offer.status == RecruitmentOfferStatus::Open)
             .map(|offer| offer.settlement_npc_id)
             .collect();
         let Some((npc, presence)) = ctx
@@ -18159,6 +18579,10 @@ fn ensure_npc_recruiting_parties(ctx: &ReducerContext, settlement_id: &str) -> R
         });
     }
     Ok(())
+}
+
+fn renewed_recruitment_offer_expiry(now: u64) -> u64 {
+    now.saturating_add(7 * 1_440)
 }
 
 fn generated_witness_visible_description(

--- a/crates/adventuresim-stdb-module/src/surgery.rs
+++ b/crates/adventuresim-stdb-module/src/surgery.rs
@@ -331,6 +331,20 @@ pub fn preview_elapsed_for_injuries(
     requested: u64,
     allow_recovery: bool,
 ) -> Result<u64, String> {
+    preview_elapsed_for_injuries_with_rest_minutes(
+        ctx,
+        character_id,
+        requested,
+        if allow_recovery { requested } else { 0 },
+    )
+}
+
+pub fn preview_elapsed_for_injuries_with_rest_minutes(
+    ctx: &ReducerContext,
+    character_id: u64,
+    requested: u64,
+    recovery_minutes: u64,
+) -> Result<u64, String> {
     crate::condition::apply_blood_loss(ctx, character_id, 0.0)?;
     let blood = ctx
         .db
@@ -359,11 +373,8 @@ pub fn preview_elapsed_for_injuries(
         blood,
         &cuts,
         requested,
-        if allow_recovery {
-            crate::condition::BLOOD_RECOVERY_FRACTION_PER_DAY
-        } else {
-            0.0
-        },
+        crate::condition::BLOOD_RECOVERY_FRACTION_PER_DAY * recovery_minutes.min(requested) as f32
+            / requested.max(1) as f32,
     )
     .elapsed)
 }
@@ -376,6 +387,20 @@ pub fn settle_injuries(
     character_id: u64,
     elapsed: u64,
     allow_healing: bool,
+) -> Result<InjurySettlement, String> {
+    settle_injuries_with_rest_minutes(
+        ctx,
+        character_id,
+        elapsed,
+        if allow_healing { elapsed } else { 0 },
+    )
+}
+
+pub fn settle_injuries_with_rest_minutes(
+    ctx: &ReducerContext,
+    character_id: u64,
+    elapsed: u64,
+    healing_minutes: u64,
 ) -> Result<InjurySettlement, String> {
     if elapsed == 0 {
         return Ok(InjurySettlement {
@@ -412,19 +437,17 @@ pub fn settle_injuries(
         starting_blood,
         &open_cuts,
         elapsed,
-        if allow_healing {
-            crate::condition::BLOOD_RECOVERY_FRACTION_PER_DAY
-        } else {
-            0.0
-        },
+        crate::condition::BLOOD_RECOVERY_FRACTION_PER_DAY * healing_minutes.min(elapsed) as f32
+            / elapsed.max(1) as f32,
     );
-    let days = interval.elapsed as f32 / MINUTES_PER_DAY as f32;
-    let physiology = if allow_healing {
+    let elapsed_days = interval.elapsed as f32 / MINUTES_PER_DAY as f32;
+    let healing_days = healing_minutes.min(interval.elapsed) as f32 / MINUTES_PER_DAY as f32;
+    let physiology = if healing_days > 0.0 {
         crate::time::party_physiology_check(ctx, character_id)?
     } else {
         0.0
     };
-    let natural = if allow_healing {
+    let natural = if healing_days > 0.0 {
         crate::time::health_recovered_per_day(physiology)
     } else {
         0.0
@@ -441,7 +464,7 @@ pub fn settle_injuries(
         } else {
             1.0
         };
-        if allow_healing {
+        if healing_days > 0.0 {
             let stitch_bonus = if injury.stitched {
                 injury.stitch_quality.max(0.0) * STITCH_HEALING_BONUS_PER_LEVEL
             } else {
@@ -449,23 +472,23 @@ pub fn settle_injuries(
             };
             if injury.bandaged {
                 injury.cut_damage = (injury.cut_damage
-                    - (natural + 0.01 + stitch_bonus) * projectile_term * days)
+                    - (natural + 0.01 + stitch_bonus) * projectile_term * healing_days)
                     .max(0.0);
-                exposure += (starting_cut + injury.cut_damage) * 0.5 * days;
+                exposure += (starting_cut + injury.cut_damage) * 0.5 * elapsed_days;
             }
             injury.bruise_damage = (injury.bruise_damage
-                - (natural + BRUISE_HEALING_PER_DAY) * projectile_term * days)
+                - (natural + BRUISE_HEALING_PER_DAY) * projectile_term * healing_days)
                 .max(0.0);
             if injury.splint_inventory_item_id.is_some() {
                 injury.fracture_damage = (injury.fracture_damage
-                    - (natural + FRACTURE_HEALING_PER_DAY) * projectile_term * days)
+                    - (natural + FRACTURE_HEALING_PER_DAY) * projectile_term * healing_days)
                     .max(0.0);
                 if injury.fracture_damage == 0.0 {
                     return_splint(ctx, injury)?;
                 }
             }
         } else if injury.bandaged {
-            exposure += injury.cut_damage * days;
+            exposure += injury.cut_damage * elapsed_days;
         }
         if injury.cut_damage > 0.0 || starting_cut > 0.0 {
             let protection = standing_infection_multiplier(

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -117,6 +117,8 @@ pub struct CharacterApprenticeship {
     pub religion_id: Option<String>,
     pub started_minute: u64,
     pub apprenticeship_minutes_accrued: u64,
+    /// Tier-weighted practice reward units. One journeyman minute contributes
+    /// one unit and one master minute contributes two, both at minute scale.
     pub practice_minutes_accrued: u64,
 }
 
@@ -1248,8 +1250,35 @@ pub fn perform_immediate_activity(
 
 const ACTIVITY_MINUTE_SCALE: u64 = MINUTES_PER_DAY;
 const APPRENTICE_COIN_INTERVAL: u64 = 8 * 60 * ACTIVITY_MINUTE_SCALE;
-const JOURNEYMAN_REWARD_INTERVAL: u64 = 8 * 60 * ACTIVITY_MINUTE_SCALE;
-const MASTER_REWARD_INTERVAL: u64 = 2 * 60 * ACTIVITY_MINUTE_SCALE;
+const PROFESSION_REWARD_UNIT_INTERVAL: u64 = 60 * ACTIVITY_MINUTE_SCALE;
+
+fn profession_reward_weight(
+    tier: adventuresim_core::profession::ProfessionTier,
+) -> Result<u64, &'static str> {
+    match tier {
+        adventuresim_core::profession::ProfessionTier::Apprentice => {
+            Err("Independent practice requires Journeyman rank (2)")
+        }
+        adventuresim_core::profession::ProfessionTier::Journeyman => Ok(1),
+        adventuresim_core::profession::ProfessionTier::Master => Ok(2),
+    }
+}
+
+fn accrued_profession_reward(
+    old_units: u64,
+    elapsed: u64,
+    allocated_minutes: u16,
+    tier: adventuresim_core::profession::ProfessionTier,
+) -> Result<(u64, u64), &'static str> {
+    let weight = profession_reward_weight(tier)?;
+    let added = elapsed
+        .saturating_mul(u64::from(allocated_minutes))
+        .saturating_mul(weight);
+    let new_units = old_units.saturating_add(added);
+    let reward =
+        new_units / PROFESSION_REWARD_UNIT_INTERVAL - old_units / PROFESSION_REWARD_UNIT_INTERVAL;
+    Ok((new_units, reward))
+}
 
 fn apply_profession_outcomes(
     ctx: &ReducerContext,
@@ -1281,21 +1310,15 @@ fn apply_profession_outcomes(
             .as_deref()
             .ok_or("Profession practice time requires a profession")?;
         let tier = profession_tier_for(ctx, character_id, service)?;
-        if tier == adventuresim_core::profession::ProfessionTier::Apprentice {
-            return Err("Independent practice requires Journeyman rank (2)".into());
-        }
         let mut row = apprenticeship_for_service(ctx, character_id, service)
             .ok_or("That profession has not been learned")?;
-        let old = row.practice_minutes_accrued;
-        row.practice_minutes_accrued = old.saturating_add(
-            elapsed.saturating_mul(u64::from(schedule.profession_practice_minutes)),
-        );
-        let interval = if tier == adventuresim_core::profession::ProfessionTier::Master {
-            MASTER_REWARD_INTERVAL
-        } else {
-            JOURNEYMAN_REWARD_INTERVAL
-        };
-        let reward = row.practice_minutes_accrued / interval - old / interval;
+        let (new_units, reward) = accrued_profession_reward(
+            row.practice_minutes_accrued,
+            elapsed,
+            schedule.profession_practice_minutes,
+            tier,
+        )?;
+        row.practice_minutes_accrued = new_units;
         let definition = adventuresim_core::profession::profession_for_service(service)
             .ok_or("Unknown profession service")?;
         match definition.practice_reward {
@@ -1493,25 +1516,52 @@ fn rest_for_minutes(
 
     validate_settlement_rest_minutes(requested_minutes)?;
 
-    let cost = inn_stay_cost(requested_minutes)?;
+    let requested_cost = inn_stay_cost(requested_minutes)?;
     if at_inn {
-        crate::item::consume_personal_currency(ctx, character_id, cost)
-            .map_err(|_| "Not enough coin to pay for the inn stay".to_string())?;
+        if crate::item::personal_currency_total(ctx, character_id) < requested_cost {
+            return Err("Not enough coin to pay for the inn stay".into());
+        }
     }
 
     if explicit {
         crate::filth::wash_before_explicit_rest(ctx, character_id)?;
     }
 
-    let injury_limit =
-        crate::surgery::preview_elapsed_for_injuries(ctx, character_id, requested_minutes, true)?;
+    let schedule = ctx
+        .db
+        .character_training_schedule()
+        .character_id()
+        .find(character_id)
+        .ok_or_else(|| "Character training schedule not found".to_string())?;
+    let starting_minute = character_time.minutes;
+    let requested_recovery = adventuresim_core::strategic_schedule::restorative_leisure_minutes(
+        core_schedule(&schedule.downtime),
+        starting_minute,
+        requested_minutes,
+    );
+    let injury_limit = crate::surgery::preview_elapsed_for_injuries_with_rest_minutes(
+        ctx,
+        character_id,
+        requested_minutes,
+        requested_recovery,
+    )?;
     let (elapsed, terminal) =
         crate::disease::clip_elapsed_for_disease(ctx, character_id, injury_limit, true)?;
     let physiology_check = party_physiology_check(ctx, character_id)?;
-    let convalescing = convalescence_minutes(ctx, character_id, physiology_check).min(elapsed);
-    let settled = crate::surgery::settle_injuries(ctx, character_id, elapsed, true)?;
+    let recovery_elapsed = adventuresim_core::strategic_schedule::restorative_leisure_minutes(
+        core_schedule(&schedule.downtime),
+        starting_minute,
+        elapsed,
+    );
+    let convalescing =
+        convalescence_minutes(ctx, character_id, physiology_check).min(recovery_elapsed);
+    let settled = crate::surgery::settle_injuries_with_rest_minutes(
+        ctx,
+        character_id,
+        elapsed,
+        recovery_elapsed,
+    )?;
     let elapsed = settled.elapsed;
-    let starting_minute = character_time.minutes;
     character_time.minutes = character_time
         .minutes
         .checked_add(elapsed)
@@ -1520,6 +1570,11 @@ fn rest_for_minutes(
         .character_time()
         .character_id()
         .update(character_time);
+    if at_inn {
+        let elapsed_cost = inn_stay_cost(elapsed)?;
+        crate::item::consume_personal_currency(ctx, character_id, elapsed_cost)
+            .map_err(|_| "Not enough coin to pay for the inn stay".to_string())?;
+    }
     crate::social::settle_shared_party_time(ctx, character_id);
     crate::condition::apply_settlement_rest_elapsed_needs(ctx, character_id, elapsed, at_inn)?;
     crate::disease::finish_disease_interval(ctx, character_id, terminal)?;
@@ -1555,33 +1610,15 @@ fn rest_for_minutes(
             ))
         })
         .unwrap_or((0, 0));
-    let maintenance_elapsed = crate::repair::field_repair(
+    let _maintenance_elapsed = crate::repair::field_repair(
         ctx,
         character_id,
         smithing_skill,
         tailoring_skill,
-        elapsed.saturating_sub(convalescing),
+        recovery_elapsed.saturating_sub(convalescing),
     );
-    let training_elapsed = elapsed
-        .saturating_sub(convalescing)
-        .saturating_sub(maintenance_elapsed);
-    let priority_rest_elapsed = elapsed.saturating_sub(training_elapsed);
-    if priority_rest_elapsed > 0 {
-        crate::condition::apply_settlement_leisure_condition(
-            ctx,
-            character_id,
-            DailySchedule::default(),
-            priority_rest_elapsed,
-            starting_minute.saturating_add(priority_rest_elapsed),
-        )?;
-    }
+    let training_elapsed = elapsed;
     if training_elapsed > 0 {
-        let schedule = ctx
-            .db
-            .character_training_schedule()
-            .character_id()
-            .find(character_id)
-            .ok_or_else(|| "Character training schedule not found".to_string())?;
         let mut skills = ctx
             .db
             .character_skills()
@@ -1623,11 +1660,11 @@ fn rest_for_minutes(
         crate::strategic::maybe_trigger_activity_incident(ctx, character_id, risks)?;
     }
 
-    crate::condition::apply_rest_condition(ctx, character_id, elapsed)?;
+    crate::condition::apply_rest_condition(ctx, character_id, recovery_elapsed)?;
     crate::food::clear_stomach_fullness(ctx, character_id);
     crate::capability::refresh_character_capability(ctx, character_id)?;
-    if automatic_social && training_elapsed > 0 {
-        crate::social::apply_automatic_social_chats(ctx, character_id, training_elapsed)?;
+    if automatic_social && recovery_elapsed > 0 {
+        crate::social::apply_automatic_social_chats(ctx, character_id, recovery_elapsed)?;
     }
     Ok(training_elapsed)
 }
@@ -2063,6 +2100,10 @@ pub fn rest_at_camp(
         crate::social::apply_automatic_social_chats(ctx, member_id, downtime)?;
     }
     let living_after = crate::strategic::living_party_member_ids(ctx, &party_id);
+    if living_after.is_empty() {
+        crate::strategic::teardown_all_dead_strategic_party(ctx, &party_id)?;
+        return Ok(());
+    }
     let fatigue_after = party_fatigue_summary(ctx, &living_after)?;
     crate::strategic::record_party_camp_rest(
         ctx,
@@ -2278,6 +2319,7 @@ mod tests {
 
     #[test]
     fn inn_stay_cost_only_rounds_up_partial_days() {
+        assert_eq!(inn_stay_cost(0), Ok(0));
         assert_eq!(inn_stay_cost(MINUTES_PER_DAY), Ok(2));
         assert_eq!(inn_stay_cost(2 * MINUTES_PER_DAY), Ok(4));
         assert_eq!(inn_stay_cost(1), Ok(2));
@@ -2293,6 +2335,19 @@ mod tests {
             .and_then(|tail| tail.split("fn validate_settlement_rest_minutes").next())
             .expect("settlement rest implementation");
         assert_eq!(rest.matches("inn_stay_cost(requested_minutes)?").count(), 1);
+        assert_eq!(rest.matches("inn_stay_cost(elapsed)?").count(), 1);
+        assert!(
+            rest.find("personal_currency_total").unwrap()
+                < rest
+                    .find("preview_elapsed_for_injuries_with_rest_minutes")
+                    .unwrap()
+        );
+        assert!(
+            rest.find("inn_stay_cost(elapsed)?").unwrap()
+                < rest
+                    .find("crate::condition::apply_settlement_rest_elapsed_needs(")
+                    .unwrap()
+        );
         let needs = "crate::condition::apply_settlement_rest_elapsed_needs(";
         assert_eq!(rest.matches(needs).count(), 1);
         assert!(rest.find("settle_shared_party_time").unwrap() < rest.find(needs).unwrap());
@@ -2342,6 +2397,51 @@ mod tests {
                 .expect("non-downtime interval");
             assert!(!ordinary.contains("apply_automatic_social_chats"));
         }
+    }
+
+    #[test]
+    fn profession_practice_pays_a_livelihood_and_master_premium() {
+        assert!(APPRENTICE_COIN_INTERVAL > PROFESSION_REWARD_UNIT_INTERVAL);
+        assert_eq!(PROFESSION_REWARD_UNIT_INTERVAL, 60 * ACTIVITY_MINUTE_SCALE);
+        let ordinary_labor = adventuresim_core::activity::labor_gold(8.0, 2.0, 2.0);
+        let (_, journeyman_day) = accrued_profession_reward(
+            0,
+            8 * 60,
+            MINUTES_PER_DAY as u16,
+            adventuresim_core::profession::ProfessionTier::Journeyman,
+        )
+        .unwrap();
+        let (_, master_day) = accrued_profession_reward(
+            0,
+            8 * 60,
+            MINUTES_PER_DAY as u16,
+            adventuresim_core::profession::ProfessionTier::Master,
+        )
+        .unwrap();
+        assert_eq!(journeyman_day, u64::from(ordinary_labor));
+        assert!(master_day > journeyman_day);
+    }
+
+    #[test]
+    fn profession_reward_units_survive_tier_transitions_and_chunking() {
+        use adventuresim_core::profession::ProfessionTier::{Journeyman, Master};
+        let (after_journeyman, first_reward) =
+            accrued_profession_reward(0, 30, MINUTES_PER_DAY as u16, Journeyman).unwrap();
+        assert_eq!(first_reward, 0);
+        let (mixed_units, mixed_reward) =
+            accrued_profession_reward(after_journeyman, 45, MINUTES_PER_DAY as u16, Master)
+                .unwrap();
+        assert_eq!(mixed_reward, 2);
+
+        let (first_chunk, first_chunk_reward) =
+            accrued_profession_reward(0, 15, MINUTES_PER_DAY as u16, Master).unwrap();
+        let (chunked_units, second_chunk_reward) =
+            accrued_profession_reward(first_chunk, 30, MINUTES_PER_DAY as u16, Master).unwrap();
+        let (bulk_units, bulk_reward) =
+            accrued_profession_reward(0, 45, MINUTES_PER_DAY as u16, Master).unwrap();
+        assert_eq!(chunked_units, bulk_units);
+        assert_eq!(first_chunk_reward + second_chunk_reward, bulk_reward);
+        assert_eq!(mixed_units, 2 * PROFESSION_REWARD_UNIT_INTERVAL);
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -176,7 +176,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
                 script src="/static/background-fetch.js?v=background-fetch-2" {}
                 script src="/static/developer-mode.js?v=dialogue-sources-1" defer {}
-                script src="/static/tooltips.js?v=skill-correlation-tooltips-1" defer {}
+                script src="/static/tooltips.js?v=ordinary-skill-correlations-2" defer {}
                 script src="/static/character-action-dialog.js?v=character-actions-1" defer {}
                 @if scripts != ScriptProfile::Entry {
                     script src="/static/live-state.js?v=sse-3" defer {}

--- a/crates/strategic-web/src/templates/settlement/character_skills.rs
+++ b/crates/strategic-web/src/templates/settlement/character_skills.rs
@@ -1,6 +1,6 @@
 use adventuresim_core::{
     activity::{PRAYER_MORALE_LIMIT, PRAYER_MORALE_SCALE_MINUTES, settlement_population_scale},
-    prelude::Skill,
+    prelude::{PlayerSkills, Skill},
     skill::aptitude_training_multiplier,
     strategic_schedule::{
         BASELINE_FATIGUE_PER_DAY, CombatTrainingProfile, DailySchedule,
@@ -37,6 +37,7 @@ struct ProfessionActivityPreview {
     apprenticeship_accrued: u64,
     practice_accrued: u64,
     practice_threshold: u64,
+    practice_weight: u64,
     practice_reward: &'static str,
     tier_label: &'static str,
 }
@@ -61,7 +62,16 @@ impl ProfessionActivityPreview {
             ),
             _ => return [0.0, 0.0],
         };
-        let after = accrued.saturating_add(u64::from(minutes) * PROFESSION_ACCRUAL_SCALE);
+        let weight = if allocation_name == "profession_practice_minutes" {
+            self.practice_weight
+        } else {
+            1
+        };
+        let after = accrued.saturating_add(
+            u64::from(minutes)
+                .saturating_mul(PROFESSION_ACCRUAL_SCALE)
+                .saturating_mul(weight),
+        );
         let delta = (after / threshold).saturating_sub(accrued / threshold) as f32 * sign;
         if reward == "virtue" {
             [0.0, delta]
@@ -183,9 +193,9 @@ impl ActivityPreviewRates {
                 }
             };
             let tier = adventuresim_core::profession::profession_tier(definition, hours, aptitude);
-            let practice_threshold = match tier {
-                adventuresim_core::profession::ProfessionTier::Master => 2 * 60 * MINUTES_PER_DAY,
-                _ => 8 * 60 * MINUTES_PER_DAY,
+            let practice_weight = match tier {
+                adventuresim_core::profession::ProfessionTier::Master => 2,
+                _ => 1,
             };
             let practice_reward = match definition.practice_reward {
                 adventuresim_core::profession::PracticeReward::Gold => "gold",
@@ -213,7 +223,8 @@ impl ActivityPreviewRates {
                         .collect(),
                     apprenticeship_accrued: row.apprenticeship_minutes_accrued,
                     practice_accrued: row.practice_minutes_accrued,
-                    practice_threshold,
+                    practice_threshold: 60 * MINUTES_PER_DAY,
+                    practice_weight,
                     practice_reward,
                     tier_label: tier.title(definition.religious),
                 },
@@ -404,26 +415,26 @@ fn skills_table(
                     th scope="col" aria-label="Skill details" {}
                 } }
                 tbody {
-                    @if skills.will_hours > 0.0 { (party_skill_row("Will", "will", Skill::Will, skills.will_hours, instinct, head_health, schedule.is_some(), None)) }
+                    @if skills.will_hours > 0.0 { (party_skill_row(skills, "Will", "will", Skill::Will, instinct, head_health, schedule.is_some(), None)) }
                     (social_skill_rows(skills, instinct, head_health, schedule))
                     @if skills.physiology_hours > 0.0 {
                         (party_skill_row(
+                            skills,
                             "Physiology",
                             "physiology",
                             Skill::Physiology,
-                            skills.physiology_hours,
                             intelligence,
                             head_health,
                             schedule.is_some(),
                             None,
                         ))
                     }
-                    (party_skill_row("Cooking", "cooking", Skill::Cooking, skills.cooking_hours, intelligence, head_health, schedule.is_some(), actions.cooking_href.map(|href| SkillAction::Get { href, label: "Open cooking menu", open: actions.cooking_open })))
+                    (party_skill_row(skills, "Cooking", "cooking", Skill::Cooking, intelligence, head_health, schedule.is_some(), actions.cooking_href.map(|href| SkillAction::Get { href, label: "Open cooking menu", open: actions.cooking_open })))
                     (religion_skill_rows(skills, intelligence, head_health, schedule, training_religion))
                     (bestiary_skill_rows(skills, intelligence, head_health, schedule.is_some()))
                     (language_skill_rows(skills, instinct, intelligence, schedule.is_some()))
                     (combat_skill_rows(skills, instinct, arm_agility, leg_agility, head_health, upper_health, lower_health, schedule, combat_profile))
-                    @if skills.stealth_hours > 0.0 { (party_skill_row("Stealth", "stealth", Skill::Stealth, skills.stealth_hours, all_agility, (upper_health + lower_health) * 0.5, schedule.is_some(), None)) }
+                    @if skills.stealth_hours > 0.0 { (party_skill_row(skills, "Stealth", "stealth", Skill::Stealth, all_agility, (upper_health + lower_health) * 0.5, schedule.is_some(), None)) }
                     (terrain_skill_rows(
                         skills,
                         intelligence,
@@ -434,9 +445,9 @@ fn skills_table(
                             open: actions.foraging_open,
                         }),
                     ))
-                    @if skills.anatomy_hours > 0.0 { (party_skill_row("Anatomy", "surgeon", Skill::Anatomy, skills.anatomy_hours, intelligence, head_health, schedule.is_some(), None)) }
-                    @if skills.tailoring_hours > 0.0 { (party_skill_row("Tailoring", "sewing-needle", Skill::Tailoring, skills.tailoring_hours, arm_agility, upper_health, schedule.is_some(), None)) }
-                    @if skills.smithing_hours > 0.0 { (party_skill_row("Smithing", "smithing", Skill::Smithing, skills.smithing_hours, arm_agility, upper_health, schedule.is_some(), None)) }
+                    @if skills.anatomy_hours > 0.0 { (party_skill_row(skills, "Anatomy", "surgeon", Skill::Anatomy, intelligence, head_health, schedule.is_some(), None)) }
+                    @if skills.tailoring_hours > 0.0 { (party_skill_row(skills, "Tailoring", "sewing-needle", Skill::Tailoring, arm_agility, upper_health, schedule.is_some(), None)) }
+                    @if skills.smithing_hours > 0.0 { (party_skill_row(skills, "Smithing", "smithing", Skill::Smithing, arm_agility, upper_health, schedule.is_some(), None)) }
                     @if let Some(schedule) = schedule {
                         @let preview = activity_preview.unwrap_or_default();
                         tr class="schedule-divider" { td colspan="9" {} }
@@ -474,7 +485,7 @@ fn skills_table(
                             @if let Some(profession) = preview.profession.get(service_id) {
                                 @if profession.tier_label != "apprentice" && profession.tier_label != "novice" {
                                     @let religious = service_id == "religion";
-                                    (schedule_special_row(&format!("Profession Practice — {}", profession_label(service_id)), if religious { "holy-symbol" } else { "anvil" }, "profession_practice_minutes", schedule.downtime.profession_practice_minutes, true, immediate_actions, ActivityEffectRates::default(), None, Some(profession), 1.0, if religious { "Practice as a cleric or teacher to serve the community and earn Virtue; teachers earn faster than clerics." } else { "Practice an enrolled profession independently. Journeymen earn one coin per eight hours; masters earn one per two hours." }))
+                                    (schedule_special_row(&format!("Profession Practice — {}", profession_label(service_id)), if religious { "holy-symbol" } else { "anvil" }, "profession_practice_minutes", schedule.downtime.profession_practice_minutes, true, immediate_actions, ActivityEffectRates::default(), None, Some(profession), 1.0, if religious { "Practice as a cleric or teacher to serve the community and earn Virtue; teachers earn faster than clerics." } else { "Practice an enrolled profession independently. Journeymen earn one coin per hour; masters earn two per hour." }))
                                 }
                             }
                         }
@@ -523,12 +534,22 @@ fn terrain_skill_rows(
     ];
     let rank = entries
         .iter()
-        .map(|entry| entry.2.capped_rank_for_aptitude(entry.3, aptitude))
+        .map(|entry| {
+            entry.2.capped_rank_for_aptitude(
+                CharacterSkillHours(skills).effective_skill_hours(entry.2),
+                aptitude,
+            )
+        })
         .sum::<f32>()
         / 4.0;
     let average_hours = entries
         .iter()
         .map(|entry| finite_hours(entry.3))
+        .sum::<f32>()
+        / 4.0;
+    let average_effective_hours = entries
+        .iter()
+        .map(|entry| CharacterSkillHours(skills).effective_skill_hours(entry.2))
         .sum::<f32>()
         / 4.0;
     html! {
@@ -548,7 +569,7 @@ fn terrain_skill_rows(
                         "Terrain",
                         "Intelligence",
                         average_hours,
-                        average_hours,
+                        average_effective_hours,
                     ),
                     skill_rail_bar_options(),
                 ))
@@ -559,15 +580,16 @@ fn terrain_skill_rows(
                 }
             }
         }
-        @for (name, icon, skill, hours) in entries {
+        @for (name, icon, skill, _hours) in entries {
             tr class="party-skill-row terrain-detail-row" data-terrain-detail hidden {
                 th scope="row" class="party-skill-name party-skill-icon-cell religion-subskill-name" {
                     (stat_icon(name, "terrain", icon, false))
                 }
                 td class="party-skill-meter" colspan=[schedule_context.then_some("7")] {
-                    @let uncapped = skill.training_rank(hours);
-                    @let sub_rank = skill.capped_rank_for_aptitude(hours, aptitude);
-                    (skill_rank_bar_with_tooltip(uncapped, sub_rank, &SkillTooltip::direct(skill, hours), skill_rail_bar_options()))
+                    @let effective_hours = CharacterSkillHours(skills).effective_skill_hours(skill);
+                    @let uncapped = skill.training_rank(effective_hours);
+                    @let sub_rank = skill.capped_rank_for_aptitude(effective_hours, aptitude);
+                    (skill_rank_bar_with_tooltip(uncapped, sub_rank, &SkillTooltip::ordinary(skills, skill), skill_rail_bar_options()))
                 }
                 td class="religion-expand-cell" {}
             }
@@ -982,20 +1004,20 @@ fn combat_skill_rows(
 ) -> Markup {
     let weights = profile.weights();
     html! {
-        (combat_meta_group("Melee", "crossed-swords", schedule, &[
+        (combat_meta_group(skills, "Melee", "crossed-swords", schedule, &[
             ("Polearm", "spear-hook", Skill::Polearm, skills.polearm_hours, arm_agility, upper_health, weights[0]),
             ("Axe", "battle-axe", Skill::Axe, skills.axe_hours, arm_agility, upper_health, weights[1]),
             ("Bludgeon", "flanged-mace", Skill::Bludgeon, skills.bludgeon_hours, arm_agility, upper_health, weights[2]),
             ("Sword", "sword", Skill::Sword, skills.sword_hours, arm_agility, upper_health, weights[3]),
             ("Knife", "bowie-knife", Skill::Knife, skills.knife_hours, arm_agility, upper_health, weights[4]),
         ]))
-        (combat_meta_group("Ranged", "archery-target", schedule, &[
+        (combat_meta_group(skills, "Ranged", "archery-target", schedule, &[
             ("Bow", "bow-arrow", Skill::Bow, skills.bow_hours, arm_agility, upper_health, weights[5]),
             ("Crossbow", "crossbow", Skill::Crossbow, skills.crossbow_hours, arm_agility, upper_health, weights[6]),
             ("Firearm", "musket", Skill::Firearm, skills.firearm_hours, arm_agility, upper_health, weights[7]),
             ("Throw", "throwing-ball", Skill::Throw, skills.throw_hours, arm_agility, upper_health, weights[8]),
         ]))
-        (combat_meta_group("Defense", "shield", schedule, &[
+        (combat_meta_group(skills, "Defense", "shield", schedule, &[
             ("Dodge", "dodge", Skill::Dodge, skills.dodge_hours, leg_agility, lower_health, weights[9]),
             ("Block", "block", Skill::Block, skills.block_hours, arm_agility, upper_health, weights[10]),
             ("Balance", "balance", Skill::Balance, skills.balance_hours, leg_agility, lower_health, weights[11]),
@@ -1005,6 +1027,7 @@ fn combat_skill_rows(
 }
 
 fn combat_meta_group(
+    skills: &CharacterSkills,
     name: &str,
     icon: &str,
     schedule: Option<&CharacterTrainingSchedule>,
@@ -1013,17 +1036,32 @@ fn combat_meta_group(
     let relevant: Vec<_> = entries.iter().filter(|entry| entry.6 > 0.0).collect();
     let rank = relevant
         .iter()
-        .map(|entry| entry.2.capped_rank_for_aptitude(entry.3, entry.4))
+        .map(|entry| {
+            entry.2.capped_rank_for_aptitude(
+                CharacterSkillHours(skills).effective_skill_hours(entry.2),
+                entry.4,
+            )
+        })
         .sum::<f32>()
         / relevant.len().max(1) as f32;
     let effective_rank = relevant
         .iter()
-        .map(|entry| entry.2.capped_rank_for_aptitude(entry.3, entry.4) * entry.5.clamp(0.0, 1.0))
+        .map(|entry| {
+            entry.2.capped_rank_for_aptitude(
+                CharacterSkillHours(skills).effective_skill_hours(entry.2),
+                entry.4,
+            ) * entry.5.clamp(0.0, 1.0)
+        })
         .sum::<f32>()
         / relevant.len().max(1) as f32;
     let average_hours = relevant
         .iter()
         .map(|entry| finite_hours(entry.3))
+        .sum::<f32>()
+        / relevant.len().max(1) as f32;
+    let average_effective_hours = relevant
+        .iter()
+        .map(|entry| CharacterSkillHours(skills).effective_skill_hours(entry.2))
         .sum::<f32>()
         / relevant.len().max(1) as f32;
     let governed_by = if relevant
@@ -1043,7 +1081,12 @@ fn combat_meta_group(
                 (skill_rank_bar_with_tooltip(
                     rank,
                     effective_rank,
-                    &SkillTooltip::aggregate(name, governed_by, average_hours, average_hours),
+                    &SkillTooltip::aggregate(
+                        name,
+                        governed_by,
+                        average_hours,
+                        average_effective_hours,
+                    ),
                     skill_rail_bar_options(),
                 ))
             }
@@ -1054,7 +1097,7 @@ fn combat_meta_group(
                 }
             }
         }
-        @for &(leaf_name, leaf_icon, skill, hours, aptitude, health, weight) in entries {
+        @for &(leaf_name, leaf_icon, skill, _hours, aptitude, health, weight) in entries {
             tr class="party-skill-row combat-detail-row" data-combat-detail=(name.to_ascii_lowercase()) data-combat-weight=(weight) hidden {
                 th scope="row" class="party-skill-name party-skill-icon-cell religion-subskill-name" {
                     span title=[(skill == Skill::Knife).then_some("Knife means short weapons: knives, daggers, and short blades.")] {
@@ -1062,9 +1105,10 @@ fn combat_meta_group(
                     }
                 }
                 td class="party-skill-meter" colspan=[schedule.map(|_| "7")] {
-                    @let uncapped = skill.training_rank(hours);
-                    @let sub_rank = skill.capped_rank_for_aptitude(hours, aptitude);
-                    (skill_rank_bar_with_tooltip(uncapped, sub_rank * health.clamp(0.0, 1.0), &SkillTooltip::direct(skill, hours), skill_rail_bar_options()))
+                    @let effective_hours = CharacterSkillHours(skills).effective_skill_hours(skill);
+                    @let uncapped = skill.training_rank(effective_hours);
+                    @let sub_rank = skill.capped_rank_for_aptitude(effective_hours, aptitude);
+                    (skill_rank_bar_with_tooltip(uncapped, sub_rank * health.clamp(0.0, 1.0), &SkillTooltip::ordinary(skills, skill), skill_rail_bar_options()))
                 }
                 td class="religion-expand-cell" {}
             }
@@ -1088,17 +1132,19 @@ fn schedule_header_icon(icon: &str, label: &str) -> Markup {
 }
 
 fn party_skill_row(
+    skills: &CharacterSkills,
     name: &str,
     icon: &str,
     skill: Skill,
-    hours: f32,
     aptitude: f32,
     health: f32,
     schedule_context: bool,
     action: Option<SkillAction<'_>>,
 ) -> Markup {
-    let uncapped_rank = skill.training_rank(hours);
-    let rank = skill.capped_rank_for_aptitude(hours, aptitude);
+    let view = CharacterSkillHours(skills);
+    let effective_hours = view.effective_skill_hours(skill);
+    let uncapped_rank = skill.training_rank(effective_hours);
+    let rank = skill.capped_rank_for_aptitude(effective_hours, aptitude);
     let effective_rank = rank * health.clamp(0.0, 1.0);
     html! {
         tr class="party-skill-row" {
@@ -1113,7 +1159,7 @@ fn party_skill_row(
                 (skill_rank_bar_with_tooltip(
                     uncapped_rank,
                     effective_rank,
-                    &SkillTooltip::direct(skill, hours),
+                    &SkillTooltip::ordinary(skills, skill),
                     skill_rail_bar_options(),
                 ))
             }
@@ -1174,6 +1220,20 @@ impl SkillTooltip {
         )
     }
 
+    fn ordinary(skills: &CharacterSkills, skill: Skill) -> Self {
+        let view = CharacterSkillHours(skills);
+        Self::new(
+            skill.label(),
+            skill.governing_aptitude_kind().label(),
+            view.skill_hours_trained(skill),
+            view.effective_skill_hours(skill),
+            skill
+                .ordinary_correlations()
+                .iter()
+                .map(|(source, rate)| (source.label(), *rate)),
+        )
+    }
+
     fn aggregate(
         name: impl Into<String>,
         governed_by: impl Into<String>,
@@ -1191,8 +1251,12 @@ impl SkillTooltip {
 
     fn accessible_description(&self) -> String {
         let mut description = format!(
-            "{}\nGoverned by {}\n{:.1} effective hours trained\n{:.1} hours from correlated skills:",
-            self.name, self.governed_by, self.trained_hours, self.correlated_hours
+            "{}\nGoverned by {}\n{:.1} direct hours trained\n{:.1} effective hours trained\n{:.1} hours from correlated skills:",
+            self.name,
+            self.governed_by,
+            self.trained_hours,
+            self.trained_hours + self.correlated_hours,
+            self.correlated_hours
         );
         for correlation in &self.correlations {
             description.push_str(&format!(
@@ -1209,6 +1273,46 @@ fn finite_hours(hours: f32) -> f32 {
         hours.max(0.0)
     } else {
         0.0
+    }
+}
+
+struct CharacterSkillHours<'a>(&'a CharacterSkills);
+
+impl PlayerSkills for CharacterSkillHours<'_> {
+    fn skill_hours_trained(&self, skill: Skill) -> f32 {
+        let skills = self.0;
+        match skill {
+            Skill::Polearm => skills.polearm_hours,
+            Skill::Axe => skills.axe_hours,
+            Skill::Bludgeon => skills.bludgeon_hours,
+            Skill::Sword => skills.sword_hours,
+            Skill::Knife => skills.knife_hours,
+            Skill::Dodge => skills.dodge_hours,
+            Skill::Block => skills.block_hours,
+            Skill::Bow => skills.bow_hours,
+            Skill::Crossbow => skills.crossbow_hours,
+            Skill::Firearm => skills.firearm_hours,
+            Skill::Throw => skills.throw_hours,
+            Skill::Will => skills.will_hours,
+            Skill::Insight => skills.insight_hours,
+            Skill::SelfAwareness => skills.self_awareness_hours,
+            Skill::Humor => skills.humor_hours,
+            Skill::Command => skills.command_hours,
+            Skill::Deception => skills.deception_hours,
+            Skill::Seduction => skills.seduction_hours,
+            Skill::Physiology => skills.physiology_hours,
+            Skill::Cooking => skills.cooking_hours,
+            Skill::Stealth => skills.stealth_hours,
+            Skill::Balance => skills.balance_hours,
+            Skill::TerrainPlains => skills.terrain_plains_hours,
+            Skill::TerrainForest => skills.terrain_forest_hours,
+            Skill::TerrainHills => skills.terrain_hills_hours,
+            Skill::TerrainUrban => skills.terrain_urban_hours,
+            Skill::Anatomy => skills.anatomy_hours,
+            Skill::Tailoring => skills.tailoring_hours,
+            Skill::Smithing => skills.smithing_hours,
+            Skill::Religion | Skill::Bestiary => 0.0,
+        }
     }
 }
 
@@ -1957,6 +2061,61 @@ mod tests {
     }
 
     #[test]
+    fn cooking_and_knife_rows_render_projected_hours_without_losing_injury_caps() {
+        let skills = CharacterSkills {
+            cooking_hours: 100.0,
+            knife_hours: 1_000.0,
+            ..Default::default()
+        };
+        let cooking = party_skill_row(
+            &skills,
+            "Cooking",
+            "cooking",
+            Skill::Cooking,
+            5.0,
+            0.5,
+            false,
+            None,
+        )
+        .into_string();
+        assert!(cooking.contains("100.0 direct hours trained"));
+        assert!(cooking.contains("200.0 effective hours trained"));
+        assert!(cooking.contains("Knife | 15%"));
+        let cooking_rank = Skill::Cooking.training_rank(200.0) * 0.5;
+        assert!(cooking.contains(&format!("aria-valuenow=\"{cooking_rank:.1}\"")));
+
+        let combat = combat_skill_rows(
+            &skills,
+            5.0,
+            5.0,
+            5.0,
+            1.0,
+            0.5,
+            1.0,
+            None,
+            CombatTrainingProfile::default(),
+        )
+        .into_string();
+        assert!(combat.contains("1000.0 direct hours trained"));
+        assert!(combat.contains("1015.0 effective hours trained"));
+        assert!(combat.contains("Cooking | 15%"));
+    }
+
+    #[test]
+    fn terrain_rows_render_intuitive_cross_habitat_projection() {
+        let skills = CharacterSkills {
+            terrain_forest_hours: 1_000.0,
+            ..Default::default()
+        };
+        let rendered = terrain_skill_rows(&skills, 5.0, false, None).into_string();
+        assert!(rendered.contains("0.0 direct hours trained"));
+        assert!(rendered.contains("200.0 effective hours trained"));
+        assert!(rendered.contains("Forest | 20%"));
+        assert!(rendered.contains("1000.0 direct hours trained"));
+        assert!(rendered.contains("Plains | 20%"));
+    }
+
+    #[test]
     fn language_families_are_expandable_accessible_and_color_coded() {
         let skills = CharacterSkills {
             oral_languages: adventuresim_world_schema::OralLanguageHours {
@@ -1980,12 +2139,14 @@ mod tests {
         assert!(rendered.contains("Governed by Instinct"));
         assert!(rendered.contains("Governed by Intelligence"));
         assert!(rendered.contains("title=\"East-central — Ostmitteldeutsch\""));
-        assert!(rendered.contains("5000.0 effective hours trained"));
-        assert!(!rendered.contains("6000.0 effective hours trained"));
         let oral_tooltip = oral_language_family_tooltip(&skills);
         assert_eq!(oral_tooltip.trained_hours, 5_000.0);
         assert!(oral_tooltip.correlated_hours > 0.0);
         assert!(!oral_tooltip.correlations.is_empty());
+        assert!(rendered.contains(&format!(
+            "{:.1} effective hours trained",
+            oral_tooltip.trained_hours + oral_tooltip.correlated_hours
+        )));
         assert!(!rendered.contains("title=\"Latin — Latine\""));
         assert!(!rendered.contains("title=\"Romani — Romani\""));
         assert_eq!(rendered.matches("data-language-detail=\"oral\"").count(), 4);
@@ -2056,6 +2217,7 @@ mod tests {
             apprenticeship_accrued: 0,
             practice_accrued: 0,
             practice_threshold: 8 * 60 * PROFESSION_ACCRUAL_SCALE,
+            practice_weight: 1,
             practice_reward: "gold",
             tier_label: "apprentice",
         };
@@ -2120,7 +2282,8 @@ mod tests {
         );
         let smith = preview.profession.get("weapons").unwrap();
         assert_eq!(smith.tier_label, "journeyman");
-        assert_eq!(smith.practice_threshold, 8 * 60 * PROFESSION_ACCRUAL_SCALE);
+        assert_eq!(smith.practice_threshold, 60 * PROFESSION_ACCRUAL_SCALE);
+        assert_eq!(smith.practice_weight, 1);
         assert_eq!(
             smith.reward_delta("apprenticeship_minutes", 60),
             [-1.0, 0.0]
@@ -2138,10 +2301,11 @@ mod tests {
         );
         let smith = preview.profession.get("weapons").unwrap();
         assert_eq!(smith.tier_label, "master");
-        assert_eq!(smith.practice_threshold, 2 * 60 * PROFESSION_ACCRUAL_SCALE);
+        assert_eq!(smith.practice_threshold, 60 * PROFESSION_ACCRUAL_SCALE);
+        assert_eq!(smith.practice_weight, 2);
         assert_eq!(
             smith.reward_delta("profession_practice_minutes", 240),
-            [2.0, 0.0]
+            [8.0, 0.0]
         );
     }
 

--- a/crates/strategic-web/static/tooltips.js
+++ b/crates/strategic-web/static/tooltips.js
@@ -81,11 +81,14 @@
       governedBy.textContent = `Governed by ${skill.governed_by}`;
       const trained = documentRoot.createElement('span');
       trained.className = 'strategic-skill-tooltip-line';
-      trained.textContent = `${Number(skill.trained_hours).toFixed(1)} effective hours trained`;
+      trained.textContent = `${Number(skill.trained_hours).toFixed(1)} direct hours trained`;
+      const effective = documentRoot.createElement('span');
+      effective.className = 'strategic-skill-tooltip-line';
+      effective.textContent = `${(Number(skill.trained_hours) + Number(skill.correlated_hours)).toFixed(1)} effective hours trained`;
       const correlated = documentRoot.createElement('span');
       correlated.className = 'strategic-skill-tooltip-line';
       correlated.textContent = `${Number(skill.correlated_hours).toFixed(1)} hours from correlated skills:`;
-      tooltip.append(title, governedBy, trained, correlated);
+      tooltip.append(title, governedBy, trained, effective, correlated);
 
       if (Array.isArray(skill.correlations) && skill.correlations.length) {
         const table = documentRoot.createElement('table');

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -468,9 +468,9 @@ migration, dual-read path, or preservation of disposable characters.
 |---------|-------------|
 | `upsert_character` | Create/update character (gives starter items) |
 | `add_item_to_inventory` | Add items |
-| `backfill_solo_parties` / `leave_party` / `disband_party` | Maintain the invariant that every character has a party |
+| `backfill_solo_parties` / `leave_party` / `disband_party` | Maintain the invariant that every character has a party; disbanding cannot discard a completed contract awaiting its shared reward |
 | `backfill_character_deaths_and_leadership` | Non-destructively supply legacy death records and normalize stale/missing standing votes |
-| internal `transition_character_to_dead` | Idempotently commit a durable death outcome and trigger leadership reevaluation |
+| internal `transition_character_to_dead` | Idempotently commit a durable death outcome and trigger leadership reevaluation; an all-dead party retains assets and tactical mission authority but retires camp, journey, strategic encounter, recruitment-role, vote, and pending-request state |
 | `create_recruitment_role` / `update_recruitment_role` / `delete_recruitment_role` | Create, resize, edit, and remove grouped party recruitment slots |
 | `save_recruitment_role` / `delete_saved_recruitment_role` | Manage reusable role presets |
 | `update_party_check_targets` | Configure non-filtering Physiology, Command, and Religion aggregate goals; surgical capability is an individual Anatomy/Knife/Tailoring composite |
@@ -481,9 +481,9 @@ migration, dual-read path, or preservation of disposable characters.
 | `send_local_chat_message` / `record_local_npc_message` | Persist location-gated, party-owned Local conversations |
 | `refresh_capabilities` | Recompute automatic character tags through the shared core evaluator |
 | `refresh_strategic_condition` | Recompute morale, pain, blood loss, fear, fatigue, readiness, and check effectiveness |
-| explicit rest reducers | Require the registered strategic gateway (or the owner of the target disposable simulation character), validate the physical rest location and one-year work bound, atomically plan washing, then advance rest and nightly alcohol chronology |
-| `set_character_religion` | Record church conversion or biography renunciation for religious relationships |
-| `ensure_settlement_activity` | Maintain 3–5 visible quests and 1–2 locally generated recruiting NPC quest parties |
+| explicit rest reducers | Require the registered strategic gateway (or the owner of the target disposable simulation character), validate the physical rest location and one-year work bound, preflight requested inn affordability, then apply healing and maintenance only to unallocated Leisure while advancing exposure and scheduled activity over the full safe elapsed interval |
+| `set_character_religion` | Authorize through the strategic gateway, then record church conversion or biography renunciation for religious relationships |
+| `ensure_settlement_activity` | Maintain 3–5 visible quests and 1–2 locally generated recruiting NPC quest parties, renewing expired offers in place only through the same exact party/leader/NPC/location predicate used by joining |
 | `start_mission` | Allocate port, record mission |
 | **`commit_mission`** | **Apply mission results (XP, items) - idempotent** |
 | `cancel_mission` | Cancel active mission |

--- a/docs/EQUIPMENT.md
+++ b/docs/EQUIPMENT.md
@@ -45,6 +45,11 @@ The catalog intentionally has more weapons than armor entries (26 weapons to
 useful, highly varied, and more likely than a complete suit to persist in an
 armory.
 
+Shield statistics preserve an actual handling tradeoff rather than making one
+catalog entry a strict upgrade. The round shield weighs 3.0 kg and provides 3.0
+block, while the heater shield weighs 3.5 kg and provides 3.5 block. A player
+therefore chooses between lower burden and greater protection.
+
 ## Representation and gameplay inference
 
 The current item schema has one armor item per existing body slot, with no

--- a/docs/FOOD_AND_COOKING.md
+++ b/docs/FOOD_AND_COOKING.md
@@ -64,6 +64,15 @@ mental, trained Cooking skill for the elapsed cooking time. A character can
 also apprentice as a cook through the inn's ordinary profession dialogue;
 apprenticeship and later independent practice follow the same progression and
 payment rules as the other non-religious settlement professions.
+
+The authoritative Cooking check includes the documented one-pass Knife
+transfer after direct Cooking study. Each rank removes 6% of setup and batch
+overhead, to a maximum 30%; ingredient safety time is never shortened. Useful
+calorie retention rises from 95% at rank zero to 99% at rank five, while meal
+quality scales derived market value from 95% to 110% of ingredient value.
+`cooked_meal` is a terminal preparation state and cannot be selected as an
+ingredient. This prevents repeated cooking from compounding the value or
+nutrition multiplier.
 # Foraged food
 
 Raw wild foods gathered through current-vicinity foraging enter personal

--- a/docs/FORAGING.md
+++ b/docs/FORAGING.md
@@ -24,6 +24,13 @@ oatmeal, and rosewater and non-plant honey are not forage targets.
 Searches last 1–24 whole hours. Rarity supplies a price-independent base
 discovery rate. The acting character's local weighted Terrain check can add at
 most 50% to discovery and yield. Multiple targets divide one time budget.
+Discovery frequency scales with the fraction of local terrain matching the
+resource's habitat; a trace of forest no longer grants full forest output, but
+a successful find retains the resource's ordinary per-discovery yield.
+Wet-ground and coast attestations count as complete matching microhabitats.
+Food alone receives a 1.75× subsistence calibration: an eight-hour low-skill
+search for the best food in an ideal habitat averages roughly the 2,000 kcal
+spent during that interval. Medicinal rarity is unchanged.
 Targets are canonicalized before resolution. The reducer chooses and privately
 persists unpredictable entropy; once that seed is chosen, replay from the
 private authority is deterministic. A completed search may find nothing.
@@ -37,6 +44,9 @@ Actual elapsed time is clipped once at the existing injury/disease boundary.
 That elapsed time is conserved over concrete Plains, Forest, and Hills training
 according to the normalized local mixture. Terrain has no stored parent value,
 and settlement illegality does not turn training into Urban.
+Checks and training use the same aptitude-capped, injury-adjusted path as
+travel. Foraging never adds raw attributes to a check, never stores correlated
+hours, and routes rejected above-cap training into mastery enjoyment.
 
 ## Legality
 

--- a/wiki/shared/Encumbrance.md
+++ b/wiki/shared/Encumbrance.md
@@ -17,7 +17,10 @@ The burden includes body weight, carried water at 1 kg per litre, and every
 carried inventory row multiplied by its quantity. Equipped items are already
 inventory rows and count exactly once. Injury-adjusted capacity uses the
 average of left and right leg strength after multiplying each leg by its
-current health.
+current health. Party calculations use each living member's authoritative body
+weight from `character_condition`; invalid or missing legacy values use the
+70 kg schema default rather than silently treating every member as the same
+weight.
 
 Inventory rails split the summary into equal-width halves. The left half shows
 the exact burden and capacity to one decimal place with the exact penalty to

--- a/wiki/shared/Health.md
+++ b/wiki/shared/Health.md
@@ -94,7 +94,7 @@ Below zero, you aren't any *less* effective, per-se, but the body part can conti
 
 ## Current strategic implementation
 
-During recovery, the existing bounded party Physiology check supplies **1 percentage point plus 1 percentage point per Physiology point** of natural recovery per full game day, combined with the wound category's own rate. This modifier is applied to the authoritative cut, bruise, and splinted-fracture components rather than directly to `character_limbs`. A retained projectile multiplies every healing component on that limb by 0.6. Resting characters convalesce before they train.
+During recovery, the existing bounded party Physiology check supplies **1 percentage point plus 1 percentage point per Physiology point** of natural recovery per full game day, combined with the wound category's own rate. This modifier is applied to the authoritative cut, bruise, and splinted-fracture components rather than directly to `character_limbs`. A retained projectile multiplies every healing component on that limb by 0.6. Only unallocated Leisure minutes convalesce or restore blood; a fully scheduled day grants no passive healing. Bleeding and infection exposure still advance over the complete elapsed interval.
 
 Autoresolve calculates every hit through the shared melee and ranged exchanges and commits its body part, cut and blunt shares, and projectile kind. Strategic wounds are split per limb into cuts, bruising, and fracture severity. Fracture severity is a condition within blunt trauma and never adds a second copy of the hit's health damage. Cuts remain open after battle: they deteriorate at 2.5% health per day and drain blood in proportion to wound size until manually bandaged. Bandaging consumes one bandage and permanently stabilizes that wound; its health-bar segment changes from solid red to banded pink. Bruising heals without a procedure. A single blunt hit over 18% limb health creates fracture severity proportional to the excess. Untreated fractures are graphite grey, while splinted fractures use lighter grey bands so treatment state is not communicated by color alone.
 
@@ -130,7 +130,13 @@ Projectile extraction uses the Anatomy-and-Knife check; procedures above DC 1
 require a reusable surgery kit. Shallower projectiles remain removable without
 one.
 
-Characters also persist current and maximum blood volume. Maximum volume currently assumes a 70 kg body at 70 ml/kg. Autoresolve commits immediate blood loss alongside final body-part injuries, open cuts continue draining blood on every authoritative personal-time path, and settlement rest recovers 1% of maximum blood volume per day. Losing 30% of maximum blood volume contributes 100% strategic incapacitation.
+Characters also persist current and maximum blood volume. Maximum volume is
+derived at 70 ml/kg from the character's authoritative body weight, whose
+schema default is 70 kg. Autoresolve commits immediate blood loss alongside
+final body-part injuries, open cuts continue draining blood on every
+authoritative personal-time path, and restorative settlement Leisure recovers
+1% of maximum blood volume per day. Losing 30% of maximum blood volume
+contributes 100% strategic incapacitation.
 
 ```rs
 const ML_BLOOD_VOLUME_PER_KG_BODY_WEIGHT = 70

--- a/wiki/shared/Stats.md
+++ b/wiki/shared/Stats.md
@@ -127,6 +127,14 @@ Selecting an explicit activity icon previews and performs one continuous one-to-
 
 A character discovers a service profession by speaking with its NPC and following the linked profession and apprenticeship topics. Apprenticeship unlocks that profession's training activity, costs Gold, and produces no wage. Once every skill associated with the profession reaches rank 2, the character is a journeyman and may practice independently in cities for a small income. At rank 4 the character is a master and earns a good income, representing paid work and the instruction of apprentices. Religious professions use the tradition-neutral titles novice, cleric, and teacher for these same tiers; their practice earns Virtue instead of Gold. These records describe training and professional standing only: guild affiliations, membership conflicts, exclusivity, and settlement restrictions are not modeled.
 
+Independent practice pays one coin per hour at Journeyman rank and two per
+hour at Master rank. Apprentices instead pay one coin per eight hours.
+Professional practice accrues tier-weighted reward units against one common
+hourly threshold, so changing rank cannot retroactively revalue earlier work.
+Accrued partial intervals are retained, so splitting work across downtime
+advances does not change its reward. Religious practice keeps the cadence but
+awards Virtue rather than Gold.
+
 Skills with no invested training hours are omitted from the skill list. Joining a profession is stored separately from skill hours, so a newly enrolled apprentice can still reach their activity through the schedule; the skill appears after the activity first awards training. Shared skills likewise do not imply membership in every profession that teaches them.
 
 An ordinary day generates 600 fatigue-reservoir units before tiring activities. Leisure removes 100 units per hour, so six hours exactly offsets ordinary wakefulness. Labor adds another 50 units per hour. Leisure beyond six hours first removes activity fatigue, then fatigue carried into the interval; only the portion of the interval after the reservoir reaches zero earns morale, approaching 4 points per full qualifying day with a 200-unit diminishing-return scale. The schedule displays a one-day preview, but the server awards the result proportionally to the settlement-downtime time actually applied. Earned Leisure morale is kept as one refreshable source capped at 4 points, rather than being projected from the post-rest schedule or stacked into separate events. It decays at a fixed rate when no qualifying Leisure is occurring; qualifying Leisure refreshes it while adding the newly earned amount. This makes the result independent of whether downtime is applied all at once or through frequent synchronization. The compact schedule preview shows one Fatigue point per 100 reservoir units: Labor therefore shows `+0.5` per hour, while Leisure includes baseline and recovery so all visible Fatigue rows sum to the authoritative net change. Positive preview values remain green and negative values red, including negative Fatigue values that represent recovery.
@@ -165,6 +173,18 @@ target evaluates to zero until it has target-specific direct hours, regardless
 of correlated knowledge. Correlation is derived in one pass, never stored, and
 never produces mastery morale. Physiology, Anatomy, Religion and Bestiary
 leaves, and Written languages are trained; Oral languages are intuitive.
+
+Ordinary skill transfer uses a deliberately sparse symmetric matrix: Cooking
+and Knife transfer at 0.15; Sword and Knife, Dodge and Balance, and every pair
+of Terrain leaves transfer at 0.20. Only direct hours enter this one pass. A
+trained target receives at most as many transferred hours as it has direct
+hours: zero remains zero and an introductory lesson cannot unlock a lifetime
+of related experience all at once. Intuitive Terrain leaves do not use this
+direct-study cap. Skill rails show direct, correlated, and resulting effective
+hours separately in their tooltips. The meter's background extent is the
+uncapped rank projected from effective hours, including correlation; it is not
+a separate direct-hours layer. The brighter foreground remains the
+aptitude- and injury-limited effective check.
 
 ## Formula
 ```rs
@@ -216,7 +236,7 @@ fn skill_check(character, skill, limb_weights: LimbWeights):
 	return check
 ```
 
-Each skill is represented in the stats window with its stored, uncapped training rank behind its current effective rank. Hover text reports the stored effective hours and governing aptitude cap. Penalties such as encumbrance, armor, or injuries reduce only the current effective portion.
+Each skill is represented in the stats window with its uncapped rank projected from effective hours (direct plus correlated) behind its current aptitude- and injury-limited rank. Hover text reports the direct hours, correlated contribution, resulting effective hours, and governing aptitude. Penalties such as encumbrance, armor, or injuries reduce only the current effective portion.
 
 ## Mental
 ### Will (intuitive, 5000 hours)
@@ -400,6 +420,10 @@ Surgery is a procedure, not a skill. Projectile extraction averages the
 treating character's Anatomy and Knife checks; stitching averages Anatomy and
 Tailoring. Bandaging and splinting use Anatomy alone. Self-treatment applies
 the shared 2.5-point penalty after the applicable skills are combined.
+
+The recruitment rail's general Surgery coverage is the lower of the extraction
+and stitching checks. A specialist therefore cannot appear able to perform
+both procedures merely because their unrelated third skill is high.
 
 ### Terrain (computed meta-skill; intuitive subskills, 30000 hours each)
 

--- a/wiki/strategic/Quests.md
+++ b/wiki/strategic/Quests.md
@@ -26,6 +26,15 @@ reinterpreted against different content.
 
 A party leader may request one of an NPC company's open roles while both parties occupy the same location and the company's typed recruitment offer remains open and unexpired. The company and offer are generated independently from quests. Acceptance merges the applying party into the destination party: the destination leader retains command, the applying leader fills the selected role, and every other source member becomes an ordinary member. Source recruitment roles and pending applications close, while party-inventory items, reserve value, and each character's absolute stake transfer intact. Generated NPC leaders auto-approve these requests in local development so the complete merge flow can be previewed.
 
+An expired generated-company offer is renewed in place when its company,
+leader, and settlement presence remain valid. This keeps recurring settlement
+activity supplied without consuming a fresh NPC on every expiry cycle; a stale
+offer whose bindings no longer exist closes instead. Renewal and joining use
+the same authority check: party and living leader must be bound to the offer's
+settlement, the NPC must belong there, and the NPC's current presence must
+match the offer's exact advertised location. A closed invalid offer does not
+reserve its NPC against a valid replacement.
+
 Recruiting NPC companies are discovered at the inn rather than through quest ownership or a global party browser. Their service presentation reveals the company leader and each open role. Role links show exact recommendations on hover and are colored blue for unrestricted roles, green when a member of the viewer's party meets every recommendation, yellow when a member meets some, and red when no member meets any. Selecting a role replaces the side panels with its detailed recommendations, party context, and the request-to-join action.
 
 Standalone strategic encounter incidents are also independent from quests.
@@ -43,6 +52,21 @@ At the destination, the strategic page retains the normal chat placeholder, show
 An incapacitated party may withdraw from a quest location to a settlement to recover, but cannot undertake further combat or ordinary travel until its members are ready.
 
 Completing the objective does not immediately close the quest or pay its promised reward. The party must travel back to the issuing settlement and speak to the same service NPC. Before completion the returning NPC says they are still awaiting results; after completion they ask whether the party has **finished**, and following that linked response turns in the quest. After the server confirms success, an Info row states the exact gold added to the party inventory. The promised gold enters the shared party inventory and its value is divided equally among the current members' stakes, with any indivisible remainder entering the captain's reserve. Only then is the quest removed from the party tracker and replacement settlement activity generated.
+
+An active contract also constrains party lifecycle. A party cannot disband
+while a completed contract is ready to report, which prevents abandoning a
+claimable shared reward. If the final living member dies during an accepted or
+ready-to-report contract, strategic authority withdraws that contract and
+clears its case-site tracking while retaining the party record and pooled
+inventory. Already paid contracts remain historical records.
+
+If the final living member dies, the retained party and pooled assets cease all
+strategic travel: camp destination, private route and encounter entropy, public
+itinerary, strategic encounter, and pending party action, leadership, and join
+requests are cleared together with recruitment roles. Both general and
+role-specific join requests reject a party without a living leader. Active
+tactical mission and server-assignment authority is intentionally untouched so
+tactical outcome ownership is not rewritten by strategic cleanup.
 ## Diegetic discovery and navigation
 
 Quest problems are discovered through local rumors and NPC testimony, not

--- a/wiki/strategic/Time.md
+++ b/wiki/strategic/Time.md
@@ -62,7 +62,49 @@ raiding_retaliation = 1 - exp(-0.35 * hours);
 
 Raiding is checked first because an organized retaliation supersedes a watch patrol. On discovery, the activity creates a typed strategic incident independent from quests and contracts. **Caught Red-Handed** pits the party against the town watch; **Retaliation at Dawn** pits it against armed retainers. Both offer tactical combat, autoresolve, or retreat through the encounter map. The party's active quest is never replaced or mutated.
 
-At a settlement, a player may rest at an inn or temple, moving that character's personal time forward even if it passes official time. Rest may be entered as whole days, or as an `HH:MM` duration keyed to a selected wake time. The wake-time slider moves in whole-hour intervals, uses the travel planner's solid night, sunrise, day, and sunset colors, and defaults to 08:00; the duration's minus and plus controls change it by one hour while direct entry accepts exact minutes. Settlement rest always schedules at least 24 hours before the next selected clock time, preserving the character clock's exact minute. The same control is available from the Map for free, party-wide rest at the party's current settlement, en-route camps, and quest destinations. Field rest permits a sub-day interval, defaults to the time needed to clear the most-fatigued living member, and lets the leader wait for a chosen departure or combat time; selecting the current clock time means its next-day occurrence. Rest first convalesces every injured body part at 1 percentage point plus 1 percentage point per point of the party Physiology check per day (capped at 6%) and restores 1% of maximum blood volume per day. Remaining time automatically maintains carried equipment, repairing condition bins one and two when the character's Smithing rating reaches the bin for weapons, armor, and shields, or Tailoring reaches it for clothing; only time left after health and maintenance applies the saved activity schedule. Convalescence and maintenance time count as pure rest for fatigue. Scheduled downtime uses the shared Leisure calculation documented in [Stats](../shared/Stats.md): six hours offsets baseline fatigue, tiring activities such as Labor must then be offset, and only recovery left after the fatigue carried into that interval reaches zero earns diminishing-return morale. That earned result updates one capped recent-morale source at the interval's end, so refreshing state cannot award prospective morale or stack repeated syncs. The automatic "until healed" recommendation includes health, field-repairable yellow equipment condition, and the remaining ETA of items left with a craftsperson at the current settlement. Inn rest costs 2 gold per started day and includes full board: elapsed calories and ordinary drinking water are covered, existing food and water deficits are cleared, and personal and party provisions are preserved. Temple rest is free sanctuary intended for characters down on their luck; it does not provide food or drinking water. A future karma system will account for taking undue advantage of it.
+At a settlement, a player may rest at an inn or temple, moving that
+character's personal time forward even if it passes official time. Rest may be
+entered as whole days, or as an `HH:MM` duration keyed to a selected wake time.
+The wake-time slider moves in whole-hour intervals, uses the travel planner's
+solid night, sunrise, day, and sunset colors, and defaults to 08:00; the
+duration's minus and plus controls change it by one hour while direct entry
+accepts exact minutes. Settlement rest always schedules at least 24 hours
+before the next selected clock time, preserving the character clock's exact
+minute. The same control is available from the Map for free, party-wide rest
+at the party's current settlement, en-route camps, and quest destinations.
+Field rest permits a sub-day interval, defaults to the time needed to clear the
+most-fatigued living member, and lets the leader wait for a chosen departure or
+combat time; selecting the current clock time means its next-day occurrence.
+
+Scheduled downtime uses the shared Leisure calculation documented in
+[Stats](../shared/Stats.md): six hours offsets baseline fatigue, tiring
+activities such as Labor must then be offset, and only recovery left after the
+fatigue carried into that interval reaches zero earns diminishing-return
+morale. That earned result updates one capped recent-morale source at the
+interval's end, so refreshing state cannot award prospective morale or stack
+repeated syncs. The automatic "until healed" recommendation includes health,
+field-repairable yellow equipment condition, and the remaining ETA of items
+left with a craftsperson at the current settlement.
+
+Inn rest costs 2 gold per started day and includes full board: elapsed calories
+and ordinary drinking water are covered, existing food and water deficits are
+cleared, and personal and party provisions are preserved. Temple rest is free
+sanctuary intended for characters down on their luck; it does not provide food
+or drinking water. A future karma system will account for taking undue
+advantage of it.
+
+Convalescence, blood recovery, and automatic field maintenance use only the
+interval's unallocated Leisure minutes. A fully allocated 24-hour schedule
+therefore grants no passive healing, while an empty schedule grants the full
+interval; the absolute-minute calculation is invariant under splitting the same
+interval into several rest calls. Bleeding and infection exposure still advance
+through every elapsed minute, and scheduled activities apply over the same
+calendar interval rather than being delayed until recovery finishes. Immediate
+activities remain non-rest actions.
+
+Inn affordability is checked against the requested stay before any rest effect
+is applied. If disease or another physiological boundary clips an affordable
+stay early, only the started days in the actual elapsed prefix are charged.
 
 The rest summary itemizes the selected inn full-board charge separately from
 other net spending during the interval, such as alcohol or apprenticeship,


### PR DESCRIPTION
## Stack
- Base: #246
- This PR contains only the strategic gameplay audit and is intended to merge after #246.

## Summary
- introduce conservative one-pass skill correlations and make authoritative Cooking/foraging checks, training, tooltips, and yields internally consistent
- remove dominated or pointless choices through useful Cooking outcomes, sustainable professional wages, a real shield tradeoff, lower-risk social tie-breaking, and authoritative body mass
- make settlement time physically exclusive: scheduled activity still advances over calendar time, while healing, blood recovery, maintenance, and automatic social recovery use only unallocated Leisure
- close contract, party-death, NPC recruiting, religion-authority, and interrupted-inn edge cases without persisting tactical state or adding a migration
- document every changed tradeoff and calibration

## Audit and review
Three independent read-only audits covered skills/progression, economy/survival, and quests/social/health. A sole writer implemented the consolidated non-controversial set. Independent balance and lifecycle reviews found nine follow-up issues (including recooking arbitrage, wage tier transitions, correlation presentation/unlock, habitat double-scaling, ghost journeys, weak recruitment bindings, and dead-party join input); all were remediated and re-reviewed to resolution.

Broader design work intentionally deferred: industry-driven markets, currency friction, raiding calibration, new Bestiary/social progression sources, inheritance/respawn, and explicit healer-time allocation.

## Verification
- `cargo test -p adventuresim-core --quiet` — 396 tests + 4 doctests passed
- `cargo test -p strategic-web --quiet` — 276 passed
- `cargo check -p adventuresim-stdb-module --tests --quiet` — all module test code compiles
- scoped `cargo fmt --check`
- project-map and diff checks; generated client bindings unchanged
- exact PR1 and PR2 native simulations (seed 42, 100 agents, 1,095 days) each replayed to digest `3046ae0a8ebfa90d30a837f1977f9843d6322c43faa4c839194d7857ff2a93cb`, confirming no unintended change to the currently modeled simulator loop

Native `cargo test --lib` for the SpacetimeDB module cannot link on Windows because database host ABI symbols are supplied only by the runtime; `--tests` compilation passes.

## Live smoke test
Rebuilt and reseeded disposable profile `gameplay-audit` at `http://127.0.0.1:24401`. Verified the updated character skill rail renders direct/correlated/effective tooltip data, ordinary settlement navigation remains healthy, and the profile serves the new module. The cached full-world import is not applied to this profile because its finalizer conflicts with the required pre-seeded Riverdale demo industry graph; earlier audit setup confirmed all cached geographic rows load before that isolated finalization rejection.