### PR TITLE
Clarify personality trait labels

### DIFF
--- a/crates/adventuresim-core/src/social.rs
+++ b/crates/adventuresim-core/src/social.rs
@@ -104,13 +104,13 @@ impl PersonalityAxis {
             (Self::Transparency, 2) => Some("Guarded"),
             (Self::SelfKnowledge, 1) => Some("Introspective"),
             (Self::SelfKnowledge, 2) => Some("Self-deceiving"),
-            (Self::Inclination, 0) => Some("Men"),
-            (Self::Inclination, 1) => Some("Either"),
-            (Self::Inclination, 2) => Some("Women"),
-            (Self::Inclination, 3) => Some("Neither"),
-            (Self::Presentation, 0) => Some("Masculine"),
+            (Self::Inclination, 0) => Some("Attracted to men"),
+            (Self::Inclination, 1) => Some("Attracted to men and women"),
+            (Self::Inclination, 2) => Some("Attracted to women"),
+            (Self::Inclination, 3) => Some("Attracted to neither"),
+            (Self::Presentation, 0) => Some("Man"),
             (Self::Presentation, 1) => Some("Ambiguous"),
-            (Self::Presentation, 2) => Some("Feminine"),
+            (Self::Presentation, 2) => Some("Woman"),
             _ => None,
         }
     }
@@ -271,17 +271,17 @@ pub enum Inclination {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Presentation {
-    Masculine,
+    Man,
     Ambiguous,
-    Feminine,
+    Woman,
 }
 
 /// Ambiguous presentation is compatible only with `Either`; a directional
 /// preference requires an unambiguous signal.
 pub const fn inclination_accepts(inclination: Inclination, presentation: Presentation) -> bool {
     match inclination {
-        Inclination::Men => matches!(presentation, Presentation::Masculine),
-        Inclination::Women => matches!(presentation, Presentation::Feminine),
+        Inclination::Men => matches!(presentation, Presentation::Man),
+        Inclination::Women => matches!(presentation, Presentation::Woman),
         Inclination::Either => true,
         Inclination::Neither => false,
     }
@@ -897,33 +897,33 @@ mod tests {
     fn attraction_gate_and_rarity_bonus_are_fail_closed() {
         assert!(!mutually_attracted(
             Inclination::Neither,
-            Presentation::Masculine,
+            Presentation::Man,
             Inclination::Women,
-            Presentation::Feminine,
+            Presentation::Woman,
         ));
         assert_eq!(
             flirt_charm_modifier(
                 Inclination::Neither,
-                Presentation::Masculine,
+                Presentation::Man,
                 Inclination::Women,
-                Presentation::Feminine,
+                Presentation::Woman,
                 Courtship::Amorous,
             ),
             None
         );
         let same = flirt_charm_modifier(
             Inclination::Men,
-            Presentation::Masculine,
+            Presentation::Man,
             Inclination::Men,
-            Presentation::Masculine,
+            Presentation::Man,
             Courtship::Neutral,
         )
         .unwrap();
         let other = flirt_charm_modifier(
             Inclination::Women,
-            Presentation::Masculine,
+            Presentation::Man,
             Inclination::Men,
-            Presentation::Feminine,
+            Presentation::Woman,
             Courtship::Neutral,
         )
         .unwrap();
@@ -947,9 +947,9 @@ mod tests {
         assert!(
             flirt_charm_modifier(
                 Inclination::Women,
-                Presentation::Masculine,
+                Presentation::Man,
                 Inclination::Men,
-                Presentation::Feminine,
+                Presentation::Woman,
                 Courtship::Amorous,
             )
             .unwrap()

--- a/crates/adventuresim-core/src/starting_character.rs
+++ b/crates/adventuresim-core/src/starting_character.rs
@@ -162,9 +162,9 @@ pub enum StartingSex {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StartingPresentation {
-    Masculine,
+    Man,
     Ambiguous,
-    Feminine,
+    Woman,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -520,10 +520,10 @@ fn personality_with_demographics(
     let sex = generated_sex(seed, tier, slot);
     let presentation = match (sex, tier_hash("presentation", seed, tier, slot) % 100) {
         (_, 0..=3) => StartingPresentation::Ambiguous,
-        (StartingSex::Female, 4) => StartingPresentation::Masculine,
-        (StartingSex::Male, 4) => StartingPresentation::Feminine,
-        (StartingSex::Female, _) => StartingPresentation::Feminine,
-        (StartingSex::Male, _) => StartingPresentation::Masculine,
+        (StartingSex::Female, 4) => StartingPresentation::Man,
+        (StartingSex::Male, 4) => StartingPresentation::Woman,
+        (StartingSex::Female, _) => StartingPresentation::Woman,
+        (StartingSex::Male, _) => StartingPresentation::Man,
     };
     let inclination = match tier_hash("inclination", seed, tier, slot) % 100 {
         0 => StartingInclination::Neither,

--- a/crates/adventuresim-stdb-client/src/npc_presentation_type.rs
+++ b/crates/adventuresim-stdb-client/src/npc_presentation_type.rs
@@ -8,11 +8,11 @@ use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 #[sats(crate = __lib)]
 #[derive(Copy, Eq, Hash)]
 pub enum NpcPresentation {
-    Masculine,
+    Man,
 
     Ambiguous,
 
-    Feminine,
+    Woman,
 }
 
 impl __sdk::InModule for NpcPresentation {

--- a/crates/adventuresim-stdb-client/src/presentation_type.rs
+++ b/crates/adventuresim-stdb-client/src/presentation_type.rs
@@ -8,11 +8,11 @@ use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 #[sats(crate = __lib)]
 #[derive(Copy, Eq, Hash)]
 pub enum Presentation {
-    Masculine,
+    Man,
 
     Ambiguous,
 
-    Feminine,
+    Woman,
 }
 
 impl __sdk::InModule for Presentation {

--- a/crates/adventuresim-stdb-module/src/character.rs
+++ b/crates/adventuresim-stdb-module/src/character.rs
@@ -1381,9 +1381,9 @@ fn insert_character_with_origin(
             StartingSex::Male => crate::personality::Sex::Male,
         };
         personality.presentation = match starting.expect("checked above").personality.presentation {
-            StartingPresentation::Masculine => crate::personality::Presentation::Masculine,
+            StartingPresentation::Man => crate::personality::Presentation::Man,
             StartingPresentation::Ambiguous => crate::personality::Presentation::Ambiguous,
-            StartingPresentation::Feminine => crate::personality::Presentation::Feminine,
+            StartingPresentation::Woman => crate::personality::Presentation::Woman,
         };
         personality.inclination = match starting.expect("checked above").personality.inclination {
             StartingInclination::Men => crate::personality::Inclination::Men,

--- a/crates/adventuresim-stdb-module/src/personality.rs
+++ b/crates/adventuresim-stdb-module/src/personality.rs
@@ -89,9 +89,9 @@ pub enum Inclination {
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, SpacetimeType)]
 pub enum Presentation {
-    Masculine,
+    Man,
     Ambiguous,
-    Feminine,
+    Woman,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, SpacetimeType)]
 pub enum Sex {
@@ -168,7 +168,7 @@ impl CharacterPersonality {
             transparency: Transparency::Neutral,
             self_knowledge: SelfKnowledge::Neutral,
             sex: Sex::Male,
-            presentation: Presentation::Masculine,
+            presentation: Presentation::Man,
             inclination: Inclination::Women,
         }
     }
@@ -315,10 +315,10 @@ pub fn random_personality(
     let presentation_roll = random() % 100;
     result.presentation = match (result.sex, presentation_roll) {
         (_, 0..=3) => Presentation::Ambiguous,
-        (Sex::Female, 4) => Presentation::Masculine,
-        (Sex::Male, 4) => Presentation::Feminine,
-        (Sex::Female, _) => Presentation::Feminine,
-        (Sex::Male, _) => Presentation::Masculine,
+        (Sex::Female, 4) => Presentation::Man,
+        (Sex::Male, 4) => Presentation::Woman,
+        (Sex::Female, _) => Presentation::Woman,
+        (Sex::Male, _) => Presentation::Man,
     };
     // Direction is generated from demographic sex rather than the public
     // presentation signal. The signal is the only field attraction consumes.

--- a/crates/adventuresim-stdb-module/src/settlement_population.rs
+++ b/crates/adventuresim-stdb-module/src/settlement_population.rs
@@ -22,9 +22,9 @@ pub enum NpcSex {
 }
 #[derive(Clone, Copy, Debug, SpacetimeType)]
 pub enum NpcPresentation {
-    Masculine,
+    Man,
     Ambiguous,
-    Feminine,
+    Woman,
 }
 
 #[derive(Clone, Debug)]
@@ -185,10 +185,10 @@ fn npc_presentation(id: &str, sex: NpcSex) -> NpcPresentation {
         population::stable_hash(&format!("{id}:presentation")) % 100,
     ) {
         (_, 0..=3) => NpcPresentation::Ambiguous,
-        (NpcSex::Female, 4) => NpcPresentation::Masculine,
-        (NpcSex::Male, 4) => NpcPresentation::Feminine,
-        (NpcSex::Female, _) => NpcPresentation::Feminine,
-        (NpcSex::Male, _) => NpcPresentation::Masculine,
+        (NpcSex::Female, 4) => NpcPresentation::Man,
+        (NpcSex::Male, 4) => NpcPresentation::Woman,
+        (NpcSex::Female, _) => NpcPresentation::Woman,
+        (NpcSex::Male, _) => NpcPresentation::Man,
     }
 }
 
@@ -452,11 +452,11 @@ mod tests {
             let id = format!("npc:test:{index}");
             female_cross_or_ambiguous += usize::from(!matches!(
                 npc_presentation(&id, NpcSex::Female),
-                NpcPresentation::Feminine
+                NpcPresentation::Woman
             ));
             male_cross_or_ambiguous += usize::from(!matches!(
                 npc_presentation(&id, NpcSex::Male),
-                NpcPresentation::Masculine
+                NpcPresentation::Man
             ));
         }
         assert!((40..160).contains(&female_cross_or_ambiguous));

--- a/crates/adventuresim-stdb-module/src/social.rs
+++ b/crates/adventuresim-stdb-module/src/social.rs
@@ -595,9 +595,9 @@ fn observe_presentation_on_contact(ctx: &ReducerContext, observer_id: u64, subje
         .find(observer_id)
         .map_or(0, |time| time.minutes);
     let truth = match personality.presentation {
-        crate::personality::Presentation::Masculine => 0,
+        crate::personality::Presentation::Man => 0,
         crate::personality::Presentation::Ambiguous => 1,
-        crate::personality::Presentation::Feminine => 2,
+        crate::personality::Presentation::Woman => 2,
     };
     if personality.presentation != crate::personality::Presentation::Ambiguous {
         upsert_belief(
@@ -1017,9 +1017,9 @@ fn personality_truth(ctx: &ReducerContext, target_id: u64, axis: PersonalityAxis
             crate::personality::Inclination::Neither => 3,
         },
         PersonalityAxis::Presentation => match p.presentation {
-            crate::personality::Presentation::Masculine => 0,
+            crate::personality::Presentation::Man => 0,
             crate::personality::Presentation::Ambiguous => 1,
-            crate::personality::Presentation::Feminine => 2,
+            crate::personality::Presentation::Woman => 2,
         },
     })
 }
@@ -1051,9 +1051,9 @@ fn core_inclination(value: crate::personality::Inclination) -> CoreInclination {
 
 fn core_presentation(value: crate::personality::Presentation) -> CorePresentation {
     match value {
-        crate::personality::Presentation::Masculine => CorePresentation::Masculine,
+        crate::personality::Presentation::Man => CorePresentation::Man,
         crate::personality::Presentation::Ambiguous => CorePresentation::Ambiguous,
-        crate::personality::Presentation::Feminine => CorePresentation::Feminine,
+        crate::personality::Presentation::Woman => CorePresentation::Woman,
     }
 }
 
@@ -1712,7 +1712,7 @@ pub(crate) fn seed_social_demo(ctx: &ReducerContext) -> Result<(), String> {
         .map_or(0, |v| v.minutes);
     let mut viewer_personality = crate::personality::personality_or_neutral(ctx, VIEWER);
     viewer_personality.sex = crate::personality::Sex::Male;
-    viewer_personality.presentation = crate::personality::Presentation::Masculine;
+    viewer_personality.presentation = crate::personality::Presentation::Man;
     viewer_personality.inclination = crate::personality::Inclination::Women;
     ctx.db
         .character_personality()
@@ -1725,7 +1725,7 @@ pub(crate) fn seed_social_demo(ctx: &ReducerContext) -> Result<(), String> {
     personality.mirth = crate::personality::Mirth::Merry;
     personality.courtship = crate::personality::Courtship::Amorous;
     personality.sex = crate::personality::Sex::Female;
-    personality.presentation = crate::personality::Presentation::Feminine;
+    personality.presentation = crate::personality::Presentation::Woman;
     personality.inclination = crate::personality::Inclination::Men;
     ctx.db
         .character_personality()

--- a/crates/adventuresim-strategic-sim/src/live_core.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core.rs
@@ -566,9 +566,9 @@ fn live_personality(character_id: u64, p: &crate::Personality) -> CharacterPerso
             crate::Inclination::Neither => adventuresim_stdb_client::Inclination::Neither,
         },
         presentation: match p.presentation {
-            crate::Presentation::Masculine => adventuresim_stdb_client::Presentation::Masculine,
+            crate::Presentation::Man => adventuresim_stdb_client::Presentation::Man,
             crate::Presentation::Ambiguous => adventuresim_stdb_client::Presentation::Ambiguous,
-            crate::Presentation::Feminine => adventuresim_stdb_client::Presentation::Feminine,
+            crate::Presentation::Woman => adventuresim_stdb_client::Presentation::Woman,
         },
         sex: match p.sex {
             crate::Sex::Female => adventuresim_stdb_client::Sex::Female,

--- a/crates/adventuresim-strategic-sim/src/profile.rs
+++ b/crates/adventuresim-strategic-sim/src/profile.rs
@@ -146,9 +146,9 @@ pub enum Inclination {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Presentation {
-    Masculine,
+    Man,
     Ambiguous,
-    Feminine,
+    Woman,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -195,7 +195,7 @@ impl Personality {
             transparency: Transparency::Neutral,
             self_knowledge: SelfKnowledge::Neutral,
             inclination: Inclination::Women,
-            presentation: Presentation::Masculine,
+            presentation: Presentation::Man,
             sex: Sex::Male,
         }
     }
@@ -565,10 +565,10 @@ fn generated_personality(rng: &mut StableRng) -> Personality {
     };
     p.presentation = match (p.sex, rng.next_u64() % 100) {
         (_, 0..=3) => Presentation::Ambiguous,
-        (Sex::Female, 4) => Presentation::Masculine,
-        (Sex::Male, 4) => Presentation::Feminine,
-        (Sex::Female, _) => Presentation::Feminine,
-        (Sex::Male, _) => Presentation::Masculine,
+        (Sex::Female, 4) => Presentation::Man,
+        (Sex::Male, 4) => Presentation::Woman,
+        (Sex::Female, _) => Presentation::Woman,
+        (Sex::Male, _) => Presentation::Man,
     };
     p.inclination = match rng.next_u64() % 100 {
         0 => Inclination::Neither,

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -370,9 +370,9 @@ personality_axis!(Inclination {
     Neither
 });
 personality_axis!(Presentation {
-    Masculine,
+    Man,
     Ambiguous,
-    Feminine
+    Woman
 });
 personality_axis!(Sex { Female, Male });
 
@@ -418,7 +418,7 @@ impl CharacterPersonality {
             transparency: Transparency::Neutral,
             self_knowledge: SelfKnowledge::Neutral,
             sex: Sex::Male,
-            presentation: Presentation::Masculine,
+            presentation: Presentation::Man,
             inclination: Inclination::Women,
         }
     }

--- a/crates/strategic-web/src/templates/character.rs
+++ b/crates/strategic-web/src/templates/character.rs
@@ -726,9 +726,9 @@ fn candidate_personality(spec: &StartingCharacterSpec) -> CharacterPersonality {
             StartingSex::Male => Sex::Male,
         },
         presentation: match spec.personality.presentation {
-            StartingPresentation::Masculine => Presentation::Masculine,
+            StartingPresentation::Man => Presentation::Man,
             StartingPresentation::Ambiguous => Presentation::Ambiguous,
-            StartingPresentation::Feminine => Presentation::Feminine,
+            StartingPresentation::Woman => Presentation::Woman,
         },
         inclination: match spec.personality.inclination {
             StartingInclination::Men => Inclination::Men,

--- a/crates/strategic-web/src/templates/settlement/character_details.rs
+++ b/crates/strategic-web/src/templates/settlement/character_details.rs
@@ -907,34 +907,22 @@ fn personality_tags(
         _ => {}
     }
     tags.push(match personality.presentation {
-        Masculine => (
-            "Masculine",
-            "Masculine presentation; normally apparent on contact.",
-        ),
+        Man => ("Man", "Apparently a man; normally apparent on contact."),
         Ambiguous => (
             "Ambiguous",
-            "Ambiguous presentation; compatible with an Either inclination.",
+            "Ambiguous presentation; compatible with attraction to men and women.",
         ),
-        Feminine => (
-            "Feminine",
-            "Feminine presentation; normally apparent on contact.",
-        ),
+        Woman => ("Woman", "Apparently a woman; normally apparent on contact."),
     });
     tags.push(match personality.inclination {
-        Men => (
-            "Inclined toward men",
-            "Romantic interest favors masculine presentation.",
-        ),
+        Men => ("Attracted to men", "Romantic interest favors men."),
         Either => (
-            "Inclined either way",
-            "Romantic interest accepts any presentation.",
+            "Attracted to men and women",
+            "Romantic interest includes men and women.",
         ),
-        Women => (
-            "Inclined toward women",
-            "Romantic interest favors feminine presentation.",
-        ),
+        Women => ("Attracted to women", "Romantic interest favors women."),
         Neither => (
-            "Inclined toward neither",
+            "Attracted to neither",
             "No gender-directed romantic interest.",
         ),
     });
@@ -964,7 +952,7 @@ mod personality_tests {
         let tags = personality_tags(&personality);
         assert_eq!(
             tags.iter().map(|tag| tag.0).collect::<Vec<_>>(),
-            ["Brave", "Cruel", "Masculine", "Inclined toward women"]
+            ["Brave", "Cruel", "Man", "Attracted to women"]
         );
     }
 

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -616,11 +616,11 @@ mod tests {
         assert!(tooltip.contains("Injury is touchy"));
         assert_eq!(
             perceived_trait(crate::spacetimedb::BeliefAxis::Inclination, 1),
-            ("Inclination", "Either")
+            ("Inclination", "Attracted to men and women")
         );
         assert_eq!(
             perceived_trait(crate::spacetimedb::BeliefAxis::Inclination, 3),
-            ("Inclination", "Neither")
+            ("Inclination", "Attracted to neither")
         );
         assert_eq!(
             perceived_trait(crate::spacetimedb::BeliefAxis::Conscience, 2),

--- a/wiki/strategic/character.md
+++ b/wiki/strategic/character.md
@@ -84,9 +84,12 @@ four distinct axes across the expanded thirteen-axis behavioral catalog.
 Mirth, Courtship, Transparency, and Self-knowledge join the existing axes.
 Presentation and Inclination are always assigned outside that sparse count;
 private Sex supplies demographic truth and never participates in attraction.
-Inclination is Men/Either/Women/Neither. Presentation is
-Masculine/Ambiguous/Feminine. Masculine and Feminine presentation are normally
-learned on contact; Ambiguous presentation requires an Insight discovery check.
+The displayed inclination traits are Attracted to men, Attracted to men and
+women, Attracted to women, and Attracted to neither. Apparent gender identity
+is Man/Ambiguous/Woman. Man and Woman are normally learned on contact;
+Ambiguous identity requires an Insight discovery check. Deliberately presenting
+traits that differ from a character's true traits is reserved for a broader
+Deception-based feature.
 
 Each actual personality discovery check conserves 0.25 real training hours.
 An Open subject awards all of it to the observer's Insight; a Neutral subject


### PR DESCRIPTION
## Summary

Renames apparent gender identity traits from `Masculine`/`Feminine` to `Man`/`Woman` throughout the personality schema, simulation, UI, and generated SpacetimeDB bindings. Renames sexuality labels to explicit `Attracted to …` wording.

The documentation now distinguishes apparent gender identity from private sex and reserves deliberate false-trait presentation for a future Deception-based feature.

## Developer impact

This changes SpacetimeDB enum variants, so disposable development databases must be recreated/reseeded.

## Validation

- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test -p adventuresim-core` (426 passed)
- `cargo test -p strategic-web` (303 passed)
- Regenerated SpacetimeDB client bindings

Known unrelated simulator-test failures remain:

- `adventuresim-strategic-sim/tests/simulation.rs` references removed `SkillHours.surgery`.
- One checked-in investigation replay fixture has a generator revision/manifest mismatch.
