### PR TITLE
Unify structured dialogue claims

### DIFF
--- a/content/quests/investigation.yaml
+++ b/content/quests/investigation.yaml
@@ -12,8 +12,7 @@
     {"id":"referral-merchant","kind":"referral","priority":30,"conditions":{"op":"fact","key":{"kind":"participant_profession","role":"player"},"equals":"merchant"},"template":"A matter of local trade may interest you: {summary} Ask {contact_name}, a {contact_profession}, at {contact_location}."},
     {"id":"referral-guild","kind":"referral","priority":20,"conditions":{"op":"fact","key":{"kind":"participant_organization","role":"player"},"equals":"merchant_guild"},"template":"As one recognized by the guild, you should hear this: {summary} Ask {contact_name} at {contact_location}."},
     {"id":"referral-faith","kind":"referral","priority":10,"conditions":{"op":"fact","key":{"kind":"participant_religion","role":"player"},"equals":"roman_catholic"},"template":"For conscience's sake: {summary} Ask {contact_name} at {contact_location}."},
-    {"id":"referral-default","kind":"referral","priority":0,"conditions":{"op":"always"},"template":"{summary} Ask {contact_name}, a {contact_profession}, at {contact_location}."},
-    {"id":"testimony-default","kind":"testimony","priority":0,"conditions":{"op":"always"},"template":"{testimony}"}
+    {"id":"referral-default","kind":"referral","priority":0,"conditions":{"op":"always"},"template":"{summary} Ask {contact_name}, a {contact_profession}, at {contact_location}."}
   ],
   "witness_demographics": [
     {"id":"child","label":"child","match_rules":[{"priority":100,"age_bands":["child","adolescent"],"sexes":[],"professions":[],"local_roles":[],"fallback":false}]},

--- a/crates/adventuresim-core/src/quest_catalog.rs
+++ b/crates/adventuresim-core/src/quest_catalog.rs
@@ -60,7 +60,6 @@ pub struct QuestDialogueVariant {
 #[serde(rename_all = "snake_case")]
 pub enum QuestDialogueVariantKind {
     Referral,
-    Testimony,
 }
 
 impl QuestDialogueVariant {
@@ -886,24 +885,6 @@ mod tests {
         assert_eq!(source.file, "content/quests/investigation.yaml");
         assert!(source.line > 1);
         assert!(source.path.ends_with(".template"));
-    }
-
-    #[test]
-    fn testimony_variant_does_not_repeat_speaker_attribution() {
-        let catalog = catalog();
-        let variant = catalog
-            .dialogue_variant(QuestDialogueVariantKind::Testimony, &FactContext::default())
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            variant
-                .render(&BTreeMap::from([(
-                    "testimony".into(),
-                    "I saw a lantern.".into()
-                )]))
-                .unwrap(),
-            "I saw a lantern."
-        );
     }
 
     #[test]

--- a/crates/adventuresim-core/src/quest_catalog_validation.rs
+++ b/crates/adventuresim-core/src/quest_catalog_validation.rs
@@ -1105,7 +1105,7 @@ pub fn validate_documents(documents: &[Value], files: &[String]) -> Result<(), S
                     "dialogue_variants" => {
                         enum_value(
                             string(item, "kind", &at)?,
-                            &["referral", "testimony"],
+                            &["referral"],
                             &format!("{at}.kind"),
                         )?;
                         signed(item, "priority", -10_000, 10_000, &at)?;

--- a/crates/adventuresim-dialogue/build.rs
+++ b/crates/adventuresim-dialogue/build.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -8,86 +7,13 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[derive(Deserialize)]
-struct BuildDocument {
-    conversations: Vec<BuildConversation>,
-}
-#[derive(Deserialize)]
-struct BuildConversation {
-    id: String,
-    roles: BTreeMap<String, BuildRole>,
-    topics: Vec<BuildTopic>,
-}
-#[derive(Deserialize)]
-struct BuildRole {
-    kind: String,
-    #[serde(default = "build_one")]
-    min: u8,
-    #[serde(default = "build_one")]
-    max: u8,
-}
-#[derive(Deserialize)]
-struct BuildTopic {
-    id: String,
-    #[serde(default)]
-    conditions: serde_json::Value,
-    responses: Vec<BuildResponse>,
-}
-#[derive(Deserialize)]
-struct BuildResponse {
-    id: String,
-    priority: i32,
-    #[serde(default)]
-    conditions: serde_json::Value,
-    turns: Vec<BuildTurn>,
-    #[serde(default)]
-    effects: Vec<BuildEffect>,
-    prompt: Option<BuildPrompt>,
-}
-#[derive(Deserialize)]
-struct BuildTurn {
-    speaker: String,
-    fragments: Vec<BuildFragment>,
-}
-#[derive(Deserialize)]
-struct BuildPrompt {
-    id: String,
-    respondent: String,
-    mode: String,
-    #[serde(default = "build_one_usize")]
-    min_choices: usize,
-    #[serde(default = "build_one_usize")]
-    max_choices: usize,
-    choices: Vec<BuildChoice>,
-}
-#[derive(Deserialize)]
-struct BuildChoice {
-    id: String,
-    #[serde(default)]
-    effects: Vec<BuildEffect>,
-    #[serde(default)]
-    result_turns: Vec<BuildTurn>,
-}
-#[derive(Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum BuildFragment {
-    Text { value: String },
-    Topic { topic: String, label: String },
-    PeriodClaim { value: String },
-    AuthoritativeExplanation { reference: String, value: String },
-    Runtime { slot: String },
-}
-#[derive(Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum BuildEffect {
-    LearnTopic { topic: String },
-    AcceptContract { contract: String },
-    ReportContract { contract: String },
-    BeginApprenticeship { profession: String },
-    SetFlag { flag: String, value: bool },
-    ReceiveReferredTestimony,
-    InvestigationAction { action: String },
-}
+#[path = "src/authoring_schema.rs"]
+mod authoring_schema;
+use authoring_schema::{
+    AuthoringDocument as BuildDocument, AuthoringEffect as BuildEffect,
+    AuthoringFragment as BuildFragment, AuthoringResponse as BuildResponse,
+    AuthoringRole as BuildRole, AuthoringTurn as BuildTurn, Condition, PromptMode,
+};
 
 fn validate_fragment(fragment: &BuildFragment, relative: &str) {
     if let BuildFragment::Runtime { slot } = fragment {
@@ -139,79 +65,120 @@ fn validate_effect(effect: &BuildEffect, relative: &str) {
         );
     }
 }
-fn build_one() -> u8 {
-    1
-}
-fn build_one_usize() -> usize {
-    1
-}
-
-fn validate_condition(value: &serde_json::Value, relative: &str) {
-    if value.is_null() {
-        return;
-    }
-    let object = value
-        .as_object()
-        .unwrap_or_else(|| panic!("condition must be an object in {relative}"));
-    match object.get("op").and_then(serde_json::Value::as_str) {
-        Some("always") => {}
-        Some("all" | "any") => {
-            for child in object
-                .get("conditions")
-                .and_then(serde_json::Value::as_array)
-                .unwrap_or_else(|| panic!("compound condition has no children in {relative}"))
-            {
-                validate_condition(child, relative);
+fn validate_condition_roles(
+    value: &Condition,
+    roles: &BTreeMap<String, BuildRole>,
+    relative: &str,
+) {
+    match value {
+        Condition::All { conditions } | Condition::Any { conditions } => {
+            for child in conditions {
+                validate_condition_roles(child, roles, relative);
             }
         }
-        Some("not") => validate_condition(
-            object
-                .get("condition")
-                .unwrap_or_else(|| panic!("not condition has no child in {relative}")),
-            relative,
-        ),
-        Some("fact") => {
-            let kind = object
-                .get("key")
-                .and_then(serde_json::Value::as_object)
-                .and_then(|key| key.get("kind"))
-                .and_then(serde_json::Value::as_str);
-            assert!(
-                matches!(
-                    kind,
-                    Some(
-                        "participant_profession"
-                            | "participant_organization"
-                            | "participant_religion"
-                            | "participant_age_band"
-                            | "participant_sex"
-                            | "participant_local_role"
-                            | "participant_status"
-                            | "participant_language_compatibility"
-                            | "participant_familiarity"
-                            | "participant_clothing_category"
-                            | "participant_count"
-                            | "participant_present"
-                            | "participant_rumor_case"
-                            | "participant_referral_contact"
-                            | "known_claim"
-                            | "known_lead"
-                            | "prior_questioning"
-                            | "confidence"
-                            | "language_check"
-                            | "social_check"
-                            | "party_leader"
-                            | "service"
-                            | "location"
-                            | "time_period"
-                            | "contract_state"
-                            | "flag"
-                    )
-                ) && object.contains_key("equals"),
-                "unknown or incomplete fact condition in {relative}"
-            );
+        Condition::Not { condition } => validate_condition_roles(condition, roles, relative),
+        Condition::Fact { key, .. } => {
+            for role in key.participant_roles() {
+                assert!(
+                    roles.contains_key(role),
+                    "unknown fact role {role} in {relative}"
+                );
+            }
         }
-        _ => panic!("unknown condition operation in {relative}"),
+        Condition::Always => {}
+    }
+}
+
+fn validate_response_contract(
+    response: &BuildResponse,
+    roles: &BTreeMap<String, BuildRole>,
+    topics: &BTreeSet<&str>,
+    relative: &str,
+) {
+    assert!(
+        !response.turns.is_empty(),
+        "response has no turns in {relative}"
+    );
+    let mut testimony_slots = 0usize;
+    for turn in &response.turns {
+        testimony_slots += validate_turn_contract(turn, roles, topics, relative, true);
+    }
+    let receives = response
+        .effects
+        .iter()
+        .filter(|effect| matches!(effect, BuildEffect::ReceiveReferredTestimony))
+        .count();
+    assert!(
+        (testimony_slots == 1 && receives == 1) || (testimony_slots == 0 && receives == 0),
+        "Runtime(testimony) and receive_referred_testimony must occur exactly once together in {relative}"
+    );
+    for effect in &response.effects {
+        validate_effect_contract(effect, topics, relative, true);
+    }
+}
+
+fn validate_turn_contract(
+    turn: &BuildTurn,
+    roles: &BTreeMap<String, BuildRole>,
+    topics: &BTreeSet<&str>,
+    relative: &str,
+    allow_testimony: bool,
+) -> usize {
+    assert!(
+        roles.contains_key(&turn.speaker),
+        "unknown speaker role {} in {relative}",
+        turn.speaker
+    );
+    assert!(
+        !turn.fragments.is_empty(),
+        "dialogue turn has no fragments in {relative}"
+    );
+    let mut testimony_slots = 0;
+    for fragment in &turn.fragments {
+        validate_fragment(fragment, relative);
+        match fragment {
+            BuildFragment::Text { value }
+            | BuildFragment::PeriodClaim { value }
+            | BuildFragment::AuthoritativeExplanation { value, .. } => {
+                assert!(!value.is_empty(), "empty dialogue content in {relative}");
+            }
+            BuildFragment::Topic { topic, label } => {
+                assert!(!label.is_empty(), "empty topic label in {relative}");
+                assert!(
+                    topics.contains(topic.as_str()),
+                    "dangling inline topic {topic} in {relative}"
+                );
+            }
+            BuildFragment::Runtime { slot } if slot == "testimony" => {
+                assert!(
+                    allow_testimony,
+                    "runtime testimony is not supported in this dialogue position in {relative}"
+                );
+                testimony_slots += 1;
+            }
+            BuildFragment::Runtime { .. } => {}
+        }
+    }
+    testimony_slots
+}
+
+fn validate_effect_contract(
+    effect: &BuildEffect,
+    topics: &BTreeSet<&str>,
+    relative: &str,
+    allow_testimony: bool,
+) {
+    validate_effect(effect, relative);
+    match effect {
+        BuildEffect::LearnTopic { topic } => assert!(
+            topics.contains(topic.as_str()),
+            "dangling LearnTopic {topic} in {relative}"
+        ),
+        BuildEffect::ReceiveReferredTestimony => assert!(
+            allow_testimony,
+            "receive_referred_testimony is not supported in this dialogue position in {relative}"
+        ),
+        _ => {}
     }
 }
 
@@ -245,8 +212,51 @@ fn validate_document(document: &BuildDocument, relative: &str, global_ids: &mut 
                 "invalid role cardinality {relative}:{role_name}"
             );
         }
+        let topic_ids = conversation
+            .topics
+            .iter()
+            .map(|topic| topic.id.as_str())
+            .collect::<BTreeSet<_>>();
+        for response in &conversation.on_start {
+            validate_condition_roles(&response.conditions, &conversation.roles, relative);
+            assert!(
+                global_ids.insert(format!("{}:start:{}", conversation.id, response.id)),
+                "duplicate start response id {relative}:{}",
+                response.id
+            );
+            validate_response_contract(response, &conversation.roles, &topic_ids, relative);
+            assert!(
+                !response
+                    .turns
+                    .iter()
+                    .flat_map(|turn| &turn.fragments)
+                    .any(|fragment| matches!(
+                        fragment,
+                        BuildFragment::Runtime { slot } if slot == "testimony"
+                    ))
+                    && !response
+                        .effects
+                        .iter()
+                        .any(|effect| matches!(effect, BuildEffect::ReceiveReferredTestimony)),
+                "on_start does not support authoritative testimony in {relative}:{}",
+                response.id
+            );
+            assert!(
+                response.prompt.is_none(),
+                "on_start response cannot prompt in {relative}"
+            );
+        }
+        for (index, response) in conversation.on_start.iter().enumerate() {
+            assert!(
+                !conversation.on_start[index + 1..]
+                    .iter()
+                    .any(|other| other.priority == response.priority
+                        && other.conditions == response.conditions),
+                "ambiguous equal-priority start responses in {relative}"
+            );
+        }
         for topic in &conversation.topics {
-            validate_condition(&topic.conditions, relative);
+            validate_condition_roles(&topic.conditions, &conversation.roles, relative);
             assert!(
                 global_ids.insert(format!("{}:{}", conversation.id, topic.id)),
                 "duplicate topic id {relative}:{}",
@@ -258,12 +268,13 @@ fn validate_document(document: &BuildDocument, relative: &str, global_ids: &mut 
                 topic.id
             );
             for response in &topic.responses {
-                validate_condition(&response.conditions, relative);
+                validate_condition_roles(&response.conditions, &conversation.roles, relative);
                 assert!(
                     !response.id.is_empty(),
                     "response has empty id {relative}:{}",
                     topic.id
                 );
+                validate_response_contract(response, &conversation.roles, &topic_ids, relative);
                 assert!(
                     global_ids.insert(format!("{}:{}:{}", conversation.id, topic.id, response.id)),
                     "duplicate response id {relative}:{}",
@@ -307,13 +318,13 @@ fn validate_document(document: &BuildDocument, relative: &str, global_ids: &mut 
                         prompt.id
                     );
                     assert!(
-                        prompt.mode == "multi"
+                        prompt.mode == PromptMode::Multi
                             || (prompt.min_choices == 1 && prompt.max_choices == 1),
                         "single-choice prompt has invalid bounds {relative}:{}",
                         prompt.id
                     );
                     assert!(
-                        prompt.mode != "yes_no" || prompt.choices.len() == 2,
+                        prompt.mode != PromptMode::YesNo || prompt.choices.len() == 2,
                         "yes/no prompt must have two choices {relative}:{}",
                         prompt.id
                     );
@@ -325,22 +336,16 @@ fn validate_document(document: &BuildDocument, relative: &str, global_ids: &mut 
                             choice.id
                         );
                         for turn in &choice.result_turns {
-                            assert!(
-                                conversation.roles.contains_key(&turn.speaker),
-                                "unknown result speaker role {relative}:{}",
-                                turn.speaker
+                            validate_turn_contract(
+                                turn,
+                                &conversation.roles,
+                                &topic_ids,
+                                relative,
+                                false,
                             );
-                            assert!(
-                                !turn.fragments.is_empty(),
-                                "dialogue result turn has no fragments {relative}:{}",
-                                choice.id
-                            );
-                            for fragment in &turn.fragments {
-                                validate_fragment(fragment, relative);
-                            }
                         }
                         for effect in &choice.effects {
-                            validate_effect(effect, relative);
+                            validate_effect_contract(effect, &topic_ids, relative, false);
                         }
                     }
                 }

--- a/crates/adventuresim-dialogue/src/authoring_schema.rs
+++ b/crates/adventuresim-dialogue/src/authoring_schema.rs
@@ -1,0 +1,222 @@
+// The runtime deliberately deserializes this strict preflight schema without
+// reading its fields; build.rs reads them for semantic validation.
+#![allow(dead_code)]
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+fn one() -> u8 {
+    1
+}
+fn one_usize() -> usize {
+    1
+}
+fn first_response() -> ResolutionPolicy {
+    ResolutionPolicy::FirstResponse
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringDocument {
+    pub conversations: Vec<AuthoringConversation>,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringConversation {
+    pub id: String,
+    pub roles: BTreeMap<String, AuthoringRole>,
+    #[serde(default)]
+    pub on_start: Vec<AuthoringResponse>,
+    pub topics: Vec<AuthoringTopic>,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringRole {
+    pub kind: String,
+    #[serde(default = "one")]
+    pub min: u8,
+    #[serde(default = "one")]
+    pub max: u8,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringTopic {
+    pub id: String,
+    pub label: String,
+    #[serde(default)]
+    pub initially_known: bool,
+    #[serde(default)]
+    pub conditions: Condition,
+    pub responses: Vec<AuthoringResponse>,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringResponse {
+    pub id: String,
+    pub priority: i32,
+    #[serde(default)]
+    pub conditions: Condition,
+    pub turns: Vec<AuthoringTurn>,
+    #[serde(default)]
+    pub effects: Vec<AuthoringEffect>,
+    pub prompt: Option<AuthoringPrompt>,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringTurn {
+    pub speaker: String,
+    pub fragments: Vec<AuthoringFragment>,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringPrompt {
+    pub id: String,
+    pub respondent: String,
+    pub mode: PromptMode,
+    #[serde(default = "one_usize")]
+    pub min_choices: usize,
+    #[serde(default = "one_usize")]
+    pub max_choices: usize,
+    #[serde(default = "first_response")]
+    pub resolution: ResolutionPolicy,
+    pub choices: Vec<AuthoringChoice>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptMode {
+    YesNo,
+    Single,
+    Multi,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolutionPolicy {
+    FirstResponse,
+    Unanimous,
+    Majority,
+    AllRespondents,
+}
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AuthoringChoice {
+    pub id: String,
+    pub label: String,
+    #[serde(default)]
+    pub effects: Vec<AuthoringEffect>,
+    #[serde(default)]
+    pub result_turns: Vec<AuthoringTurn>,
+}
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AuthoringFragment {
+    Text { value: String },
+    Topic { topic: String, label: String },
+    PeriodClaim { value: String },
+    AuthoritativeExplanation { reference: String, value: String },
+    Runtime { slot: String },
+}
+#[derive(Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AuthoringEffect {
+    LearnTopic { topic: String },
+    AcceptContract { contract: String },
+    ReportContract { contract: String },
+    BeginApprenticeship { profession: String },
+    SetFlag { flag: String, value: bool },
+    ReceiveReferredTestimony,
+    InvestigationAction { action: String },
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "op", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Condition {
+    #[default]
+    Always,
+    All {
+        conditions: Vec<Condition>,
+    },
+    Any {
+        conditions: Vec<Condition>,
+    },
+    Not {
+        condition: Box<Condition>,
+    },
+    Fact {
+        key: FactKey,
+        equals: FactValue,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum FactKey {
+    ParticipantProfession { role: String },
+    ParticipantOrganization { role: String },
+    ParticipantReligion { role: String },
+    ParticipantAgeBand { role: String },
+    ParticipantSex { role: String },
+    ParticipantLocalRole { role: String },
+    ParticipantStatus { role: String },
+    ParticipantLanguageCompatibility { left: String, right: String },
+    ParticipantFamiliarity { left: String, right: String },
+    ParticipantClothingCategory { role: String },
+    ParticipantHasVisibleClothing { role: String },
+    ParticipantPriorInteraction { left: String, right: String },
+    ParticipantCount { role: String },
+    ParticipantPresent { role: String },
+    ParticipantRumorCase { role: String },
+    ParticipantReferralContact { role: String },
+    KnownClaim,
+    KnownLead,
+    PriorQuestioning { role: String },
+    Confidence,
+    LanguageCheck { left: String, right: String },
+    SocialCheck,
+    PartyLeader { role: String },
+    Service { role: String },
+    Location,
+    LocationRole,
+    LocalCircumstance,
+    TimePeriod,
+    ContractState { contract: String },
+    Flag { flag: String },
+}
+
+impl FactKey {
+    pub fn participant_roles(&self) -> impl Iterator<Item = &str> {
+        let roles: [Option<&str>; 2] = match self {
+            Self::ParticipantProfession { role }
+            | Self::ParticipantOrganization { role }
+            | Self::ParticipantReligion { role }
+            | Self::ParticipantAgeBand { role }
+            | Self::ParticipantSex { role }
+            | Self::ParticipantLocalRole { role }
+            | Self::ParticipantStatus { role }
+            | Self::ParticipantClothingCategory { role }
+            | Self::ParticipantHasVisibleClothing { role }
+            | Self::ParticipantCount { role }
+            | Self::ParticipantPresent { role }
+            | Self::ParticipantRumorCase { role }
+            | Self::ParticipantReferralContact { role }
+            | Self::PriorQuestioning { role }
+            | Self::PartyLeader { role }
+            | Self::Service { role } => [Some(role.as_str()), None],
+            Self::ParticipantLanguageCompatibility { left, right }
+            | Self::ParticipantFamiliarity { left, right }
+            | Self::ParticipantPriorInteraction { left, right }
+            | Self::LanguageCheck { left, right } => [Some(left.as_str()), Some(right.as_str())],
+            _ => [None, None],
+        };
+        roles.into_iter().flatten()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum FactValue {
+    Bool(bool),
+    Integer(i64),
+    Text(String),
+}

--- a/crates/adventuresim-dialogue/src/lib.rs
+++ b/crates/adventuresim-dialogue/src/lib.rs
@@ -6,14 +6,19 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
 
+mod authoring_schema;
+pub use authoring_schema::{Condition, FactKey, FactValue, PromptMode, ResolutionPolicy};
+
 include!(concat!(env!("OUT_DIR"), "/dialogue_catalog.rs"));
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct CatalogDocument {
     pub conversations: Vec<Conversation>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Conversation {
     pub id: String,
     pub roles: BTreeMap<String, Role>,
@@ -24,6 +29,7 @@ pub struct Conversation {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Role {
     pub kind: ParticipantKind,
     #[serde(default = "one")]
@@ -43,6 +49,7 @@ pub enum ParticipantKind {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Topic {
     pub id: String,
     pub label: String,
@@ -54,6 +61,7 @@ pub struct Topic {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Response {
     pub id: String,
     pub priority: i32,
@@ -66,13 +74,14 @@ pub struct Response {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Turn {
     pub speaker: String,
     pub fragments: Vec<Fragment>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Fragment {
     Text {
         value: String,
@@ -127,6 +136,7 @@ pub enum RuntimeSlot {
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RuntimeBindings {
     values: BTreeMap<RuntimeSlot, String>,
+    testimony: Option<Vec<TestimonyLine>>,
 }
 
 impl RuntimeBindings {
@@ -134,10 +144,55 @@ impl RuntimeBindings {
         self.values.insert(slot, value.into());
     }
 
-    pub fn resolve(&self, fragments: &[Fragment]) -> Result<Vec<Fragment>, DialogueError> {
-        fragments
-            .iter()
-            .map(|fragment| match fragment {
+    pub fn bind_testimony(&mut self, testimony: Vec<TestimonyLine>) {
+        self.testimony = Some(testimony);
+    }
+
+    pub fn resolve(&self, fragments: &[Fragment]) -> Result<Vec<ResolvedFragment>, DialogueError> {
+        let mut resolved = Vec::new();
+        let mut claim_order = 0u32;
+        for fragment in fragments {
+            match fragment {
+                Fragment::Runtime {
+                    slot: RuntimeSlot::Testimony,
+                } => {
+                    let testimony = self
+                        .testimony
+                        .as_ref()
+                        .ok_or_else(|| DialogueError::MissingRuntimeSlot(RuntimeSlot::Testimony))?;
+                    for (line_index, line) in testimony.iter().enumerate() {
+                        if line.spoken_text.chars().count() > 512
+                            || line.claim_text.is_empty()
+                            || line.claim_text.chars().count() > 512
+                            || line.spoken_text.chars().any(char::is_control)
+                            || line.claim_text.chars().any(char::is_control)
+                        {
+                            return Err(DialogueError::InvalidRuntimeValue(RuntimeSlot::Testimony));
+                        }
+                        let Some(claim_at) = line.spoken_text.find(&line.claim_text) else {
+                            return Err(DialogueError::InvalidRuntimeValue(RuntimeSlot::Testimony));
+                        };
+                        let claim_end = claim_at + line.claim_text.len();
+                        if line_index > 0 {
+                            resolved.push(ResolvedFragment::Text { value: " ".into() });
+                        }
+                        if claim_at > 0 {
+                            resolved.push(ResolvedFragment::Text {
+                                value: line.spoken_text[..claim_at].into(),
+                            });
+                        }
+                        resolved.push(ResolvedFragment::Claim {
+                            value: line.claim_text.clone(),
+                            claim_order,
+                        });
+                        claim_order = claim_order.saturating_add(1);
+                        if claim_end < line.spoken_text.len() {
+                            resolved.push(ResolvedFragment::Text {
+                                value: line.spoken_text[claim_end..].into(),
+                            });
+                        }
+                    }
+                }
                 Fragment::Runtime { slot } => {
                     let value = self
                         .values
@@ -146,17 +201,80 @@ impl RuntimeBindings {
                     if value.chars().count() > 512 || value.chars().any(char::is_control) {
                         return Err(DialogueError::InvalidRuntimeValue(slot.clone()));
                     }
-                    Ok(Fragment::Text {
+                    resolved.push(ResolvedFragment::Text {
+                        value: value.clone(),
+                    });
+                }
+                Fragment::Text { value } => resolved.push(ResolvedFragment::Text {
+                    value: value.clone(),
+                }),
+                Fragment::Topic { topic, label } => resolved.push(ResolvedFragment::Topic {
+                    topic: topic.clone(),
+                    label: label.clone(),
+                }),
+                Fragment::PeriodClaim { value } => resolved.push(ResolvedFragment::PeriodClaim {
+                    value: value.clone(),
+                }),
+                Fragment::AuthoritativeExplanation { reference, value } => {
+                    resolved.push(ResolvedFragment::AuthoritativeExplanation {
+                        reference: reference.clone(),
                         value: value.clone(),
                     })
                 }
-                authored => Ok(authored.clone()),
+            }
+        }
+        Ok(resolved)
+    }
+
+    pub fn resolve_turn(
+        &self,
+        turn: &Turn,
+        authored_sources: &[Option<SourceRef>],
+    ) -> Result<ResolvedTurn, DialogueError> {
+        if turn.fragments.len() != authored_sources.len() {
+            return Err(DialogueError::SourceAlignment);
+        }
+        let fragments = self.resolve(&turn.fragments)?;
+        let ordinary_count = turn
+            .fragments
+            .iter()
+            .filter(|fragment| {
+                !matches!(
+                    fragment,
+                    Fragment::Runtime {
+                        slot: RuntimeSlot::Testimony
+                    }
+                )
             })
-            .collect()
+            .count();
+        let testimony_count = fragments.len().saturating_sub(ordinary_count);
+        let mut source_refs = Vec::with_capacity(fragments.len());
+        for (fragment, source) in turn.fragments.iter().zip(authored_sources) {
+            let count = if matches!(
+                fragment,
+                Fragment::Runtime {
+                    slot: RuntimeSlot::Testimony
+                }
+            ) {
+                testimony_count
+            } else {
+                1
+            };
+            source_refs.extend(std::iter::repeat(source.clone()).take(count));
+        }
+        if source_refs.len() != fragments.len() {
+            return Err(DialogueError::SourceAlignment);
+        }
+        Ok(ResolvedTurn {
+            speaker: turn.speaker.clone(),
+            fragments,
+            source_refs,
+        })
     }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Prompt {
     pub id: String,
     pub respondent: String,
@@ -177,23 +295,7 @@ fn first_response() -> ResolutionPolicy {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum PromptMode {
-    YesNo,
-    Single,
-    Multi,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ResolutionPolicy {
-    FirstResponse,
-    Unanimous,
-    Majority,
-    AllRespondents,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct Choice {
     pub id: String,
     pub label: String,
@@ -206,7 +308,7 @@ pub struct Choice {
 
 /// Closed, auditable effect vocabulary. Clients submit only response/choice IDs.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(tag = "kind", rename_all = "snake_case")]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum Effect {
     LearnTopic { topic: String },
     AcceptContract { contract: String },
@@ -232,269 +334,56 @@ pub enum InvestigationAction {
     ReportToIssuer,
 }
 
-/// Authoring pattern for how a witness transmits individual propositions.
-/// This is private generation input; topic eligibility must use only the
-/// resulting observer-safe claims, never this classification.
+/// Persisted and transported dialogue output. Unlike [`Fragment`], this type
+/// cannot contain unresolved runtime slots. `Claim` carries only its
+/// event-local presentation identity; all proposition and assessment authority
+/// remains private to the strategic server.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum TestimonyReliability {
-    Truthful,
-    Mistaken,
-    Evasive,
-    Deceptive,
-    PartlyTruthful,
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ResolvedFragment {
+    Text { value: String },
+    Topic { topic: String, label: String },
+    PeriodClaim { value: String },
+    AuthoritativeExplanation { reference: String, value: String },
+    Claim { value: String, claim_order: u32 },
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub struct PropositionTestimony {
-    pub proposition_id: String,
-    pub statement: String,
-    pub confidence_bps: u16,
-    pub disclosed: bool,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub struct TestimonyStageDraft {
-    pub proposition_id: String,
-    pub perceived_text: String,
-    pub recalled_text: String,
-    pub disclosed_text: Option<String>,
-    pub transmitted_text: String,
-    pub confidence_bps: u16,
-}
-
-/// Production authoring path for proposition-level testimony. The alternate
-/// account is server-authored; no model or client invents canonical facts.
-pub fn build_testimony_bundle(
-    reliability: TestimonyReliability,
-    event: PropositionTestimony,
-    circumstance: PropositionTestimony,
-    mistaken_account: &str,
-    deceptive_account: &str,
-) -> Vec<TestimonyStageDraft> {
-    let stage = |source: &PropositionTestimony,
-                 recalled: String,
-                 disclosed: Option<String>,
-                 transmitted: String,
-                 confidence_bps| TestimonyStageDraft {
-        proposition_id: source.proposition_id.clone(),
-        perceived_text: source.statement.clone(),
-        recalled_text: recalled,
-        disclosed_text: disclosed,
-        transmitted_text: transmitted,
-        confidence_bps,
-    };
-    match reliability {
-        TestimonyReliability::Truthful => vec![
-            stage(
-                &event,
-                event.statement.clone(),
-                Some(event.statement.clone()),
-                event.statement.clone(),
-                event.confidence_bps,
-            ),
-            stage(
-                &circumstance,
-                circumstance.statement.clone(),
-                Some(circumstance.statement.clone()),
-                circumstance.statement.clone(),
-                circumstance.confidence_bps,
-            ),
-        ],
-        TestimonyReliability::Mistaken => vec![stage(
-            &event,
-            mistaken_account.into(),
-            Some(mistaken_account.into()),
-            mistaken_account.into(),
-            event.confidence_bps.min(4_000),
-        )],
-        TestimonyReliability::Evasive => vec![
-            stage(
-                &event,
-                event.statement.clone(),
-                Some(event.statement.clone()),
-                event.statement.clone(),
-                event.confidence_bps,
-            ),
-            stage(
-                &circumstance,
-                circumstance.statement.clone(),
-                None,
-                String::new(),
-                circumstance.confidence_bps,
-            ),
-        ],
-        TestimonyReliability::Deceptive => vec![stage(
-            &event,
-            event.statement.clone(),
-            Some(deceptive_account.into()),
-            deceptive_account.into(),
-            event.confidence_bps.min(6_000),
-        )],
-        TestimonyReliability::PartlyTruthful => vec![
-            stage(
-                &event,
-                event.statement.clone(),
-                Some(event.statement.clone()),
-                event.statement.clone(),
-                event.confidence_bps,
-            ),
-            stage(
-                &circumstance,
-                circumstance.statement.clone(),
-                None,
-                String::new(),
-                circumstance.confidence_bps,
-            ),
-        ],
+impl ResolvedFragment {
+    pub fn from_authored(fragment: &Fragment) -> Option<Self> {
+        match fragment {
+            Fragment::Text { value } => Some(Self::Text {
+                value: value.clone(),
+            }),
+            Fragment::Topic { topic, label } => Some(Self::Topic {
+                topic: topic.clone(),
+                label: label.clone(),
+            }),
+            Fragment::PeriodClaim { value } => Some(Self::PeriodClaim {
+                value: value.clone(),
+            }),
+            Fragment::AuthoritativeExplanation { reference, value } => {
+                Some(Self::AuthoritativeExplanation {
+                    reference: reference.clone(),
+                    value: value.clone(),
+                })
+            }
+            Fragment::Runtime { .. } => None,
+        }
     }
 }
 
-pub fn testimony_pattern(
-    reliability: TestimonyReliability,
-    event: PropositionTestimony,
-    circumstance: PropositionTestimony,
-) -> Vec<PropositionTestimony> {
-    match reliability {
-        TestimonyReliability::Truthful => vec![event, circumstance],
-        TestimonyReliability::Mistaken => vec![PropositionTestimony {
-            confidence_bps: event.confidence_bps.min(4_000),
-            ..event
-        }],
-        TestimonyReliability::Evasive => vec![PropositionTestimony {
-            disclosed: false,
-            ..circumstance
-        }],
-        TestimonyReliability::Deceptive => vec![PropositionTestimony {
-            confidence_bps: event.confidence_bps.min(6_000),
-            ..event
-        }],
-        TestimonyReliability::PartlyTruthful => vec![
-            event,
-            PropositionTestimony {
-                disclosed: false,
-                ..circumstance
-            },
-        ],
-    }
-}
-
-/// Typed fact predicates. New game systems extend this enum and the server-side fact resolver.
-#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(tag = "op", rename_all = "snake_case")]
-pub enum Condition {
-    #[default]
-    Always,
-    All {
-        conditions: Vec<Condition>,
-    },
-    Any {
-        conditions: Vec<Condition>,
-    },
-    Not {
-        condition: Box<Condition>,
-    },
-    Fact {
-        key: FactKey,
-        equals: FactValue,
-    },
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum FactKey {
-    /// An NPC's occupational description, or a player's canonical profession
-    /// derived from their locally effective presented organization.
-    ParticipantProfession {
-        role: String,
-    },
-    /// A player's locally effective presented organization. This deliberately
-    /// differs from profession: a guild chapter and its profession family are
-    /// separate authoring concerns.
-    ParticipantOrganization {
-        role: String,
-    },
-    /// A player's authoritative profession of faith.
-    ParticipantReligion {
-        role: String,
-    },
-    ParticipantAgeBand {
-        role: String,
-    },
-    ParticipantSex {
-        role: String,
-    },
-    ParticipantLocalRole {
-        role: String,
-    },
-    ParticipantStatus {
-        role: String,
-    },
-    ParticipantLanguageCompatibility {
-        left: String,
-        right: String,
-    },
-    ParticipantFamiliarity {
-        left: String,
-        right: String,
-    },
-    ParticipantClothingCategory {
-        role: String,
-    },
-    ParticipantHasVisibleClothing {
-        role: String,
-    },
-    ParticipantPriorInteraction {
-        left: String,
-        right: String,
-    },
-    ParticipantCount {
-        role: String,
-    },
-    ParticipantPresent {
-        role: String,
-    },
-    ParticipantRumorCase {
-        role: String,
-    },
-    ParticipantReferralContact {
-        role: String,
-    },
-    KnownClaim,
-    KnownLead,
-    PriorQuestioning {
-        role: String,
-    },
-    Confidence,
-    LanguageCheck {
-        left: String,
-        right: String,
-    },
-    SocialCheck,
-    PartyLeader {
-        role: String,
-    },
-    Service {
-        role: String,
-    },
-    Location,
-    LocationRole,
-    LocalCircumstance,
-    TimePeriod,
-    ContractState {
-        contract: String,
-    },
-    Flag {
-        flag: String,
-    },
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(untagged)]
-pub enum FactValue {
-    Bool(bool),
-    Integer(i64),
-    Text(String),
+#[serde(deny_unknown_fields)]
+pub struct ResolvedTurn {
+    pub speaker: String,
+    pub fragments: Vec<ResolvedFragment>,
+    pub source_refs: Vec<Option<SourceRef>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TestimonyLine {
+    pub spoken_text: String,
+    pub claim_text: String,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -531,13 +420,142 @@ pub enum DialogueError {
     AmbiguousPriority { topic: String, priority: i32 },
     NoEligibleResponse(String),
     InvalidPrompt(String),
+    EmptyContent(String),
+    DanglingTopic(String),
+    InvalidTestimonyContract(String),
+    SourceAlignment,
     MissingRuntimeSlot(RuntimeSlot),
     InvalidRuntimeValue(RuntimeSlot),
+}
+
+fn validate_condition_roles(
+    condition: &Condition,
+    roles: &BTreeMap<String, Role>,
+    errors: &mut Vec<DialogueError>,
+) {
+    match condition {
+        Condition::All { conditions } | Condition::Any { conditions } => {
+            for child in conditions {
+                validate_condition_roles(child, roles, errors);
+            }
+        }
+        Condition::Not { condition } => validate_condition_roles(condition, roles, errors),
+        Condition::Fact { key, .. } => {
+            for role in key.participant_roles() {
+                if !roles.contains_key(role) {
+                    errors.push(DialogueError::UnknownRole(role.into()));
+                }
+            }
+        }
+        Condition::Always => {}
+    }
+}
+
+fn validate_response_semantics(
+    conversation: &Conversation,
+    response: &Response,
+    errors: &mut Vec<DialogueError>,
+) {
+    validate_condition_roles(&response.conditions, &conversation.roles, errors);
+    if response.turns.is_empty() {
+        errors.push(DialogueError::EmptyContent(response.id.clone()));
+    }
+    let mut testimony_slots = 0usize;
+    let topic_ids = conversation
+        .topics
+        .iter()
+        .map(|topic| topic.id.as_str())
+        .collect::<BTreeSet<_>>();
+    for turn in &response.turns {
+        testimony_slots +=
+            validate_turn_semantics(turn, &response.id, &conversation.roles, &topic_ids, errors);
+    }
+    let primary_testimony_slots = testimony_slots;
+    let receives = response
+        .effects
+        .iter()
+        .filter(|effect| matches!(effect, Effect::ReceiveReferredTestimony))
+        .count();
+    for effect in &response.effects {
+        if let Effect::LearnTopic { topic } = effect
+            && !topic_ids.contains(topic.as_str())
+        {
+            errors.push(DialogueError::DanglingTopic(topic.clone()));
+        }
+    }
+    if let Some(prompt) = &response.prompt {
+        for choice in &prompt.choices {
+            for turn in &choice.result_turns {
+                testimony_slots += validate_turn_semantics(
+                    turn,
+                    &response.id,
+                    &conversation.roles,
+                    &topic_ids,
+                    errors,
+                );
+            }
+            for effect in &choice.effects {
+                match effect {
+                    Effect::LearnTopic { topic } if !topic_ids.contains(topic.as_str()) => {
+                        errors.push(DialogueError::DanglingTopic(topic.clone()));
+                    }
+                    Effect::ReceiveReferredTestimony => {
+                        errors.push(DialogueError::InvalidTestimonyContract(response.id.clone()));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    if !((primary_testimony_slots == 1 && testimony_slots == 1 && receives == 1)
+        || (testimony_slots == 0 && receives == 0))
+    {
+        errors.push(DialogueError::InvalidTestimonyContract(response.id.clone()));
+    }
+}
+
+fn validate_turn_semantics(
+    turn: &Turn,
+    response_id: &str,
+    roles: &BTreeMap<String, Role>,
+    topic_ids: &BTreeSet<&str>,
+    errors: &mut Vec<DialogueError>,
+) -> usize {
+    if !roles.contains_key(&turn.speaker) {
+        errors.push(DialogueError::UnknownRole(turn.speaker.clone()));
+    }
+    if turn.fragments.is_empty() {
+        errors.push(DialogueError::EmptyContent(response_id.into()));
+    }
+    let mut testimony_slots = 0;
+    for fragment in &turn.fragments {
+        match fragment {
+            Fragment::Text { value }
+            | Fragment::PeriodClaim { value }
+            | Fragment::AuthoritativeExplanation { value, .. }
+                if value.is_empty() =>
+            {
+                errors.push(DialogueError::EmptyContent(response_id.into()));
+            }
+            Fragment::Topic { topic, label } => {
+                if label.is_empty() || !topic_ids.contains(topic.as_str()) {
+                    errors.push(DialogueError::DanglingTopic(topic.clone()));
+                }
+            }
+            Fragment::Runtime {
+                slot: RuntimeSlot::Testimony,
+            } => testimony_slots += 1,
+            _ => {}
+        }
+    }
+    testimony_slots
 }
 
 pub fn catalog() -> &'static [CatalogDocument] {
     static CATALOG: OnceLock<Vec<CatalogDocument>> = OnceLock::new();
     CATALOG.get_or_init(|| {
+        let _: Vec<authoring_schema::AuthoringDocument> =
+            serde_json::from_str(CATALOG_JSON).expect("strict build-shared dialogue schema");
         serde_json::from_str(CATALOG_JSON).expect("build-validated dialogue catalog")
     })
 }
@@ -615,10 +633,25 @@ pub fn validate(documents: &[CatalogDocument]) -> Result<(), Vec<DialogueError>>
                 if !ids.insert(format!("{}:start:{}", conversation.id, response.id)) {
                     errors.push(DialogueError::DuplicateId(response.id.clone()));
                 }
-                for turn in &response.turns {
-                    if !conversation.roles.contains_key(&turn.speaker) {
-                        errors.push(DialogueError::UnknownRole(turn.speaker.clone()));
-                    }
+                validate_response_semantics(conversation, response, &mut errors);
+                if response
+                    .turns
+                    .iter()
+                    .flat_map(|turn| &turn.fragments)
+                    .any(|fragment| {
+                        matches!(
+                            fragment,
+                            Fragment::Runtime {
+                                slot: RuntimeSlot::Testimony
+                            }
+                        )
+                    })
+                    || response
+                        .effects
+                        .iter()
+                        .any(|effect| matches!(effect, Effect::ReceiveReferredTestimony))
+                {
+                    errors.push(DialogueError::InvalidTestimonyContract(response.id.clone()));
                 }
                 if response.prompt.is_some() {
                     errors.push(DialogueError::InvalidPrompt(response.id.clone()));
@@ -635,6 +668,7 @@ pub fn validate(documents: &[CatalogDocument]) -> Result<(), Vec<DialogueError>>
                 }
             }
             for topic in &conversation.topics {
+                validate_condition_roles(&topic.conditions, &conversation.roles, &mut errors);
                 if !ids.insert(format!("{}:{}", conversation.id, topic.id)) {
                     errors.push(DialogueError::DuplicateId(topic.id.clone()));
                 }
@@ -642,11 +676,7 @@ pub fn validate(documents: &[CatalogDocument]) -> Result<(), Vec<DialogueError>>
                     if !ids.insert(format!("{}:{}:{}", conversation.id, topic.id, response.id)) {
                         errors.push(DialogueError::DuplicateId(response.id.clone()));
                     }
-                    for turn in &response.turns {
-                        if !conversation.roles.contains_key(&turn.speaker) {
-                            errors.push(DialogueError::UnknownRole(turn.speaker.clone()));
-                        }
-                    }
+                    validate_response_semantics(conversation, response, &mut errors);
                     if let Some(prompt) = &response.prompt {
                         if !ids.insert(format!("{}:prompt:{}", conversation.id, prompt.id)) {
                             errors.push(DialogueError::DuplicateId(prompt.id.clone()));
@@ -1090,6 +1120,128 @@ mod tests {
     }
 
     #[test]
+    fn shared_authoring_schema_is_strict_and_covers_on_start() {
+        let unknown = r#"{"conversations":[{"id":"strict","roles":{"player":{"kind":"player"},"npc":{"kind":"npc"}},"on_start":[],"topics":[],"surprise":true}]}"#;
+        assert!(
+            serde_json::from_str::<authoring_schema::AuthoringDocument>(unknown).is_err(),
+            "unknown authoring fields must fail in the schema shared by build and runtime"
+        );
+
+        let malformed: CatalogDocument = serde_json::from_str(
+            r#"{"conversations":[{"id":"start","roles":{"player":{"kind":"player"},"npc":{"kind":"npc"}},"on_start":[{"id":"bad","priority":0,"turns":[{"speaker":"missing","fragments":[{"kind":"text","value":"Hello"}]}],"effects":[],"prompt":null}],"topics":[]}]}"#,
+        )
+        .unwrap();
+        assert!(
+            validate(&[malformed]).unwrap_err().iter().any(
+                |error| matches!(error, DialogueError::UnknownRole(role) if role == "missing")
+            )
+        );
+
+        let mut start_testimony = catalog().to_vec();
+        let start = start_testimony
+            .iter_mut()
+            .flat_map(|document| &mut document.conversations)
+            .find_map(|conversation| conversation.on_start.first_mut())
+            .expect("compiled dialogue has an authored start response");
+        let start_id = start.id.clone();
+        start.turns[0].fragments.push(Fragment::Runtime {
+            slot: RuntimeSlot::Testimony,
+        });
+        start.effects.push(Effect::ReceiveReferredTestimony);
+        assert!(validate(&start_testimony).unwrap_err().iter().any(
+            |error| matches!(error, DialogueError::InvalidTestimonyContract(id) if id == &start_id)
+        ));
+    }
+
+    #[test]
+    fn shared_prompt_schema_closes_mode_and_resolution_with_a_real_default() {
+        let prefix = r#"{"conversations":[{"id":"prompt","roles":{"player":{"kind":"player"},"npc":{"kind":"npc"}},"on_start":[],"topics":[{"id":"topic","label":"Topic","responses":[{"id":"response","priority":0,"turns":[{"speaker":"npc","fragments":[{"kind":"text","value":"Choose."}]}],"effects":[],"prompt":{"id":"choice","respondent":"player","mode":"single","#;
+        let suffix = r#""min_choices":1,"max_choices":1,"choices":[{"id":"a","label":"A"},{"id":"b","label":"B"}]}}]}]}]}"#;
+        let omitted = format!("{prefix}{suffix}");
+        let parsed: authoring_schema::AuthoringDocument = serde_json::from_str(&omitted).unwrap();
+        assert_eq!(
+            parsed.conversations[0].topics[0].responses[0]
+                .prompt
+                .as_ref()
+                .unwrap()
+                .resolution,
+            ResolutionPolicy::FirstResponse
+        );
+        for invalid in [
+            format!("{prefix}\"resolution\":null,{suffix}"),
+            omitted.replace("\"mode\":\"single\"", "\"mode\":\"bogus\""),
+            format!("{prefix}\"resolution\":\"bogus\",{suffix}"),
+        ] {
+            assert!(serde_json::from_str::<authoring_schema::AuthoringDocument>(&invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn validation_rejects_dangling_topics_and_testimony_contract_mismatches() {
+        let mut documents = catalog().to_vec();
+        let conversation = &mut documents[0].conversations[0];
+        conversation.topics[0].responses[0]
+            .effects
+            .push(Effect::LearnTopic {
+                topic: "does-not-exist".into(),
+            });
+        conversation.topics[0].responses[0].turns[0]
+            .fragments
+            .push(Fragment::Runtime {
+                slot: RuntimeSlot::Testimony,
+            });
+        let errors = validate(&documents).unwrap_err();
+        assert!(errors.iter().any(
+            |error| matches!(error, DialogueError::DanglingTopic(topic) if topic == "does-not-exist")
+        ));
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error, DialogueError::InvalidTestimonyContract(_)))
+        );
+    }
+
+    #[test]
+    fn prompt_results_share_turn_and_effect_semantic_validation() {
+        let mut documents = catalog().to_vec();
+        let response = documents
+            .iter_mut()
+            .flat_map(|document| &mut document.conversations)
+            .flat_map(|conversation| &mut conversation.topics)
+            .flat_map(|topic| &mut topic.responses)
+            .find(|response| response.prompt.is_some())
+            .unwrap();
+        let speaker = response.turns[0].speaker.clone();
+        let choice = &mut response.prompt.as_mut().unwrap().choices[0];
+        choice.result_turns.push(Turn {
+            speaker: speaker.clone(),
+            fragments: Vec::new(),
+        });
+        choice.result_turns.push(Turn {
+            speaker,
+            fragments: vec![Fragment::Topic {
+                topic: "missing-inline-topic".into(),
+                label: "missing".into(),
+            }],
+        });
+        choice.effects.push(Effect::LearnTopic {
+            topic: "missing-result-topic".into(),
+        });
+        let errors = validate(&documents).unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error, DialogueError::EmptyContent(_)))
+        );
+        assert!(errors.iter().any(
+            |error| matches!(error, DialogueError::DanglingTopic(topic) if topic == "missing-result-topic")
+        ));
+        assert!(errors.iter().any(
+            |error| matches!(error, DialogueError::DanglingTopic(topic) if topic == "missing-inline-topic")
+        ));
+    }
+
+    #[test]
     fn runtime_slots_are_typed_and_resolve_to_inert_text() {
         let authored = vec![
             Fragment::Text {
@@ -1106,7 +1258,7 @@ mod tests {
         );
         assert_eq!(
             bindings.resolve(&authored).unwrap()[1],
-            Fragment::Text {
+            ResolvedFragment::Text {
                 value: "<img src=x onerror=alert(1)>".into()
             }
         );
@@ -1114,77 +1266,83 @@ mod tests {
     }
 
     #[test]
-    fn testimony_reliability_is_per_proposition() {
-        let event = PropositionTestimony {
-            proposition_id: "event".into(),
-            statement: "I saw an upright shape.".into(),
-            confidence_bps: 8_000,
-            disclosed: true,
-        };
-        let motive = PropositionTestimony {
-            proposition_id: "circumstance".into(),
-            statement: "I was meeting someone there.".into(),
-            confidence_bps: 9_000,
-            disclosed: true,
-        };
-        let partial =
-            testimony_pattern(TestimonyReliability::PartlyTruthful, event.clone(), motive);
-        assert_eq!(partial[0], event);
-        assert!(!partial[1].disclosed);
-        for reliability in [
-            TestimonyReliability::Truthful,
-            TestimonyReliability::Mistaken,
-            TestimonyReliability::Evasive,
-            TestimonyReliability::Deceptive,
-            TestimonyReliability::PartlyTruthful,
-        ] {
-            assert!(
-                !testimony_pattern(
-                    reliability,
-                    event.clone(),
-                    PropositionTestimony {
-                        proposition_id: "why".into(),
-                        statement: "I was fishing.".into(),
-                        confidence_bps: 7_000,
-                        disclosed: true,
-                    },
-                )
-                .is_empty()
-            );
-        }
-        let mistaken = build_testimony_bundle(
-            TestimonyReliability::Mistaken,
-            event.clone(),
-            PropositionTestimony {
-                proposition_id: "why".into(),
-                statement: "I was fishing.".into(),
-                confidence_bps: 7_000,
-                disclosed: true,
+    fn testimony_resolves_exact_claim_boundaries_and_order() {
+        let authored = vec![Fragment::Runtime {
+            slot: RuntimeSlot::Testimony,
+        }];
+        let mut bindings = RuntimeBindings::default();
+        bindings.bind_testimony(vec![
+            TestimonyLine {
+                spoken_text: "Before repeated words; repeated words after.".into(),
+                claim_text: "repeated words".into(),
             },
-            "I saw a stooped child.",
-            "I saw nothing.",
-        );
-        assert_eq!(mistaken[0].recalled_text, "I saw a stooped child.");
-        assert_ne!(mistaken[0].recalled_text, mistaken[0].perceived_text);
-        let deceptive = build_testimony_bundle(
-            TestimonyReliability::Deceptive,
-            event,
-            PropositionTestimony {
-                proposition_id: "why".into(),
-                statement: "I was fishing.".into(),
-                confidence_bps: 7_000,
-                disclosed: true,
+            TestimonyLine {
+                spoken_text: "“The gate was open,” I insist.".into(),
+                claim_text: "The gate was open".into(),
             },
-            "I saw a stooped child.",
-            "I saw nothing.",
-        );
+        ]);
         assert_eq!(
-            deceptive[0].disclosed_text.as_deref(),
-            Some("I saw nothing.")
+            bindings.resolve(&authored).unwrap(),
+            vec![
+                ResolvedFragment::Text {
+                    value: "Before ".into()
+                },
+                ResolvedFragment::Claim {
+                    value: "repeated words".into(),
+                    claim_order: 0
+                },
+                ResolvedFragment::Text {
+                    value: "; repeated words after.".into()
+                },
+                ResolvedFragment::Text { value: " ".into() },
+                ResolvedFragment::Text {
+                    value: "“".into()
+                },
+                ResolvedFragment::Claim {
+                    value: "The gate was open".into(),
+                    claim_order: 1
+                },
+                ResolvedFragment::Text {
+                    value: ",” I insist.".into()
+                },
+            ]
         );
-        assert_ne!(
-            deceptive[0].disclosed_text.as_deref(),
-            Some(deceptive[0].perceived_text.as_str())
+        let encoded = serde_json::to_string(&bindings.resolve(&authored).unwrap()).unwrap();
+        for private in [
+            "proposition",
+            "reliability",
+            "factually",
+            "demeanor",
+            "roll",
+            "threshold",
+            "chance",
+        ] {
+            assert!(!encoded.contains(private));
+        }
+        let source = SourceRef {
+            document: 0,
+            path: "conversations.0.topics.0.responses.0.turns.0.fragments.0.slot".into(),
+            file: "content/dialogue/test.yaml".into(),
+            line: 12,
+            column: 4,
+            value_json: "\"testimony\"".into(),
+        };
+        let turn = Turn {
+            speaker: "npc".into(),
+            fragments: authored,
+        };
+        let resolved_turn = bindings
+            .resolve_turn(&turn, &[Some(source.clone())])
+            .unwrap();
+        assert_eq!(
+            resolved_turn.fragments.len(),
+            resolved_turn.source_refs.len()
+        );
+        assert!(
+            resolved_turn
+                .source_refs
+                .iter()
+                .all(|resolved| resolved.as_ref() == Some(&source))
         );
     }
 }

--- a/crates/adventuresim-stdb-module/src/social.rs
+++ b/crates/adventuresim-stdb-module/src/social.rs
@@ -1044,6 +1044,7 @@ pub(crate) fn passively_assess_dialogue_witness(
     ctx: &ReducerContext,
     observer_character_id: u64,
     session_id: &str,
+    event_sequence: u32,
 ) -> Result<(), String> {
     let session = crate::strategic::require_session_member(ctx, session_id, observer_character_id)?;
     let capability = ctx
@@ -1052,12 +1053,13 @@ pub(crate) fn passively_assess_dialogue_witness(
         .id()
         .find(&format!("{session_id}:{observer_character_id}"))
         .ok_or("Dialogue has no witness social capability")?;
-    let (event_sequence, claims) = crate::strategic::referred_testimony_claims(
+    let claims = crate::strategic::referred_testimony_claims(
         ctx,
         observer_character_id,
         &session,
         &capability.npc_id,
         false,
+        event_sequence,
     )?;
     persist_claim_assessments(
         ctx,
@@ -1074,13 +1076,15 @@ fn passively_assess_released_testimony(
     observer_character_id: u64,
     session: &crate::strategic::DialogueSession,
     npc_id: &str,
+    event_sequence: u32,
 ) -> Result<(), String> {
-    let (event_sequence, claims) = crate::strategic::referred_testimony_claims(
+    let claims = crate::strategic::referred_testimony_claims(
         ctx,
         observer_character_id,
         session,
         npc_id,
         true,
+        event_sequence,
     )?;
     persist_claim_assessments(
         ctx,
@@ -1388,7 +1392,7 @@ pub fn approach_dialogue_witness(
         .challenge_token()
         .update(claim.clone());
     if released {
-        crate::strategic::release_referred_withheld_testimony(
+        let released_event_sequence = crate::strategic::release_referred_withheld_testimony(
             ctx,
             observer_character_id,
             &session,
@@ -1401,6 +1405,7 @@ pub fn approach_dialogue_witness(
             observer_character_id,
             &session,
             &capability.npc_id,
+            released_event_sequence,
         )?;
     }
     ctx.db

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -5872,6 +5872,7 @@ pub fn start_dialogue(
                 "start",
                 session.revision,
                 effect,
+                None,
             )?;
         }
     }
@@ -6791,29 +6792,20 @@ fn dialogue_runtime_bindings(
             &session.settlement_id,
             &session.location_id,
         )? {
-            let mut testimony_parts =
-                adventuresim_core::quest_generation::initial_testimony_projection(
-                    &selected_witness,
-                )
-                .into_iter()
-                .map(|(_, draft)| draft.spoken_text.trim().to_owned())
-                .filter(|text| !text.is_empty())
-                .collect::<Vec<_>>();
-            if let Some(variant) = adventuresim_core::quest_catalog::catalog().dialogue_variant(
-                adventuresim_core::quest_catalog::QuestDialogueVariantKind::Testimony,
-                &dialogue_fact_context(ctx, session, character_id)?,
-            )? {
-                for testimony in &mut testimony_parts {
-                    let mut values = std::collections::BTreeMap::new();
-                    values.insert("testimony".into(), testimony.clone());
-                    *testimony = variant.render(&values)?;
-                }
-            }
-            let testimony = testimony_parts.join(" ");
-            if testimony.is_empty() || testimony.len() > 4_096 {
+            let testimony = adventuresim_core::quest_generation::initial_testimony_projection(
+                &selected_witness,
+            )
+            .into_iter()
+            .map(|(_, draft)| adventuresim_dialogue::TestimonyLine {
+                spoken_text: draft.spoken_text.trim().to_owned(),
+                claim_text: draft.challenge_text.clone(),
+            })
+            .filter(|line| !line.spoken_text.is_empty())
+            .collect::<Vec<_>>();
+            if testimony.is_empty() {
                 return Err("Generated witness testimony is unavailable or too large".into());
             }
-            bindings.bind(S::Testimony, testimony);
+            bindings.bind_testimony(testimony);
         }
     }
     Ok(bindings)
@@ -6851,30 +6843,12 @@ fn receive_referred_testimony(
         &session.location_id,
     )?
     .ok_or("Addressed NPC is not the exact referred witness here")?;
-    // Select once before the claim/lead pipeline runs. Only the observer's
-    // wording is changed; proposition IDs, reliability, destinations, and all
-    // authority remain those in the validated manifest.
-    let presentation_texts = if let Some(variant) = adventuresim_core::quest_catalog::catalog()
-        .dialogue_variant(
-            adventuresim_core::quest_catalog::QuestDialogueVariantKind::Testimony,
-            &dialogue_fact_context(ctx, session, character_id)?,
-        )? {
-        let mut texts = Vec::with_capacity(witness.testimony.len());
-        for draft in &witness.testimony {
-            let mut values = std::collections::BTreeMap::new();
-            values.insert("testimony".into(), draft.spoken_text.clone());
-            texts.push(variant.render(&values)?);
-        }
-        Some(texts)
-    } else {
-        None
-    };
     crate::investigation::persist_generated_testimony(
         ctx,
         character_id,
         &generated,
         &witness,
-        presentation_texts.as_deref(),
+        None,
         action_id,
         false,
     )
@@ -6936,7 +6910,8 @@ pub(crate) fn referred_testimony_claims(
     session: &DialogueSession,
     npc_id: &str,
     withheld: bool,
-) -> Result<(u32, Vec<ReferredTestimonyClaim>), String> {
+    event_sequence: u32,
+) -> Result<Vec<ReferredTestimonyClaim>, String> {
     let (_, witness) = dialogue_referred_witness(ctx, character_id, session, npc_id)?
         .ok_or("Dialogue has no bound witness testimony")?;
     let claims = witness
@@ -6964,21 +6939,35 @@ pub(crate) fn referred_testimony_claims(
             })
         })
         .collect::<Result<Vec<_>, String>>()?;
-    let response_id = if withheld {
-        "witness-social-release"
-    } else {
-        "hear-referred-testimony"
-    };
-    let event_sequence = ctx
+    let event = ctx
         .db
         .dialogue_event()
         .session_id()
         .filter(&session.id)
-        .filter(|event| event.response_id == response_id)
-        .map(|event| event.sequence)
-        .max()
+        .find(|event| event.sequence == event_sequence)
         .ok_or("Heard witness claim event is unavailable")?;
-    Ok((event_sequence, claims))
+    let fragments: Vec<adventuresim_dialogue::ResolvedFragment> =
+        serde_json::from_str(&event.fragments_json)
+            .map_err(|_| "Heard witness claim event is malformed")?;
+    let emitted = fragments
+        .iter()
+        .filter_map(|fragment| match fragment {
+            adventuresim_dialogue::ResolvedFragment::Claim { value, claim_order } => {
+                Some((*claim_order, value.as_str()))
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    if emitted.len() != claims.len()
+        || emitted.iter().zip(&claims).enumerate().any(
+            |(order, ((emitted_order, emitted_text), claim))| {
+                *emitted_order != order as u32 || *emitted_text != claim.displayed_text
+            },
+        )
+    {
+        return Err("Heard witness claim projection does not match private authority".into());
+    }
+    Ok(claims)
 }
 
 pub(crate) fn release_referred_withheld_testimony(
@@ -6987,36 +6976,22 @@ pub(crate) fn release_referred_withheld_testimony(
     session: &DialogueSession,
     npc_id: &str,
     action_id: &str,
-) -> Result<(), String> {
+) -> Result<u32, String> {
     let (generated, witness) = dialogue_referred_witness(ctx, character_id, session, npc_id)?
         .ok_or("Dialogue has no bound witness testimony")?;
-    let variant = adventuresim_core::quest_catalog::catalog().dialogue_variant(
-        adventuresim_core::quest_catalog::QuestDialogueVariantKind::Testimony,
-        &dialogue_fact_context(ctx, session, character_id)?,
-    )?;
-    let mut presentation_texts = Vec::with_capacity(witness.testimony.len());
-    for draft in &witness.testimony {
-        let text = if let Some(variant) = variant {
-            let mut values = std::collections::BTreeMap::new();
-            values.insert("testimony".into(), draft.spoken_text.clone());
-            variant.render(&values)?
-        } else {
-            draft.spoken_text.clone()
-        };
-        presentation_texts.push(text);
-    }
     let released = witness
         .testimony
         .iter()
-        .enumerate()
-        .filter(|(_, draft)| {
+        .filter(|draft| {
             draft.delivery == adventuresim_core::quest_generation::TestimonyDelivery::Withheld
         })
-        .map(|(index, _)| presentation_texts[index].trim())
-        .filter(|text| !text.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
-    if released.is_empty() || released.chars().count() > 4_096 {
+        .map(|draft| adventuresim_dialogue::TestimonyLine {
+            spoken_text: draft.spoken_text.trim().to_owned(),
+            claim_text: draft.challenge_text.clone(),
+        })
+        .filter(|line| !line.spoken_text.is_empty())
+        .collect::<Vec<_>>();
+    if released.is_empty() {
         return Err("Bound witness testimony is unavailable or too large".into());
     }
     crate::investigation::persist_generated_testimony(
@@ -7024,7 +6999,7 @@ pub(crate) fn release_referred_withheld_testimony(
         character_id,
         &generated,
         &witness,
-        Some(&presentation_texts),
+        None,
         action_id,
         true,
     )?;
@@ -7042,21 +7017,30 @@ pub(crate) fn release_referred_withheld_testimony(
         .session_id()
         .filter(&session.id)
         .count() as u32;
+    let mut bindings = adventuresim_dialogue::RuntimeBindings::default();
+    bindings.bind_testimony(released);
+    let fragments = bindings
+        .resolve(&[adventuresim_dialogue::Fragment::Runtime {
+            slot: adventuresim_dialogue::RuntimeSlot::Testimony,
+        }])
+        .map_err(|_| "Could not resolve released witness testimony")?;
     ctx.db.dialogue_event().insert(DialogueEvent {
         id: format!("{}:event:{sequence}", session.id),
         gateway_bucket: 0,
         session_id: session.id.clone(),
         sequence,
-        response_id: "witness-social-release".into(),
+        response_id: format!("claim-release:{action_id}"),
         speaker_role,
-        fragments_json: serde_json::to_string(&vec![adventuresim_dialogue::Fragment::Text {
-            value: released,
-        }])
-        .map_err(|_| "Could not encode released witness testimony")?,
-        source_refs_json: "[null]".into(),
+        fragments_json: serde_json::to_string(&fragments)
+            .map_err(|_| "Could not encode released witness testimony")?,
+        source_refs_json: serde_json::to_string(&vec![
+            Option::<adventuresim_dialogue::SourceRef>::None;
+            fragments.len()
+        ])
+        .map_err(|_| "Could not encode released witness testimony sources")?,
         created_micros: ctx.timestamp.to_micros_since_unix_epoch(),
     });
-    Ok(())
+    Ok(sequence)
 }
 
 fn resolve_dialogue_fragments(
@@ -7065,7 +7049,7 @@ fn resolve_dialogue_fragments(
     character_id: u64,
     speaker_role: &str,
     fragments: &[adventuresim_dialogue::Fragment],
-) -> Result<Vec<adventuresim_dialogue::Fragment>, String> {
+) -> Result<Vec<adventuresim_dialogue::ResolvedFragment>, String> {
     if fragments
         .iter()
         .any(|fragment| matches!(fragment, adventuresim_dialogue::Fragment::Runtime { .. }))
@@ -7074,8 +7058,35 @@ fn resolve_dialogue_fragments(
             .resolve(fragments)
             .map_err(|_| "Dialogue runtime binding is incomplete or unsafe".into())
     } else {
-        Ok(fragments.to_vec())
+        fragments
+            .iter()
+            .map(|fragment| {
+                adventuresim_dialogue::ResolvedFragment::from_authored(fragment)
+                    .ok_or_else(|| "Dialogue fragment remained unresolved".into())
+            })
+            .collect()
     }
+}
+
+fn resolve_dialogue_turn(
+    ctx: &ReducerContext,
+    session: &DialogueSession,
+    character_id: u64,
+    turn: &adventuresim_dialogue::Turn,
+    authored_sources: &[Option<adventuresim_dialogue::SourceRef>],
+) -> Result<adventuresim_dialogue::ResolvedTurn, String> {
+    let bindings = if turn
+        .fragments
+        .iter()
+        .any(|fragment| matches!(fragment, adventuresim_dialogue::Fragment::Runtime { .. }))
+    {
+        dialogue_runtime_bindings(ctx, session, character_id, &turn.speaker)?
+    } else {
+        adventuresim_dialogue::RuntimeBindings::default()
+    };
+    bindings
+        .resolve_turn(turn, authored_sources)
+        .map_err(|_| "Dialogue turn binding or source alignment is invalid".into())
 }
 
 fn dialogue_binding_id(
@@ -7777,44 +7788,46 @@ pub fn choose_dialogue_topic(
         .session_id()
         .filter(&session_id)
         .count() as u32;
+    let mut testimony_event_sequence = None;
     for (offset, turn) in response.turns.iter().enumerate() {
-        let source_refs: Vec<_> =
-            turn.fragments
-                .iter()
-                .enumerate()
-                .map(|(fragment, authored)| {
-                    if matches!(
-                        authored,
-                        adventuresim_dialogue::Fragment::Runtime {
-                            slot: adventuresim_dialogue::RuntimeSlot::Testimony
-                        }
-                    ) {
-                        if let Ok(Some(variant)) = adventuresim_core::quest_catalog::catalog()
-                            .dialogue_variant(
-                            adventuresim_core::quest_catalog::QuestDialogueVariantKind::Testimony,
-                            &facts,
-                        ) {
-                            return adventuresim_core::quest_catalog::catalog()
-                                .dialogue_variant_source(variant);
-                        }
-                    }
-                    let field = match authored {
-                        adventuresim_dialogue::Fragment::Text { .. } => "value",
-                        adventuresim_dialogue::Fragment::Topic { .. } => "label",
-                        adventuresim_dialogue::Fragment::PeriodClaim { .. } => "value",
-                        adventuresim_dialogue::Fragment::AuthoritativeExplanation { .. } => "value",
-                        adventuresim_dialogue::Fragment::Runtime { .. } => "slot",
-                    };
-                    adventuresim_dialogue::source_for_fragment(
-                        &session.conversation_id,
-                        &topic.id,
-                        &response.id,
-                        offset,
-                        fragment,
-                        field,
-                    )
-                })
-                .collect();
+        let authored_sources = turn
+            .fragments
+            .iter()
+            .enumerate()
+            .map(|(fragment, authored)| {
+                let field = match authored {
+                    adventuresim_dialogue::Fragment::Text { .. } => "value",
+                    adventuresim_dialogue::Fragment::Topic { .. } => "label",
+                    adventuresim_dialogue::Fragment::PeriodClaim { .. } => "value",
+                    adventuresim_dialogue::Fragment::AuthoritativeExplanation { .. } => "value",
+                    adventuresim_dialogue::Fragment::Runtime { .. } => "slot",
+                };
+                adventuresim_dialogue::source_for_fragment(
+                    &session.conversation_id,
+                    &topic.id,
+                    &response.id,
+                    offset,
+                    fragment,
+                    field,
+                )
+                .cloned()
+            })
+            .collect::<Vec<_>>();
+        let resolved_turn =
+            resolve_dialogue_turn(ctx, &session, character_id, turn, &authored_sources)?;
+        let resolved = resolved_turn.fragments;
+        let source_refs = resolved_turn.source_refs;
+        if resolved.iter().any(|fragment| {
+            matches!(
+                fragment,
+                adventuresim_dialogue::ResolvedFragment::Claim { .. }
+            )
+        }) {
+            let emitted_sequence = sequence + offset as u32;
+            if testimony_event_sequence.replace(emitted_sequence).is_some() {
+                return Err("Testimony binding expanded into more than one event".into());
+            }
+        }
         ctx.db.dialogue_event().insert(DialogueEvent {
             id: format!("{session_id}:event:{}", sequence + offset as u32),
             gateway_bucket: 0,
@@ -7822,14 +7835,8 @@ pub fn choose_dialogue_topic(
             sequence: sequence + offset as u32,
             response_id: response.id.clone(),
             speaker_role: turn.speaker.clone(),
-            fragments_json: serde_json::to_string(&resolve_dialogue_fragments(
-                ctx,
-                &session,
-                character_id,
-                &turn.speaker,
-                &turn.fragments,
-            )?)
-            .map_err(|_| "Could not encode dialogue turn")?,
+            fragments_json: serde_json::to_string(&resolved)
+                .map_err(|_| "Could not encode dialogue turn")?,
             source_refs_json: serde_json::to_string(&source_refs)
                 .map_err(|_| "Could not encode dialogue sources")?,
             created_micros: ctx.timestamp.to_micros_since_unix_epoch(),
@@ -7845,6 +7852,7 @@ pub fn choose_dialogue_topic(
             &action_id,
             session.revision.saturating_add(1),
             effect,
+            testimony_event_sequence,
         )?;
     }
     if let Some(prompt) = &response.prompt {
@@ -8051,6 +8059,7 @@ pub fn answer_dialogue_prompt(
                     &action_id,
                     session.revision.saturating_add(1),
                     effect,
+                    None,
                 )?;
             }
             let mut sequence = ctx
@@ -8133,6 +8142,7 @@ fn apply_dialogue_effect(
     action_id: &str,
     resulting_revision: u64,
     effect: &adventuresim_dialogue::Effect,
+    testimony_event_sequence: Option<u32>,
 ) -> Result<(), String> {
     let live_npc = require_live_dialogue_presence(ctx, session, character_id)?;
     match effect {
@@ -8177,8 +8187,15 @@ fn apply_dialogue_effect(
             crate::organization::join_organization(ctx, character_id, organization_id)
         }
         adventuresim_dialogue::Effect::ReceiveReferredTestimony => {
+            let event_sequence = testimony_event_sequence
+                .ok_or("Testimony effect has no structured emitted claim event")?;
             receive_referred_testimony(ctx, character_id, session, &live_npc, action_id)?;
-            crate::social::passively_assess_dialogue_witness(ctx, character_id, &session.id)
+            crate::social::passively_assess_dialogue_witness(
+                ctx,
+                character_id,
+                &session.id,
+                event_sequence,
+            )
         }
         adventuresim_dialogue::Effect::InvestigationAction { action } => {
             apply_dialogue_investigation_action(
@@ -19749,5 +19766,18 @@ mod developer_quest_source_tests {
             .expect("passive Insight assessment");
         assert!(receive < assess);
         assert!(effect.contains("?;"));
+    }
+
+    #[test]
+    fn released_testimony_aligns_one_source_entry_per_resolved_fragment() {
+        let source = include_str!("strategic.rs");
+        let release = source
+            .split("pub(crate) fn release_referred_withheld_testimony")
+            .nth(1)
+            .and_then(|tail| tail.split("fn resolve_dialogue_fragments").next())
+            .expect("released testimony emitter");
+        assert!(release.contains("fragments.len()"));
+        assert!(release.contains("Option::<adventuresim_dialogue::SourceRef>::None"));
+        assert!(!release.contains("source_refs_json: \"[null]\""));
     }
 }

--- a/crates/strategic-web/src/routes/dialogue.rs
+++ b/crates/strategic-web/src/routes/dialogue.rs
@@ -175,28 +175,21 @@ struct EventView {
 }
 #[derive(Serialize)]
 struct FragmentView {
-    fragment: adventuresim_dialogue::Fragment,
+    fragment: adventuresim_dialogue::ResolvedFragment,
     source: Option<EditSource>,
-    claim_segments: Option<Vec<ClaimSegmentView>>,
+    claim: Option<ClaimView>,
 }
 #[derive(Serialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-enum ClaimSegmentView {
-    Text {
-        value: String,
-    },
-    Claim {
-        value: String,
-        challenge_token: String,
-        charm_response: Option<String>,
-        command_response: Option<String>,
-        bluff_response: Option<String>,
-        assessment_direction: String,
-        assessment_strength: f32,
-        resolved: bool,
-        outcome: String,
-        affinity_delta: f32,
-    },
+struct ClaimView {
+    challenge_token: String,
+    charm_response: Option<String>,
+    command_response: Option<String>,
+    bluff_response: Option<String>,
+    assessment_direction: String,
+    assessment_strength: f32,
+    resolved: bool,
+    outcome: String,
+    affinity_delta: f32,
 }
 #[derive(Serialize)]
 struct TopicView {
@@ -603,39 +596,28 @@ async fn chat_with_npc(
     ))
 }
 
-fn claim_segments(text: &str, claims: &[WitnessClaimRow]) -> Option<Vec<ClaimSegmentView>> {
-    if claims.is_empty() {
-        return None;
-    }
-    let mut segments = Vec::new();
-    let mut remainder = text;
-    for claim in claims {
-        let (before, after) = remainder.split_once(&claim.displayed_text)?;
-        if !before.is_empty() {
-            segments.push(ClaimSegmentView::Text {
-                value: before.into(),
-            });
-        }
-        segments.push(ClaimSegmentView::Claim {
-            value: claim.displayed_text.clone(),
-            challenge_token: claim.challenge_token.clone(),
-            charm_response: claim.charm_response.clone(),
-            command_response: claim.command_response.clone(),
-            bluff_response: claim.bluff_response.clone(),
-            assessment_direction: claim.assessment_direction.clone(),
-            assessment_strength: claim.assessment_strength.clamp(0.0, 1.0),
-            resolved: claim.resolved,
-            outcome: claim.outcome.clone(),
-            affinity_delta: claim.affinity_delta,
-        });
-        remainder = after;
-    }
-    if !remainder.is_empty() {
-        segments.push(ClaimSegmentView::Text {
-            value: remainder.into(),
-        });
-    }
-    Some(segments)
+fn claim_view(
+    event_sequence: u32,
+    claim_order: u32,
+    displayed_text: &str,
+    claims: &[WitnessClaimRow],
+) -> Option<ClaimView> {
+    let claim = claims.iter().find(|claim| {
+        claim.event_sequence == event_sequence
+            && claim.claim_order == claim_order
+            && claim.displayed_text == displayed_text
+    })?;
+    Some(ClaimView {
+        challenge_token: claim.challenge_token.clone(),
+        charm_response: claim.charm_response.clone(),
+        command_response: claim.command_response.clone(),
+        bluff_response: claim.bluff_response.clone(),
+        assessment_direction: claim.assessment_direction.clone(),
+        assessment_strength: claim.assessment_strength.clamp(0.0, 1.0),
+        resolved: claim.resolved,
+        outcome: claim.outcome.clone(),
+        affinity_delta: claim.affinity_delta,
+    })
 }
 
 async fn build_view(
@@ -692,7 +674,7 @@ async fn build_view(
     let events: Vec<_> = events
         .into_iter()
         .map(|event| {
-            let fragments: Vec<adventuresim_dialogue::Fragment> =
+            let fragments: Vec<adventuresim_dialogue::ResolvedFragment> =
                 serde_json::from_str(&event.fragments_json).unwrap_or_default();
             let sources: Vec<Option<adventuresim_dialogue::SourceRef>> =
                 serde_json::from_str(&event.source_refs_json).unwrap_or_default();
@@ -700,11 +682,6 @@ async fn build_view(
                 .iter()
                 .find(|p| p.role == event.speaker_role)
                 .is_some_and(|p| p.character_id.is_some());
-            let event_claims = claims
-                .iter()
-                .filter(|claim| claim.event_sequence == event.sequence)
-                .cloned()
-                .collect::<Vec<_>>();
             EventView {
                 sequence: event.sequence,
                 speaker_name: names
@@ -717,16 +694,17 @@ async fn build_view(
                     .into_iter()
                     .enumerate()
                     .map(|(index, fragment)| {
-                        let segments = match &fragment {
-                            adventuresim_dialogue::Fragment::Text { value } => {
-                                claim_segments(value, &event_claims)
-                            }
+                        let claim = match &fragment {
+                            adventuresim_dialogue::ResolvedFragment::Claim {
+                                value,
+                                claim_order,
+                            } => claim_view(event.sequence, *claim_order, value, &claims),
                             _ => None,
                         };
                         FragmentView {
                             fragment,
                             source: sources.get(index).cloned().flatten().and_then(edit_source),
-                            claim_segments: segments,
+                            claim,
                         }
                     })
                     .collect(),
@@ -1039,15 +1017,12 @@ mod tests {
     }
 
     #[test]
-    fn claim_segmentation_preserves_authoritative_order_and_fails_closed() {
+    fn structured_claim_projection_requires_exact_event_order_and_text() {
         let rows = vec![claim("alone", 0), claim("a creature as tall as a tree", 1)];
-        let segments = claim_segments(
-            "I was there alone and saw a creature as tall as a tree.",
-            &rows,
-        )
-        .expect("authoritative boundaries match");
-        assert_eq!(segments.len(), 5);
-        assert!(claim_segments("I was there with company.", &rows).is_none());
-        assert!(claim_segments("A creature as tall as a tree saw me alone.", &rows).is_none());
+        assert!(claim_view(4, 0, "alone", &rows).is_some());
+        assert!(claim_view(4, 1, "a creature as tall as a tree", &rows).is_some());
+        assert!(claim_view(3, 0, "alone", &rows).is_none());
+        assert!(claim_view(4, 1, "alone", &rows).is_none());
+        assert!(claim_view(4, 0, "different text", &rows).is_none());
     }
 }

--- a/crates/strategic-web/static/dialogue-client.js
+++ b/crates/strategic-web/static/dialogue-client.js
@@ -227,12 +227,13 @@
       const timestamp = document.createElement("span"); timestamp.className = "chat-timestamp"; timestamp.textContent = "[--:--] ";
       const speaker = document.createElement("strong"); speaker.textContent = `${event.speaker_name}: `;
       row.append(timestamp, speaker);
-      event.fragments.forEach(({ fragment, source, claim_segments }) => {
+      event.fragments.forEach(({ fragment, source, claim }) => {
         if (fragment.kind === "text") {
-          if (claim_segments) claim_segments.forEach((segment) => {
-            row.append(segment.kind === "claim" ? claimControl(segment, binding, row) : document.createTextNode(segment.value));
-          });
-          else row.append(document.createTextNode(fragment.value));
+          row.append(document.createTextNode(fragment.value));
+          const edit = sourceLink(source); if (edit) row.append(edit);
+        }
+        else if (fragment.kind === "claim") {
+          row.append(claim ? claimControl({ ...claim, value: fragment.value }, binding, row) : document.createTextNode(fragment.value));
           const edit = sourceLink(source); if (edit) row.append(edit);
         }
         else if (fragment.kind === "period_claim") { const claim = document.createElement("q"); claim.className = "dialogue-period-claim"; claim.textContent = fragment.value; row.append(claim); const edit = sourceLink(source); if (edit) row.append(edit); }
@@ -240,8 +241,9 @@
         else if (fragment.kind === "topic") row.append(topicAnchor({ id: fragment.topic, label: fragment.label, source }, { ...binding, topicId: fragment.topic }));
       });
       messages.append(row);
-      const expanded = event.fragments.flatMap((entry) => entry.claim_segments || [])
-        .find((segment) => segment.kind === "claim" && segment.challenge_token === expandedClaimToken);
+      const expanded = event.fragments
+        .map((entry) => entry.fragment.kind === "claim" && entry.claim ? { ...entry.claim, value: entry.fragment.value } : null)
+        .find((claim) => claim?.challenge_token === expandedClaimToken);
       if (expanded) row.append(claimResponsePanel(expanded, binding));
     });
     renderPrompt(view.open_prompt);

--- a/crates/strategic-web/tests/dialogue-client.test.cjs
+++ b/crates/strategic-web/tests/dialogue-client.test.cjs
@@ -39,7 +39,9 @@ test("client renders only persisted authoritative views and enforces prompt boun
 });
 
 test("atomic witness claims use observer-safe projections and authoritative responses", () => {
-  assert.match(source, /claim_segments/);
+  assert.match(source, /fragment\.kind === "claim"/);
+  assert.match(source, /fragment\.kind === "claim"[\s\S]*sourceLink\(source\)/);
+  assert.doesNotMatch(source, /claim_segments|split_once/);
   assert.doesNotMatch(source, /api\/dialogue\/spend-time/);
   assert.doesNotMatch(source, /api\/dialogue\/insight/);
   assert.match(source, /api\/dialogue\/claim-response/);

--- a/wiki/reference/dialogue.md
+++ b/wiki/reference/dialogue.md
@@ -86,6 +86,22 @@ servers do not read loose content files.
 
 ## Authoring model
 
+The distinction between generic and quest dialogue is authority, not a
+separate rendering system. A direct topic response may contain the typed
+`runtime: testimony` binding when—and only when—the same response applies
+`receive_referred_testimony`. For the exact generated witness, the server
+expands that slot through the normal turn pipeline into persisted `text`,
+`claim`, and `text` fragments. A claim fragment transports only its displayed
+value and event-local order. Proposition identity, reliability, factual
+accuracy, demeanor, checks, and rolls never enter event JSON. The private
+assessment row must match the exact session event, claim order, and displayed
+text before the gateway makes the fragment interactive; a missing or
+mismatched row leaves ordinary inert text. `period_claim` remains display-only
+and literal YAML cannot manufacture claim authority.
+Conversation-start responses and prompt result turns cannot contain
+authoritative testimony because those execution paths do not carry the exact
+emitted claim-event sequence into the receiving effect.
+
 Each conversation has a stable ID and named participant roles. A role declares
 `player` or `npc` plus minimum/maximum cardinality, so one authored exchange can
 require a shopkeeper and assistant or address several players. Optional
@@ -101,6 +117,11 @@ evidence, testimony, or contract terms. Authored literals and runtime slots
 remain distinct in the compiled catalog and source map. The server resolves
 slots from authoritative strategic rows and persists only bounded inert text;
 generated values are never scripts, conditions, effects, or canonical truth.
+Runtime testimony is the one structured binding: each authoritative draft
+becomes a claim boundary with surrounding punctuation retained as text, and
+multiple drafts retain deterministic event-local order. The compiler rejects
+a testimony slot without its receive effect, the effect without exactly one
+slot, and attempts to place more than one testimony slot in a response.
 Prompts support `yes_no`, `single`, and `multi` choices and
 `first_response`, `unanimous`, `majority`, or `all_respondents` resolution.
 Choices may contain `result_turns`; these are appended to the durable transcript

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1331)
+## Files (1332)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -103,6 +103,7 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-core/src/surgery.rs` — Rust source module for this component.
 - `crates/adventuresim-dialogue/Cargo.toml` — Cargo package/workspace manifest.
 - `crates/adventuresim-dialogue/build.rs` — Rust source module.
+- `crates/adventuresim-dialogue/src/authoring_schema.rs` — Rust source module for this component.
 - `crates/adventuresim-dialogue/src/bin/dialogue-check.rs` — Rust source module.
 - `crates/adventuresim-dialogue/src/lib.rs` — Rust source module for this component.
 - `crates/adventuresim-stdb-client/Cargo.toml` — Cargo package/workspace manifest.

--- a/wiki/reference/quest-generation-and-investigation.md
+++ b/wiki/reference/quest-generation-and-investigation.md
@@ -123,14 +123,23 @@ sites, and rare bridges. `generation.yaml` owns templates and separate
 plausibility/curation weights, including explicit hard zeros.
 
 Quest files may also declare `dialogue_variants`: bounded inert templates for
-generated `referral` or `testimony` prose. Variants reuse dialogue's typed
+generated `referral` prose. Variants reuse dialogue's typed
 condition tree and highest-priority selection semantics. They are presentation
 only: no variant can change canonical facts, reliability, recipient, route,
 or eligibility. Templates are rendered only from server-supplied values. The
 quest compiler records the exact template scalar source span, so generated
-referrals and testimony use the existing developer-mode edit link to the
+referrals use the existing developer-mode edit link to the
 selected quest YAML. Contract and finale exchanges remain ordinary compiled
 dialogue content; use `content/dialogue/` for those surfaces.
+
+Generated testimony does not use a parallel quest prose wrapper. Its authored
+`spoken_text` and exact `challenge_text` are expanded by a generic dialogue
+response's typed testimony binding into structured resolved fragments. This
+preserves punctuation and duplicate surrounding text without browser
+substring reconstruction. Volunteered and socially released withheld drafts
+use the same emitter, and private claim authority is attached to the exact
+emitted event sequence and event-local claim order before the gateway can
+project an opaque challenge token.
 
 Run `cargo run -p adventuresim-core --bin questgen-check -- validate` after an
 edit. Build-time embedding, process startup, and the authoring checker use the


### PR DESCRIPTION
## What changed

- Introduced shared resolved dialogue fragments and turns, including first-class claim fragments.
- Made quest testimony expand through the generic dialogue response runtime so topic responses can render highlighted, interrogable claims.
- Removed browser-side substring reconstruction and duplicate testimony projection models.
- Centralized strict YAML authoring types and validation for conditions, prompt modes, resolution policies, topics, effects, and testimony slots.
- Preserved exact dialogue source links and claim ordering through runtime projection.
- Updated dialogue and investigation documentation.

## Why

Quest testimony and generic topic responses previously used overlapping but inconsistent pipelines. Quest testimony could expose interactive claims, while ordinary authored responses were largely projected as plain text and the browser reconstructed claim spans. This made feature parity fragile and split validation across multiple representations.

The new model keeps conversation entry semantics distinct while sharing response resolution, structured fragment projection, claim interaction, validation, and rendering.

## Impact

Dialogue authors can place the testimony runtime slot in an ordinary topic response and receive the same highlighted claim/interrogation behavior used by quest-driven witness dialogue. Invalid or ambiguous YAML is rejected earlier, including unknown prompt modes, dangling topic/effect references, and testimony in unsupported `on_start` responses.

## Verification

- `just fmt`
- `just check`
- `cargo test -p adventuresim-dialogue`
- `cargo test -p adventuresim-core quest_catalog`
- `cargo test -p strategic-web`
- `node --test crates/strategic-web/tests/dialogue-client.test.cjs`
- `just dialogue-check`
- `just verify-db-client`
- `python scripts/update_project_map.py --check`
- `git diff --check`
- Isolated local stack returned HTTP 200 and was exercised through character selection, settlement navigation, dialogue UI, and developer quest authoring.
