### PR TITLE
Harden local world loading and Windows output

### DIFF
--- a/crates/adventuresim-stdb-module/README.md
+++ b/crates/adventuresim-stdb-module/README.md
@@ -53,8 +53,11 @@ just publish
 just web
 ```
 
-Canonical reset recipes intentionally refuse to delete data. Use an explicitly
-isolated profile for disposable schema work:
+General canonical reset recipes intentionally refuse to delete data. The
+world-specific `just load-world` command is the explicit local exception: it
+reset-publishes the selected loopback `adventuresim-*` database and discards
+all of its existing data before importing the pinned world. For other
+disposable schema work, use an explicitly isolated profile:
 
 ```bash
 just web-isolated-strategic module-dev 23100

--- a/justfile
+++ b/justfile
@@ -241,12 +241,15 @@ build-strategic-map: compile-world
 # Compatibility name for the former Python normalizer.
 normalise-viabundus: compile-world
 
-# Download the pinned compiled runtime when absent, then load it without rebuilding.
+# Destructively recreate the selected local database with the current module,
+# then download and load the pinned compiled world runtime.
 load-world server=spacetime_url database=spacetime_module: spacetime-version-check init-world-runtime
+    @{{ python_bin }} scripts/just_tasks.py recreate-world-database --server {{ server }} --database {{ database }} --module-dir {{ quote(strategic_dir) }}
     @cargo run --package adventuresim-world-import --bin adventuresim-world-import -- --input target/world-1544.json --load --server {{ server }} --database {{ database }}
 
 # Compatibility name for the former Viabundus-only loader.
 load-viabundus-world server=spacetime_url database=spacetime_module: spacetime-version-check init-world-runtime
+    @{{ python_bin }} scripts/just_tasks.py recreate-world-database --server {{ server }} --database {{ database }} --module-dir {{ quote(strategic_dir) }}
     @cargo run --package adventuresim-world-import --bin adventuresim-world-import -- --input target/world-1544.json --load --server {{ server }} --database {{ database }}
 
 # Build the tactical server and spawner

--- a/scripts/dev_stack.py
+++ b/scripts/dev_stack.py
@@ -140,13 +140,27 @@ def validate_loopback_server(server: str, expected_port: int | None = None) -> N
 
 
 def run_checked(command: list[str], cwd: Path = ROOT) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def write_console(output: str) -> None:
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    safe_output = output.encode(encoding, errors="replace").decode(encoding)
+    sys.stdout.write(safe_output)
 
 
 def publish(server: str, database: str) -> int:
     command = ["spacetime", "publish", "--server", server, database]
     result = run_checked(command, MODULE_DIR)
-    sys.stdout.write(result.stdout)
+    write_console(result.stdout)
     if result.returncode:
         print("\nSpacetimeDB rejected the module before any client or spawner was launched.", file=sys.stderr)
         print(f"Server: {server}\nDatabase: {database}", file=sys.stderr)
@@ -163,7 +177,7 @@ def seed(server: str, database: str, bootstrap_token: str, include_damaged_demo:
         "bootstrap_development_world", bootstrap_token,
         "true" if include_damaged_demo else "false",
     ])
-    sys.stdout.write(result.stdout)
+    write_console(result.stdout)
     if result.returncode:
         print("development bootstrap failed; refusing to hide the reducer error.", file=sys.stderr)
     return result.returncode
@@ -209,7 +223,7 @@ def verify_bindings() -> int:
             "--module-path", str(MODULE_DIR), "--yes",
         ])
         if result.returncode:
-            sys.stdout.write(result.stdout)
+            write_console(result.stdout)
             return result.returncode
         generated.joinpath("lib.rs").write_bytes(CLIENT_DIR.joinpath("lib.rs").read_bytes())
         temp_root.joinpath("Cargo.toml").write_text(
@@ -339,7 +353,7 @@ def reset_publish(capability: ResetCapability) -> int:
         "--server", capability.server, capability.database,
     ]
     result = run_checked(command, MODULE_DIR)
-    sys.stdout.write(result.stdout)
+    write_console(result.stdout)
     if result.returncode:
         print("\nIsolated reset publication failed.", file=sys.stderr)
         print(f"Server: {capability.server}\nDatabase: {capability.database}", file=sys.stderr)
@@ -745,7 +759,7 @@ def run_profile(
                     "seed_standalone_tactical_mission", bootstrap_token,
                     str(character_id), mission_id, scene_key, str(enemy_count),
                 ])
-                sys.stdout.write(result.stdout)
+                write_console(result.stdout)
                 if result.returncode:
                     print("standalone tactical mission seed failed; refusing to hide the reducer error.", file=sys.stderr)
                     return result.returncode

--- a/scripts/just_tasks.py
+++ b/scripts/just_tasks.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from urllib.parse import urlparse
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -251,6 +252,44 @@ def run_spawner(spacetime_url: str, database: str, base_port: str) -> int:
 def refuse(message: str) -> int:
     print(message, file=sys.stderr)
     return 2
+
+
+def validate_destructive_world_target(server: str, database: str) -> None:
+    parsed = urlparse(server)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or parsed.hostname not in {"localhost", "127.0.0.1", "::1"}
+        or parsed.port is None
+        or parsed.username
+        or parsed.password
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise RuntimeError(
+            "destructive world loading requires a bare loopback server URL with an explicit port"
+        )
+    if (
+        not database.startswith("adventuresim-")
+        or len(database) > 128
+        or any(character not in "abcdefghijklmnopqrstuvwxyz0123456789-" for character in database)
+    ):
+        raise RuntimeError(
+            "destructive world loading requires a lowercase adventuresim-* database name"
+        )
+
+
+def recreate_world_database(server: str, database: str, module_dir: Path) -> int:
+    validate_destructive_world_target(server, database)
+    print(
+        f"Recreating disposable local database {database!r} on {server}; "
+        "all existing data will be discarded.",
+        flush=True,
+    )
+    return run([
+        executable("spacetime"), "publish", "--delete-data=always", "--yes",
+        "--server", server, database,
+    ], cwd=module_dir)
 
 
 def verified_world_identity(world_input: Path) -> tuple[str, str]:
@@ -508,6 +547,10 @@ def parser() -> argparse.ArgumentParser:
     spawner.add_argument("--spacetime-url", default=SPACETIME_URL)
     spawner.add_argument("--database", default=SPACETIME_DATABASE)
     spawner.add_argument("--base-port", default="6000")
+    recreate = commands.add_parser("recreate-world-database")
+    recreate.add_argument("--server", required=True)
+    recreate.add_argument("--database", required=True)
+    recreate.add_argument("--module-dir", default=str(MODULE_DIR))
     refusal = commands.add_parser("refuse")
     refusal.add_argument("message")
     simulation = commands.add_parser("strategic-sim-core-loop")
@@ -547,6 +590,10 @@ def main(argv: list[str] | None = None) -> int:
             return generate_bindings(Path(args.module_dir))
         if args.command == "spawner":
             return run_spawner(args.spacetime_url, args.database, args.base_port)
+        if args.command == "recreate-world-database":
+            return recreate_world_database(
+                args.server, args.database, Path(args.module_dir)
+            )
         if args.command == "refuse":
             return refuse(args.message)
         if args.command == "strategic-sim-core-loop":

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -155,6 +155,29 @@ class WorkflowTests(unittest.TestCase):
         self.assertEqual(dev_stack.publish("http://localhost:3000", "canonical"), 0)
         self.assertNotIn("--delete-data=always", run_checked.call_args.args[0])
 
+    @mock.patch.object(dev_stack.subprocess, "run")
+    def test_checked_commands_decode_output_as_utf8(self, run):
+        run.return_value = mock.Mock(returncode=0, stdout="")
+
+        dev_stack.run_checked(["spacetime", "publish"])
+
+        self.assertEqual(run.call_args.kwargs["encoding"], "utf-8")
+        self.assertEqual(run.call_args.kwargs["errors"], "replace")
+        self.assertTrue(run.call_args.kwargs["text"])
+        self.assertEqual(run.call_args.kwargs["stderr"], dev_stack.subprocess.STDOUT)
+
+    def test_console_output_replaces_characters_unsupported_by_windows_encoding(self):
+        class LegacyConsole(io.StringIO):
+            @property
+            def encoding(self):
+                return "cp1252"
+
+        console = LegacyConsole()
+        with mock.patch.object(dev_stack.sys, "stdout", console):
+            dev_stack.write_console("published \u0101")
+
+        self.assertEqual(console.getvalue(), "published ?")
+
     @mock.patch.object(dev_stack, "run_checked")
     def test_internal_reset_is_noninteractive_and_identity_bound(self, run_checked):
         run_checked.return_value = mock.Mock(returncode=0, stdout="")

--- a/scripts/tests/test_just_tasks.py
+++ b/scripts/tests/test_just_tasks.py
@@ -12,7 +12,7 @@ import utils.generate_certificates as certificates
 
 
 class JustTaskTests(unittest.TestCase):
-    def test_load_world_preserves_default_database_and_accepts_isolated_database(self):
+    def test_load_world_recreates_selected_database_before_import(self):
         justfile = (Path(__file__).resolve().parents[2] / "justfile").read_text(encoding="utf-8")
         self.assertIn(
             "load-world server=spacetime_url database=spacetime_module:",
@@ -25,7 +25,55 @@ class JustTaskTests(unittest.TestCase):
         load_recipe = justfile.split("load-world server=", 1)[1].split(
             "# Compatibility name", 1
         )[0]
+        self.assertIn("recreate-world-database", load_recipe)
+        self.assertLess(
+            load_recipe.index("recreate-world-database"),
+            load_recipe.index("adventuresim-world-import"),
+        )
         self.assertIn("--database {{ database }}", load_recipe)
+
+    @mock.patch.object(just_tasks, "run", return_value=0)
+    @mock.patch.object(just_tasks, "executable", return_value="spacetime")
+    def test_recreate_world_database_is_noninteractive_and_destructive(
+        self, _executable, run
+    ):
+        self.assertEqual(
+            just_tasks.recreate_world_database(
+                "http://127.0.0.1:23100",
+                "adventuresim-stdb-module",
+                just_tasks.MODULE_DIR,
+            ),
+            0,
+        )
+        self.assertEqual(
+            run.call_args.args[0],
+            [
+                "spacetime",
+                "publish",
+                "--delete-data=always",
+                "--yes",
+                "--server",
+                "http://127.0.0.1:23100",
+                "adventuresim-stdb-module",
+            ],
+        )
+        self.assertEqual(run.call_args.kwargs["cwd"], just_tasks.MODULE_DIR)
+
+    @mock.patch.object(just_tasks, "run")
+    def test_recreate_world_database_refuses_remote_or_unscoped_targets(self, run):
+        for server, database in [
+            ("https://example.com:443", "adventuresim-stdb-module"),
+            ("http://127.0.0.1:23100/path", "adventuresim-stdb-module"),
+            ("http://127.0.0.1:23100", "production"),
+            ("http://127.0.0.1:23100", "adventuresim_BAD"),
+        ]:
+            with self.subTest(server=server, database=database), self.assertRaises(
+                RuntimeError
+            ):
+                just_tasks.recreate_world_database(
+                    server, database, just_tasks.MODULE_DIR
+                )
+        run.assert_not_called()
 
     def test_web_environment_uses_absolute_cross_platform_paths(self):
         environment = just_tasks.web_environment()

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -168,8 +168,10 @@ schema 25 and inference rules 9.
 
 The playable region, spatial grid, source identities, inference versions, and
 compiled records contribute to artifact identity. Import is resumable only for
-the same artifact; loading a different completed artifact requires an
-explicitly reviewed reset of an isolated or otherwise disposable database.
+the same artifact. The local `just load-world` workflow therefore explicitly
+reset-publishes its selected loopback `adventuresim-*` database before loading
+the pinned artifact; all existing data in that database is disposable and
+discarded.
 
 Normal development consumes the separately pinned compiled runtime bundle:
 

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -254,8 +254,8 @@ just build-base-terrain # Build documented-road-only inference terrain
 just compile-world      # Build base terrain, then compile the 1544 world
 just build-strategic-map # Build base, world, and final map/terrain artifacts
 just normalise-viabundus # Compatibility alias for compile-world
-just load-world         # Load it into a published local SpacetimeDB module
-just load-world http://127.0.0.1:24610 adventuresim-dev-example # Load an isolated profile database
+just load-world         # Recreate the canonical local database and load it
+just load-world http://127.0.0.1:24610 adventuresim-dev-example # Recreate and load an isolated profile database
 ```
 
 `just test` runs the strategic browser tests and the native Rust test suites,
@@ -274,11 +274,14 @@ and WASM builds run `just verify-db-client`, which generates and formats into a
 temporary directory and compares the result without changing the checkout.
 
 Schema changes are clean pre-launch changes. Regenerate client bindings and
-recreate an explicitly isolated profile rather than adding a migration or
+recreate the development database rather than adding a migration or
 compatibility path. Routine `just dev`, `just web`, and `just publish` preserve
-data. `web-reset` and `publish-reset` refuse to run; never pass destructive
-publish flags manually against a public or player-bearing database without
-explicit approval and a verified recovery copy.
+data. `just load-world` is the explicit destructive exception: it accepts only
+a bare loopback server and a lowercase `adventuresim-*` database, reset-publishes
+the current module, and discards all existing data before importing the pinned
+world. `web-reset` and `publish-reset` remain unavailable; never pass
+destructive publish flags manually against a public or player-bearing database
+without explicit approval and a verified recovery copy.
 
 `web-isolated` owns its loopback server and database, reset-publishes, reseeds
 the normal world and visual test fixtures, and discards only that profile's
@@ -316,11 +319,14 @@ just init-world-runtime
 just load-world
 ```
 
-`just load-world` installs the runtime bundle when absent and loads
-`target/world-1544.json` into the selected loopback server and database. Pass
-an isolated profile's server and database explicitly when its contents may be
-discarded. A completed import accepts no different artifact; use a fresh
-isolated profile or a separately reviewed operator reset for another build.
+`just load-world` installs the runtime bundle when absent, destructively
+reset-publishes the current module into the selected loopback
+`adventuresim-*` database, and then loads `target/world-1544.json`. This
+deliberately discards characters and every other existing row so the database
+schema and compiled world always match the checkout. Stop any web process using
+the database before loading, then restart it afterward. Pass an isolated
+profile's server and generated database name explicitly when targeting that
+profile.
 
 ### Rebuilding world artifacts
 

--- a/wiki/reference/world-data-bundles.md
+++ b/wiki/reference/world-data-bundles.md
@@ -176,13 +176,15 @@ repeated in the generated notice.
 runtime file already matches, initialization performs no network request. On a
 fresh checkout it downloads the single archive from
 `s3://adventuresim-world-data/releases/world-runtime/`, verifies the checked-in
-archive and member hashes, installs the files under `target/`, and loads the
-compiled world without invoking the source compiler. A conflicting local build
-is never overwritten implicitly; `just replace-world-runtime` retains replaced
-files below `target/world-runtime-backups/`. A previously pinned runtime that is
-still byte-for-byte intact is recognized as downloaded output and upgraded
-automatically, with the prior files retained by the same backup mechanism.
-The optional second argument selects the published database while retaining
+archive and member hashes, and installs the files under `target/` without
+invoking the source compiler. It then reset-publishes the current module and
+loads the compiled world, discarding all existing rows in the selected
+loopback `adventuresim-*` database. A conflicting local build is never
+overwritten implicitly; `just replace-world-runtime` retains replaced files
+below `target/world-runtime-backups/`. A previously pinned runtime that is still
+byte-for-byte intact is recognized as downloaded output and upgraded
+automatically, with the prior files retained by the same backup mechanism. The
+optional second argument selects the database to recreate while retaining
 `spacetime_module` as the default, for example
 `just load-world http://127.0.0.1:24610 adventuresim-dev-example` for an
 isolated strategic profile. The `load-viabundus-world` compatibility alias


### PR DESCRIPTION
## What changed

- Make `just load-world` reset-publish the selected local `adventuresim-*` database before importing the pinned compiled world.
- Guard destructive loading to bare loopback URLs with explicit ports and project-scoped database names.
- Decode SpacetimeDB subprocess output explicitly as UTF-8 and safely render it on legacy Windows console encodings.
- Add regression coverage and update the architecture, development, module, and world-runtime documentation.

## Why

A completed world import rejects a different artifact, leaving the canonical development database stuck on an old world/schema unless it is manually recreated. This project is pre-launch and local development data is disposable, so the explicit world-loading command should recreate that database and load a schema/world pair matching the checkout.

On Windows, `dev-strategic` also crashed while Python decoded UTF-8 output from `spacetime publish` through the active Windows code page. Explicit UTF-8 decoding and console-safe output forwarding prevent that wrapper failure.

## Impact

`just load-world` is now intentionally destructive for its selected local database: existing characters and all other rows are discarded. Routine `just dev`, `just web`, and `just publish` remain non-destructive. Remote URLs and non-`adventuresim-*` database names are rejected.

## Validation

- 21 focused Python workflow tests passed.
- `git diff --cached --check` passed before commit.
- Live `just load-world` reset-published and imported 1,228 nodes, 1,745 edges, and 714 settlements.
- SQL verification returned 714 settlements.
- A real non-destructive `just publish` completed through the formerly crashing Windows migration-plan output.
