### PR TITLE
Fix canonical strategic startup

### DIFF
--- a/crates/strategic-web/README.md
+++ b/crates/strategic-web/README.md
@@ -68,7 +68,7 @@ Environment variables:
 | `TACTICAL_STATIC_DIR` | `crates/adventuresim-stdb-module/static` | Path to tactical web client static files |
 | `SPACETIMEDB_HOST` | `http://localhost:3000` | SpacetimeDB HTTP API URL |
 | `SPACETIMEDB_DATABASE` | `adventuresim-stdb-module` | SpacetimeDB database name |
-| `SPACETIMEDB_TOKEN` | (none) | Optional auth token |
+| `SPACETIMEDB_TOKEN` | (none) | Required auth token for the registered strategic gateway identity |
 
 ## Routes
 

--- a/justfile
+++ b/justfile
@@ -55,11 +55,11 @@ dev-full: web
 dev-strategic: web-strategic
 
 # Start the local browser stack.
-web: preflight spacetime-start publish _seed-world build-wasm build-tactical
+web: preflight spacetime-start publish build-wasm build-tactical
     @{{ python_bin }} scripts/just_tasks.py web --spacetime-url {{ spacetime_url }} --database {{ spacetime_module }} --bind-address 127.0.0.1:{{ web_port }} --static-dir {{ quote(strategic_web_dir + "/static") }} --tactical-static-dir {{ quote(strategic_static) }} --tactical-web-port {{ tactical_web_port }}
 
 # Start the strategic browser stack without building or running tactical services.
-web-strategic: preflight spacetime-start publish _seed-world verify-db-client
+web-strategic: preflight spacetime-start publish verify-db-client
     @{{ python_bin }} scripts/just_tasks.py web --strategic-only --spacetime-url {{ spacetime_url }} --database {{ spacetime_module }} --bind-address 127.0.0.1:{{ web_port }} --static-dir {{ quote(strategic_web_dir + "/static") }} --tactical-static-dir {{ quote(strategic_static) }}
 
 # Start a disposable, worktree-safe stack. Every destructive target is derived
@@ -77,7 +77,7 @@ web-reset:
 
 # Start the browser stack behind locally trusted HTTPS. Caddy negotiates HTTP/2
 # (and HTTP/3 when available) while strategic-web remains internal on port 8080.
-web-secure: preflight caddy-preflight spacetime-start publish _seed-world build-wasm build-tactical
+web-secure: preflight caddy-preflight spacetime-start publish build-wasm build-tactical
     @{{ python_bin }} scripts/just_tasks.py web --secure --spacetime-url {{ spacetime_url }} --database {{ spacetime_module }} --bind-address 127.0.0.1:{{ web_port }} --static-dir {{ quote(strategic_web_dir + "/static") }} --tactical-static-dir {{ quote(strategic_static) }} --tactical-web-port {{ tactical_web_port }} --secure-port {{ secure_web_port }} --caddy-config {{ quote(caddy_config) }}
 
 # Install Caddy's development root certificate in the host trust store.
@@ -87,10 +87,6 @@ secure-web-trust: caddy-preflight
 # Start a fresh local stack with an injured character for stat-bar UI verification.
 web-damaged:
     @{{ python_bin }} scripts/just_tasks.py refuse "Canonical reset demos are disabled. Start an isolated profile, then seed the damaged character there."
-
-# Seed the world with initial settlements and quests
-_seed-world server=spacetime_url: spacetime-version-check
-    @{{ python_bin }} scripts/dev_stack.py seed --server {{ server }} --database {{ spacetime_module }}
 
 # Create or reset the injured Wounded Demo character used to verify damage bars.
 _seed-damaged-character server=spacetime_url: spacetime-version-check

--- a/scripts/just_tasks.py
+++ b/scripts/just_tasks.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import secrets
 import shutil
 import signal
@@ -28,6 +29,7 @@ WEB_STATIC = ROOT / "crates" / "strategic-web" / "static"
 SPACETIME_VERSION = "2.6.1"
 SPACETIME_URL = "http://localhost:3000"
 SPACETIME_DATABASE = "adventuresim-stdb-module"
+JWT_RE = re.compile(r"[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
 
 
 def executable(name: str, message: str | None = None) -> str:
@@ -166,6 +168,7 @@ def web_environment(
     bind_address: str = "127.0.0.1:8080",
     static_dir: Path = WEB_STATIC,
     tactical_static_dir: Path = STRATEGIC_STATIC,
+    spacetime_token: str | None = None,
 ) -> dict[str, str]:
     environment = os.environ.copy()
     environment.update({
@@ -175,13 +178,40 @@ def web_environment(
         "STATIC_DIR": str(static_dir.resolve()),
         "TACTICAL_STATIC_DIR": str(tactical_static_dir.resolve()),
     })
+    if spacetime_token is not None:
+        environment["SPACETIMEDB_TOKEN"] = spacetime_token
     return environment
 
 
+def spacetime_auth_token() -> str:
+    result = subprocess.run(
+        [executable("spacetime"), "login", "show", "--token"],
+        cwd=ROOT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if result.returncode:
+        raise RuntimeError(
+            "SpacetimeDB login is required for the strategic gateway; "
+            "run `spacetime login` and retry"
+        )
+    tokens = JWT_RE.findall(result.stdout)
+    if len(tokens) != 1:
+        raise RuntimeError(
+            "SpacetimeDB CLI did not return exactly one authenticated gateway token"
+        )
+    return tokens[0]
+
+
 def web(args: argparse.Namespace) -> int:
+    spacetime_token = os.environ.get("SPACETIMEDB_TOKEN") or spacetime_auth_token()
     environment = web_environment(
         args.spacetime_url, args.database, args.bind_address,
         Path(args.static_dir), Path(args.tactical_static_dir),
+        spacetime_token,
     )
     if args.strategic_only:
         if run([executable("just"), "_spawner-stop"]):

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -329,6 +329,16 @@ class WorkflowTests(unittest.TestCase):
             self.assertNotIn("build-wasm", line)
             self.assertNotIn("build-tactical", line)
 
+    def test_canonical_web_recipes_do_not_invoke_private_fixture_bootstrap(self):
+        source = Path(dev_stack.ROOT, "justfile").read_text()
+        recipes = [
+            next(line for line in source.splitlines() if line.startswith(prefix))
+            for prefix in ("web:", "web-strategic:", "web-secure:")
+        ]
+        for recipe in recipes:
+            self.assertNotIn("_seed-world", recipe)
+        self.assertNotIn("\n_seed-world ", source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_just_tasks.py
+++ b/scripts/tests/test_just_tasks.py
@@ -76,12 +76,45 @@ class JustTaskTests(unittest.TestCase):
         run.assert_not_called()
 
     def test_web_environment_uses_absolute_cross_platform_paths(self):
-        environment = just_tasks.web_environment()
+        environment = just_tasks.web_environment(spacetime_token="header.payload.signature")
 
         self.assertEqual(environment["SPACETIMEDB_HOST"], "http://localhost:3000")
         self.assertEqual(environment["BIND_ADDRESS"], "127.0.0.1:8080")
+        self.assertEqual(
+            environment["SPACETIMEDB_TOKEN"], "header.payload.signature"
+        )
         self.assertTrue(Path(environment["STATIC_DIR"]).is_absolute())
         self.assertTrue(Path(environment["TACTICAL_STATIC_DIR"]).is_absolute())
+
+    @mock.patch.object(just_tasks.shutil, "which", return_value="spacetime")
+    @mock.patch.object(just_tasks.subprocess, "run")
+    def test_spacetime_auth_token_is_captured_without_logging(self, run, _which):
+        run.return_value = mock.Mock(
+            returncode=0,
+            stdout="Authenticated token: header.payload.signature\n",
+        )
+
+        self.assertEqual(
+            just_tasks.spacetime_auth_token(), "header.payload.signature"
+        )
+        self.assertEqual(
+            run.call_args.args[0], ["spacetime", "login", "show", "--token"]
+        )
+        self.assertEqual(run.call_args.kwargs["encoding"], "utf-8")
+        self.assertEqual(run.call_args.kwargs["errors"], "replace")
+
+    @mock.patch.object(just_tasks.shutil, "which", return_value="spacetime")
+    @mock.patch.object(just_tasks.subprocess, "run")
+    def test_spacetime_auth_token_rejects_missing_or_ambiguous_tokens(
+        self, run, _which
+    ):
+        for output in (
+            "not logged in",
+            "one.two.three and four.five.six",
+        ):
+            run.return_value = mock.Mock(returncode=0, stdout=output)
+            with self.subTest(output=output), self.assertRaises(RuntimeError):
+                just_tasks.spacetime_auth_token()
 
     @mock.patch.object(just_tasks.shutil, "which", return_value="spacetime")
     @mock.patch.object(just_tasks.subprocess, "run")

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -83,9 +83,9 @@ just dev
 Open http://localhost:8080
 
 Ordinary `just dev` / `just web` startup publishes without deleting database
-data. Publication failures stop startup before the seed reducer, tactical
-spawner, or web process starts and print the server/database identity plus
-recovery choices. Canonical reset recipes are intentionally disabled.
+data. Publication failures stop startup before the tactical spawner or web
+process starts and print the server/database identity plus recovery choices.
+Canonical reset recipes are intentionally disabled.
 
 For a disposable demo or worktree, use an explicit isolated profile:
 
@@ -189,6 +189,10 @@ package `gcc-mingw-w64-x86-64` must already be installed.
 - wasm-bindgen (`cargo install wasm-bindgen-cli`) - for WASM builds
 - Caddy (for the HTTPS HTTP/2 development entry point)
 
+Run `spacetime login` before starting the strategic web stack. Canonical local
+startup reads the authenticated token without printing it and passes it only to
+the trusted strategic-web child process.
+
 The `justfile` and repository automation do not require Bash. Stateful or
 compound recipes are implemented in Python, and simple recipes are compatible
 with the host shell. On Windows the default interpreter is `python`; on other
@@ -288,10 +292,10 @@ the normal world and visual test fixtures, and discards only that profile's
 contents. Its data remains available in the profile directory for inspection
 until the next run resets the same profile.
 
-`bootstrap_development_world` is itself idempotent: it inserts only missing demo rows. The local
-seed workflow then resets `Sick Demo` and its party of staggered patients plus a
-high-Physiology physician so symptoms, diagnosis, and treatment can be tested
-immediately. It propagates every reducer failure
+`bootstrap_development_world` is itself idempotent: it inserts only missing demo
+rows. The isolated profile seed workflow then resets `Sick Demo` and its party
+of staggered patients plus a high-Physiology physician so symptoms, diagnosis,
+and treatment can be tested immediately. It propagates every reducer failure
 instead of treating arbitrary errors as evidence that seeding already happened.
 
 Individual fixture reducers are not published. The isolated profile launcher


### PR DESCRIPTION
## What changed

- Remove `_seed-world` from canonical `web`, `web-strategic`, and `web-secure` startup.
- Keep development fixture bootstrap confined to tokenized isolated profiles.
- Read the authenticated SpacetimeDB JWT from an existing `SPACETIMEDB_TOKEN` or `spacetime login show --token`.
- Pass the token only through the trusted strategic-web child environment without printing or persisting it.
- Update startup/authentication documentation and add regression coverage.

## Why

This follows PR #266. Canonical startup was invoking a fixture reducer that is intentionally unavailable in ordinary module builds because no development bootstrap capability is compiled into them. Once that blocker was removed, strategic-web correctly required the authenticated gateway token, but the canonical launcher did not provide it.

Together these issues prevented `just dev-strategic` on `main` from reaching the web server even after the database and world had been recreated.

## Binding audit

Four local untracked discovery binding files were confirmed by `just generate-db-client` to be stale files not produced by the current module ABI. They were removed locally. They never existed on `main`, so there is no generated binding diff in this PR. `just verify-db-client` passes.

## Validation

- `just verify-db-client` passed.
- 21 focused workflow tests passed.
- `git diff --cached --check` passed before commit.
- A real `just dev-strategic` startup completed publication, verified bindings, registered the authenticated strategic gateway, and served HTTP 200 at `http://127.0.0.1:8080/`.
- The complete `just test-dev-stack` run passed 51 of 52 tests. Its sole failure is the pre-existing Windows process-identity test `test_reused_pid_wrong_executable_or_start_token_rejected`, whose implementation logs that the path change is accepted as a likely `exec`.
