### PR TITLE
Add tradition-specific social prayer

### DIFF
--- a/crates/adventuresim-core/src/social.rs
+++ b/crates/adventuresim-core/src/social.rs
@@ -707,28 +707,69 @@ pub const fn actor_allows_social_prayer(conviction_code: i8) -> bool {
 /// Select the available automatic approach which best combines the actor's
 /// effective skill with their personality fit. Risk only breaks exact ties,
 /// so automation does not collapse to the universally low-risk action.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AutomaticSocialCandidate {
+    pub action: SocialActionKind,
+    pub skill_check: f32,
+    pub personality_fit: f32,
+    /// Resolved risk for this actor, target, and topic.
+    pub risk: f32,
+}
+
+impl AutomaticSocialCandidate {
+    pub const fn ordinary(
+        action: SocialActionKind,
+        skill_check: f32,
+        personality_fit: f32,
+    ) -> Self {
+        Self {
+            action,
+            skill_check,
+            personality_fit,
+            risk: action.risk(),
+        }
+    }
+
+    pub const fn with_resolved_risk(
+        action: SocialActionKind,
+        skill_check: f32,
+        personality_fit: f32,
+        risk: f32,
+    ) -> Self {
+        Self {
+            action,
+            skill_check,
+            personality_fit,
+            risk,
+        }
+    }
+}
+
 pub fn choose_automatic_social_action(
     topic: SocialTopic,
-    candidates: impl IntoIterator<Item = (SocialActionKind, f32, f32)>,
+    candidates: impl IntoIterator<Item = AutomaticSocialCandidate>,
 ) -> Option<SocialActionKind> {
     candidates
         .into_iter()
-        .filter(|(action, skill_check, personality_fit)| {
-            *action != SocialActionKind::Reflect
-                && action.available_for(topic)
-                && skill_check.is_finite()
-                && personality_fit.is_finite()
+        .filter(|candidate| {
+            candidate.action != SocialActionKind::Reflect
+                && candidate.action.available_for(topic)
+                && candidate.skill_check.is_finite()
+                && candidate.personality_fit.is_finite()
+                && candidate.risk.is_finite()
         })
         .max_by(|left, right| {
-            let left_score = left.1.clamp(0.0, 5.0) + left.2.clamp(-2.0, 2.0);
-            let right_score = right.1.clamp(0.0, 5.0) + right.2.clamp(-2.0, 2.0);
+            let left_score =
+                left.skill_check.clamp(0.0, 5.0) + left.personality_fit.clamp(-2.0, 2.0);
+            let right_score =
+                right.skill_check.clamp(0.0, 5.0) + right.personality_fit.clamp(-2.0, 2.0);
             left_score
                 .total_cmp(&right_score)
-                .then_with(|| left.2.total_cmp(&right.2))
-                .then_with(|| left.1.total_cmp(&right.1))
-                .then_with(|| right.0.risk().total_cmp(&left.0.risk()))
+                .then_with(|| left.personality_fit.total_cmp(&right.personality_fit))
+                .then_with(|| left.skill_check.total_cmp(&right.skill_check))
+                .then_with(|| right.risk.total_cmp(&left.risk))
         })
-        .map(|(action, _, _)| action)
+        .map(|candidate| candidate.action)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1676,10 +1717,10 @@ mod tests {
         let action = choose_automatic_social_action(
             SocialTopic::Defeat,
             [
-                (SocialActionKind::Listen, 3.0, 0.0),
-                (SocialActionKind::LightenMood, 3.5, 1.0),
-                (SocialActionKind::Rally, 4.0, 0.0),
-                (SocialActionKind::Flirt, 1.0, 0.0),
+                AutomaticSocialCandidate::ordinary(SocialActionKind::Listen, 3.0, 0.0),
+                AutomaticSocialCandidate::ordinary(SocialActionKind::LightenMood, 3.5, 1.0),
+                AutomaticSocialCandidate::ordinary(SocialActionKind::Rally, 4.0, 0.0),
+                AutomaticSocialCandidate::ordinary(SocialActionKind::Flirt, 1.0, 0.0),
             ],
         );
         assert_eq!(action, Some(SocialActionKind::LightenMood));
@@ -1687,8 +1728,8 @@ mod tests {
         let skilled = choose_automatic_social_action(
             SocialTopic::Defeat,
             [
-                (SocialActionKind::Listen, 1.0, 1.0),
-                (SocialActionKind::Rally, 4.5, 0.0),
+                AutomaticSocialCandidate::ordinary(SocialActionKind::Listen, 1.0, 1.0),
+                AutomaticSocialCandidate::ordinary(SocialActionKind::Rally, 4.5, 0.0),
             ],
         );
         assert_eq!(skilled, Some(SocialActionKind::Rally));
@@ -1700,8 +1741,8 @@ mod tests {
             choose_automatic_social_action(
                 SocialTopic::Hunger,
                 [
-                    (SocialActionKind::Flirt, 5.0, 2.0),
-                    (SocialActionKind::Listen, 1.0, 0.0),
+                    AutomaticSocialCandidate::ordinary(SocialActionKind::Flirt, 5.0, 2.0),
+                    AutomaticSocialCandidate::ordinary(SocialActionKind::Listen, 1.0, 0.0),
                 ],
             ),
             Some(SocialActionKind::Listen)
@@ -1714,11 +1755,41 @@ mod tests {
             choose_automatic_social_action(
                 SocialTopic::Defeat,
                 [
-                    (SocialActionKind::Rally, 3.0, 0.0),
-                    (SocialActionKind::Listen, 3.0, 0.0),
+                    AutomaticSocialCandidate::ordinary(SocialActionKind::Rally, 3.0, 0.0),
+                    AutomaticSocialCandidate::ordinary(SocialActionKind::Listen, 3.0, 0.0),
                 ],
             ),
             Some(SocialActionKind::Listen)
+        );
+        assert_eq!(
+            choose_automatic_social_action(
+                SocialTopic::Fatigue,
+                [
+                    AutomaticSocialCandidate::with_resolved_risk(
+                        SocialActionKind::Pray,
+                        3.0,
+                        0.0,
+                        0.30,
+                    ),
+                    AutomaticSocialCandidate::ordinary(SocialActionKind::LightenMood, 3.0, 0.0,),
+                ],
+            ),
+            Some(SocialActionKind::Pray)
+        );
+        assert_eq!(
+            choose_automatic_social_action(
+                SocialTopic::Faith,
+                [
+                    AutomaticSocialCandidate::with_resolved_risk(
+                        SocialActionKind::Pray,
+                        3.0,
+                        0.0,
+                        0.60,
+                    ),
+                    AutomaticSocialCandidate::ordinary(SocialActionKind::Rally, 3.0, 0.0),
+                ],
+            ),
+            Some(SocialActionKind::Rally)
         );
     }
 
@@ -1845,8 +1916,13 @@ mod tests {
             choose_automatic_social_action(
                 SocialTopic::Injury,
                 [
-                    (SocialActionKind::Listen, 2.0, 0.0),
-                    (SocialActionKind::Pray, 4.0, 0.25),
+                    AutomaticSocialCandidate::ordinary(SocialActionKind::Listen, 2.0, 0.0),
+                    AutomaticSocialCandidate::with_resolved_risk(
+                        SocialActionKind::Pray,
+                        4.0,
+                        0.25,
+                        0.4,
+                    ),
                 ],
             ),
             Some(SocialActionKind::Pray)
@@ -1854,7 +1930,12 @@ mod tests {
         assert_eq!(
             choose_automatic_social_action(
                 SocialTopic::Filth,
-                [(SocialActionKind::Pray, 5.0, 2.0)],
+                [AutomaticSocialCandidate::with_resolved_risk(
+                    SocialActionKind::Pray,
+                    5.0,
+                    2.0,
+                    0.3,
+                )],
             ),
             None
         );

--- a/crates/adventuresim-core/src/social.rs
+++ b/crates/adventuresim-core/src/social.rs
@@ -6,6 +6,8 @@
 
 use std::collections::HashSet;
 
+use adventuresim_world_schema::OfficialReligion;
+
 pub const AFFINITY_MIN: f32 = -100.0;
 pub const AFFINITY_MAX: f32 = 100.0;
 pub const AFFINITY_HALF_LIFE_MINUTES: u64 = 30 * 24 * 60;
@@ -469,6 +471,7 @@ pub enum SocialActionKind {
     Reflect,
     Listen,
     Commiserate,
+    Pray,
     LightenMood,
     Rally,
     Reframe,
@@ -481,6 +484,7 @@ impl SocialActionKind {
             Self::Reflect => "reflect",
             Self::Listen => "listen",
             Self::Commiserate => "commiserate",
+            Self::Pray => "pray",
             Self::LightenMood => "lighten_mood",
             Self::Rally => "command",
             Self::Reframe => "deception",
@@ -494,6 +498,7 @@ impl SocialActionKind {
             Self::Listen => "Insight",
             Self::Commiserate if shares_concern => "Insight",
             Self::Commiserate => "Deception",
+            Self::Pray => "Religion",
             Self::LightenMood => "Charm",
             Self::Rally => "Command",
             Self::Reframe => "Deception",
@@ -504,6 +509,7 @@ impl SocialActionKind {
     pub const fn available_for(self, topic: SocialTopic) -> bool {
         match self {
             Self::Reflect | Self::Listen | Self::Commiserate => true,
+            Self::Pray => !matches!(topic, SocialTopic::Filth),
             Self::LightenMood => !matches!(topic, SocialTopic::Faith),
             Self::Rally => matches!(
                 topic,
@@ -542,6 +548,7 @@ impl SocialActionKind {
                 "Feign sympathy about the moral setback"
             }
             (Self::Commiserate, SocialTopic::Filth, false) => "Feign sympathy about being filthy",
+            (Self::Pray, _, _) => "Offer a prayer in their tradition",
             (Self::LightenMood, SocialTopic::Defeat, _) => "Joke about bouncing back from defeat",
             (Self::LightenMood, SocialTopic::Injury, _) => "Joke to distract them from the pain",
             (Self::LightenMood, SocialTopic::Fatigue, _) => "Joke to help keep them awake",
@@ -572,11 +579,109 @@ impl SocialActionKind {
             Self::Reflect => 0.05,
             Self::Listen => 0.05,
             Self::Commiserate => 0.2,
+            Self::Pray => 0.45,
             Self::LightenMood => 0.45,
             Self::Rally => 0.55,
             Self::Reframe => 0.65,
             Self::Flirt => 0.85,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PrayerApproach {
+    pub devotion: &'static str,
+    pub intention: &'static str,
+    pub effectiveness: f32,
+    pub risk: f32,
+}
+
+/// Closed, exhaustive social-prayer catalog. Topic stems carry the mechanical
+/// profile while each tradition supplies grounded, concise devotional copy.
+pub const fn prayer_approach(
+    religion: OfficialReligion,
+    topic: SocialTopic,
+) -> Option<PrayerApproach> {
+    let (base_effectiveness, risk) = match topic {
+        SocialTopic::Defeat => (1.0, 0.45),
+        SocialTopic::Injury => (1.0, 0.40),
+        SocialTopic::Fatigue => (0.80, 0.30),
+        SocialTopic::Hunger => (0.65, 0.30),
+        SocialTopic::Faith => (1.15, 0.55),
+        SocialTopic::Filth => return None,
+    };
+    let bonus = match (religion, topic) {
+        (OfficialReligion::Lutheran | OfficialReligion::Reformed, SocialTopic::Defeat)
+        | (
+            OfficialReligion::RomanCatholic
+            | OfficialReligion::EasternOrthodox
+            | OfficialReligion::Judaism,
+            SocialTopic::Injury,
+        )
+        | (OfficialReligion::Islamic, SocialTopic::Fatigue) => 0.10,
+        _ => 0.0,
+    };
+    let devotion = match religion {
+        OfficialReligion::RomanCatholic => "Pray a psalm and the Pater Noster",
+        OfficialReligion::Lutheran => "Pray a psalm and recall Christ's promise",
+        OfficialReligion::Reformed => "Pray from Scripture and trust in providence",
+        OfficialReligion::Anglican => "Offer a psalm, litany, and supplication",
+        OfficialReligion::EasternOrthodox => "Pray a psalm and the Jesus Prayer",
+        OfficialReligion::Islamic => "Make du'a",
+        OfficialReligion::Judaism => "Recite Tehillim and pray",
+    };
+    let intention = match topic {
+        SocialTopic::Defeat => "for courage after defeat",
+        SocialTopic::Injury => "for healing",
+        SocialTopic::Fatigue => "for patience and renewed strength",
+        SocialTopic::Hunger => "for daily provision",
+        SocialTopic::Faith => "for guidance and steadfast faith",
+        SocialTopic::Filth => return None,
+    };
+    Some(PrayerApproach {
+        devotion,
+        intention,
+        effectiveness: base_effectiveness + bonus,
+        risk,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SocialResolutionProfile {
+    pub risk: f32,
+    pub effectiveness: f32,
+    pub chance_modifier: f32,
+    pub failure_multiplier: f32,
+}
+
+impl SocialResolutionProfile {
+    pub const fn ordinary(action: SocialActionKind) -> Self {
+        Self {
+            risk: action.risk(),
+            effectiveness: 1.0,
+            chance_modifier: 0.0,
+            failure_multiplier: 1.0,
+        }
+    }
+}
+
+/// Conviction codes are canonical axis-local values: 1 Zealous, 2
+/// Irreverent, and 0 neutral. The bounded modifiers affect prayer without
+/// leaking the target's true personality into presentation.
+pub fn prayer_resolution_profile(
+    approach: PrayerApproach,
+    target_conviction: i8,
+) -> SocialResolutionProfile {
+    let (risk_delta, effectiveness, chance_modifier, failure_multiplier) = match target_conviction {
+        1 => (0.05, 1.10, 0.04, 1.15),
+        2 => (0.15, 0.85, -0.12, 1.10),
+        _ => (0.0, 1.0, 0.0, 1.0),
+    };
+    SocialResolutionProfile {
+        risk: (approach.risk + risk_delta).clamp(0.0, 0.95),
+        effectiveness: (approach.effectiveness * effectiveness).clamp(0.0, 1.5),
+        chance_modifier,
+        failure_multiplier,
     }
 }
 
@@ -593,6 +698,10 @@ pub const fn actor_allows_social_action(
         SocialActionKind::Flirt => !matches!(courtship, Courtship::Proper),
         _ => true,
     }
+}
+
+pub const fn actor_allows_social_prayer(conviction_code: i8) -> bool {
+    conviction_code != 1
 }
 
 /// Select the available automatic approach which best combines the actor's
@@ -778,7 +887,14 @@ pub fn effective_familiarity_hours(
 }
 
 pub fn resolve_social_attempt(attempt: SocialAttempt) -> SocialOutcome {
-    let risk = attempt.action.risk();
+    resolve_social_attempt_with_profile(attempt, SocialResolutionProfile::ordinary(attempt.action))
+}
+
+pub fn resolve_social_attempt_with_profile(
+    attempt: SocialAttempt,
+    profile: SocialResolutionProfile,
+) -> SocialOutcome {
+    let risk = profile.risk.clamp(0.0, 0.95);
     let relationship = (attempt.affinity / 100.0).clamp(-1.0, 1.0) * 0.18
         + (attempt.familiarity_hours / 100.0).min(1.0) * 0.12;
     let diagnosis = match attempt.diagnosis_correct {
@@ -789,15 +905,19 @@ pub fn resolve_social_attempt(attempt: SocialAttempt) -> SocialOutcome {
     let presumptuousness = risk
         * attempt.sensitivity.clamp(0.0, 1.0)
         * (1.0 - ((attempt.affinity + 100.0) / 200.0).clamp(0.0, 1.0));
-    let chance = (0.38 + attempt.skill_check.clamp(0.0, 5.0) * 0.08 + relationship + diagnosis
+    let chance = (0.38
+        + attempt.skill_check.clamp(0.0, 5.0) * 0.08
+        + relationship
+        + diagnosis
+        + profile.chance_modifier.clamp(-0.25, 0.25)
         - presumptuousness)
         .clamp(0.05, 0.95);
     let succeeded = attempt.roll.clamp(0.0, 1.0) < chance;
     let magnitude = 1.0 + 5.0 * risk;
     let morale_delta = if succeeded {
-        magnitude
+        magnitude * profile.effectiveness.clamp(0.0, 2.0)
     } else {
-        -(0.5 + 5.5 * risk)
+        -(0.5 + 5.5 * risk) * profile.failure_multiplier.clamp(0.5, 1.5)
     };
     let affinity_delta = if morale_delta > 0.0 {
         affinity_gain(attempt.affinity, morale_delta)
@@ -1627,9 +1747,116 @@ mod tests {
         assert!(!SocialActionKind::Flirt.available_for(SocialTopic::Hunger));
         assert!(!SocialActionKind::Rally.available_for(SocialTopic::Filth));
         assert!(!SocialActionKind::LightenMood.available_for(SocialTopic::Faith));
+        assert!(SocialActionKind::Pray.available_for(SocialTopic::Faith));
+        assert!(!SocialActionKind::Pray.available_for(SocialTopic::Filth));
         assert_eq!(
             SocialActionKind::Flirt.description(SocialTopic::Injury, false),
             "Tell them the scar makes them look striking"
+        );
+    }
+
+    #[test]
+    fn prayer_catalog_is_exhaustive_and_keeps_authored_relative_profiles() {
+        for religion in OfficialReligion::ALL {
+            for topic in [
+                SocialTopic::Defeat,
+                SocialTopic::Injury,
+                SocialTopic::Fatigue,
+                SocialTopic::Hunger,
+                SocialTopic::Faith,
+            ] {
+                let approach = prayer_approach(religion, topic).expect("catalog entry");
+                assert!(!approach.devotion.is_empty());
+                assert!(!approach.intention.is_empty());
+                assert!(approach.effectiveness > 0.0);
+                assert!((0.0..1.0).contains(&approach.risk));
+            }
+            assert_eq!(prayer_approach(religion, SocialTopic::Filth), None);
+        }
+        assert!(
+            prayer_approach(OfficialReligion::Lutheran, SocialTopic::Defeat)
+                .unwrap()
+                .effectiveness
+                > prayer_approach(OfficialReligion::Anglican, SocialTopic::Defeat)
+                    .unwrap()
+                    .effectiveness
+        );
+        assert!(
+            prayer_approach(OfficialReligion::Islamic, SocialTopic::Fatigue)
+                .unwrap()
+                .effectiveness
+                > prayer_approach(OfficialReligion::Anglican, SocialTopic::Fatigue)
+                    .unwrap()
+                    .effectiveness
+        );
+    }
+
+    #[test]
+    fn target_tradition_study_gates_correlated_religion_knowledge() {
+        let mut hours = adventuresim_world_schema::ReligionHours {
+            roman_catholic: 1_000.0,
+            ..Default::default()
+        };
+        assert_eq!(hours.effective(OfficialReligion::Lutheran), 0.0);
+        hours.lutheran = 1.0;
+        assert!(hours.effective(OfficialReligion::Lutheran) > 800.0);
+    }
+
+    #[test]
+    fn conviction_orders_prayer_success_and_backfire() {
+        let approach = prayer_approach(OfficialReligion::Anglican, SocialTopic::Injury).unwrap();
+        let neutral = prayer_resolution_profile(approach, 0);
+        let zealous = prayer_resolution_profile(approach, 1);
+        let irreverent = prayer_resolution_profile(approach, 2);
+        assert!(zealous.effectiveness > neutral.effectiveness);
+        assert!(irreverent.chance_modifier < neutral.chance_modifier);
+        assert!(zealous.failure_multiplier > neutral.failure_multiplier);
+        assert!(irreverent.risk > neutral.risk);
+
+        let attempt = SocialAttempt {
+            action: SocialActionKind::Pray,
+            topic: SocialTopic::Injury,
+            skill_check: 5.0,
+            affinity: 0.0,
+            familiarity_hours: 0.0,
+            diagnosis_correct: None,
+            sensitivity: 0.5,
+            roll: 0.0,
+        };
+        let zealous_success = resolve_social_attempt_with_profile(attempt, zealous);
+        let neutral_success = resolve_social_attempt_with_profile(attempt, neutral);
+        assert!(zealous_success.morale_delta > neutral_success.morale_delta);
+        let failed = SocialAttempt {
+            roll: 1.0,
+            ..attempt
+        };
+        assert!(
+            resolve_social_attempt_with_profile(failed, zealous).morale_delta
+                < resolve_social_attempt_with_profile(failed, neutral).morale_delta
+        );
+        assert!(!actor_allows_social_prayer(1));
+        assert!(actor_allows_social_prayer(0));
+        assert!(actor_allows_social_prayer(2));
+    }
+
+    #[test]
+    fn automatic_care_can_select_prayer_but_never_for_filth() {
+        assert_eq!(
+            choose_automatic_social_action(
+                SocialTopic::Injury,
+                [
+                    (SocialActionKind::Listen, 2.0, 0.0),
+                    (SocialActionKind::Pray, 4.0, 0.25),
+                ],
+            ),
+            Some(SocialActionKind::Pray)
+        );
+        assert_eq!(
+            choose_automatic_social_action(
+                SocialTopic::Filth,
+                [(SocialActionKind::Pray, 5.0, 2.0)],
+            ),
+            None
         );
     }
 

--- a/crates/adventuresim-stdb-module/src/social.rs
+++ b/crates/adventuresim-stdb-module/src/social.rs
@@ -7,18 +7,19 @@ use adventuresim_core::social::{
     Inclination as CoreInclination, Mirth as CoreMirth, PersonalityAxis,
     Presentation as CorePresentation, SOCIAL_COOLDOWN_MINUTES, SOCIAL_RESPONSE_MINUTES,
     SelfKnowledge as CoreSelfKnowledge, SocialActionKind, SocialAttempt, SocialTopic,
-    Transparency as CoreTransparency, actor_allows_social_action, affinity_gain,
-    assess_testimony_claim, axis_for_topic, canonical_cooldown_id, canonical_pair,
+    Transparency as CoreTransparency, actor_allows_social_action, actor_allows_social_prayer,
+    affinity_gain, assess_testimony_claim, axis_for_topic, canonical_cooldown_id, canonical_pair,
     choose_automatic_social_action, command_gravitas_modifier, diagnosed_axis, diagnosis_for_axis,
     discovery_training_split, flirt_charm_modifier, humor_charm_modifier,
-    incompatible_flirt_outcome, realized_affinity_delta, resolve_casual_chat,
-    resolve_claim_challenge, resolve_social_attempt, self_knowledge_insight_modifier,
-    settle_affinity, should_replace_belief, social_source_eligible, topic_for_source_kind,
+    incompatible_flirt_outcome, prayer_approach, prayer_resolution_profile,
+    realized_affinity_delta, resolve_casual_chat, resolve_claim_challenge, resolve_social_attempt,
+    resolve_social_attempt_with_profile, self_knowledge_insight_modifier, settle_affinity,
+    should_replace_belief, social_source_eligible, topic_for_source_kind,
 };
 use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, reducer, table, view};
 
-use crate::character::{character, character__view};
-use crate::condition::{character_morale_source__view, morale_event};
+use crate::character::{character, character__view, character_limbs, character_stats};
+use crate::condition::{character_condition, character_morale_source__view, morale_event};
 use crate::strategic::{
     dialogue_event__view, dialogue_session__view, strategic_gateway_authority__view,
 };
@@ -1978,6 +1979,7 @@ fn parse_action(value: &str) -> Result<SocialActionKind, String> {
         "reflect" => Ok(SocialActionKind::Reflect),
         "listen" => Ok(SocialActionKind::Listen),
         "commiserate" => Ok(SocialActionKind::Commiserate),
+        "pray" => Ok(SocialActionKind::Pray),
         "lighten_mood" => Ok(SocialActionKind::LightenMood),
         "command" => Ok(SocialActionKind::Rally),
         "deception" => Ok(SocialActionKind::Reframe),
@@ -1992,6 +1994,7 @@ fn social_action_skill(action: SocialActionKind, shares_concern: bool) -> Skill 
         SocialActionKind::Listen => Skill::Insight,
         SocialActionKind::Commiserate if shares_concern => Skill::Insight,
         SocialActionKind::Commiserate => Skill::Deception,
+        SocialActionKind::Pray => Skill::Religion,
         SocialActionKind::LightenMood => Skill::Charm,
         SocialActionKind::Rally => Skill::Command,
         SocialActionKind::Reframe => Skill::Deception,
@@ -2116,7 +2119,80 @@ fn automatic_personality_fit(
             _ => {}
         }
     }
+    if action == SocialActionKind::Pray {
+        match personality.conviction {
+            Conviction::Neutral => fit += 0.25,
+            Conviction::Irreverent => fit -= 1.0,
+            Conviction::Zealous => fit -= 2.0,
+        }
+    }
     fit
+}
+
+fn conviction_code(value: crate::personality::Conviction) -> i8 {
+    match value {
+        crate::personality::Conviction::Neutral => 0,
+        crate::personality::Conviction::Zealous => 1,
+        crate::personality::Conviction::Irreverent => 2,
+    }
+}
+
+fn target_religion(
+    ctx: &ReducerContext,
+    target_id: u64,
+) -> Result<adventuresim_world_schema::OfficialReligion, String> {
+    let religion_id = ctx
+        .db
+        .character_condition()
+        .character_id()
+        .find(target_id)
+        .ok_or("Target religion is unavailable")?
+        .religion_id
+        .ok_or("Target professes no religion")?;
+    adventuresim_world_schema::OfficialReligion::from_id(&religion_id)
+        .ok_or_else(|| "Target religion is unknown".into())
+}
+
+fn target_religion_check(
+    ctx: &ReducerContext,
+    actor_id: u64,
+    religion: adventuresim_world_schema::OfficialReligion,
+) -> Result<f32, String> {
+    let skills = ctx
+        .db
+        .character_skills()
+        .character_id()
+        .find(actor_id)
+        .ok_or("Actor skills not found")?;
+    let direct_hours = skills.religion_hours.direct(religion);
+    if !direct_hours.is_finite() || direct_hours <= 0.0 {
+        return Err("You have not directly studied the target's religion".into());
+    }
+    let attributes = ctx
+        .db
+        .character_attributes()
+        .character_id()
+        .find(actor_id)
+        .ok_or("Character attributes not found")?;
+    let limbs = ctx
+        .db
+        .character_limbs()
+        .character_id()
+        .find(actor_id)
+        .ok_or("Character limbs not found")?;
+    let stats = ctx
+        .db
+        .character_stats()
+        .character_id()
+        .find(actor_id)
+        .ok_or("Character stats not found")?;
+    Ok(adventuresim_core::capability::religion_knowledge_check(
+        skills.religion_hours.effective(religion),
+        attributes.instinct,
+        attributes.intelligence,
+        stats.focus,
+        limbs.head_health,
+    ))
 }
 
 fn automatic_social_action(
@@ -2125,9 +2201,10 @@ fn automatic_social_action(
     target_id: u64,
     topic: SocialTopic,
 ) -> Result<Option<SocialActionKind>, String> {
-    const ACTIONS: [SocialActionKind; 6] = [
+    const ACTIONS: [SocialActionKind; 7] = [
         SocialActionKind::Listen,
         SocialActionKind::Commiserate,
+        SocialActionKind::Pray,
         SocialActionKind::LightenMood,
         SocialActionKind::Rally,
         SocialActionKind::Reframe,
@@ -2136,6 +2213,7 @@ fn automatic_social_action(
 
     let shares_concern = shares_concern(ctx, actor_id, topic);
     let personality = crate::personality::personality_or_neutral(ctx, actor_id);
+    let prayer_religion = target_religion(ctx, target_id).ok();
     let now = ctx
         .db
         .character_time()
@@ -2146,6 +2224,9 @@ fn automatic_social_action(
     let mut candidates = Vec::with_capacity(ACTIONS.len());
     for action in ACTIONS.into_iter().filter(|action| {
         action.available_for(topic)
+            && (*action != SocialActionKind::Pray
+                || (actor_allows_social_prayer(conviction_code(personality.conviction))
+                    && prayer_religion.is_some()))
             && actor_allows_social_action(
                 *action,
                 core_mirth(personality.mirth),
@@ -2163,11 +2244,21 @@ fn automatic_social_action(
         {
             continue;
         }
-        let mut unscaled_skill_check = crate::condition::mental_check(
-            ctx,
-            actor_id,
-            social_action_skill(action, shares_concern),
-        )?;
+        let mut unscaled_skill_check = if action == SocialActionKind::Pray {
+            let Some(religion) = prayer_religion else {
+                continue;
+            };
+            match target_religion_check(ctx, actor_id, religion) {
+                Ok(check) => check,
+                Err(_) => continue,
+            }
+        } else {
+            crate::condition::mental_check(
+                ctx,
+                actor_id,
+                social_action_skill(action, shares_concern),
+            )?
+        };
         if action == SocialActionKind::Rally {
             unscaled_skill_check += command_gravitas_modifier(
                 core_mirth(personality.mirth),
@@ -2381,6 +2472,7 @@ fn discovery_axes(
         SocialActionKind::Commiserate => {
             vec![PersonalityAxis::Conscience, PersonalityAxis::Sociability]
         }
+        SocialActionKind::Pray => vec![PersonalityAxis::Conviction],
         SocialActionKind::LightenMood => vec![PersonalityAxis::Mirth],
         SocialActionKind::Rally => vec![
             PersonalityAxis::Nerve,
@@ -2577,6 +2669,11 @@ fn perform_social_action_authoritative(
     ) {
         return Err("Your disposition does not permit that social approach".into());
     }
+    if action == SocialActionKind::Pray
+        && !actor_allows_social_prayer(conviction_code(actor_personality.conviction))
+    {
+        return Err("A Zealous character will not lead a companion's prayer".into());
+    }
     let source = ctx
         .db
         .character_morale_source()
@@ -2593,6 +2690,16 @@ fn perform_social_action_authoritative(
     if !action.available_for(topic) {
         return Err("That social approach does not fit this concern".into());
     }
+    let prayer = if action == SocialActionKind::Pray {
+        let religion = target_religion(ctx, target_id)?;
+        Some((
+            religion,
+            prayer_approach(religion, topic)
+                .ok_or("That social approach does not fit this concern")?,
+        ))
+    } else {
+        None
+    };
     let now = ctx
         .db
         .character_time()
@@ -2619,8 +2726,12 @@ fn perform_social_action_authoritative(
         current_affinity(ctx, target_id, actor_id)
     };
     let actor_shares_concern = shares_concern(ctx, actor_id, topic);
-    let skill = social_action_skill(action, actor_shares_concern);
-    let mut skill_check = crate::condition::mental_check(ctx, actor_id, skill)?;
+    let mut skill_check = if let Some((religion, _)) = prayer {
+        target_religion_check(ctx, actor_id, religion)?
+    } else {
+        let skill = social_action_skill(action, actor_shares_concern);
+        crate::condition::mental_check(ctx, actor_id, skill)?
+    };
     if action == SocialActionKind::Rally {
         skill_check += command_gravitas_modifier(
             core_mirth(actor_personality.mirth),
@@ -2691,21 +2802,27 @@ fn perform_social_action_authoritative(
     if let Some(modifier) = flirt_modifier {
         skill_check += modifier;
     }
+    let attempt = SocialAttempt {
+        action,
+        topic,
+        skill_check,
+        affinity,
+        familiarity_hours: familiarity,
+        diagnosis_correct,
+        sensitivity: sensitivity(ctx, target_id, topic),
+        roll: social_roll,
+    };
     let outcome = if flirt_modifier.is_none() {
         // Incompatibility is a hard gate: it cannot leak the resolver's
         // minimum success chance or any positive outcome.
         incompatible_flirt_outcome()
+    } else if let Some((_, approach)) = prayer {
+        resolve_social_attempt_with_profile(
+            attempt,
+            prayer_resolution_profile(approach, conviction_code(target_personality.conviction)),
+        )
     } else {
-        resolve_social_attempt(SocialAttempt {
-            action,
-            topic,
-            skill_check,
-            affinity,
-            familiarity_hours: familiarity,
-            diagnosis_correct,
-            sensitivity: sensitivity(ctx, target_id, topic),
-            roll: social_roll,
-        })
+        resolve_social_attempt(attempt)
     };
     if consume_time {
         let participants = if is_self {
@@ -3027,6 +3144,8 @@ pub fn cleanup_character_social(ctx: &ReducerContext, character_id: u64) {
 pub(crate) fn seed_social_demo(ctx: &ReducerContext) -> Result<(), String> {
     const VIEWER: u64 = 9_999_999_999_999_977;
     const TARGET: u64 = 9_999_999_999_999_976;
+    const ZEALOUS_VIEWER: u64 = 9_999_999_999_999_975;
+    const ZEALOUS_TARGET: u64 = 9_999_999_999_999_974;
     if ctx.db.character().id().find(VIEWER).is_none() {
         crate::character::insert_new_character(ctx, "Social Demo".into(), VIEWER, false)?;
     }
@@ -3034,6 +3153,23 @@ pub(crate) fn seed_social_demo(ctx: &ReducerContext) -> Result<(), String> {
         crate::character::insert_new_npc_character(ctx, "Greta the Guard".into(), TARGET, false)?;
     }
     crate::strategic::attach_seeded_party_member(ctx, VIEWER, TARGET, "Guard")?;
+    if ctx.db.character().id().find(ZEALOUS_VIEWER).is_none() {
+        crate::character::insert_new_character(
+            ctx,
+            "Zealous Prayer Demo".into(),
+            ZEALOUS_VIEWER,
+            false,
+        )?;
+    }
+    if ctx.db.character().id().find(ZEALOUS_TARGET).is_none() {
+        crate::character::insert_new_npc_character(
+            ctx,
+            "Margareta the Pilgrim".into(),
+            ZEALOUS_TARGET,
+            false,
+        )?;
+    }
+    crate::strategic::attach_seeded_party_member(ctx, ZEALOUS_VIEWER, ZEALOUS_TARGET, "Pilgrim")?;
     let now = ctx
         .db
         .character_time()
@@ -3044,6 +3180,7 @@ pub(crate) fn seed_social_demo(ctx: &ReducerContext) -> Result<(), String> {
     viewer_personality.sex = crate::personality::Sex::Male;
     viewer_personality.presentation = crate::personality::Presentation::Man;
     viewer_personality.inclination = crate::personality::Inclination::Women;
+    viewer_personality.conviction = crate::personality::Conviction::Neutral;
     ctx.db
         .character_personality()
         .character_id()
@@ -3061,6 +3198,70 @@ pub(crate) fn seed_social_demo(ctx: &ReducerContext) -> Result<(), String> {
         .character_personality()
         .character_id()
         .update(personality);
+    crate::condition::initialize_character_condition(ctx, TARGET)?;
+    if let Some(mut condition) = ctx.db.character_condition().character_id().find(TARGET) {
+        condition.religion_id = Some("lutheran".into());
+        ctx.db
+            .character_condition()
+            .character_id()
+            .update(condition);
+    }
+    if let Some(mut skills) = ctx.db.character_skills().character_id().find(VIEWER) {
+        // Direct Lutheran study opens the action; related Catholic study
+        // demonstrates that correlated knowledge then contributes.
+        skills.religion_hours.lutheran = 900.0;
+        skills.religion_hours.roman_catholic = 600.0;
+        ctx.db.character_skills().character_id().update(skills);
+    }
+    let mut zealous_personality = crate::personality::personality_or_neutral(ctx, ZEALOUS_VIEWER);
+    zealous_personality.conviction = crate::personality::Conviction::Zealous;
+    ctx.db
+        .character_personality()
+        .character_id()
+        .update(zealous_personality);
+    crate::condition::initialize_character_condition(ctx, ZEALOUS_TARGET)?;
+    if let Some(mut condition) = ctx
+        .db
+        .character_condition()
+        .character_id()
+        .find(ZEALOUS_TARGET)
+    {
+        condition.religion_id = Some("lutheran".into());
+        ctx.db
+            .character_condition()
+            .character_id()
+            .update(condition);
+    }
+    if let Some(mut skills) = ctx
+        .db
+        .character_skills()
+        .character_id()
+        .find(ZEALOUS_VIEWER)
+    {
+        skills.religion_hours.lutheran = 900.0;
+        ctx.db.character_skills().character_id().update(skills);
+    }
+    for row in ctx
+        .db
+        .morale_event()
+        .character_id()
+        .filter(ZEALOUS_TARGET)
+        .filter(|row| {
+            row.source_id
+                .as_deref()
+                .is_some_and(|id| id.starts_with("social-demo:"))
+        })
+        .collect::<Vec<_>>()
+    {
+        ctx.db.morale_event().id().delete(row.id);
+    }
+    crate::condition::record_morale_event(
+        ctx,
+        ZEALOUS_TARGET,
+        "defeat",
+        -8.0,
+        Some("social-demo:zealous-defeat".into()),
+    )?;
     for row in ctx
         .db
         .morale_event()
@@ -3163,6 +3364,7 @@ mod contract_tests {
             (SocialActionKind::Listen, SocialTopic::Faith, false),
             (SocialActionKind::Listen, SocialTopic::Filth, false),
             (SocialActionKind::Commiserate, SocialTopic::Defeat, false),
+            (SocialActionKind::Pray, SocialTopic::Faith, false),
             (SocialActionKind::LightenMood, SocialTopic::Defeat, false),
             (SocialActionKind::Rally, SocialTopic::Defeat, false),
             (SocialActionKind::Rally, SocialTopic::Faith, false),
@@ -3190,6 +3392,31 @@ mod contract_tests {
         ] {
             assert!(axes.contains(&axis), "{axis:?} is unreachable");
         }
+    }
+
+    #[test]
+    fn prayer_contract_is_typed_and_zealotry_is_an_actor_gate() {
+        assert_eq!(parse_action("pray"), Ok(SocialActionKind::Pray));
+        assert_eq!(
+            social_action_skill(SocialActionKind::Pray, false),
+            Skill::Religion
+        );
+        assert!(!actor_allows_social_prayer(conviction_code(
+            crate::personality::Conviction::Zealous
+        )));
+        assert!(actor_allows_social_prayer(conviction_code(
+            crate::personality::Conviction::Irreverent
+        )));
+        let source = include_str!("social.rs");
+        let check = source
+            .split("fn target_religion_check")
+            .nth(1)
+            .and_then(|tail| tail.split("fn automatic_social_action").next())
+            .expect("target-specific Religion check");
+        assert!(check.contains("religion_hours.direct(religion)"));
+        assert!(check.contains("religion_hours.effective(religion)"));
+        assert!(!check.contains("maximum_effective"));
+        assert!(!check.contains("aggregate_party_check"));
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/social.rs
+++ b/crates/adventuresim-stdb-module/src/social.rs
@@ -2,19 +2,20 @@
 
 use adventuresim_core::skill::Skill;
 use adventuresim_core::social::{
-    AFFINITY_MAX, AFFINITY_MIN, CasualChatDisposition, CasualChatInput, ClaimAssessmentDirection,
-    ClaimChallengeApproach, ClaimChallengeInput, Courtship as CoreCourtship,
-    Inclination as CoreInclination, Mirth as CoreMirth, PersonalityAxis,
-    Presentation as CorePresentation, SOCIAL_COOLDOWN_MINUTES, SOCIAL_RESPONSE_MINUTES,
-    SelfKnowledge as CoreSelfKnowledge, SocialActionKind, SocialAttempt, SocialTopic,
-    Transparency as CoreTransparency, actor_allows_social_action, actor_allows_social_prayer,
-    affinity_gain, assess_testimony_claim, axis_for_topic, canonical_cooldown_id, canonical_pair,
-    choose_automatic_social_action, command_gravitas_modifier, diagnosed_axis, diagnosis_for_axis,
-    discovery_training_split, flirt_charm_modifier, humor_charm_modifier,
-    incompatible_flirt_outcome, prayer_approach, prayer_resolution_profile,
-    realized_affinity_delta, resolve_casual_chat, resolve_claim_challenge, resolve_social_attempt,
-    resolve_social_attempt_with_profile, self_knowledge_insight_modifier, settle_affinity,
-    should_replace_belief, social_source_eligible, topic_for_source_kind,
+    AFFINITY_MAX, AFFINITY_MIN, AutomaticSocialCandidate, CasualChatDisposition, CasualChatInput,
+    ClaimAssessmentDirection, ClaimChallengeApproach, ClaimChallengeInput,
+    Courtship as CoreCourtship, Inclination as CoreInclination, Mirth as CoreMirth,
+    PersonalityAxis, Presentation as CorePresentation, SOCIAL_COOLDOWN_MINUTES,
+    SOCIAL_RESPONSE_MINUTES, SelfKnowledge as CoreSelfKnowledge, SocialActionKind, SocialAttempt,
+    SocialTopic, Transparency as CoreTransparency, actor_allows_social_action,
+    actor_allows_social_prayer, affinity_gain, assess_testimony_claim, axis_for_topic,
+    canonical_cooldown_id, canonical_pair, choose_automatic_social_action,
+    command_gravitas_modifier, diagnosed_axis, diagnosis_for_axis, discovery_training_split,
+    flirt_charm_modifier, humor_charm_modifier, incompatible_flirt_outcome, prayer_approach,
+    prayer_resolution_profile, realized_affinity_delta, resolve_casual_chat,
+    resolve_claim_challenge, resolve_social_attempt, resolve_social_attempt_with_profile,
+    self_knowledge_insight_modifier, settle_affinity, should_replace_belief,
+    social_source_eligible, topic_for_source_kind,
 };
 use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, reducer, table, view};
 
@@ -2213,6 +2214,7 @@ fn automatic_social_action(
 
     let shares_concern = shares_concern(ctx, actor_id, topic);
     let personality = crate::personality::personality_or_neutral(ctx, actor_id);
+    let target_personality = crate::personality::personality_or_neutral(ctx, target_id);
     let prayer_religion = target_religion(ctx, target_id).ok();
     let now = ctx
         .db
@@ -2267,11 +2269,22 @@ fn automatic_social_action(
         }
         let skill_check =
             adventuresim_world_schema::language_scaled_effect(unscaled_skill_check, language);
-        candidates.push((
-            action,
-            skill_check,
-            automatic_personality_fit(&personality, action, topic),
-        ));
+        let personality_fit = automatic_personality_fit(&personality, action, topic);
+        let candidate = if action == SocialActionKind::Pray {
+            let religion = prayer_religion.expect("Prayer candidates require a target religion");
+            let approach =
+                prayer_approach(religion, topic).expect("Prayer candidates require a valid topic");
+            AutomaticSocialCandidate::with_resolved_risk(
+                action,
+                skill_check,
+                personality_fit,
+                prayer_resolution_profile(approach, conviction_code(target_personality.conviction))
+                    .risk,
+            )
+        } else {
+            AutomaticSocialCandidate::ordinary(action, skill_check, personality_fit)
+        };
+        candidates.push(candidate);
     }
     Ok(choose_automatic_social_action(topic, candidates))
 }

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -4324,9 +4324,17 @@ async fn party_social(
         .collect::<Vec<_>>();
     shared_concerns.sort_by_key(|topic| format!("{topic:?}"));
     shared_concerns.dedup();
-    let religion_id = query_single::<CharacterCondition>(&state, "character_condition", target_id)
-        .await
-        .and_then(|value| value.religion_id);
+    let target_condition_result = state
+        .db
+        .query_one::<CharacterCondition>(&format!(
+            "SELECT * FROM character_condition WHERE character_id = {target_id}"
+        ))
+        .await;
+    let religion_id = target_condition_result
+        .as_ref()
+        .ok()
+        .and_then(|value| value.as_ref())
+        .and_then(|value| value.religion_id.clone());
     let virtue = query_single::<CharacterVirtue>(&state, "character_virtue", target_id)
         .await
         .map_or(0.0, |value| value.value);
@@ -4425,6 +4433,57 @@ async fn party_social(
             None
         }
     };
+    let actor_skills_result = state
+        .db
+        .query_one::<CharacterSkills>(&format!(
+            "SELECT * FROM character_skills WHERE character_id = {}",
+            active.id
+        ))
+        .await;
+    let prayer_disabled_reason = if target_id == active.id {
+        None
+    } else if !actor_personality_available || actor_personality.is_none() {
+        Some("Prayer eligibility is unavailable right now.".to_owned())
+    } else if actor_personality.as_ref().is_some_and(|personality| {
+        personality.conviction == crate::spacetimedb::Conviction::Zealous
+    }) {
+        Some("Your Zealous conviction prevents you from leading a companion's prayer.".to_owned())
+    } else {
+        match &target_condition_result {
+            Err(error) => {
+                tracing::error!(%error, target_id, "target religion query failed closed");
+                Some("Their religion is unavailable right now.".to_owned())
+            }
+            Ok(None) => Some("Their religion is unavailable right now.".to_owned()),
+            Ok(Some(condition)) => match condition.religion_id.as_deref() {
+                None => Some("They profess no religion.".to_owned()),
+                Some(religion_id) => {
+                    match adventuresim_world_schema::OfficialReligion::from_id(religion_id) {
+                        None => Some("Their religion is unknown.".to_owned()),
+                        Some(religion) => match &actor_skills_result {
+                            Err(error) => {
+                                tracing::error!(%error, actor_id=active.id, "private Religion knowledge query failed closed");
+                                Some("Your Religion knowledge is unavailable right now.".to_owned())
+                            }
+                            Ok(None) => {
+                                Some("Your Religion knowledge is unavailable right now.".to_owned())
+                            }
+                            Ok(Some(skills))
+                                if !skills.religion_hours.direct(religion).is_finite()
+                                    || skills.religion_hours.direct(religion) <= 0.0 =>
+                            {
+                                Some(format!(
+                                    "You have not directly studied {}.",
+                                    religion.label()
+                                ))
+                            }
+                            Ok(Some(_)) => None,
+                        },
+                    }
+                }
+            },
+        }
+    };
     let social = SocialPresentation {
         affinity,
         familiarity_hours: adventuresim_core::social::effective_familiarity_hours(
@@ -4448,6 +4507,7 @@ async fn party_social(
             actor_personality.as_ref(),
             adventuresim_core::social::SocialActionKind::Flirt,
         ),
+        prayer_disabled_reason,
         feedback: social_feedback(building.social_feedback.as_deref()),
         unavailable: !beliefs_available || !affinity_available || !familiarity_available,
     };
@@ -6817,6 +6877,22 @@ mod social_notification_query_tests {
             None,
             SocialActionKind::Flirt
         ));
+    }
+
+    #[test]
+    fn prayer_preview_uses_private_actor_study_and_fails_closed() {
+        let source = include_str!("settlements.rs");
+        let handler = source
+            .split("async fn party_social")
+            .nth(1)
+            .and_then(|tail| tail.split("struct SocialActionForm").next())
+            .expect("social dialog handler");
+        assert!(handler.contains("private actor personality query failed closed"));
+        assert!(handler.contains("private Religion knowledge query failed closed"));
+        assert!(handler.contains("skills.religion_hours.direct(religion) <= 0.0"));
+        assert!(!handler.contains("maximum_effective"));
+        assert!(handler.contains("Their religion is unknown."));
+        assert!(handler.contains("They profess no religion."));
     }
 }
 

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -334,7 +334,7 @@ pub fn party_social_dialog(
                                         input type="hidden" name="source_id" value=(&source.id);
                                         button type="submit" name="action_kind" value=(value) class="social-action"
                                             disabled[disabled_reason.is_some()]
-                                            aria-disabled=[disabled_reason.is_some()]
+                                            aria-disabled=[disabled_reason.map(|_| "true")]
                                             aria-label=(if let Some(reason) = disabled_reason { format!("{}. Unavailable: {}.", label, reason) } else { format!("{}. {}. Takes {} minutes.", label, description, adventuresim_core::social::SOCIAL_RESPONSE_MINUTES) })
                                             data-strategic-tooltip=(&tooltip) {
                                             span class="social-action-icon"

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -21,6 +21,7 @@ pub struct SocialPresentation {
     pub automatic_chat_enabled: bool,
     pub joke_blocked: bool,
     pub flirt_blocked: bool,
+    pub prayer_disabled_reason: Option<String>,
     pub feedback: Option<SocialFeedback>,
     pub unavailable: bool,
 }
@@ -58,6 +59,7 @@ fn social_actions(
     [
         ("awareness", Listen, "listen"),
         ("awareness", Commiserate, "commiserate"),
+        ("prayer", Pray, "pray"),
         ("juggler", LightenMood, "lighten_mood"),
         ("crown", Rally, "command"),
         ("conversation", Reframe, "deception"),
@@ -82,6 +84,7 @@ fn social_action_label(
         SocialActionKind::Listen => "Listen",
         SocialActionKind::Commiserate if shares_concern => "Commiserate",
         SocialActionKind::Commiserate => "Feign sympathy",
+        SocialActionKind::Pray => "Pray",
         SocialActionKind::LightenMood => "Joke",
         SocialActionKind::Rally => "Rally",
         SocialActionKind::Reframe => "Reframe",
@@ -308,13 +311,31 @@ pub fn party_social_dialog(
                                     @for (default_icon, action, value) in social_actions(is_self, topic, social.joke_blocked, social.flirt_blocked) {
                                       @let action_shares_concern = action != adventuresim_core::social::SocialActionKind::Commiserate || shares_concern;
                                       @let icon = if action == adventuresim_core::social::SocialActionKind::Commiserate && !shares_concern { "conversation" } else { default_icon };
-                                      @let description = action.description(topic, action_shares_concern);
+                                      @let prayer_approach = social.religion_id.as_deref()
+                                          .and_then(adventuresim_world_schema::OfficialReligion::from_id)
+                                          .and_then(|religion| adventuresim_core::social::prayer_approach(religion, topic));
+                                      @let description = if action == adventuresim_core::social::SocialActionKind::Pray {
+                                          prayer_approach.map_or_else(
+                                              || action.description(topic, action_shares_concern).to_owned(),
+                                              |approach| format!("{} {}", approach.devotion, approach.intention),
+                                          )
+                                      } else {
+                                          action.description(topic, action_shares_concern).to_owned()
+                                      };
                                       @let label = social_action_label(action, action_shares_concern);
-                                      @let tooltip = format!("{}\nTakes {} minutes.\n{} · {} risk", description, adventuresim_core::social::SOCIAL_RESPONSE_MINUTES, action.skill_name(action_shares_concern), if action.risk() >= 0.6 { "high" } else if action.risk() >= 0.3 { "moderate" } else { "low" });
+                                      @let disabled_reason = if action == adventuresim_core::social::SocialActionKind::Pray { social.prayer_disabled_reason.as_deref() } else { None };
+                                      @let risk = prayer_approach.map_or(action.risk(), |approach| approach.risk);
+                                      @let tooltip = if let Some(reason) = disabled_reason {
+                                          format!("{}\nUnavailable: {}", description, reason)
+                                      } else {
+                                          format!("{}\nTakes {} minutes.\n{} · {} risk", description, adventuresim_core::social::SOCIAL_RESPONSE_MINUTES, action.skill_name(action_shares_concern), if risk >= 0.6 { "high" } else if risk >= 0.3 { "moderate" } else { "low" })
+                                      };
                                     form method="post" action=(&social_href) {
                                         input type="hidden" name="source_id" value=(&source.id);
                                         button type="submit" name="action_kind" value=(value) class="social-action"
-                                            aria-label=(format!("{}. {}. Takes {} minutes.", label, description, adventuresim_core::social::SOCIAL_RESPONSE_MINUTES))
+                                            disabled[disabled_reason.is_some()]
+                                            aria-disabled=[disabled_reason.is_some()]
+                                            aria-label=(if let Some(reason) = disabled_reason { format!("{}. Unavailable: {}.", label, reason) } else { format!("{}. {}. Takes {} minutes.", label, description, adventuresim_core::social::SOCIAL_RESPONSE_MINUTES) })
                                             data-strategic-tooltip=(&tooltip) {
                                             span class="social-action-icon"
                                                 data-strategic-tooltip=(&tooltip) {
@@ -658,13 +679,70 @@ mod tests {
     }
 
     #[test]
+    fn prayer_is_themed_and_disabled_with_an_accessible_reason() {
+        let character = |id: u64, name: &str| Character {
+            id,
+            name: name.into(),
+            xp: 0,
+            level: 1,
+            gold: 0,
+            current_settlement_id: Some("lubeck".into()),
+            current_case_site_id: None,
+            party_id: Some("party".into()),
+            age_years: 20,
+            alive: true,
+            temporary: false,
+            social_notification_count: 0,
+            automatic_social_chat_enabled: false,
+        };
+        let location = LocationView {
+            kind: super::super::LocationKind::Settlement,
+            id: "lubeck".into(),
+            name: "Lubeck".into(),
+            religion_id: None,
+            category: None,
+            active_building: None,
+        };
+        let source = CharacterMoraleSource {
+            id: "defeat".into(),
+            character_id: 2,
+            kind: "defeat".into(),
+            label: "Recent defeat".into(),
+            magnitude: -2.0,
+        };
+        let social = SocialPresentation {
+            religion_id: Some("lutheran".into()),
+            prayer_disabled_reason: Some(
+                "Your Zealous conviction prevents you from leading a companion's prayer.".into(),
+            ),
+            ..Default::default()
+        };
+        let markup = party_social_dialog(
+            &location,
+            &character(2, "Greta"),
+            &character(1, "Ada"),
+            &[source],
+            &social,
+        )
+        .into_string();
+        assert!(markup.contains("value=\"pray\""));
+        assert!(markup.contains("Pray a psalm and recall Christ"));
+        assert!(markup.contains("value=\"pray\" class=\"social-action\" disabled"));
+        assert!(markup.contains("aria-disabled=\"true\""));
+        assert!(markup.contains("Unavailable: Your Zealous conviction"));
+        let css = include_str!("../../../static/css/strategic.css");
+        assert!(css.contains(".social-action:disabled"));
+        assert!(css.contains("filter: grayscale(0.8)"));
+    }
+
+    #[test]
     fn social_catalog_labels_are_generic_grounded_and_accessible() {
         use adventuresim_core::social::{SocialActionKind, SocialTopic};
         let defeat = SocialActionKind::Commiserate.description(SocialTopic::Defeat, true);
         assert_eq!(defeat, "Commiserate about the defeat");
         assert!(!defeat.to_ascii_lowercase().contains("goblin"));
         let actions = social_actions(false, SocialTopic::Defeat, false, false);
-        assert_eq!(actions.len(), 6);
+        assert_eq!(actions.len(), 7);
         assert!(
             actions
                 .iter()
@@ -684,14 +762,14 @@ mod tests {
         );
         assert_eq!(
             social_actions(false, SocialTopic::Hunger, false, false).len(),
-            3
+            4
         );
         assert_eq!(
             social_actions(false, SocialTopic::Faith, false, false).len(),
-            4
+            5
         );
         let reserved = social_actions(false, SocialTopic::Defeat, true, true);
-        assert_eq!(reserved.len(), 4);
+        assert_eq!(reserved.len(), 5);
         assert!(reserved.iter().all(|(_, action, _)| !matches!(
             action,
             SocialActionKind::LightenMood | SocialActionKind::Flirt

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -3423,6 +3423,8 @@ button.party-portrait-action {
 .social-action { display: inline-flex; width: auto; min-height: 2rem; padding: 0.3rem 0.55rem; align-items: center; gap: 0.4rem; border: 1px solid var(--border-color); border-radius: 0.3rem; background: var(--panel-bg); color: var(--text); cursor: pointer; }
 .social-action:hover,
 .social-action:focus-visible { border-color: var(--accent); color: var(--accent); outline: none; }
+.social-action:disabled,
+.social-action[aria-disabled="true"] { opacity: 0.46; filter: grayscale(0.8); cursor: not-allowed; border-color: var(--border-color); color: var(--text-muted); }
 .social-action-icon { display: inline-grid; flex: 0 0 auto; place-items: center; cursor: help; }
 .social-action .game-icon { width: 1.15rem; height: 1.15rem; }
 .social-action-label { white-space: nowrap; }

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -483,10 +483,15 @@ Select **Social Demo**, open **Greta the Guard**, and press the raised Social
 icon beside the Morale meter.
 The fixture includes defeat and injury penalties, established Familiarity,
 positive Affinity, exact multi-valued observer beliefs, presentation, and one
-deliberately incorrect perceived sensitivity. The Social rail shows Insight,
-Charm, Command, and Deception; Lighten Mood and Flirt are distinct Charm
+deliberately incorrect perceived sensitivity. Greta professes Lutheranism, and
+Social Demo has direct Lutheran study plus correlated Catholic knowledge, so
+the themed Prayer response is immediately usable. The Social rail shows
+Insight, Charm, Command, Deception, and target-specific Religion; Lighten Mood
+and Flirt are distinct Charm
 approaches, and repeated supported observations demonstrate the
 Transparency-controlled Insight/Deception training split. The bootstrap capability is
 compiled only for the isolated workflow; there is no standalone public fixture
 reducer. Schema changes are destructive in this pre-launch workflow, so rerun
-the isolated profile to recreate its database.
+the isolated profile to recreate its database. Select **Zealous Prayer Demo**
+and open **Margareta the Pilgrim** to inspect the same Lutheran action kept
+visible, greyed out, and annotated with its unavailable reason.

--- a/wiki/shared/morale.md
+++ b/wiki/shared/morale.md
@@ -17,6 +17,21 @@ short label; hovering the icon explains the contextual approach, skill, and
 risk. Every manual response spends five strategic minutes. Automatic responses
 occur within already-consumed downtime and do not advance the clock again.
 
+Companion responses also include **Pray** for defeat, injury, fatigue, hunger,
+and faith concerns, but not filth. Prayer uses the companion's authoritative
+professed tradition and the actor's effective Religion knowledge for that
+exact tradition. At least some direct study of the tradition is required before
+correlated knowledge contributes; the actor need not profess it. Zealous actors
+will not lead another character's prayer, so the action remains visible but
+disabled. Target Conviction changes prayer fit: Zealous targets respond more
+strongly to a successful prayer but are more sensitive to a poor one, while
+Irreverent targets are harder and riskier to reach. The prayer catalog shares
+mechanical topic profiles while supplying Catholic, Lutheran, Reformed,
+Anglican, Orthodox, Islamic, and Jewish devotional language. Opt-in automatic
+social care considers Prayer alongside the other eligible approaches using the
+same target-specific check, personality fit, cooldown, and authoritative
+resolver.
+
 Living, co-located companions show an observer-specific Party Rail badge for
 each current actionable negative source row that this character has not yet
 successfully addressed. Separate sources count separately even when they share


### PR DESCRIPTION
## Summary
- add Prayer as a full social approach for suitable morale problems, with normal cooldown, transaction, history, affinity, language, and backfire behavior
- require direct study of the target's religion while allowing correlated religion knowledge to contribute; no matching profession is required
- keep Prayer visible but disabled for Zealous actors, enforce that rule server-side, and exclude it from their downtime automation
- theme prayer through reusable tradition devotions and morale-topic intentions, with tradition-specific effectiveness and risk
- add automatic downtime selection using the resolved prayer risk for the target and morale topic
- add strategic UI presentation, accessible disabled-state styling, isolated demo fixtures, tests, and documentation

## Design choices
Prayer applies to Defeat, Injury, Fatigue, Hunger, and Faith, but not Filth. Target Conviction modifies resolution without exposing the private value. Lutheran/Reformed traditions favor Defeat; Catholic/Orthodox/Judaism favor Injury; Islam favors Fatigue. Faith has the strongest potential effect and greatest backfire risk.

## Verification
- `cargo test -p adventuresim-core --lib` — 479 passed
- `cargo test -p strategic-web` — 313 passed
- `node --test crates/strategic-web/tests/social-menu.test.cjs crates/strategic-web/tests/character-action-dialog.test.cjs` — 10 passed
- `just build-strategic` — passed
- `cargo fmt --all -- --check` — passed
- `python scripts/update_project_map.py --check` — current
- `git diff --check 9d23f8c..HEAD` — passed

## Review
Independent correctness and security/maintainability reviews found no blocking issues. Review identified one automatic-selection tie-break issue: Prayer initially used its generic risk instead of its resolved topic/Conviction risk. Commit `29239b6` fixes that and adds equal-score regression coverage.

## Demo
The isolated strategic demo completed database initialization, but the bounded local launcher did not reach HTTP readiness before timeout. The web rendering path is covered by the passing strategic-web and Node test suites. To retry locally:

```powershell
$env:CARGO_TARGET_DIR='C:\Users\adler\projects\adventure-simulator\target-social-prayer'
just web-isolated-strategic social-demo 23100
```

Then select **Social Demo**, open **Greta the Guard**, and open the Social panel. **Zealous Prayer Demo** demonstrates the disabled state.

## Risk / rollback
This changes social-resolution behavior and downtime choice ordering but does not change the database schema. Roll back by reverting commits `29239b6` and `a90762d`.