### PR TITLE
Add organization chapter buildings and representative dialogue

### DIFF
--- a/content/dialogue/organizations.yaml
+++ b/content/dialogue/organizations.yaml
@@ -16,7 +16,9 @@
               "fragments": [
                 { "kind": "text", "value": "Welcome to " },
                 { "kind": "runtime", "slot": "organization_name" },
-                { "kind": "text", "value": ". I conduct the institution's business here." }
+                { "kind": "text", "value": ". I conduct the institution's " },
+                { "kind": "topic", "topic": "organization-business", "label": "business" },
+                { "kind": "text", "value": " here." }
               ]
             }
           ],
@@ -25,6 +27,335 @@
         }
       ],
       "topics": [
+        {
+          "id": "organization-business",
+          "label": "Organization business",
+          "initially_known": true,
+          "responses": [
+            {
+              "id": "business-for-nonmember",
+              "priority": 30,
+              "conditions": {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_membership",
+                  "player": "player",
+                  "representative": "representative"
+                },
+                "equals": "none"
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "If you seek a place among us, ask to " },
+                    { "kind": "topic", "topic": "join", "label": "join" },
+                    { "kind": "text", "value": "." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            },
+            {
+              "id": "business-for-suspended-member",
+              "priority": 30,
+              "conditions": {
+                "op": "all",
+                "conditions": [
+                  {
+                    "op": "fact",
+                    "key": {
+                      "kind": "organization_membership",
+                      "player": "player",
+                      "representative": "representative"
+                    },
+                    "equals": "suspended"
+                  },
+                  {
+                    "op": "fact",
+                    "key": {
+                      "kind": "organization_dues_required",
+                      "representative": "representative"
+                    },
+                    "equals": true
+                  }
+                ]
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "Your membership is suspended. You may " },
+                    { "kind": "topic", "topic": "dues", "label": "pay dues" },
+                    { "kind": "text", "value": " to restore it." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            },
+            {
+              "id": "business-for-suspended-member-without-dues",
+              "priority": 30,
+              "conditions": {
+                "op": "all",
+                "conditions": [
+                  {
+                    "op": "fact",
+                    "key": {
+                      "kind": "organization_membership",
+                      "player": "player",
+                      "representative": "representative"
+                    },
+                    "equals": "suspended"
+                  },
+                  {
+                    "op": "fact",
+                    "key": {
+                      "kind": "organization_dues_required",
+                      "representative": "representative"
+                    },
+                    "equals": false
+                  }
+                ]
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "Your membership is suspended, but this chapter has no dues payment to receive." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            },
+            {
+              "id": "business-for-current-member",
+              "priority": 30,
+              "conditions": {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_membership",
+                  "player": "player",
+                  "representative": "representative"
+                },
+                "equals": "current"
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "Let us review your " },
+                    { "kind": "topic", "topic": "member-business", "label": "membership" },
+                    { "kind": "text", "value": "." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            }
+          ]
+        },
+        {
+          "id": "member-business",
+          "label": "Membership business",
+          "initially_known": true,
+          "conditions": {
+            "op": "fact",
+            "key": {
+              "kind": "organization_membership",
+              "player": "player",
+              "representative": "representative"
+            },
+            "equals": "current"
+          },
+          "responses": [
+            {
+              "id": "current-member-with-dues",
+              "priority": 10,
+              "conditions": {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_dues_required",
+                  "representative": "representative"
+                },
+                "equals": true
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "You may " },
+                    { "kind": "topic", "topic": "dues", "label": "pay dues" },
+                    { "kind": "text", "value": " for the next interval, or discuss your " },
+                    { "kind": "topic", "topic": "advancement-business", "label": "standing and advancement" },
+                    { "kind": "text", "value": "." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            },
+            {
+              "id": "current-member-without-dues",
+              "priority": 10,
+              "conditions": {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_dues_required",
+                  "representative": "representative"
+                },
+                "equals": false
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "This organization charges no dues. We can discuss your " },
+                    { "kind": "topic", "topic": "advancement-business", "label": "standing and advancement" },
+                    { "kind": "text", "value": "." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            }
+          ]
+        },
+        {
+          "id": "advancement-business",
+          "label": "Standing and advancement",
+          "initially_known": true,
+          "conditions": {
+            "op": "fact",
+            "key": {
+              "kind": "organization_membership",
+              "player": "player",
+              "representative": "representative"
+            },
+            "equals": "current"
+          },
+          "responses": [
+            {
+              "id": "advancement-available",
+              "priority": 10,
+              "conditions": {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_promotion_available",
+                  "player": "player",
+                  "representative": "representative"
+                },
+                "equals": true
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "You may " },
+                    { "kind": "topic", "topic": "promotion", "label": "request promotion" },
+                    { "kind": "text", "value": ", or review how you " },
+                    { "kind": "topic", "topic": "presentation-business", "label": "represent the organization" },
+                    { "kind": "text", "value": "." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            },
+            {
+              "id": "advancement-unavailable",
+              "priority": 10,
+              "conditions": {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_promotion_available",
+                  "player": "player",
+                  "representative": "representative"
+                },
+                "equals": false
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "There is no promotion to record now. We can review how you " },
+                    { "kind": "topic", "topic": "presentation-business", "label": "represent the organization" },
+                    { "kind": "text", "value": "." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            }
+          ]
+        },
+        {
+          "id": "presentation-business",
+          "label": "Organization representation",
+          "initially_known": true,
+          "conditions": {
+            "op": "fact",
+            "key": {
+              "kind": "organization_membership",
+              "player": "player",
+              "representative": "representative"
+            },
+            "equals": "current"
+          },
+          "responses": [
+            {
+              "id": "presentation-available",
+              "priority": 10,
+              "conditions": {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_presentation",
+                  "player": "player",
+                  "representative": "representative"
+                },
+                "equals": false
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "You may choose to " },
+                    { "kind": "topic", "topic": "present", "label": "present this organization" },
+                    { "kind": "text", "value": " in your travels." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            },
+            {
+              "id": "presentation-current",
+              "priority": 10,
+              "conditions": {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_presentation",
+                  "player": "player",
+                  "representative": "representative"
+                },
+                "equals": true
+              },
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "You already travel under this organization's name." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": null
+            }
+          ]
+        },
         {
           "id": "join",
           "label": "Join",

--- a/content/dialogue/organizations.yaml
+++ b/content/dialogue/organizations.yaml
@@ -1,0 +1,351 @@
+{
+  "conversations": [
+    {
+      "id": "organization-representative",
+      "roles": {
+        "player": { "kind": "player", "min": 1, "max": 4 },
+        "representative": { "kind": "npc" }
+      },
+      "on_start": [
+        {
+          "id": "organization-greeting",
+          "priority": 0,
+          "turns": [
+            {
+              "speaker": "representative",
+              "fragments": [
+                { "kind": "text", "value": "Welcome to " },
+                { "kind": "runtime", "slot": "organization_name" },
+                { "kind": "text", "value": ". I conduct the institution's business here." }
+              ]
+            }
+          ],
+          "effects": [],
+          "prompt": null
+        }
+      ],
+      "topics": [
+        {
+          "id": "join",
+          "label": "Join",
+          "initially_known": true,
+          "conditions": {
+            "op": "fact",
+            "key": {
+              "kind": "organization_membership",
+              "player": "player",
+              "representative": "representative"
+            },
+            "equals": "none"
+          },
+          "responses": [
+            {
+              "id": "offer-membership",
+              "priority": 0,
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "You are asking to join " },
+                    { "kind": "runtime", "slot": "organization_name" },
+                    { "kind": "text", "value": ". " },
+                    { "kind": "runtime", "slot": "organization_admission_terms" },
+                    { "kind": "text", "value": " Shall I enter your name on the rolls?" }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": {
+                "id": "join-organization",
+                "respondent": "player",
+                "mode": "yes_no",
+                "choices": [
+                  {
+                    "id": "join",
+                    "label": "Join this organization.",
+                    "effects": [{ "kind": "join_organization" }],
+                    "result_turns": [
+                      {
+                        "speaker": "representative",
+                        "fragments": [
+                          { "kind": "text", "value": "Your membership is recorded. Observe our rules and keep your obligations current." }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "decline",
+                    "label": "Not now.",
+                    "result_turns": [
+                      {
+                        "speaker": "representative",
+                        "fragments": [
+                          { "kind": "text", "value": "Return if you change your mind." }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "dues",
+          "label": "Pay dues",
+          "initially_known": true,
+          "conditions": {
+            "op": "all",
+            "conditions": [
+              {
+                "op": "fact",
+                "key": { "kind": "organization_dues_required", "representative": "representative" },
+                "equals": true
+              },
+              {
+                "op": "not",
+                "condition": {
+                  "op": "fact",
+                  "key": {
+                    "kind": "organization_membership",
+                    "player": "player",
+                    "representative": "representative"
+                  },
+                  "equals": "none"
+                }
+              }
+            ]
+          },
+          "responses": [
+            {
+              "id": "offer-dues-payment",
+              "priority": 0,
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "runtime", "slot": "organization_dues_terms" },
+                    { "kind": "text", "value": " I can receive one interval now and restore a suspended membership." }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": {
+                "id": "pay-organization-dues",
+                "respondent": "player",
+                "mode": "yes_no",
+                "choices": [
+                  {
+                    "id": "pay",
+                    "label": "Pay one dues interval.",
+                    "effects": [{ "kind": "pay_organization_dues" }],
+                    "result_turns": [
+                      {
+                        "speaker": "representative",
+                        "fragments": [
+                          { "kind": "text", "value": "Your payment is recorded and your standing is current." }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "wait",
+                    "label": "Not now.",
+                    "result_turns": [
+                      {
+                        "speaker": "representative",
+                        "fragments": [{ "kind": "text", "value": "Very well." }]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "promotion",
+          "label": "Request promotion",
+          "initially_known": true,
+          "conditions": {
+            "op": "fact",
+            "key": {
+              "kind": "organization_promotion_available",
+              "player": "player",
+              "representative": "representative"
+            },
+            "equals": true
+          },
+          "responses": [
+            {
+              "id": "consider-promotion",
+              "priority": 0,
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "runtime", "slot": "organization_rank_standing" },
+                    { "kind": "text", "value": " Shall I examine your claim to promotion?" }
+                  ]
+                }
+              ],
+              "effects": [],
+              "prompt": {
+                "id": "request-organization-promotion",
+                "respondent": "player",
+                "mode": "yes_no",
+                "choices": [
+                  {
+                    "id": "request",
+                    "label": "Request promotion.",
+                    "effects": [{ "kind": "request_organization_promotion" }],
+                    "result_turns": [
+                      {
+                        "speaker": "representative",
+                        "fragments": [
+                          { "kind": "text", "value": "Your new rank is recorded." }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "id": "wait",
+                    "label": "Not now.",
+                    "result_turns": [
+                      {
+                        "speaker": "representative",
+                        "fragments": [{ "kind": "text", "value": "Very well." }]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "id": "present",
+          "label": "Present organization",
+          "initially_known": true,
+          "conditions": {
+            "op": "all",
+            "conditions": [
+              {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_membership",
+                  "player": "player",
+                  "representative": "representative"
+                },
+                "equals": "current"
+              },
+              {
+                "op": "fact",
+                "key": {
+                  "kind": "organization_presentation",
+                  "player": "player",
+                  "representative": "representative"
+                },
+                "equals": false
+              }
+            ]
+          },
+          "responses": [
+            {
+              "id": "record-presentation",
+              "priority": 0,
+              "turns": [
+                {
+                  "speaker": "representative",
+                  "fragments": [
+                    { "kind": "text", "value": "I will record that you travel under the name of " },
+                    { "kind": "runtime", "slot": "organization_name" },
+                    { "kind": "text", "value": "." }
+                  ]
+                }
+              ],
+              "effects": [{ "kind": "present_organization" }],
+              "prompt": null
+            }
+          ]
+        },
+        {
+          "id": "referred-testimony",
+          "label": "What I saw",
+          "initially_known": true,
+          "conditions": {
+            "op": "fact",
+            "key": { "kind": "participant_referral_contact", "role": "representative" },
+            "equals": true
+          },
+          "responses": [
+            {
+              "id": "hear-referred-testimony",
+              "priority": 0,
+              "turns": [
+                {
+                  "speaker": "player",
+                  "fragments": [
+                    { "kind": "text", "value": "I was told you know what happened. What did you see or hear?" }
+                  ]
+                },
+                {
+                  "speaker": "representative",
+                  "fragments": [{ "kind": "runtime", "slot": "testimony" }]
+                }
+              ],
+              "effects": [{ "kind": "receive_referred_testimony" }],
+              "prompt": null
+            }
+          ]
+        },
+        {
+          "id": "return-recovered-property",
+          "label": "Return recovered property",
+          "initially_known": true,
+          "responses": [
+            {
+              "id": "return-recovered-property",
+              "priority": 0,
+              "turns": [
+                {
+                  "speaker": "player",
+                  "fragments": [{ "kind": "text", "value": "I found the missing property and brought it back." }]
+                },
+                {
+                  "speaker": "representative",
+                  "fragments": [{ "kind": "text", "value": "I will see that it is returned to its proper place." }]
+                }
+              ],
+              "effects": [{ "kind": "investigation_action", "action": "return_asset" }],
+              "prompt": null
+            }
+          ]
+        },
+        {
+          "id": "expose-false-account",
+          "label": "Challenge the account",
+          "initially_known": true,
+          "responses": [
+            {
+              "id": "expose-false-account",
+              "priority": 0,
+              "turns": [
+                {
+                  "speaker": "player",
+                  "fragments": [{ "kind": "text", "value": "The evidence contradicts the story that was told." }]
+                },
+                {
+                  "speaker": "representative",
+                  "fragments": [{ "kind": "text", "value": "Then state what you have proved, and the false account will be challenged." }]
+                }
+              ],
+              "effects": [{ "kind": "investigation_action", "action": "expose" }],
+              "prompt": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/content/organizations/catalog.yaml
+++ b/content/organizations/catalog.yaml
@@ -10,9 +10,30 @@
                               "old_rank_id":  "master"
                           },
         "chapters":  [
-                         "viabundus-0",
-                         "viabundus-2337",
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-0",
+                             "location_id":  "organization-merchant-guild",
+                             "building_name":  "Merchants Guildhall",
+                             "building_kind":  "guildhall",
+                             "representative_title":  "guild factor",
+                             "representative_profession":  "merchant"
+                         },
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-merchant-guild",
+                             "building_name":  "Merchants Guildhall",
+                             "building_kind":  "guildhall",
+                             "representative_title":  "guild factor",
+                             "representative_profession":  "merchant"
+                         },
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-merchant-guild",
+                             "building_name":  "Merchants Guildhall",
+                             "building_kind":  "guildhall",
+                             "representative_title":  "guild factor",
+                             "representative_profession":  "merchant"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -97,9 +118,30 @@
                               "old_rank_id":  "master"
                           },
         "chapters":  [
-                         "viabundus-0",
-                         "viabundus-2337",
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-0",
+                             "location_id":  "organization-weaponsmith-guild",
+                             "building_name":  "Weaponsmiths Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "weaponsmith"
+                         },
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-weaponsmith-guild",
+                             "building_name":  "Weaponsmiths Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "weaponsmith"
+                         },
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-weaponsmith-guild",
+                             "building_name":  "Weaponsmiths Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "weaponsmith"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -180,9 +222,30 @@
                               "old_rank_id":  "master"
                           },
         "chapters":  [
-                         "viabundus-0",
-                         "viabundus-2337",
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-0",
+                             "location_id":  "organization-armourers-guild",
+                             "building_name":  "Armourers Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "armourer"
+                         },
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-armourers-guild",
+                             "building_name":  "Armourers Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "armourer"
+                         },
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-armourers-guild",
+                             "building_name":  "Armourers Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "armourer"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -263,9 +326,30 @@
                               "old_rank_id":  "master"
                           },
         "chapters":  [
-                         "viabundus-0",
-                         "viabundus-2337",
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-0",
+                             "location_id":  "organization-tailors-guild",
+                             "building_name":  "Tailors Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "tailor"
+                         },
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-tailors-guild",
+                             "building_name":  "Tailors Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "tailor"
+                         },
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-tailors-guild",
+                             "building_name":  "Tailors Hall",
+                             "building_kind":  "workshop",
+                             "representative_title":  "guild master",
+                             "representative_profession":  "tailor"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -346,9 +430,30 @@
                               "old_rank_id":  "physician"
                           },
         "chapters":  [
-                         "viabundus-0",
-                         "viabundus-2337",
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-0",
+                             "location_id":  "organization-herbalists-college",
+                             "building_name":  "College of Herbalists",
+                             "building_kind":  "college",
+                             "representative_title":  "college registrar",
+                             "representative_profession":  "herbalist"
+                         },
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-herbalists-college",
+                             "building_name":  "College of Herbalists",
+                             "building_kind":  "college",
+                             "representative_title":  "college registrar",
+                             "representative_profession":  "herbalist"
+                         },
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-herbalists-college",
+                             "building_name":  "College of Herbalists",
+                             "building_kind":  "college",
+                             "representative_title":  "college registrar",
+                             "representative_profession":  "herbalist"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -449,9 +554,30 @@
                               "old_rank_id":  "master"
                           },
         "chapters":  [
-                         "viabundus-0",
-                         "viabundus-2337",
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-0",
+                             "location_id":  "organization-cooks-guild",
+                             "building_name":  "Cooks Guildhall",
+                             "building_kind":  "guildhall",
+                             "representative_title":  "guild steward",
+                             "representative_profession":  "cook"
+                         },
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-cooks-guild",
+                             "building_name":  "Cooks Guildhall",
+                             "building_kind":  "guildhall",
+                             "representative_title":  "guild steward",
+                             "representative_profession":  "cook"
+                         },
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-cooks-guild",
+                             "building_name":  "Cooks Guildhall",
+                             "building_kind":  "guildhall",
+                             "representative_title":  "guild steward",
+                             "representative_profession":  "cook"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -532,7 +658,14 @@
                               "old_rank_id":  "doctor"
                           },
         "chapters":  [
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-roman-catholic-learned-chapter",
+                             "building_name":  "Confraternity House",
+                             "building_kind":  "confraternity",
+                             "representative_title":  "confraternity reader",
+                             "representative_profession":  "learned religious practitioner"
+                         }
                      ],
         "recognition":  {
                             "kind":  "universal"
@@ -757,7 +890,7 @@
     {
         "id":  "lutheran_learned_visitation",
         "name":  "Lutheran Visitation of Readers",
-        "description":  "A learned Lutheran visitation represented at Goslar and GÃ¶ttingen.",
+        "description":  "A learned Lutheran visitation represented at Goslar and GÃƒÂ¶ttingen.",
         "service_id":  "religion",
         "starting_role":  {
                               "profession":  "learned_religious_practitioner",
@@ -765,8 +898,22 @@
                               "old_rank_id":  "visitor"
                           },
         "chapters":  [
-                         "viabundus-2337",
-                         "viabundus-0"
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-lutheran-learned-visitation",
+                             "building_name":  "Visitation House",
+                             "building_kind":  "confraternity",
+                             "representative_title":  "visitation reader",
+                             "representative_profession":  "learned religious practitioner"
+                         },
+                         {
+                             "settlement_id":  "viabundus-0",
+                             "location_id":  "organization-lutheran-learned-visitation",
+                             "building_name":  "Visitation House",
+                             "building_kind":  "confraternity",
+                             "representative_title":  "visitation reader",
+                             "representative_profession":  "learned religious practitioner"
+                         }
                      ],
         "recognition":  {
                             "kind":  "universal"
@@ -795,7 +942,9 @@
                           "id":  "reader",
                           "name":  "Reader",
                           "description":  "A newly licensed reader of doctrine.",
-                          "requirements":  [],
+                          "requirements":  [
+
+                                           ],
                           "practice_allowed":  true,
                           "practice_reward_interval_minutes":  240
                       },
@@ -803,7 +952,9 @@
                           "id":  "visitor",
                           "name":  "Visitor",
                           "description":  "A master entrusted to examine doctrine and teachers.",
-                          "requirements":  [],
+                          "requirements":  [
+
+                                           ],
                           "practice_allowed":  true,
                           "practice_reward_interval_minutes":  120
                       }
@@ -973,7 +1124,14 @@
                               "old_rank_id":  "inquisitor"
                           },
         "chapters":  [
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-brotherhood-saint-peter-martyr",
+                             "building_name":  "House of Saint Peter Martyr",
+                             "building_kind":  "confraternity",
+                             "representative_title":  "brotherhood prior",
+                             "representative_profession":  "witch hunter"
+                         }
                      ],
         "recognition":  {
                             "kind":  "universal"
@@ -1027,7 +1185,9 @@
                           "id":  "inquisitor",
                           "name":  "Inquisitor",
                           "description":  "A master examiner trusted to direct investigations.",
-                          "requirements":  [],
+                          "requirements":  [
+
+                                           ],
                           "practice_allowed":  true,
                           "practice_reward_interval_minutes":  60
                       }
@@ -1067,7 +1227,14 @@
                               "old_rank_id":  "visitor"
                           },
         "chapters":  [
-                         "viabundus-2337"
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-brotherhood-watchful-lamp",
+                             "building_name":  "House of the Watchful Lamp",
+                             "building_kind":  "confraternity",
+                             "representative_title":  "brotherhood prior",
+                             "representative_profession":  "witch hunter"
+                         }
                      ],
         "recognition":  {
                             "kind":  "universal"
@@ -1096,7 +1263,9 @@
                           "id":  "examiner",
                           "name":  "Examiner",
                           "description":  "A licensed investigator of supernatural reports.",
-                          "requirements":  [],
+                          "requirements":  [
+
+                                           ],
                           "practice_allowed":  true,
                           "practice_reward_interval_minutes":  240
                       },
@@ -1104,7 +1273,9 @@
                           "id":  "visitor",
                           "name":  "Visitor",
                           "description":  "A master examiner who directs territorial visitations.",
-                          "requirements":  [],
+                          "requirements":  [
+
+                                           ],
                           "practice_allowed":  true,
                           "practice_reward_interval_minutes":  120
                       }
@@ -1312,7 +1483,14 @@
                               "old_rank_id":  "commander"
                           },
         "chapters":  [
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-order-saint-george",
+                             "building_name":  "Saint George Commandery",
+                             "building_kind":  "commandery",
+                             "representative_title":  "order commander",
+                             "representative_profession":  "knight"
+                         }
                      ],
         "recognition":  {
                             "kind":  "universal"
@@ -1355,7 +1533,9 @@
                           "id":  "commander",
                           "name":  "Commander",
                           "description":  "A veteran knight entrusted with command.",
-                          "requirements":  [],
+                          "requirements":  [
+
+                                           ],
                           "practice_allowed":  true,
                           "practice_reward_interval_minutes":  60
                       }
@@ -1394,7 +1574,14 @@
                               "old_rank_id":  "commander"
                           },
         "chapters":  [
-                         "viabundus-2337"
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-brandenburg-bailiwick-saint-john",
+                             "building_name":  "Saint John Commandery",
+                             "building_kind":  "commandery",
+                             "representative_title":  "order commander",
+                             "representative_profession":  "knight"
+                         }
                      ],
         "recognition":  {
                             "kind":  "universal"
@@ -1423,7 +1610,9 @@
                           "id":  "knight",
                           "name":  "Knight Brother",
                           "description":  "A newly proven brother of the bailiwick.",
-                          "requirements":  [],
+                          "requirements":  [
+
+                                           ],
                           "practice_allowed":  true,
                           "practice_reward_interval_minutes":  240
                       },
@@ -1431,7 +1620,9 @@
                           "id":  "commander",
                           "name":  "Commander",
                           "description":  "A veteran knight entrusted with a commandery.",
-                          "requirements":  [],
+                          "requirements":  [
+
+                                           ],
                           "practice_allowed":  true,
                           "practice_reward_interval_minutes":  120
                       }
@@ -1639,7 +1830,14 @@
                           },
         "historical_fantasy_note":  "An invented body using period-appropriate territorial forest-office language.",
         "chapters":  [
-                         "viabundus-2337"
+                         {
+                             "settlement_id":  "viabundus-2337",
+                             "location_id":  "organization-wardens-harz",
+                             "building_name":  "Harz Warden Lodge",
+                             "building_kind":  "lodge",
+                             "representative_title":  "chief warden",
+                             "representative_profession":  "forester"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -1682,7 +1880,7 @@
                       {
                           "id":  "master",
                           "name":  "Master",
-                          "description":  "A master warden entrusted with the prince's high game.",
+                          "description":  "A master warden entrusted with the prince\u0027s high game.",
                           "requirements":  [
                                                {
                                                    "kind":  "skill_rating",
@@ -1734,7 +1932,14 @@
                           },
         "historical_fantasy_note":  "An invented body using period-appropriate forest-office language.",
         "chapters":  [
-                         "viabundus-0"
+                         {
+                             "settlement_id":  "viabundus-0",
+                             "location_id":  "organization-keepers-solling",
+                             "building_name":  "Solling Keeper Lodge",
+                             "building_kind":  "lodge",
+                             "representative_title":  "chief keeper",
+                             "representative_profession":  "forester"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -1762,7 +1967,7 @@
                       {
                           "id":  "master",
                           "name":  "Master",
-                          "description":  "A master keeper entrusted with the prince's high game.",
+                          "description":  "A master keeper entrusted with the prince\u0027s high game.",
                           "requirements":  [
                                                {
                                                    "kind":  "skill_rating",
@@ -1814,7 +2019,14 @@
                           },
         "historical_fantasy_note":  "An invented body using period-appropriate forest-office language.",
         "chapters":  [
-                         "viabundus-1826"
+                         {
+                             "settlement_id":  "viabundus-1826",
+                             "location_id":  "organization-company-green-staff-thuringia",
+                             "building_name":  "Green Staff Lodge",
+                             "building_kind":  "lodge",
+                             "representative_title":  "company warden",
+                             "representative_profession":  "forester"
+                         }
                      ],
         "recognition":  {
                             "kind":  "settlements",
@@ -1842,7 +2054,7 @@
                       {
                           "id":  "master",
                           "name":  "Master",
-                          "description":  "A master forester entrusted with the prince's high game.",
+                          "description":  "A master forester entrusted with the prince\u0027s high game.",
                           "requirements":  [
                                                {
                                                    "kind":  "skill_rating",

--- a/crates/adventuresim-core/src/organization.rs
+++ b/crates/adventuresim-core/src/organization.rs
@@ -29,7 +29,7 @@ pub struct OrganizationDefinition {
     #[serde(default)]
     pub starting_role: Option<OrganizationStartingRole>,
     #[serde(default)]
-    pub chapters: Vec<String>,
+    pub chapters: Vec<OrganizationChapter>,
     pub recognition: Recognition,
     #[serde(default)]
     pub admission: Admission,
@@ -39,6 +39,29 @@ pub struct OrganizationDefinition {
     pub activity: OrganizationActivity,
     #[serde(default)]
     pub privileges: Vec<Privilege>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OrganizationChapter {
+    pub settlement_id: String,
+    /// Stable, settlement-scoped navigation and NPC-presence identifier.
+    pub location_id: String,
+    pub building_name: String,
+    pub building_kind: ChapterBuildingKind,
+    pub representative_title: String,
+    pub representative_profession: String,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChapterBuildingKind {
+    Guildhall,
+    Workshop,
+    College,
+    Confraternity,
+    Commandery,
+    Lodge,
 }
 
 /// Explicit character-creation metadata. This is deliberately authored rather
@@ -227,7 +250,23 @@ impl Recognition {
 
 impl OrganizationDefinition {
     pub fn has_chapter(&self, settlement_id: &str) -> bool {
-        self.chapters.iter().any(|id| id == settlement_id)
+        self.chapter(settlement_id).is_some()
+    }
+
+    pub fn chapter(&self, settlement_id: &str) -> Option<&OrganizationChapter> {
+        self.chapters
+            .iter()
+            .find(|chapter| chapter.settlement_id == settlement_id)
+    }
+
+    pub fn chapter_at_location(
+        &self,
+        settlement_id: &str,
+        location_id: &str,
+    ) -> Option<&OrganizationChapter> {
+        self.chapters.iter().find(|chapter| {
+            chapter.settlement_id == settlement_id && chapter.location_id == location_id
+        })
     }
 
     pub fn has_privilege(&self, privilege: Privilege) -> bool {
@@ -274,6 +313,20 @@ pub fn organizations_for_chapter(
         .organizations
         .iter()
         .filter(move |organization| organization.has_chapter(settlement_id))
+}
+
+pub fn organization_chapter_at(
+    settlement_id: &str,
+    location_id: &str,
+) -> Option<(
+    &'static OrganizationDefinition,
+    &'static OrganizationChapter,
+)> {
+    catalog().organizations.iter().find_map(|organization| {
+        organization
+            .chapter_at_location(settlement_id, location_id)
+            .map(|chapter| (organization, chapter))
+    })
 }
 
 pub fn settlement_policy(settlement_id: &str) -> Option<&'static SettlementPolicy> {
@@ -336,5 +389,19 @@ mod tests {
             "learned_religious_practitioner"
         );
         assert_eq!(StartingProfession::WitchHunter.id(), "witch_hunter");
+    }
+
+    #[test]
+    fn chapter_locations_are_stable_distinct_and_reverse_resolvable() {
+        let mut seen = std::collections::BTreeSet::new();
+        for organization in &catalog().organizations {
+            for chapter in &organization.chapters {
+                assert!(seen.insert((chapter.settlement_id.clone(), chapter.location_id.clone())));
+                let (found, found_chapter) =
+                    organization_chapter_at(&chapter.settlement_id, &chapter.location_id).unwrap();
+                assert_eq!(found.id, organization.id);
+                assert_eq!(found_chapter, chapter);
+            }
+        }
     }
 }

--- a/crates/adventuresim-core/src/organization_catalog_validation.rs
+++ b/crates/adventuresim-core/src/organization_catalog_validation.rs
@@ -206,6 +206,7 @@ pub fn validate_documents(
 ) -> Result<(), String> {
     let mut ids = BTreeSet::new();
     let mut starting_professions = BTreeSet::new();
+    let mut chapter_location_pairs = BTreeSet::new();
     for (document, source) in documents.iter().zip(sources) {
         let org = object(document, source, "organization")?;
         keys(
@@ -268,7 +269,58 @@ pub fn validate_documents(
             }
             starting_professions.insert(profession.to_owned());
         }
-        unique_strings(array(org, source, "chapters")?, source, "chapters")?;
+        let chapters = array(org, source, "chapters")?;
+        let mut chapter_settlements = BTreeSet::new();
+        for (index, chapter) in chapters.iter().enumerate() {
+            let at = format!("chapters[{index}]");
+            let chapter = object(chapter, source, &at)?;
+            keys(
+                chapter,
+                &[
+                    "settlement_id",
+                    "location_id",
+                    "building_name",
+                    "building_kind",
+                    "representative_title",
+                    "representative_profession",
+                ],
+                source,
+                &at,
+            )?;
+            let settlement_id = text(chapter, source, "settlement_id")?;
+            let location_id = text(chapter, source, "location_id")?;
+            if !location_id.starts_with("organization-")
+                || location_id.len() > 96
+                || !location_id.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'-' | b'_')
+                })
+            {
+                return Err(format!(
+                    "{source}: {at}.location_id must be a bounded organization-* location ID"
+                ));
+            }
+            if !chapter_settlements.insert(settlement_id) {
+                return Err(format!(
+                    "{source}: chapters contains duplicate settlement {settlement_id:?}"
+                ));
+            }
+            if !chapter_location_pairs.insert((settlement_id.to_owned(), location_id.to_owned())) {
+                return Err(format!(
+                    "{source}: chapter location {location_id:?} is already authored at {settlement_id:?}"
+                ));
+            }
+            text(chapter, source, "building_name")?;
+            if !matches!(
+                text(chapter, source, "building_kind")?,
+                "guildhall" | "workshop" | "college" | "confraternity" | "commandery" | "lodge"
+            ) {
+                return Err(format!("{source}: {at}.building_kind is invalid"));
+            }
+            text(chapter, source, "representative_title")?;
+            text(chapter, source, "representative_profession")?;
+        }
         let recognition = object(
             org.get("recognition")
                 .ok_or_else(|| format!("{source}: recognition is required"))?,
@@ -408,9 +460,12 @@ pub fn validate_documents(
                 ));
             }
             if recognition.get("kind").and_then(Value::as_str) == Some("settlements") {
-                let chapters = array(org, source, "chapters")?;
                 let recognized = array(recognition, source, "settlement_ids")?;
-                if !chapters.iter().any(|chapter| recognized.contains(chapter)) {
+                if !chapters.iter().any(|chapter| {
+                    chapter
+                        .get("settlement_id")
+                        .is_some_and(|settlement_id| recognized.contains(settlement_id))
+                }) {
                     return Err(format!(
                         "{source}: starting_role organization has no chapter in a recognized settlement"
                     ));
@@ -586,7 +641,14 @@ mod tests {
             "id": "test_body",
             "name": "Test Body",
             "description": "A validator fixture.",
-            "chapters": ["viabundus-0"],
+            "chapters": [{
+                "settlement_id": "viabundus-0",
+                "location_id": "organization-test-body",
+                "building_name": "Test Hall",
+                "building_kind": "guildhall",
+                "representative_title": "Test Warden",
+                "representative_profession": "administrator"
+            }],
             "recognition": {"kind": "settlements", "settlement_ids": ["viabundus-0"]},
             "admission": {"joining_fee": 0, "requirements": []},
             "ranks": [{
@@ -640,11 +702,11 @@ mod tests {
     #[test]
     fn rejects_non_string_and_duplicate_settlement_ids() {
         let mut non_string = valid_organization();
-        non_string["chapters"] = json!(["viabundus-0", 7]);
+        non_string["chapters"][0]["settlement_id"] = json!(7);
         assert!(
             validate(non_string, json!([]))
                 .unwrap_err()
-                .contains("must be a non-empty string")
+                .contains("settlement_id must be a non-empty string")
         );
 
         let mut duplicate = valid_organization();
@@ -653,6 +715,26 @@ mod tests {
             validate(duplicate, json!([]))
                 .unwrap_err()
                 .contains("duplicate")
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_or_foreign_chapter_locations() {
+        let mut duplicate = valid_organization();
+        let chapter = duplicate["chapters"][0].clone();
+        duplicate["chapters"].as_array_mut().unwrap().push(chapter);
+        assert!(
+            validate(duplicate, json!([]))
+                .unwrap_err()
+                .contains("duplicate settlement")
+        );
+
+        let mut foreign = valid_organization();
+        foreign["chapters"][0]["location_id"] = json!("inn");
+        assert!(
+            validate(foreign, json!([]))
+                .unwrap_err()
+                .contains("bounded organization-*")
         );
     }
 
@@ -781,5 +863,11 @@ mod tests {
                 .unwrap_err()
                 .contains("conflicts with admission religion")
         );
+    }
+
+    #[test]
+    fn build_and_runtime_share_organization_catalog_validation() {
+        let build = include_str!("../build.rs");
+        assert!(build.contains("#[path = \"src/organization_catalog_validation.rs\"]"));
     }
 }

--- a/crates/adventuresim-core/src/quest_generation.rs
+++ b/crates/adventuresim-core/src/quest_generation.rs
@@ -4634,7 +4634,8 @@ mod tests {
         Vec<WitnessCandidate>,
     ) {
         let profile = adventuresim_world_schema::SettlementEconomyProfile::stage_placeholder();
-        let tabs = crate::settlement_economy::player_visible_npc_tabs(&profile, false);
+        let tabs =
+            crate::settlement_economy::player_visible_npc_tabs(&profile, false, "fixture-no-orgs");
         let mut candidates = test_witnesses();
         for (candidate, location) in candidates.iter_mut().zip(["residences", "overview", "inn"]) {
             candidate.expected_location = location.into();

--- a/crates/adventuresim-core/src/settlement_economy.rs
+++ b/crates/adventuresim-core/src/settlement_economy.rs
@@ -96,6 +96,7 @@ pub const fn action_service_at_inn(service: SettlementActionService) -> bool {
 pub fn player_visible_npc_tabs(
     profile: &SettlementEconomyProfile,
     has_keep: bool,
+    settlement_id: &str,
 ) -> Vec<SettlementNpcTab> {
     let mut tabs = vec![
         SettlementNpcTab {
@@ -154,6 +155,15 @@ pub fn player_visible_npc_tabs(
             tabs.push(SettlementNpcTab { location_id, label });
         }
     }
+    for organization in crate::organization::organizations_for_chapter(settlement_id) {
+        let chapter = organization
+            .chapter(settlement_id)
+            .expect("chapter iterator guarantees a local chapter");
+        tabs.push(SettlementNpcTab {
+            location_id: chapter.location_id.as_str(),
+            label: chapter.building_name.as_str(),
+        });
+    }
     tabs
 }
 
@@ -167,9 +177,14 @@ pub fn visible_npc_tab<'a>(
 pub fn npc_location_is_navigable(
     profile: &SettlementEconomyProfile,
     has_keep: bool,
+    settlement_id: &str,
     location_id: &str,
 ) -> bool {
-    visible_npc_tab(&player_visible_npc_tabs(profile, has_keep), location_id).is_some()
+    visible_npc_tab(
+        &player_visible_npc_tabs(profile, has_keep, settlement_id),
+        location_id,
+    )
+    .is_some()
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -393,12 +408,39 @@ mod tests {
     #[test]
     fn npc_navigation_rejects_hidden_services_and_impossible_keeps() {
         let p = profile(vec![Service::Inn], vec![Stock::GeneralGoods]);
-        assert!(npc_location_is_navigable(&p, false, "inn"));
-        assert!(npc_location_is_navigable(&p, false, "residences"));
-        assert!(!npc_location_is_navigable(&p, false, "church"));
-        assert!(!npc_location_is_navigable(&p, false, "armoury"));
-        assert!(!npc_location_is_navigable(&p, false, "keep"));
-        assert!(npc_location_is_navigable(&p, true, "keep"));
+        assert!(npc_location_is_navigable(&p, false, "viabundus-0", "inn"));
+        assert!(npc_location_is_navigable(
+            &p,
+            false,
+            "viabundus-0",
+            "residences"
+        ));
+        assert!(!npc_location_is_navigable(
+            &p,
+            false,
+            "viabundus-0",
+            "church"
+        ));
+        assert!(!npc_location_is_navigable(
+            &p,
+            false,
+            "viabundus-0",
+            "armoury"
+        ));
+        assert!(!npc_location_is_navigable(&p, false, "viabundus-0", "keep"));
+        assert!(npc_location_is_navigable(&p, true, "viabundus-0", "keep"));
+        assert!(npc_location_is_navigable(
+            &p,
+            false,
+            "viabundus-0",
+            "organization-merchant-guild"
+        ));
+        assert!(!npc_location_is_navigable(
+            &p,
+            false,
+            "viabundus-0",
+            "organization-brotherhood-saint-peter-martyr"
+        ));
     }
 
     #[test]

--- a/crates/adventuresim-core/src/settlement_population.rs
+++ b/crates/adventuresim-core/src/settlement_population.rs
@@ -51,6 +51,7 @@ pub enum LocationContext {
     Church,
     Residences,
     Keep,
+    Organization,
     AdultVenue,
 }
 

--- a/crates/adventuresim-dialogue/build.rs
+++ b/crates/adventuresim-dialogue/build.rs
@@ -39,6 +39,10 @@ fn validate_fragment(fragment: &BuildFragment, relative: &str) {
                     | "proof"
                     | "testimony"
                     | "contract_terms"
+                    | "organization_name"
+                    | "organization_admission_terms"
+                    | "organization_dues_terms"
+                    | "organization_rank_standing"
             ),
             "unknown runtime slot {slot} in {relative}"
         );

--- a/crates/adventuresim-dialogue/src/authoring_schema.rs
+++ b/crates/adventuresim-dialogue/src/authoring_schema.rs
@@ -124,6 +124,10 @@ pub enum AuthoringEffect {
     AcceptContract { contract: String },
     ReportContract { contract: String },
     BeginApprenticeship { profession: String },
+    JoinOrganization,
+    PayOrganizationDues,
+    RequestOrganizationPromotion,
+    PresentOrganization,
     SetFlag { flag: String, value: bool },
     ReceiveReferredTestimony,
     InvestigationAction { action: String },
@@ -152,36 +156,99 @@ pub enum Condition {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
 pub enum FactKey {
-    ParticipantProfession { role: String },
-    ParticipantOrganization { role: String },
-    ParticipantReligion { role: String },
-    ParticipantAgeBand { role: String },
-    ParticipantSex { role: String },
-    ParticipantLocalRole { role: String },
-    ParticipantStatus { role: String },
-    ParticipantLanguageCompatibility { left: String, right: String },
-    ParticipantFamiliarity { left: String, right: String },
-    ParticipantClothingCategory { role: String },
-    ParticipantHasVisibleClothing { role: String },
-    ParticipantPriorInteraction { left: String, right: String },
-    ParticipantCount { role: String },
-    ParticipantPresent { role: String },
-    ParticipantRumorCase { role: String },
-    ParticipantReferralContact { role: String },
+    ParticipantProfession {
+        role: String,
+    },
+    ParticipantOrganization {
+        role: String,
+    },
+    ParticipantReligion {
+        role: String,
+    },
+    ParticipantAgeBand {
+        role: String,
+    },
+    ParticipantSex {
+        role: String,
+    },
+    ParticipantLocalRole {
+        role: String,
+    },
+    ParticipantStatus {
+        role: String,
+    },
+    ParticipantLanguageCompatibility {
+        left: String,
+        right: String,
+    },
+    ParticipantFamiliarity {
+        left: String,
+        right: String,
+    },
+    ParticipantClothingCategory {
+        role: String,
+    },
+    ParticipantHasVisibleClothing {
+        role: String,
+    },
+    ParticipantPriorInteraction {
+        left: String,
+        right: String,
+    },
+    ParticipantCount {
+        role: String,
+    },
+    ParticipantPresent {
+        role: String,
+    },
+    ParticipantRumorCase {
+        role: String,
+    },
+    ParticipantReferralContact {
+        role: String,
+    },
+    OrganizationMembership {
+        player: String,
+        representative: String,
+    },
+    OrganizationPromotionAvailable {
+        player: String,
+        representative: String,
+    },
+    OrganizationPresentation {
+        player: String,
+        representative: String,
+    },
+    OrganizationDuesRequired {
+        representative: String,
+    },
     KnownClaim,
     KnownLead,
-    PriorQuestioning { role: String },
+    PriorQuestioning {
+        role: String,
+    },
     Confidence,
-    LanguageCheck { left: String, right: String },
+    LanguageCheck {
+        left: String,
+        right: String,
+    },
     SocialCheck,
-    PartyLeader { role: String },
-    Service { role: String },
+    PartyLeader {
+        role: String,
+    },
+    Service {
+        role: String,
+    },
     Location,
     LocationRole,
     LocalCircumstance,
     TimePeriod,
-    ContractState { contract: String },
-    Flag { flag: String },
+    ContractState {
+        contract: String,
+    },
+    Flag {
+        flag: String,
+    },
 }
 
 impl FactKey {
@@ -207,6 +274,21 @@ impl FactKey {
             | Self::ParticipantFamiliarity { left, right }
             | Self::ParticipantPriorInteraction { left, right }
             | Self::LanguageCheck { left, right } => [Some(left.as_str()), Some(right.as_str())],
+            Self::OrganizationMembership {
+                player,
+                representative,
+            }
+            | Self::OrganizationPromotionAvailable {
+                player,
+                representative,
+            }
+            | Self::OrganizationPresentation {
+                player,
+                representative,
+            } => [Some(player.as_str()), Some(representative.as_str())],
+            Self::OrganizationDuesRequired { representative } => {
+                [Some(representative.as_str()), None]
+            }
             _ => [None, None],
         };
         roles.into_iter().flatten()

--- a/crates/adventuresim-dialogue/src/lib.rs
+++ b/crates/adventuresim-dialogue/src/lib.rs
@@ -1150,6 +1150,106 @@ mod tests {
     }
 
     #[test]
+    fn organization_business_topics_are_reachable_only_when_authorized() {
+        fn anchored_topics(response: &Response) -> Vec<String> {
+            response
+                .turns
+                .iter()
+                .flat_map(|turn| &turn.fragments)
+                .filter_map(|fragment| match fragment {
+                    Fragment::Topic { topic, .. } => Some(topic.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        fn reachable_topics(conversation: &Conversation, facts: &FactContext) -> BTreeSet<String> {
+            let start = select_start_response(conversation, facts).expect("eligible greeting");
+            let mut pending = anchored_topics(start);
+            let mut reachable = BTreeSet::new();
+            while let Some(topic_id) = pending.pop() {
+                if !reachable.insert(topic_id.clone()) {
+                    continue;
+                }
+                let topic = conversation
+                    .topics
+                    .iter()
+                    .find(|topic| topic.id == topic_id)
+                    .expect("anchored topic exists");
+                assert!(
+                    topic.initially_known && facts.matches(&topic.conditions),
+                    "greeting flow exposed unauthorized topic {topic_id}"
+                );
+                let response = select_response(topic, facts).expect("reachable topic response");
+                pending.extend(anchored_topics(response));
+            }
+            reachable
+        }
+
+        let conversation = find_conversation("organization-representative").unwrap();
+        let states = [
+            ("none", false, false, false, vec!["join"]),
+            ("none", true, false, false, vec!["join"]),
+            ("suspended", false, false, false, vec![]),
+            ("suspended", true, false, false, vec!["dues"]),
+            ("current", false, false, false, vec!["present"]),
+            ("current", false, false, true, vec![]),
+            ("current", false, true, false, vec!["promotion", "present"]),
+            ("current", false, true, true, vec!["promotion"]),
+            ("current", true, false, false, vec!["dues", "present"]),
+            ("current", true, false, true, vec!["dues"]),
+            (
+                "current",
+                true,
+                true,
+                false,
+                vec!["dues", "promotion", "present"],
+            ),
+            ("current", true, true, true, vec!["dues", "promotion"]),
+        ];
+        for (membership, dues, promotion, presentation, expected) in states {
+            let mut facts = FactContext::default();
+            facts.facts.insert(
+                FactKey::OrganizationMembership {
+                    player: "player".into(),
+                    representative: "representative".into(),
+                },
+                FactValue::Text(membership.into()),
+            );
+            facts.facts.insert(
+                FactKey::OrganizationDuesRequired {
+                    representative: "representative".into(),
+                },
+                FactValue::Bool(dues),
+            );
+            facts.facts.insert(
+                FactKey::OrganizationPromotionAvailable {
+                    player: "player".into(),
+                    representative: "representative".into(),
+                },
+                FactValue::Bool(promotion),
+            );
+            facts.facts.insert(
+                FactKey::OrganizationPresentation {
+                    player: "player".into(),
+                    representative: "representative".into(),
+                },
+                FactValue::Bool(presentation),
+            );
+            let reachable = reachable_topics(conversation, &facts);
+            let actionable = ["join", "dues", "promotion", "present"]
+                .into_iter()
+                .filter(|topic| reachable.contains(*topic))
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                actionable,
+                expected.into_iter().collect(),
+                "wrong reachable business for membership={membership}, dues={dues}, promotion={promotion}, presentation={presentation}"
+            );
+        }
+    }
+
+    #[test]
     fn build_and_runtime_share_authoring_schema_and_runtime_slot_allowlist() {
         let build = include_str!("../build.rs");
         assert!(build.contains("#[path = \"src/authoring_schema.rs\"]"));

--- a/crates/adventuresim-dialogue/src/lib.rs
+++ b/crates/adventuresim-dialogue/src/lib.rs
@@ -131,6 +131,10 @@ pub enum RuntimeSlot {
     Proof,
     Testimony,
     ContractTerms,
+    OrganizationName,
+    OrganizationAdmissionTerms,
+    OrganizationDuesTerms,
+    OrganizationRankStanding,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -314,6 +318,10 @@ pub enum Effect {
     AcceptContract { contract: String },
     ReportContract { contract: String },
     BeginApprenticeship { profession: String },
+    JoinOrganization,
+    PayOrganizationDues,
+    RequestOrganizationPromotion,
+    PresentOrganization,
     SetFlag { flag: String, value: bool },
     ReceiveReferredTestimony,
     InvestigationAction { action: InvestigationAction },
@@ -1037,6 +1045,7 @@ mod tests {
             ("religion-service", "cleric"),
             ("local-resident", "local"),
             ("recruitment", "employer"),
+            ("organization-representative", "representative"),
         ] {
             let conversation = find_conversation(conversation_id).unwrap();
             let topic = conversation
@@ -1069,6 +1078,91 @@ mod tests {
                 .all(|topic| topic.id != "introduction" && topic.id != "local-problem")
         );
     }
+
+    #[test]
+    fn organization_dialogue_effects_never_carry_client_selected_ids() {
+        let conversation = find_conversation("organization-representative").unwrap();
+        let effects = conversation
+            .topics
+            .iter()
+            .flat_map(|topic| &topic.responses)
+            .flat_map(|response| {
+                response.effects.iter().chain(
+                    response
+                        .prompt
+                        .iter()
+                        .flat_map(|prompt| &prompt.choices)
+                        .flat_map(|choice| &choice.effects),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(effects.contains(&&Effect::JoinOrganization));
+        assert!(effects.contains(&&Effect::PayOrganizationDues));
+        assert!(effects.contains(&&Effect::RequestOrganizationPromotion));
+        assert!(effects.contains(&&Effect::PresentOrganization));
+        let encoded = serde_json::to_string(&effects).unwrap();
+        assert!(!encoded.contains("organization_id"));
+    }
+
+    #[test]
+    fn organization_dialogue_discloses_authoritative_terms_before_confirmation() {
+        let conversation = find_conversation("organization-representative").unwrap();
+        for (topic_id, required_slots, effect) in [
+            (
+                "join",
+                vec!["organization_name", "organization_admission_terms"],
+                Effect::JoinOrganization,
+            ),
+            (
+                "dues",
+                vec!["organization_dues_terms"],
+                Effect::PayOrganizationDues,
+            ),
+            (
+                "promotion",
+                vec!["organization_rank_standing"],
+                Effect::RequestOrganizationPromotion,
+            ),
+        ] {
+            let response = &conversation
+                .topics
+                .iter()
+                .find(|topic| topic.id == topic_id)
+                .expect("organization business topic")
+                .responses[0];
+            let spoken_before_prompt = serde_json::to_string(&response.turns).unwrap();
+            for slot in required_slots {
+                assert!(
+                    spoken_before_prompt.contains(slot),
+                    "{topic_id} must disclose {slot} before confirmation"
+                );
+            }
+            let prompt = response.prompt.as_ref().expect("business confirmation");
+            assert!(
+                prompt
+                    .choices
+                    .iter()
+                    .flat_map(|choice| &choice.effects)
+                    .any(|candidate| candidate == &effect),
+                "{topic_id} mutation must occur only after confirmation"
+            );
+        }
+    }
+
+    #[test]
+    fn build_and_runtime_share_authoring_schema_and_runtime_slot_allowlist() {
+        let build = include_str!("../build.rs");
+        assert!(build.contains("#[path = \"src/authoring_schema.rs\"]"));
+        for slot in [
+            "organization_name",
+            "organization_admission_terms",
+            "organization_dues_terms",
+            "organization_rank_standing",
+        ] {
+            assert!(build.contains(&format!("| \"{slot}\"")));
+        }
+    }
+
     #[test]
     fn multi_party_and_prompt_are_first_class() {
         let c = find_conversation("shop-with-assistant").unwrap();

--- a/crates/adventuresim-stdb-client/src/backend_settlement_npc_type.rs
+++ b/crates/adventuresim-stdb-client/src/backend_settlement_npc_type.rs
@@ -26,6 +26,7 @@ pub struct BackendSettlementNpc {
     pub household: String,
     pub local_role: String,
     pub service_id: String,
+    pub organization_id: String,
     pub conversation_id: String,
 }
 
@@ -53,6 +54,7 @@ pub struct BackendSettlementNpcCols {
     pub household: __sdk::__query_builder::Col<BackendSettlementNpc, String>,
     pub local_role: __sdk::__query_builder::Col<BackendSettlementNpc, String>,
     pub service_id: __sdk::__query_builder::Col<BackendSettlementNpc, String>,
+    pub organization_id: __sdk::__query_builder::Col<BackendSettlementNpc, String>,
     pub conversation_id: __sdk::__query_builder::Col<BackendSettlementNpc, String>,
 }
 
@@ -76,6 +78,7 @@ impl __sdk::__query_builder::HasCols for BackendSettlementNpc {
             household: __sdk::__query_builder::Col::new(table_name, "household"),
             local_role: __sdk::__query_builder::Col::new(table_name, "local_role"),
             service_id: __sdk::__query_builder::Col::new(table_name, "service_id"),
+            organization_id: __sdk::__query_builder::Col::new(table_name, "organization_id"),
             conversation_id: __sdk::__query_builder::Col::new(table_name, "conversation_id"),
         }
     }

--- a/crates/adventuresim-stdb-client/src/settlement_npc_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_npc_type.rs
@@ -29,6 +29,7 @@ pub struct SettlementNpc {
     pub household: String,
     pub local_role: String,
     pub service_id: String,
+    pub organization_id: String,
     pub conversation_id: String,
 }
 
@@ -58,6 +59,7 @@ pub struct SettlementNpcCols {
     pub household: __sdk::__query_builder::Col<SettlementNpc, String>,
     pub local_role: __sdk::__query_builder::Col<SettlementNpc, String>,
     pub service_id: __sdk::__query_builder::Col<SettlementNpc, String>,
+    pub organization_id: __sdk::__query_builder::Col<SettlementNpc, String>,
     pub conversation_id: __sdk::__query_builder::Col<SettlementNpc, String>,
 }
 
@@ -83,6 +85,7 @@ impl __sdk::__query_builder::HasCols for SettlementNpc {
             household: __sdk::__query_builder::Col::new(table_name, "household"),
             local_role: __sdk::__query_builder::Col::new(table_name, "local_role"),
             service_id: __sdk::__query_builder::Col::new(table_name, "service_id"),
+            organization_id: __sdk::__query_builder::Col::new(table_name, "organization_id"),
             conversation_id: __sdk::__query_builder::Col::new(table_name, "conversation_id"),
         }
     }

--- a/crates/adventuresim-stdb-module/src/settlement_population.rs
+++ b/crates/adventuresim-stdb-module/src/settlement_population.rs
@@ -53,6 +53,8 @@ pub struct SettlementNpc {
     pub household: String,
     pub local_role: String,
     pub service_id: String,
+    /// Explicit institution authority. Empty for NPCs not representing an organization.
+    pub organization_id: String,
     pub conversation_id: String,
 }
 
@@ -79,6 +81,7 @@ pub struct BackendSettlementNpc {
     pub household: String,
     pub local_role: String,
     pub service_id: String,
+    pub organization_id: String,
     pub conversation_id: String,
 }
 
@@ -100,6 +103,7 @@ fn project_backend_settlement_npc(npc: SettlementNpc) -> BackendSettlementNpc {
         household: npc.household,
         local_role: npc.local_role,
         service_id: npc.service_id,
+        organization_id: npc.organization_id,
         conversation_id: npc.conversation_id,
     }
 }
@@ -209,6 +213,7 @@ fn location_context(location: &str) -> Result<LocationContext, String> {
         "church" => LocationContext::Church,
         "residences" => LocationContext::Residences,
         "keep" => LocationContext::Keep,
+        location if location.starts_with("organization-") => LocationContext::Organization,
         _ => return Err(format!("Unknown population location {location}")),
     })
 }
@@ -342,6 +347,7 @@ fn insert_npc(
         household,
         local_role: local_role.into(),
         service_id: service.into(),
+        organization_id: String::new(),
         conversation_id: if service.is_empty() {
             "local-resident".into()
         } else if service == "herbalist" {
@@ -474,6 +480,34 @@ pub fn ensure_settlement_population(
             false,
         )?;
     }
+    for organization in adventuresim_core::organization::organizations_for_chapter(settlement_id) {
+        let chapter = organization
+            .chapter(settlement_id)
+            .expect("chapter iterator guarantees a local chapter");
+        insert_npc(
+            ctx,
+            settlement_id,
+            &chapter.location_id,
+            "organization",
+            &chapter.representative_profession,
+            &chapter.representative_title,
+            0,
+            true,
+        )?;
+        let npc_id = format!("npc:{settlement_id}:{}:0", chapter.location_id);
+        let mut representative = ctx
+            .db
+            .settlement_npc()
+            .id()
+            .find(&npc_id)
+            .ok_or("Organization representative was not seeded")?;
+        representative.service_id.clear();
+        representative.organization_id = organization.id.clone();
+        representative.conversation_id = "organization-representative".into();
+        representative.clothing =
+            "well-kept clothing bearing the institution's public insignia".into();
+        ctx.db.settlement_npc().id().update(representative);
+    }
     Ok(())
 }
 pub fn npc_is_present(presence: &SettlementNpcPresence, minute: u64) -> bool {
@@ -525,6 +559,7 @@ mod tests {
             household: "market household".into(),
             local_role: "market steward".into(),
             service_id: "merchants".into(),
+            organization_id: String::new(),
             conversation_id: "service-professions".into(),
         }
     }
@@ -613,6 +648,7 @@ mod tests {
         assert_eq!(row.household, "market household");
         assert_eq!(row.local_role, "market steward");
         assert_eq!(row.service_id, "merchants");
+        assert!(row.organization_id.is_empty());
         assert_eq!(row.conversation_id, "service-professions");
     }
 
@@ -641,6 +677,7 @@ mod tests {
             "household",
             "local_role",
             "service_id",
+            "organization_id",
             "conversation_id",
         ] {
             assert!(
@@ -660,5 +697,21 @@ mod tests {
         assert!(view.contains(".filter(npc_is_dialogue_capable)"));
         assert!(view.contains(".map(project_backend_settlement_npc)"));
         assert!(!view.contains("-> Vec<SettlementNpc>"));
+    }
+
+    #[test]
+    fn every_authored_chapter_seeds_one_bound_persistent_representative() {
+        let source = include_str!("settlement_population.rs");
+        let ensure = source
+            .split("pub fn ensure_settlement_population")
+            .nth(1)
+            .and_then(|tail| tail.split("pub fn npc_is_present").next())
+            .expect("population seeding body");
+        assert!(ensure.contains("organizations_for_chapter(settlement_id)"));
+        assert!(ensure.contains("chapter.location_id"));
+        assert!(ensure.contains("representative.organization_id = organization.id.clone()"));
+        assert!(ensure.contains("\"organization-representative\""));
+        assert!(ensure.contains("ordinal"));
+        assert!(source.contains("id = format!(\"npc:{settlement_id}:{location}:{ordinal}\")"));
     }
 }

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -45,6 +45,7 @@ use crate::{
     item::{InventoryItem, inventory_item, item},
     local_problem::{local_problem_receipt, local_problem_rumor_delivery},
     npc_adventurer::npc_adventuring_party_authority,
+    organization::organization_presentation,
     repair::{item_condition, settlement_smith},
     settlement_population::{
         settlement_npc, settlement_npc_presence, settlement_npc_seed_explanation,
@@ -5914,6 +5915,7 @@ fn require_navigable_npc_location(
     if adventuresim_core::settlement_economy::npc_location_is_navigable(
         &settlement.economy,
         has_keep,
+        settlement_id,
         location_id,
     ) {
         Ok(())
@@ -6684,6 +6686,74 @@ fn dialogue_fact_context(
             }
         }
     }
+    if let Some(player) = participants
+        .iter()
+        .find(|participant| participant.character_id == Some(character_id))
+    {
+        for representative in participants
+            .iter()
+            .filter(|participant| participant.character_id.is_none())
+        {
+            let Some(npc) = ctx.db.settlement_npc().id().find(&representative.actor_id) else {
+                continue;
+            };
+            let Ok(organization_id) = dialogue_organization_id(session, &npc) else {
+                continue;
+            };
+            let definition = adventuresim_core::organization::organization(&organization_id)
+                .expect("bound organization was resolved");
+            let membership = crate::organization::membership(ctx, character_id, &organization_id);
+            let minute = ctx
+                .db
+                .character_time()
+                .character_id()
+                .find(character_id)
+                .map_or(0, |time| time.minutes);
+            let membership_state = membership.as_ref().map_or("none", |row| {
+                if crate::organization::membership_is_current(row, minute) {
+                    "current"
+                } else {
+                    "suspended"
+                }
+            });
+            result.facts.insert(
+                FactKey::OrganizationMembership {
+                    player: player.role.clone(),
+                    representative: representative.role.clone(),
+                },
+                FactValue::Text(membership_state.into()),
+            );
+            result.facts.insert(
+                FactKey::OrganizationPromotionAvailable {
+                    player: player.role.clone(),
+                    representative: representative.role.clone(),
+                },
+                FactValue::Bool(membership.as_ref().is_some_and(|row| {
+                    crate::organization::membership_is_current(row, minute)
+                        && definition.next_rank(&row.rank_id).is_some()
+                })),
+            );
+            result.facts.insert(
+                FactKey::OrganizationPresentation {
+                    player: player.role.clone(),
+                    representative: representative.role.clone(),
+                },
+                FactValue::Bool(
+                    ctx.db
+                        .organization_presentation()
+                        .character_id()
+                        .find(character_id)
+                        .is_some_and(|row| row.organization_id == organization_id),
+                ),
+            );
+            result.facts.insert(
+                FactKey::OrganizationDuesRequired {
+                    representative: representative.role.clone(),
+                },
+                FactValue::Bool(definition.dues.is_some()),
+            );
+        }
+    }
     if let Some(npc) = participants.iter().find(|p| p.character_id.is_none()) {
         let delivery_receipt = ctx
             .db
@@ -6904,6 +6974,138 @@ mod participant_language_compatibility_tests {
     }
 }
 
+fn organization_requirement_label(
+    requirement: &adventuresim_core::organization::Requirement,
+) -> String {
+    use adventuresim_core::organization::Requirement;
+    match requirement {
+        Requirement::SkillRating {
+            skill,
+            minimum,
+            leaf,
+        } => format!(
+            "{}{} rating {:.1}",
+            skill.replace('_', " "),
+            leaf.as_ref().map_or(String::new(), |leaf| format!(
+                " ({})",
+                leaf.replace('_', " ")
+            )),
+            minimum
+        ),
+        Requirement::ProfessedReligion { religion } => {
+            format!("profession of {}", religion.replace('_', " "))
+        }
+    }
+}
+
+fn organization_requirements_summary<'a>(
+    requirements: impl Iterator<Item = &'a adventuresim_core::organization::Requirement>,
+) -> String {
+    let requirements = requirements
+        .map(organization_requirement_label)
+        .collect::<BTreeSet<_>>();
+    if requirements.is_empty() {
+        "no additional requirements".into()
+    } else {
+        requirements.into_iter().collect::<Vec<_>>().join(", ")
+    }
+}
+
+fn bind_organization_business_terms(
+    ctx: &ReducerContext,
+    session: &DialogueSession,
+    character_id: u64,
+    npc: &crate::settlement_population::SettlementNpc,
+    bindings: &mut adventuresim_dialogue::RuntimeBindings,
+) -> Result<(), String> {
+    use adventuresim_dialogue::RuntimeSlot as S;
+    let organization_id = dialogue_organization_id(session, npc)?;
+    let definition = adventuresim_core::organization::organization(&organization_id)
+        .ok_or("Organization representative has an unknown organization")?;
+    bindings.bind(S::OrganizationName, definition.name.clone());
+
+    let admission_requirements = organization_requirements_summary(
+        definition
+            .admission
+            .requirements
+            .iter()
+            .chain(definition.ranks[0].requirements.iter()),
+    );
+    let fee = if definition.admission.joining_fee == 0 {
+        "There is no joining fee".to_owned()
+    } else {
+        format!(
+            "The joining fee is {} coin{}",
+            definition.admission.joining_fee,
+            if definition.admission.joining_fee == 1 {
+                ""
+            } else {
+                "s"
+            }
+        )
+    };
+    bindings.bind(
+        S::OrganizationAdmissionTerms,
+        format!("{fee}; admission requires {admission_requirements}."),
+    );
+
+    let membership = crate::organization::membership(ctx, character_id, &organization_id);
+    let minute = ctx
+        .db
+        .character_time()
+        .character_id()
+        .find(character_id)
+        .map_or(0, |time| time.minutes);
+    let standing = membership.as_ref().map_or("not enrolled", |membership| {
+        if crate::organization::membership_is_current(membership, minute) {
+            "current"
+        } else {
+            "suspended"
+        }
+    });
+    if let Some(dues) = &definition.dues {
+        bindings.bind(
+            S::OrganizationDuesTerms,
+            format!(
+                "Your standing is {standing}. Dues are {} coin{} every {} day{}.",
+                dues.amount,
+                if dues.amount == 1 { "" } else { "s" },
+                dues.interval_days,
+                if dues.interval_days == 1 { "" } else { "s" },
+            ),
+        );
+    } else {
+        bindings.bind(
+            S::OrganizationDuesTerms,
+            format!("Your standing is {standing}. This organization charges no dues."),
+        );
+    }
+
+    let rank_standing = membership
+        .as_ref()
+        .and_then(|membership| {
+            let current = definition.rank(&membership.rank_id)?;
+            Some(
+                if let Some(next) = definition.next_rank(&membership.rank_id) {
+                    format!(
+                        "Your current rank is {}. The next rank is {}; it requires {}.",
+                        current.name,
+                        next.name,
+                        organization_requirements_summary(next.requirements.iter()),
+                    )
+                } else {
+                    format!(
+                        "Your current rank is {}, the organization's highest rank.",
+                        current.name
+                    )
+                },
+            )
+        })
+        .unwrap_or_else(|| "You do not hold a rank in this organization.".into());
+    bindings.bind(S::OrganizationRankStanding, rank_standing);
+    Ok(())
+}
+
 fn dialogue_runtime_bindings(
     ctx: &ReducerContext,
     session: &DialogueSession,
@@ -6935,6 +7137,9 @@ fn dialogue_runtime_bindings(
     );
     bindings.bind(S::Settlement, session.settlement_id.clone());
     bindings.bind(S::Location, session.location_id.clone());
+    if !npc.organization_id.is_empty() {
+        bind_organization_business_terms(ctx, session, character_id, &npc, &mut bindings)?;
+    }
     let minute = ctx
         .db
         .character_time()
@@ -8268,6 +8473,24 @@ pub fn choose_dialogue_topic(
     Ok(())
 }
 
+fn dialogue_answer_is_committed_retry(
+    receipt: Option<&DialogueAction>,
+    prompt_state: &str,
+    prompt_row_id: &str,
+) -> Result<bool, String> {
+    if let Some(receipt) = receipt {
+        return if receipt.action_kind == format!("answer:{prompt_row_id}") {
+            Ok(true)
+        } else {
+            Err("Dialogue action ID conflicts with another action".into())
+        };
+    }
+    if prompt_state != "open" {
+        return Err("Dialogue prompt is closed".into());
+    }
+    Ok(false)
+}
+
 #[reducer]
 pub fn answer_dialogue_prompt(
     ctx: &ReducerContext,
@@ -8288,19 +8511,7 @@ pub fn answer_dialogue_prompt(
         .find(&prompt_row_id)
         .ok_or("Dialogue prompt not found")?;
     let action_row_id = format!("{}:{action_id}", prompt.session_id);
-    if prompt.state != "open" {
-        return Err("Dialogue prompt is closed".into());
-    }
     let mut session = require_session_member(ctx, &prompt.session_id, character_id)?;
-    if ctx.db.dialogue_action().id().find(&action_row_id).is_some() {
-        return Ok(());
-    }
-    if session.catalog_revision != catalog_revision {
-        return Err("Dialogue session revision is stale".into());
-    }
-    if session.revision != expected_revision {
-        return Err("Dialogue answer used a stale session revision".into());
-    }
     let participant = ctx
         .db
         .dialogue_participant()
@@ -8310,6 +8521,16 @@ pub fn answer_dialogue_prompt(
         .ok_or("Character is not a dialogue participant")?;
     if participant.role != prompt.respondent_role {
         return Err("Character is not an eligible respondent for this prompt".into());
+    }
+    let receipt = ctx.db.dialogue_action().id().find(&action_row_id);
+    if dialogue_answer_is_committed_retry(receipt.as_ref(), &prompt.state, &prompt_row_id)? {
+        return Ok(());
+    }
+    if session.catalog_revision != catalog_revision {
+        return Err("Dialogue session revision is stale".into());
+    }
+    if session.revision != expected_revision {
+        return Err("Dialogue answer used a stale session revision".into());
     }
     let chosen: Vec<String> =
         serde_json::from_str(&choice_ids_json).map_err(|_| "Invalid dialogue choices")?;
@@ -8332,7 +8553,7 @@ pub fn answer_dialogue_prompt(
     }
     ctx.db.dialogue_answer().insert(DialogueAnswer {
         id,
-        prompt_row_id,
+        prompt_row_id: prompt_row_id.clone(),
         character_id,
         choice_ids_json: serde_json::to_string(&chosen).unwrap(),
         created_micros: ctx.timestamp.to_micros_since_unix_epoch(),
@@ -8492,7 +8713,7 @@ pub fn answer_dialogue_prompt(
         id: action_row_id,
         session_id: session.id.clone(),
         action_id,
-        action_kind: "answer".into(),
+        action_kind: format!("answer:{prompt_row_id}"),
         resulting_revision: session.revision,
     });
     refresh_dialogue_topic_options(ctx, &session, character_id)?;
@@ -8550,6 +8771,22 @@ fn apply_dialogue_effect(
                     .map(|organization| organization.id.clone())
                     .ok_or("No organization chapter offers that professional activity here")?;
             crate::organization::join_organization(ctx, character_id, organization_id)
+        }
+        adventuresim_dialogue::Effect::JoinOrganization => {
+            let organization_id = dialogue_organization_id(session, &live_npc)?;
+            crate::organization::join_organization(ctx, character_id, organization_id)
+        }
+        adventuresim_dialogue::Effect::PayOrganizationDues => {
+            let organization_id = dialogue_organization_id(session, &live_npc)?;
+            crate::organization::pay_organization_dues(ctx, character_id, organization_id)
+        }
+        adventuresim_dialogue::Effect::RequestOrganizationPromotion => {
+            let organization_id = dialogue_organization_id(session, &live_npc)?;
+            crate::organization::promote_organization_membership(ctx, character_id, organization_id)
+        }
+        adventuresim_dialogue::Effect::PresentOrganization => {
+            let organization_id = dialogue_organization_id(session, &live_npc)?;
+            crate::organization::present_organization(ctx, character_id, organization_id)
         }
         adventuresim_dialogue::Effect::ReceiveReferredTestimony => {
             let event_sequence = testimony_event_sequence
@@ -8652,6 +8889,25 @@ fn apply_dialogue_effect(
         }
         adventuresim_dialogue::Effect::SetFlag { .. } => Err("Unknown dialogue flag".into()),
     }
+}
+
+/// Resolve organization business only from the trusted persistent NPC and its
+/// exact authored chapter. Dialogue content and clients never supply this ID.
+fn dialogue_organization_id(
+    session: &DialogueSession,
+    npc: &crate::settlement_population::SettlementNpc,
+) -> Result<String, String> {
+    let organization = adventuresim_core::organization::organization(&npc.organization_id)
+        .ok_or("Dialogue NPC is not bound to an organization")?;
+    if organization
+        .chapter_at_location(&session.settlement_id, &session.location_id)
+        .is_none()
+        || npc.home_settlement_id != session.settlement_id
+        || npc.conversation_id != "organization-representative"
+    {
+        return Err("Dialogue NPC is not the representative of this chapter".into());
+    }
+    Ok(organization.id.clone())
 }
 
 fn dialogue_service_id(ctx: &ReducerContext, session: &DialogueSession) -> Result<String, String> {
@@ -19870,7 +20126,7 @@ fn generated_witness_candidates(
         settlement.category,
         SettlementCategory::Town | SettlementCategory::City | SettlementCategory::Capital
     );
-    let visible_tabs = player_visible_npc_tabs(&settlement.economy, has_keep);
+    let visible_tabs = player_visible_npc_tabs(&settlement.economy, has_keep, settlement_id);
     let mut candidates = ctx
         .db
         .settlement_npc()
@@ -19940,7 +20196,7 @@ fn developer_witness_candidates(
         settlement.category,
         SettlementCategory::Town | SettlementCategory::City | SettlementCategory::Capital
     );
-    let visible_tabs = player_visible_npc_tabs(&settlement.economy, has_keep);
+    let visible_tabs = player_visible_npc_tabs(&settlement.economy, has_keep, settlement_id);
     let mut candidates = ctx
         .db
         .settlement_npc()
@@ -20427,6 +20683,7 @@ mod developer_quest_source_tests {
                 household: "market household".into(),
                 local_role: "resident".into(),
                 service_id: String::new(),
+                organization_id: String::new(),
                 conversation_id: "local-resident".into(),
             };
             let age_band = format!("{:?}", npc.age_band);
@@ -20537,5 +20794,90 @@ mod developer_quest_source_tests {
             .and_then(|tail| tail.split("pub fn choose_dialogue_topic").next())
             .expect("dialogue topic refresh");
         assert!(refresh.contains("dialogue_public_case_id"));
+    }
+
+    #[test]
+    fn organization_effects_resolve_only_from_the_bound_live_representative() {
+        let source = include_str!("strategic.rs");
+        let resolver = source
+            .split("fn dialogue_organization_id")
+            .nth(1)
+            .and_then(|tail| tail.split("fn dialogue_service_id").next())
+            .expect("organization dialogue authority");
+        assert!(resolver.contains("npc.organization_id"));
+        assert!(resolver.contains("chapter_at_location"));
+        assert!(resolver.contains("session.settlement_id"));
+        assert!(resolver.contains("session.location_id"));
+        assert!(resolver.contains("\"organization-representative\""));
+
+        let effects = source
+            .split("adventuresim_dialogue::Effect::JoinOrganization =>")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("adventuresim_dialogue::Effect::ReceiveReferredTestimony")
+                    .next()
+            })
+            .expect("organization dialogue effects");
+        assert!(effects.contains("dialogue_organization_id(session, &live_npc)"));
+        assert!(!effects.contains("organization_id: String"));
+    }
+
+    #[test]
+    fn committed_join_and_dues_answers_are_retry_safe_after_prompt_closes() {
+        for (action_id, prompt_row_id) in [
+            ("join-lost-response", "session:prompt:join"),
+            ("dues-lost-response", "session:prompt:dues"),
+        ] {
+            let receipt = DialogueAction {
+                id: format!("session:{action_id}"),
+                session_id: "session".into(),
+                action_id: action_id.into(),
+                action_kind: format!("answer:{prompt_row_id}"),
+                resulting_revision: 3,
+            };
+            assert!(
+                dialogue_answer_is_committed_retry(Some(&receipt), "resolved", prompt_row_id)
+                    .unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn new_or_conflicting_action_against_closed_prompt_fails() {
+        assert!(dialogue_answer_is_committed_retry(None, "resolved", "prompt").is_err());
+        let conflicting = DialogueAction {
+            id: "session:collision".into(),
+            session_id: "session".into(),
+            action_id: "collision".into(),
+            action_kind: "topic".into(),
+            resulting_revision: 2,
+        };
+        assert!(
+            dialogue_answer_is_committed_retry(Some(&conflicting), "resolved", "prompt").is_err()
+        );
+        let other_prompt = DialogueAction {
+            action_kind: "answer:other-prompt".into(),
+            ..conflicting
+        };
+        assert!(
+            dialogue_answer_is_committed_retry(Some(&other_prompt), "resolved", "prompt").is_err()
+        );
+    }
+
+    #[test]
+    fn prompt_retry_receipt_is_checked_only_after_session_and_role_scope() {
+        let source = include_str!("strategic.rs");
+        let answer = source
+            .split("pub fn answer_dialogue_prompt")
+            .nth(1)
+            .and_then(|tail| tail.split("fn apply_dialogue_effect").next())
+            .expect("answer dialogue reducer");
+        let session_scope = answer.find("require_session_member").unwrap();
+        let participant_scope = answer
+            .find("Character is not an eligible respondent")
+            .unwrap();
+        let retry = answer.find("dialogue_answer_is_committed_retry").unwrap();
+        assert!(session_scope < retry);
+        assert!(participant_scope < retry);
     }
 }

--- a/crates/strategic-web/src/routes/developer_quests.rs
+++ b/crates/strategic-web/src/routes/developer_quests.rs
@@ -100,6 +100,7 @@ async fn active_context(
                 | crate::spacetimedb::SettlementCategory::City
                 | crate::spacetimedb::SettlementCategory::Capital
         ),
+        &settlement_id,
     );
     let presences = presences.map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
     let mut candidates = npcs

--- a/crates/strategic-web/src/routes/dialogue.rs
+++ b/crates/strategic-web/src/routes/dialogue.rs
@@ -215,13 +215,19 @@ fn edit_source(source: adventuresim_dialogue::SourceRef) -> Option<EditSource> {
 fn npc_location_is_navigable(
     profile: &adventuresim_world_schema::SettlementEconomyProfile,
     category: &SettlementCategory,
+    settlement_id: &str,
     location_id: &str,
 ) -> bool {
     let has_keep = matches!(
         category,
         SettlementCategory::Town | SettlementCategory::City | SettlementCategory::Capital
     );
-    adventuresim_core::settlement_economy::npc_location_is_navigable(profile, has_keep, location_id)
+    adventuresim_core::settlement_economy::npc_location_is_navigable(
+        profile,
+        has_keep,
+        settlement_id,
+        location_id,
+    )
 }
 
 fn npc_presence_contains(start_minute: u16, end_minute: u16, minute: u64) -> bool {
@@ -234,6 +240,20 @@ fn npc_presence_contains(start_minute: u16, end_minute: u16, minute: u64) -> boo
         start <= minute && minute < end
     } else {
         minute >= start || minute < end
+    }
+}
+
+fn npc_matches_location_binding(
+    npc: &SettlementNpcRow,
+    settlement_id: &str,
+    location_id: &str,
+) -> bool {
+    match adventuresim_core::organization::organization_chapter_at(settlement_id, location_id) {
+        Some((organization, _)) => {
+            npc.organization_id == organization.id
+                && npc.conversation_id == "organization-representative"
+        }
+        None => npc.organization_id.is_empty(),
     }
 }
 
@@ -269,22 +289,49 @@ mod npc_navigation_tests {
         assert!(npc_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "inn"
         ));
         assert!(!npc_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "church"
         ));
         assert!(!npc_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "armoury"
         ));
         assert!(!npc_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "keep"
+        ));
+    }
+
+    #[test]
+    fn chapter_navigation_accepts_only_the_authored_settlement_location_pair() {
+        let profile = adventuresim_world_schema::SettlementEconomyProfile::stage_placeholder();
+        assert!(npc_location_is_navigable(
+            &profile,
+            &SettlementCategory::City,
+            "viabundus-0",
+            "organization-merchant-guild"
+        ));
+        assert!(!npc_location_is_navigable(
+            &profile,
+            &SettlementCategory::City,
+            "viabundus-0",
+            "organization-brotherhood-saint-peter-martyr"
+        ));
+        assert!(!npc_location_is_navigable(
+            &profile,
+            &SettlementCategory::City,
+            "viabundus-0",
+            "organization-not-authored"
         ));
     }
 
@@ -358,7 +405,12 @@ async fn location_npcs(
         .await
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
         .ok_or(StatusCode::NOT_FOUND)?;
-    if !npc_location_is_navigable(&settlement.economy, &settlement.category, &location_id) {
+    if !npc_location_is_navigable(
+        &settlement.economy,
+        &settlement.category,
+        &settlement_id,
+        &location_id,
+    ) {
         return Err(StatusCode::NOT_FOUND);
     }
     let npcs = state
@@ -388,7 +440,10 @@ async fn location_npcs(
         .map_or(720, |time| time.minutes)
         % 1_440;
     let mut views = presences.into_iter().filter(|presence| presence.settlement_id == settlement_id && presence.location_id == location_id && npc_presence_contains(presence.start_minute, presence.end_minute, minute)).filter_map(|presence| {
-        let npc = npcs.iter().find(|npc| npc.id == presence.npc_id)?;
+        let npc = npcs.iter().find(|npc| {
+            npc.id == presence.npc_id
+                && npc_matches_location_binding(npc, &settlement_id, &location_id)
+        })?;
         let facial = if npc.facial_hair == "none visible" { String::new() } else { format!(", with {}", npc.facial_hair) };
         Some(NpcView { id: npc.id.clone(), name: npc.name.clone(), initials: npc.name.split_whitespace().filter_map(|part| part.chars().next()).take(2).collect(), description: format!("{} is a {} {} person with {} presentation, a {} build, {}{}, and a {} complexion. Visible details include {}. They wear {}. Occupation: {}. Household: {}. Local role: {}.", npc.name, npc.height, npc.age_band.to_lowercase(), npc.presentation.to_lowercase(), npc.build, npc.hair, facial, npc.complexion, npc.visible_features, npc.clothing, npc.profession, npc.household, npc.local_role), is_default: presence.is_default })
     }).collect::<Vec<_>>();
@@ -423,7 +478,12 @@ async fn social_npc_in_scope(
         .await
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
         .ok_or(StatusCode::NOT_FOUND)?;
-    if !npc_location_is_navigable(&settlement.economy, &settlement.category, location_id) {
+    if !npc_location_is_navigable(
+        &settlement.economy,
+        &settlement.category,
+        settlement_id,
+        location_id,
+    ) {
         return Err(StatusCode::NOT_FOUND);
     }
     state
@@ -434,7 +494,10 @@ async fn social_npc_in_scope(
         ))
         .await
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
-        .filter(|npc| npc.home_settlement_id == settlement_id)
+        .filter(|npc| {
+            npc.home_settlement_id == settlement_id
+                && npc_matches_location_binding(npc, settlement_id, location_id)
+        })
         .ok_or(StatusCode::NOT_FOUND)
 }
 
@@ -776,6 +839,9 @@ async fn start(
         .await
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
         .ok_or(StatusCode::BAD_REQUEST)?;
+    if !npc_matches_location_binding(&npc, &npc.home_settlement_id, &request.location_id) {
+        return Err(StatusCode::NOT_FOUND);
+    }
     let settlement = state
         .db
         .query_one::<Settlement>(&format!(
@@ -788,6 +854,7 @@ async fn start(
     if !npc_location_is_navigable(
         &settlement.economy,
         &settlement.category,
+        &npc.home_settlement_id,
         &request.location_id,
     ) {
         return Err(StatusCode::NOT_FOUND);

--- a/crates/strategic-web/src/routes/local_chat.rs
+++ b/crates/strategic-web/src/routes/local_chat.rs
@@ -102,13 +102,19 @@ fn npc_authority_matches(
 fn npc_history_location_is_navigable(
     profile: &adventuresim_world_schema::SettlementEconomyProfile,
     category: &SettlementCategory,
+    settlement_id: &str,
     location_id: &str,
 ) -> bool {
     let has_keep = matches!(
         category,
         SettlementCategory::Town | SettlementCategory::City | SettlementCategory::Capital
     );
-    adventuresim_core::settlement_economy::npc_location_is_navigable(profile, has_keep, location_id)
+    adventuresim_core::settlement_economy::npc_location_is_navigable(
+        profile,
+        has_keep,
+        settlement_id,
+        location_id,
+    )
 }
 
 enum ConversationSelector {
@@ -150,6 +156,7 @@ async fn actor_and_selector(
             if !npc_history_location_is_navigable(
                 &settlement_authority.economy,
                 &settlement_authority.category,
+                settlement,
                 location_id,
             ) {
                 return Err("NPC is not local".into());
@@ -384,26 +391,31 @@ mod tests {
         assert!(npc_history_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "inn"
         ));
         assert!(npc_history_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "residences"
         ));
         assert!(!npc_history_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "church"
         ));
         assert!(!npc_history_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "armoury"
         ));
         assert!(!npc_history_location_is_navigable(
             &profile,
             &SettlementCategory::Hamlet,
+            "fixture-no-orgs",
             "keep"
         ));
         profile
@@ -412,11 +424,13 @@ mod tests {
         assert!(npc_history_location_is_navigable(
             &profile,
             &SettlementCategory::Town,
+            "fixture-no-orgs",
             "church"
         ));
         assert!(npc_history_location_is_navigable(
             &profile,
             &SettlementCategory::Town,
+            "fixture-no-orgs",
             "keep"
         ));
     }

--- a/crates/strategic-web/src/routes/mod.rs
+++ b/crates/strategic-web/src/routes/mod.rs
@@ -74,6 +74,7 @@ pub(crate) struct BackendSettlementNpcRow {
     /// service-provider routes currently deserialize their own minimal DTO.
     #[allow(dead_code)]
     pub service_id: String,
+    pub organization_id: String,
     pub conversation_id: String,
 }
 

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -21,7 +21,7 @@ use futures_util::{
     future::join_all,
     stream::{self, StreamExt},
 };
-use maud::{Markup, html};
+use maud::Markup;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashSet;
@@ -243,15 +243,11 @@ pub fn routes() -> Router<AppState> {
             get(party_personal),
         )
         .route(
-            "/locations/settlement/{id}/party/{character_id}/organizations",
-            get(character_organizations),
+            "/locations/settlement/{id}/party/{character_id}/organization-presentation/{organization_id}",
+            post(update_organization_presentation),
         )
         .route(
-            "/locations/settlement/{id}/party/{character_id}/organizations/{organization_id}/{action}",
-            post(update_character_organization),
-        )
-        .route(
-            "/locations/settlement/{id}/party/{character_id}/organizations-none",
+            "/locations/settlement/{id}/party/{character_id}/organization-presentation-none",
             post(clear_presented_organization),
         )
         .route(
@@ -809,7 +805,11 @@ async fn settlement_npc_place(
     Path((id, place)): Path<(String, String)>,
     session: Session,
 ) -> Html<String> {
-    if !matches!(place.as_str(), "overview" | "residences" | "keep") {
+    let organization_chapter =
+        adventuresim_core::organization::organization_chapter_at(&id, &place);
+    if !matches!(place.as_str(), "overview" | "residences" | "keep")
+        && organization_chapter.is_none()
+    {
         return Html("<h1>Settlement place not found</h1>".into());
     }
     let settlement = state
@@ -2090,6 +2090,10 @@ async fn begin_service_apprenticeship(
     Path((id, service_id)): Path<(String, String)>,
     session: Session,
 ) -> Json<ApprenticeshipResult> {
+    // This is deliberately narrower than organization business dialogue:
+    // a local trainer's service resolves one catalog-linked apprenticeship.
+    // The route cannot select arbitrary organizations or pay dues, promote,
+    // or change presentation.
     let Some(organization) = adventuresim_core::organization::organizations_for_chapter(&id)
         .find(|organization| organization.service_id.as_deref() == Some(service_id.as_str()))
     else {
@@ -2133,202 +2137,24 @@ async fn begin_service_apprenticeship(
     }
 }
 
-fn organization_requirement_label(
-    requirement: &adventuresim_core::organization::Requirement,
-) -> String {
-    use adventuresim_core::organization::Requirement;
-    match requirement {
-        Requirement::SkillRating {
-            skill,
-            minimum,
-            leaf,
-        } => format!(
-            "{}{} {:.1}",
-            skill.replace('_', " "),
-            leaf.as_ref()
-                .map_or(String::new(), |leaf| format!(" ({leaf})")),
-            minimum
-        ),
-        Requirement::ProfessedReligion { religion } => {
-            format!("Professes {}", religion.replace('_', " "))
-        }
-    }
-}
-
-async fn character_organizations(
+async fn update_organization_presentation(
     State(state): State<AppState>,
-    Path((id, character_id)): Path<(String, u64)>,
+    Path((id, character_id, organization_id)): Path<(String, u64, String)>,
     session: Session,
 ) -> Response {
     if session.character_id_u64() != Some(character_id) {
         return (StatusCode::FORBIDDEN, "Select this character first").into_response();
     }
-    let Some(character) = state
-        .db
-        .query_one::<Character>(&format!(
-            "SELECT * FROM character WHERE id = {character_id}"
-        ))
-        .await
-        .ok()
-        .flatten()
-    else {
-        return (StatusCode::NOT_FOUND, "Character not found").into_response();
-    };
-    if character.current_settlement_id.as_deref() != Some(id.as_str()) {
-        return (
-            StatusCode::BAD_REQUEST,
-            "Organizations can only be managed at the current settlement",
-        )
-            .into_response();
-    }
-    let memberships: Vec<crate::spacetimedb::OrganizationMembership> = state
-        .db
-        .query(&format!(
-            "SELECT * FROM organization_membership WHERE character_id = {character_id}"
-        ))
-        .await
-        .unwrap_or_default();
-    let presentation = state
-        .db
-        .query_one::<crate::spacetimedb::OrganizationPresentation>(&format!(
-            "SELECT * FROM organization_presentation WHERE character_id = {character_id}"
-        ))
-        .await
-        .ok()
-        .flatten();
-    let minute = state
-        .db
-        .query_one::<CharacterTime>(&format!(
-            "SELECT * FROM character_time WHERE character_id = {character_id}"
-        ))
-        .await
-        .ok()
-        .flatten()
-        .map_or(0, |row| row.minutes);
-    let base = format!("/locations/settlement/{id}/party/{character_id}");
-    let markup = html! {
-        (maud::DOCTYPE)
-        html lang="en" {
-            head {
-                meta charset="utf-8";
-                meta name="viewport" content="width=device-width, initial-scale=1";
-                title { "Organizations — " (character.name) }
-                link rel="stylesheet" href="/static/style.css";
-            }
-            body {
-                main class="center-content settlement-main" data-live-region="organizations" {
-                    nav { a href=(base) { "← Back to character" } }
-                    h1 { "Organizations" }
-                    p { "Memberships are independent. Exactly one recognized, dues-current organization may be presented, or none." }
-                    section aria-labelledby="membership-heading" {
-                        h2 id="membership-heading" { "Memberships" }
-                        @if memberships.is_empty() {
-                            p { "No memberships." }
-                        }
-                        @for membership in &memberships {
-                            @let definition = adventuresim_core::organization::organization(&membership.organization_id);
-                            @let rank = definition.and_then(|definition| definition.rank(&membership.rank_id));
-                            article class="card organization-membership" {
-                                h3 { (definition.map_or(membership.organization_id.as_str(), |entry| entry.name.as_str())) }
-                                p { strong { (rank.map_or(membership.rank_id.as_str(), |rank| rank.name.as_str())) } }
-                                @if let Some(rank) = rank { p { (rank.description) } }
-                                p {
-                                    "Status: " (membership.status)
-                                    @if membership.dues_paid_through_minute != u64::MAX {
-                                        " · paid through minute " (membership.dues_paid_through_minute)
-                                        @if minute > membership.dues_paid_through_minute { " (payment required)" }
-                                    } @else { " · no dues" }
-                                }
-                                @if let Some(definition) = definition {
-                                    p { "Privileges: "
-                                        @if definition.privileges.is_empty() { "none" }
-                                        @for privilege in &definition.privileges { code { (format!("{privilege:?}")) } " " }
-                                    }
-                                    p { "Recognition: " (match &definition.recognition {
-                                        adventuresim_core::organization::Recognition::Universal => "universal".into(),
-                                        adventuresim_core::organization::Recognition::Settlements { settlement_ids } => settlement_ids.join(", "),
-                                    }) }
-                                    @if let Some(next) = definition.next_rank(&membership.rank_id) {
-                                        p { "Next rank: " strong { (next.name) } " — " (next.description) }
-                                        form method="post" action=(format!("{base}/organizations/{}/promote", definition.id)) {
-                                            button type="submit" { "Request promotion" }
-                                        }
-                                    }
-                                    @if definition.dues.is_some() {
-                                        form method="post" action=(format!("{base}/organizations/{}/pay", definition.id)) {
-                                            button type="submit" { "Pay one dues interval" }
-                                        }
-                                    }
-                                    @if definition.recognition.includes(&id) && membership.status == "active" && minute <= membership.dues_paid_through_minute {
-                                        form method="post" action=(format!("{base}/organizations/{}/present", definition.id)) {
-                                            button type="submit" aria-pressed=(presentation.as_ref().is_some_and(|row| row.organization_id == definition.id)) {
-                                                "Present as " (definition.name)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        form method="post" action=(format!("{base}/organizations-none")) {
-                            button type="submit" aria-pressed=(presentation.is_none()) { "Present as none" }
-                        }
-                    }
-                    section aria-labelledby="available-heading" {
-                        h2 id="available-heading" { "Available here" }
-                        @for definition in adventuresim_core::organization::organizations_for_chapter(&id) {
-                            @if !memberships.iter().any(|row| row.organization_id == definition.id) {
-                                article class="card organization-available" {
-                                    h3 { (definition.name) }
-                                    p { (definition.description) }
-                                    @if let Some(note) = &definition.historical_fantasy_note {
-                                        p class="text-muted" { (note) }
-                                    }
-                                    p { "Joining fee: " (definition.admission.joining_fee) " coin(s)" }
-                                    @if !definition.admission.requirements.is_empty() {
-                                        ul {
-                                            @for requirement in &definition.admission.requirements {
-                                                li { (organization_requirement_label(requirement)) }
-                                            }
-                                        }
-                                    }
-                                    form method="post" action=(format!("{base}/organizations/{}/join", definition.id)) {
-                                        button type="submit" { "Join" }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    };
-    Html(markup.into_string()).into_response()
-}
-
-async fn update_character_organization(
-    State(state): State<AppState>,
-    Path((id, character_id, organization_id, action)): Path<(String, u64, String, String)>,
-    Query(query): Query<OrganizationActionQuery>,
-    session: Session,
-) -> Response {
-    if session.character_id_u64() != Some(character_id) {
-        return (StatusCode::FORBIDDEN, "Select this character first").into_response();
-    }
-    let reducer = match action.as_str() {
-        "join" => "join_organization",
-        "promote" => "promote_organization_membership",
-        "pay" => "pay_organization_dues",
-        "present" => "present_organization",
-        _ => return (StatusCode::NOT_FOUND, "Unknown organization action").into_response(),
-    };
     match state
         .db
-        .call(reducer, &[json!(character_id), json!(organization_id)])
+        .call(
+            "present_organization",
+            &[json!(character_id), json!(organization_id)],
+        )
         .await
     {
-        Ok(()) => {
-            Redirect::to(&organization_action_redirect(&id, character_id, &query)).into_response()
-        }
+        Ok(()) => Redirect::to(&format!("/locations/settlement/{id}/party/{character_id}"))
+            .into_response(),
         Err(error) => (StatusCode::BAD_REQUEST, error.to_string()).into_response(),
     }
 }
@@ -2336,7 +2162,6 @@ async fn update_character_organization(
 async fn clear_presented_organization(
     State(state): State<AppState>,
     Path((id, character_id)): Path<(String, u64)>,
-    Query(query): Query<OrganizationActionQuery>,
     session: Session,
 ) -> Response {
     if session.character_id_u64() != Some(character_id) {
@@ -2347,28 +2172,9 @@ async fn clear_presented_organization(
         .call("clear_organization_presentation", &[json!(character_id)])
         .await
     {
-        Ok(()) => {
-            Redirect::to(&organization_action_redirect(&id, character_id, &query)).into_response()
-        }
+        Ok(()) => Redirect::to(&format!("/locations/settlement/{id}/party/{character_id}"))
+            .into_response(),
         Err(error) => (StatusCode::BAD_REQUEST, error.to_string()).into_response(),
-    }
-}
-
-#[derive(Default, Deserialize)]
-struct OrganizationActionQuery {
-    return_to: Option<String>,
-}
-
-fn organization_action_redirect(
-    settlement_id: &str,
-    character_id: u64,
-    query: &OrganizationActionQuery,
-) -> String {
-    let base = format!("/locations/settlement/{settlement_id}/party/{character_id}");
-    if query.return_to.as_deref() == Some("character") {
-        base
-    } else {
-        format!("{base}/organizations")
     }
 }
 
@@ -5669,7 +5475,7 @@ mod service_availability_tests {
             &profile,
             SettlementActionService::Inn
         ));
-        let tabs = player_visible_npc_tabs(&profile, false);
+        let tabs = player_visible_npc_tabs(&profile, false, "fixture-no-orgs");
         assert!(visible_npc_tab(&tabs, "church").is_none());
         assert!(visible_npc_tab(&tabs, "inn").is_none());
         assert!(visible_npc_tab(&tabs, "armoury").is_none());
@@ -5684,6 +5490,51 @@ mod service_availability_tests {
             &profile,
             SettlementActionService::Inn
         ));
+    }
+
+    #[test]
+    fn organization_management_page_and_business_routes_are_removed() {
+        let source = include_str!("settlements.rs");
+        let routes = source
+            .split("pub fn routes()")
+            .nth(1)
+            .and_then(|tail| tail.split("#[derive").next())
+            .expect("settlement router");
+        let production = source
+            .split("mod service_availability_tests")
+            .next()
+            .expect("production settlement routes");
+        assert!(!routes.contains("character_organizations"));
+        assert!(!production.contains("fn character_organizations"));
+        assert!(!routes.contains("/organizations/{organization_id}/{action}"));
+        assert!(!production.contains("\"join\" => \"join_organization\""));
+        assert!(!production.contains("\"pay\" => \"pay_organization_dues\""));
+        assert!(!production.contains("\"promote\" => \"promote_organization_membership\""));
+        assert!(routes.contains("organization-presentation/{organization_id}"));
+        assert!(production.contains("organization_chapter_at(&id, &place)"));
+    }
+
+    #[test]
+    fn service_apprenticeship_is_a_narrow_trainer_mediated_join_exception() {
+        let source = include_str!("settlements.rs");
+        let handler = source
+            .split("async fn begin_service_apprenticeship")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("async fn update_organization_presentation")
+                    .next()
+            })
+            .expect("service apprenticeship handler");
+        assert!(handler.contains("organizations_for_chapter(&id)"));
+        assert!(handler.contains("organization.service_id"));
+        assert!(handler.contains("\"join_organization\""));
+        for forbidden in [
+            "pay_organization_dues",
+            "promote_organization_membership",
+            "present_organization",
+        ] {
+            assert!(!handler.contains(forbidden));
+        }
     }
 }
 

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -333,6 +333,25 @@ fn settlement_top_bar(
                     }
                     }
                 }
+                @for organization in adventuresim_core::organization::organizations_for_chapter(settlement_id) {
+                    @let chapter = organization.chapter(settlement_id).expect("local chapter");
+                    @let kind = format!("{:?}", chapter.building_kind).to_ascii_lowercase();
+                    @let tint = building_tint(settlement_id, &chapter.location_id, material);
+                    a href=(format!("/settlements/{}/places/{}", settlement_id, chapter.location_id))
+                        class=(if active_service == chapter.location_id { "nav-tab active" } else { "nav-tab" })
+                        style=(format!("--building-tint:{tint}"))
+                        data-service-id="organization"
+                        data-organization-building-kind=(kind)
+                        data-building-material=(material)
+                        data-service-label=(&chapter.building_name)
+                        aria-label=(&chapter.building_name)
+                        data-strategic-tooltip=(&chapter.building_name)
+                        aria-current=(if active_service == chapter.location_id { "page" } else { "false" }) {
+                        span class="service-tab-building" aria-hidden="true" {}
+                        span class="service-tab-icon service-tab-icon-organization" aria-hidden="true" {}
+                        span class="service-tab-label" aria-hidden="true" { (&chapter.building_name) }
+                    }
+                }
             }
 
             div class="top-bar-right" {
@@ -405,7 +424,11 @@ fn service_tab_available(
         "religion" => "church",
         _ => return false,
     };
-    visible_npc_tab(&player_visible_npc_tabs(profile, false), location_id).is_some()
+    visible_npc_tab(
+        &player_visible_npc_tabs(profile, false, "fixture-no-orgs"),
+        location_id,
+    )
+    .is_some()
 }
 
 fn quest_location_top_bar(

--- a/crates/strategic-web/src/templates/settlement/character_details.rs
+++ b/crates/strategic-web/src/templates/settlement/character_details.rs
@@ -628,7 +628,7 @@ fn religion_identity_button(
 fn organization_identity_picker(
     character: &Character,
     settlement_id: &str,
-    location_path: &str,
+    _location_path: &str,
     memberships: &[OrganizationMembership],
     presentation: Option<&OrganizationPresentation>,
     minute: u64,
@@ -673,7 +673,7 @@ fn organization_identity_picker(
                 span class="organization-picker-arrow" aria-hidden="true" {}
             }
             div class="organization-picker-menu" role="menu" {
-                form method="post" action=(format!("{base}/organizations-none?return_to=character")) {
+                form method="post" action=(format!("{base}/organization-presentation-none")) {
                     button type="submit" class=(if selected.is_none() { "organization-picker-option is-selected" } else { "organization-picker-option" })
                         role="menuitem" {
                         (empty_organization_crest())
@@ -682,16 +682,13 @@ fn organization_identity_picker(
                 }
                 @for (_, definition, rank) in choices {
                     @let is_selected = selected.is_some_and(|(_, selected_definition, _)| selected_definition.id == definition.id);
-                    form method="post" action=(format!("{base}/organizations/{}/present?return_to=character", definition.id)) {
+                    form method="post" action=(format!("{base}/organization-presentation/{}", definition.id)) {
                         button type="submit" class=(if is_selected { "organization-picker-option is-selected" } else { "organization-picker-option" })
                             role="menuitem" {
                             (organization_crest(definition))
                             (organization_identity_copy(definition.name.as_str(), &profession_name(definition, rank)))
                         }
                     }
-                }
-                a class="organization-picker-manage" href=(format!("{location_path}/party/{}/organizations", character.id)) {
-                    "Manage memberships"
                 }
             }
         }

--- a/crates/strategic-web/src/templates/settlement/chrome.rs
+++ b/crates/strategic-web/src/templates/settlement/chrome.rs
@@ -24,6 +24,7 @@ fn public_square_place_link(settlement: &Settlement, current: bool) -> Markup {
     let tabs = player_visible_npc_tabs(
         &settlement.economy,
         settlement_has_keep(&settlement.category),
+        &settlement.id,
     );
     let tab = visible_npc_tab(&tabs, "overview")
         .expect("every settlement exposes its overview as a navigable NPC tab");
@@ -137,6 +138,8 @@ pub fn settlement_npc_location_page(
     location_id: &str,
     logged_in_as: Option<&str>,
 ) -> Markup {
+    let chapter =
+        adventuresim_core::organization::organization_chapter_at(&settlement.id, location_id);
     let (title, description) = match location_id {
         "residences" => (
             "Residential quarter",
@@ -146,10 +149,17 @@ pub fn settlement_npc_location_page(
             "The keep",
             "The seat of local authority, occupied by retainers, servants, and petitioners.",
         ),
-        _ => (
+        _ if chapter.is_none() => (
             "Public square",
             "A public gathering place for residents and travelers.",
         ),
+        _ => {
+            let (organization, chapter) = chapter.expect("guarded chapter");
+            (
+                chapter.building_name.as_str(),
+                organization.description.as_str(),
+            )
+        }
     };
     let content = html! {
         aside class="left-sidebar" {
@@ -166,6 +176,14 @@ pub fn settlement_npc_location_page(
                             class=(if location_id == "keep" { "active" } else { "" })
                             aria-current=(if location_id == "keep" { "page" } else { "false" }) {
                             "Keep"
+                        }
+                    }
+                    @for organization in adventuresim_core::organization::organizations_for_chapter(&settlement.id) {
+                        @let chapter = organization.chapter(&settlement.id).expect("local chapter");
+                        a href=(format!("/settlements/{}/places/{}", settlement.id, chapter.location_id))
+                            class=(if location_id == chapter.location_id { "active" } else { "" })
+                            aria-current=(if location_id == chapter.location_id { "page" } else { "false" }) {
+                            (&chapter.building_name)
                         }
                     }
                 }
@@ -696,7 +714,7 @@ mod tests {
         use adventuresim_core::settlement_economy::{player_visible_npc_tabs, visible_npc_tab};
 
         let settlement = settlement();
-        let tabs = player_visible_npc_tabs(&settlement.economy, true);
+        let tabs = player_visible_npc_tabs(&settlement.economy, true, &settlement.id);
         let public_square = visible_npc_tab(&tabs, "overview").unwrap();
         assert_eq!(public_square.label, "Public square");
 

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -839,6 +839,10 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
   .nav-tab[data-service-id="religion"] {
   --service-building-image: url("/static/styles/timber-framed/building/village/religion.png?v=facade-2");
 }
+.settlement-top-bar:is([data-building-tier="village"], [data-building-tier="town"], [data-building-tier="city"])
+  .nav-tab[data-service-id="organization"] {
+  --service-building-image: url("/static/styles/timber-framed/building/village/residences.png");
+}
 
 /* Higher tiers are complete sets; village remains the explicit fallback above. */
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="map"] { --service-building-image: url("/static/styles/timber-framed/building/town/map.png?v=watchtower-2"); }
@@ -852,6 +856,7 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="herbalist"] { --service-building-image: url("/static/styles/timber-framed/building/town/herbalist.png"); }
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="inn"] { --service-building-image: url("/static/styles/timber-framed/building/town/inn.png"); }
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="religion"] { --service-building-image: url("/static/styles/timber-framed/building/town/religion.png"); }
+.settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="organization"] { --service-building-image: url("/static/styles/timber-framed/building/town/residences.png"); }
 
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="map"] { --service-building-image: url("/static/styles/timber-framed/building/city/map.png?v=watchtower-2"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="public-square"] { --service-building-image: url("/static/styles/timber-framed/building/city/public-square.png"); }
@@ -864,6 +869,7 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="herbalist"] { --service-building-image: url("/static/styles/timber-framed/building/city/herbalist.png"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="inn"] { --service-building-image: url("/static/styles/timber-framed/building/city/inn.png"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="religion"] { --service-building-image: url("/static/styles/timber-framed/building/city/religion.png"); }
+.settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="organization"] { --service-building-image: url("/static/styles/timber-framed/building/city/residences.png"); }
 
 .service-notification-badge {
   position: absolute;
@@ -958,6 +964,7 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
 .service-tab-icon-medical-pack { --service-tab-icon: url("/static/icons/settlement-services/herbalist.png"); }
 .service-tab-icon-inn { --service-tab-icon: url("/static/icons/settlement-services/inn.png"); }
 .service-tab-icon-church { --service-tab-icon: url("/static/icons/game/church.svg"); }
+.service-tab-icon-organization { --service-tab-icon: url("/static/icons/game/templar-shield.svg"); }
 
 .service-tab-icon-map { --service-tab-icon: url("/static/icons/settlement-services/travel.png"); }
 .service-tab-icon-enemy { --service-tab-icon: url("/static/icons/game/death-skull.svg"); }

--- a/scripts/validate_organization_world.py
+++ b/scripts/validate_organization_world.py
@@ -36,7 +36,11 @@ def main() -> int:
         documents = parsed if isinstance(parsed, list) else [parsed]
         for definition in documents:
             organization_id = definition.get("id", "<missing>")
-            references = list(definition.get("chapters", []))
+            references = [
+                chapter.get("settlement_id")
+                for chapter in definition.get("chapters", [])
+                if isinstance(chapter, dict)
+            ]
             recognition = definition.get("recognition", {})
             if recognition.get("kind") == "settlements":
                 references.extend(recognition.get("settlement_ids", []))

--- a/wiki/reference/dialogue.md
+++ b/wiki/reference/dialogue.md
@@ -195,6 +195,11 @@ joining fee and admission requirements, the dues amount, interval, and current
 standing, or the current rank and next-rank requirements as applicable.
 Committed prompt answers are retry-safe when a response is lost; a new answer
 or an action receipt from a different prompt cannot mutate a closed prompt.
+The representative's greeting anchors a highlighted organization-business
+topic. Its follow-up links are selected from authoritative membership facts:
+nonmembers see joining, suspended members see dues only where dues exist, and
+current members can follow a gated chain through dues, promotion, and
+presentation without seeing actions unavailable in their current state.
 
 The web conversation surface exposes topics only as highlighted phrases in
 NPC dialogue. Clicking one asks about that subject; there is no separate list

--- a/wiki/reference/dialogue.md
+++ b/wiki/reference/dialogue.md
@@ -182,6 +182,20 @@ encounter so contextual and prior-interaction facts are reevaluated; old
 sessions remain history rather than an indefinitely reusable active view.
 Free-form `local_chat_message` remains an independent stream.
 
+Organization business uses the dedicated compiled
+`organization-representative` conversation. Join, dues/reactivation,
+promotion, and presentation are closed effects with no authored or
+client-submitted organization ID. Strategic authority derives the institution
+only from the organization-bound representative NPC, verifies that the NPC
+occupies that institution's exact authored chapter location, then applies the
+existing membership authority. Membership state, promotion availability,
+dues, and current presentation are server-built dialogue facts. Before asking
+for confirmation, the representative names the organization and states the
+joining fee and admission requirements, the dues amount, interval, and current
+standing, or the current rank and next-rank requirements as applicable.
+Committed prompt answers are retry-safe when a response is lost; a new answer
+or an action receipt from a different prompt cannot mutate a closed prompt.
+
 The web conversation surface exposes topics only as highlighted phrases in
 NPC dialogue. Clicking one asks about that subject; there is no separate list
 of generic or undiscovered topics. While a prompt is open, the shared composer

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1334)
+## Files (1335)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -33,6 +33,7 @@ development, or other wiki document before changing a subsystem.
 - `assets/world-data/ieg-religion-1544.csv` — Repository support file.
 - `book.toml` — Tooling or build configuration.
 - `content/dialogue/examples.yaml` — Repository support file.
+- `content/dialogue/organizations.yaml` — Repository support file.
 - `content/dialogue/services.yaml` — Repository support file.
 - `content/items/catalog.yaml` — Repository support file.
 - `content/organizations/catalog.yaml` — Repository support file.

--- a/wiki/reference/organizations.md
+++ b/wiki/reference/organizations.md
@@ -14,6 +14,13 @@ and privileges such as bearing arms, wearing armor, or licensed foraging.
 Organization-level privileges are inherited at every rank; rank-level
 privileges are additive.
 
+Chapters are explicit authored records, not settlement-ID flags. Every record
+names its settlement, a bounded stable `organization-*` location ID, building
+name and kind, and the title and profession of its representative. Each
+chapter therefore becomes a distinct navigable building even when several
+organizations share a settlement or an organization is also linked to an
+ordinary settlement service.
+
 An organization may also declare explicit `starting_role` metadata: one of the
 ten authored start profession families plus distinct adult and old rank IDs.
 Presence of this block makes an organization eligible for deterministic
@@ -51,7 +58,9 @@ These are historically informed fictional institutions rather than claims that
 each exact organization existed in every listed settlement.
 
 The character sheet exposes the presented organization as a compact profession
-picker. Its large label combines the member's rank with the service profession
+picker; it is only a self-presentation control. Joining, dues, reactivation,
+and promotion are conducted by speaking to the representative in the
+organization's chapter building. Its large label combines the member's rank with the service profession
 where one exists (for example, `Apprentice Weaponsmith`), while the smaller
 label names the organization. Crests are stable heraldic marks derived from the
 organization ID and service using the locally vendored Game Icons charges, so
@@ -61,8 +70,13 @@ presentation-only persistence fields.
 ## Persistence and authority
 
 SpacetimeDB owns membership, rank, dues, presentation, payment, promotion, and
-equipment-law enforcement. Reducers verify control of the character and local
-chapter presence. Joining is idempotent; the joining fee is charged once.
+equipment-law enforcement. Startup seeds exactly one deterministic persistent
+representative per authored chapter. The NPC carries an explicit organization
+binding, has an all-day authoritative presence at the exact chapter location,
+and uses the compiled `organization-representative` conversation. Dialogue
+effects carry no organization ID: authority resolves it from that live NPC and
+revalidates the actor, session settlement, and exact chapter location before
+reusing membership reducers. Joining is idempotent; the joining fee is charged once.
 Crossing a paid-through boundary suspends membership and clears its
 presentation. Paying at a chapter reactivates it without retroactive arrears.
 
@@ -85,7 +99,8 @@ pre-launch schema does not yet add a composite unique index.
 
 Build validation rejects unknown fields and invalid or duplicate IDs,
 requirements, ranks, weights, organization- and rank-level privileges,
-religions, skill leaves, and
+religions, skill leaves, malformed chapter locations, duplicate chapter
+settlements, and
 settlement policies. A canonical check against a compiled Viabundus world is
 also required:
 

--- a/wiki/strategic/settlement.md
+++ b/wiki/strategic/settlement.md
@@ -224,3 +224,11 @@ where specialists are absent. The server enforces service availability for
 trade, herbalist care, and repairs. The overview exposes prosperity,
 specializations, and every religion represented by the canonical legal status,
 not merely the faith selected for the single church/priest presentation.
+
+Authored organization chapters add distinct Place Facades alongside ordinary
+settlement services. Each opens a real organization building with one
+deterministic persistent representative. Visitors may enter and speak to the
+representative; nonmembers may ask to join, while members conduct dues,
+reactivation, promotion, and presentation business through the compiled
+dialogue. A service-linked guild keeps its ordinary merchant or craft service
+and dialogue in addition to its separate chapter building.


### PR DESCRIPTION
## Summary
- materialize organization chapters as authored settlement buildings
- seed persistent chapter representatives bound to those buildings
- move membership, dues, promotion, and presentation business into NPC dialogue
- retain trainer-mediated apprenticeship and existing recruitment behavior
- update generated bindings and organization/dialogue documentation

## Verification
- organization core tests: 15 passed
- dialogue tests: 19 passed
- strategic web tests: 314 passed
- content and dialogue catalog checks passed
- workspace check and generated-client verification passed
- isolated full-world browser demo verified guildhall membership, dues, and advancement dialogue

## Stack
PR 1 of 2. The threat escalation/publicity PR is stacked on this branch.