### PR TITLE
Consolidate adventurer organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ characters are age 16 and professionless; adults are age 22 and newly
 journeyman-equivalent in one of ten profession families; old characters are
 age 40 and master-equivalent. Professional rosters contain one candidate per
 family, with the specific eligible organization selected deterministically
-from the tab's private seed. Candidate state remains untrusted browser
+from the tab's private seed when a family has multiple options. Witch hunters,
+knights, and foresters each have one denomination-neutral organization and
+therefore always receive that family's organization. Candidate state remains untrusted browser
 coordinates until confirmation authoritatively regenerates and atomically
 persists the selected character.
 Confirmed characters accumulate in a browser-scoped roster and can be switched

--- a/content/organizations/catalog.yaml
+++ b/content/organizations/catalog.yaml
@@ -1127,999 +1127,299 @@
         "public_threat_referrals":  false
     },
     {
-        "id":  "brotherhood_saint_peter_martyr",
-        "name":  "Brotherhood of Saint Peter Martyr",
-        "description":  "A commissioned Roman Catholic confraternity investigating supernatural threats.",
-        "historical_fantasy_note":  "A historical-fantasy institution inspired by confraternities and judicial commissions, not a claim of a standing historical witch-hunter guild.",
-        "starting_role":  {
-                              "profession":  "witch_hunter",
-                              "adult_rank_id":  "examiner",
-                              "old_rank_id":  "inquisitor"
-                          },
-        "chapters":  [
-                         {
-                             "settlement_id":  "viabundus-1826",
-                             "location_id":  "organization-brotherhood-saint-peter-martyr",
-                             "building_name":  "House of Saint Peter Martyr",
-                             "building_kind":  "confraternity",
-                             "representative_title":  "brotherhood prior",
-                             "representative_profession":  "witch hunter"
-                         }
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "dues":  {
-                     "amount":  2,
-                     "interval_days":  30
-                 },
-        "admission":  {
-                          "joining_fee":  3,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "roman_catholic"
-                                               },
-                                               {
-                                                   "kind":  "skill_rating",
-                                                   "skill":  "religion",
-                                                   "leaf":  "roman_catholic",
-                                                   "minimum":  1.0
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "familiar",
-                          "name":  "Familiar",
-                          "description":  "A sworn assistant.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  false,
-                          "practice_reward_interval_minutes":  0
-                      },
-                      {
-                          "id":  "examiner",
-                          "name":  "Examiner",
-                          "description":  "An investigator trusted to examine cases.",
-                          "requirements":  [
-                                               {
-                                                   "kind":  "skill_rating",
-                                                   "skill":  "bestiary",
-                                                   "leaf":  "spirit",
-                                                   "minimum":  2.0
-                                               }
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  120
-                      },
-                      {
-                          "id":  "inquisitor",
-                          "name":  "Inquisitor",
-                          "description":  "A master examiner trusted to direct investigations.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  60
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "religion",
-                                              "religion":  "roman_catholic",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "bestiary",
-                                              "category":  "spirit",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.4
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  true
+        "id": "hunt_pale_lantern",
+        "name": "The Hunt of the Pale Lantern",
+        "description": "A secular fellowship investigating supernatural threats and protecting the public from them.",
+        "historical_fantasy_note": "An invented historical-fantasy institution modeled on commissioned investigators and territorial visitations.",
+        "starting_role": {
+            "profession": "witch_hunter",
+            "adult_rank_id": "hunter",
+            "old_rank_id": "huntmaster"
+        },
+        "chapters": [
+            {
+                "settlement_id": "viabundus-1826",
+                "location_id": "organization-hunt-pale-lantern",
+                "building_name": "House of the Pale Lantern",
+                "building_kind": "confraternity",
+                "representative_title": "huntmaster",
+                "representative_profession": "witch hunter"
+            },
+            {
+                "settlement_id": "viabundus-2337",
+                "location_id": "organization-hunt-pale-lantern",
+                "building_name": "House of the Pale Lantern",
+                "building_kind": "confraternity",
+                "representative_title": "huntmaster",
+                "representative_profession": "witch hunter"
+            }
+        ],
+        "recognition": {
+            "kind": "universal"
+        },
+        "dues": {
+            "amount": 2,
+            "interval_days": 30
+        },
+        "admission": {
+            "joining_fee": 3,
+            "requirements": []
+        },
+        "ranks": [
+            {
+                "id": "watcher",
+                "name": "Watcher",
+                "description": "A sworn assistant learning to recognize and record unnatural threats.",
+                "requirements": [],
+                "practice_allowed": false,
+                "practice_reward_interval_minutes": 0
+            },
+            {
+                "id": "hunter",
+                "name": "Hunter",
+                "description": "An investigator trusted to pursue supernatural threats.",
+                "requirements": [
+                    {
+                        "kind": "skill_rating",
+                        "skill": "bestiary",
+                        "leaf": "spirit",
+                        "minimum": 2.0
+                    }
+                ],
+                "practice_allowed": true,
+                "practice_reward_interval_minutes": 120
+            },
+            {
+                "id": "huntmaster",
+                "name": "Huntmaster",
+                "description": "A veteran hunter trusted to direct investigations and field parties.",
+                "requirements": [],
+                "practice_allowed": true,
+                "practice_reward_interval_minutes": 60
+            }
+        ],
+        "activity": {
+            "training": [
+                {
+                    "kind": "bestiary",
+                    "category": "spirit",
+                    "weight": 0.5
+                },
+                {
+                    "kind": "equipped_weapon_skills",
+                    "weight": 0.5
+                }
+            ],
+            "reward": "gold"
+        },
+        "privileges": [
+            "bear_arms",
+            "wear_armor"
+        ],
+        "public_threat_referrals": true
     },
     {
-        "id":  "brotherhood_watchful_lamp",
-        "name":  "Brotherhood of the Watchful Lamp",
-        "description":  "A commissioned Lutheran fellowship investigating supernatural threats.",
-        "historical_fantasy_note":  "A historical-fantasy institution modeled as a territorial visitation.",
-        "starting_role":  {
-                              "profession":  "witch_hunter",
-                              "adult_rank_id":  "examiner",
-                              "old_rank_id":  "visitor"
-                          },
-        "chapters":  [
-                         {
-                             "settlement_id":  "viabundus-2337",
-                             "location_id":  "organization-brotherhood-watchful-lamp",
-                             "building_name":  "House of the Watchful Lamp",
-                             "building_kind":  "confraternity",
-                             "representative_title":  "brotherhood prior",
-                             "representative_profession":  "witch hunter"
-                         }
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  3,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "lutheran"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "watcher",
-                          "name":  "Watcher",
-                          "description":  "A sworn assistant.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      },
-                      {
-                          "id":  "examiner",
-                          "name":  "Examiner",
-                          "description":  "A licensed investigator of supernatural reports.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  240
-                      },
-                      {
-                          "id":  "visitor",
-                          "name":  "Visitor",
-                          "description":  "A master examiner who directs territorial visitations.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  120
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "religion",
-                                              "religion":  "lutheran",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "bestiary",
-                                              "category":  "spirit",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.4
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  true
+        "id": "order_saint_george",
+        "name": "The Order of St. George",
+        "description": "A military fellowship dedicated to defending travelers and settlements from extraordinary threats.",
+        "historical_fantasy_note": "An invented historical-fantasy order named for the widely honored warrior saint.",
+        "starting_role": {
+            "profession": "knight",
+            "adult_rank_id": "knight",
+            "old_rank_id": "commander"
+        },
+        "chapters": [
+            {
+                "settlement_id": "viabundus-1826",
+                "location_id": "organization-order-saint-george",
+                "building_name": "St. George Commandery",
+                "building_kind": "commandery",
+                "representative_title": "order commander",
+                "representative_profession": "knight"
+            },
+            {
+                "settlement_id": "viabundus-2337",
+                "location_id": "organization-order-saint-george",
+                "building_name": "St. George Commandery",
+                "building_kind": "commandery",
+                "representative_title": "order commander",
+                "representative_profession": "knight"
+            }
+        ],
+        "recognition": {
+            "kind": "universal"
+        },
+        "admission": {
+            "joining_fee": 5,
+            "requirements": []
+        },
+        "ranks": [
+            {
+                "id": "sergeant",
+                "name": "Sergeant",
+                "description": "A serving brother-at-arms.",
+                "requirements": [],
+                "practice_allowed": false,
+                "practice_reward_interval_minutes": 0
+            },
+            {
+                "id": "knight",
+                "name": "Knight Brother",
+                "description": "A proven mounted brother.",
+                "requirements": [
+                    {
+                        "kind": "skill_rating",
+                        "skill": "sword",
+                        "minimum": 3.0
+                    }
+                ],
+                "practice_allowed": true,
+                "practice_reward_interval_minutes": 120
+            },
+            {
+                "id": "commander",
+                "name": "Commander",
+                "description": "A veteran knight entrusted with command.",
+                "requirements": [],
+                "practice_allowed": true,
+                "practice_reward_interval_minutes": 60
+            }
+        ],
+        "activity": {
+            "training": [
+                {
+                    "kind": "equipped_weapon_skills",
+                    "weight": 0.7
+                },
+                {
+                    "kind": "fixed_skill",
+                    "skill": "dodge",
+                    "weight": 0.15
+                },
+                {
+                    "kind": "fixed_skill",
+                    "skill": "block",
+                    "weight": 0.15
+                }
+            ],
+            "reward": "gold"
+        },
+        "privileges": [
+            "bear_arms",
+            "wear_armor"
+        ],
+        "public_threat_referrals": true
     },
     {
-        "id":  "commission_false_wonders",
-        "name":  "Commission for False Wonders and Malefic Arts",
-        "description":  "A commissioned Reformed body investigating supernatural threats.",
-        "historical_fantasy_note":  "A historical-fantasy institution modeled as a magistrates\u0027 commission.",
-        "chapters":  [
-
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  3,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "reformed"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "assistant",
-                          "name":  "Commission Assistant",
-                          "description":  "A sworn assistant.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "religion",
-                                              "religion":  "reformed",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "bestiary",
-                                              "category":  "spirit",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.4
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  false
-    },
-    {
-        "id":  "fellowship_kings_watch",
-        "name":  "Fellowship of the King\u0027s Watch",
-        "description":  "A royal Anglican fellowship investigating supernatural threats.",
-        "historical_fantasy_note":  "A historical-fantasy royal commission.",
-        "chapters":  [
-
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  3,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "anglican"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "watchman",
-                          "name":  "Watchman",
-                          "description":  "A sworn assistant.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "religion",
-                                              "religion":  "anglican",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "bestiary",
-                                              "category":  "spirit",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.4
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  false
-    },
-    {
-        "id":  "brotherhood_archangel_michael",
-        "name":  "Brotherhood of the Holy Archangel Michael",
-        "description":  "An Orthodox brotherhood investigating supernatural threats.",
-        "historical_fantasy_note":  "A historical-fantasy episcopal brotherhood.",
-        "chapters":  [
-
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  3,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "eastern_orthodox"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "companion",
-                          "name":  "Companion",
-                          "description":  "A sworn assistant.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "religion",
-                                              "religion":  "eastern_orthodox",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "bestiary",
-                                              "category":  "spirit",
-                                              "weight":  0.3
-                                          },
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.4
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  false
-    },
-    {
-        "id":  "order_saint_george",
-        "name":  "Order of Saint George",
-        "description":  "A Roman Catholic military-religious fellowship.",
-        "historical_fantasy_note":  "An invented historical-fantasy order.",
-        "starting_role":  {
-                              "profession":  "knight",
-                              "adult_rank_id":  "knight",
-                              "old_rank_id":  "commander"
-                          },
-        "chapters":  [
-                         {
-                             "settlement_id":  "viabundus-1826",
-                             "location_id":  "organization-order-saint-george",
-                             "building_name":  "Saint George Commandery",
-                             "building_kind":  "commandery",
-                             "representative_title":  "order commander",
-                             "representative_profession":  "knight"
-                         }
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  5,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "roman_catholic"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "sergeant",
-                          "name":  "Sergeant",
-                          "description":  "A serving brother-at-arms.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  false,
-                          "practice_reward_interval_minutes":  0
-                      },
-                      {
-                          "id":  "knight",
-                          "name":  "Knight Brother",
-                          "description":  "A proven mounted brother.",
-                          "requirements":  [
-                                               {
-                                                   "kind":  "skill_rating",
-                                                   "skill":  "sword",
-                                                   "minimum":  3.0
-                                               }
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  120
-                      },
-                      {
-                          "id":  "commander",
-                          "name":  "Commander",
-                          "description":  "A veteran knight entrusted with command.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  60
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.7
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "dodge",
-                                              "weight":  0.15
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "block",
-                                              "weight":  0.15
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  true
-    },
-    {
-        "id":  "brandenburg_bailiwick_saint_john",
-        "name":  "Brandenburg Bailiwick of Saint John",
-        "description":  "The Lutheran Brandenburg bailiwick of the Order of Saint John.",
-        "starting_role":  {
-                              "profession":  "knight",
-                              "adult_rank_id":  "knight",
-                              "old_rank_id":  "commander"
-                          },
-        "chapters":  [
-                         {
-                             "settlement_id":  "viabundus-2337",
-                             "location_id":  "organization-brandenburg-bailiwick-saint-john",
-                             "building_name":  "Saint John Commandery",
-                             "building_kind":  "commandery",
-                             "representative_title":  "order commander",
-                             "representative_profession":  "knight"
-                         }
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  5,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "lutheran"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "sergeant",
-                          "name":  "Sergeant",
-                          "description":  "A serving brother-at-arms.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      },
-                      {
-                          "id":  "knight",
-                          "name":  "Knight Brother",
-                          "description":  "A newly proven brother of the bailiwick.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  240
-                      },
-                      {
-                          "id":  "commander",
-                          "name":  "Commander",
-                          "description":  "A veteran knight entrusted with a commandery.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  120
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.7
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "dodge",
-                                              "weight":  0.15
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "block",
-                                              "weight":  0.15
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  true
-    },
-    {
-        "id":  "covenanted_company_shield",
-        "name":  "Covenanted Company of the Shield",
-        "description":  "A Reformed sworn defensive company.",
-        "historical_fantasy_note":  "An invented historical-fantasy company.",
-        "chapters":  [
-
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  5,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "reformed"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "companion",
-                          "name":  "Covenanted Companion",
-                          "description":  "A sworn defender.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.7
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "dodge",
-                                              "weight":  0.15
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "block",
-                                              "weight":  0.15
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  false
-    },
-    {
-        "id":  "royal_fellowship_saint_george",
-        "name":  "Royal Fellowship of Saint George",
-        "description":  "An Anglican royal military fellowship.",
-        "historical_fantasy_note":  "An invented historical-fantasy fellowship.",
-        "chapters":  [
-
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  5,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "anglican"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "man_at_arms",
-                          "name":  "Man-at-Arms",
-                          "description":  "A sworn royal defender.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.7
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "dodge",
-                                              "weight":  0.15
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "block",
-                                              "weight":  0.15
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  false
-    },
-    {
-        "id":  "military_brotherhood_saint_george",
-        "name":  "Military Brotherhood of Saint George",
-        "description":  "An Eastern Orthodox military brotherhood.",
-        "historical_fantasy_note":  "An invented historical-fantasy brotherhood.",
-        "chapters":  [
-
-                     ],
-        "recognition":  {
-                            "kind":  "universal"
-                        },
-        "admission":  {
-                          "joining_fee":  5,
-                          "requirements":  [
-                                               {
-                                                   "kind":  "professed_religion",
-                                                   "religion":  "eastern_orthodox"
-                                               }
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "brother_at_arms",
-                          "name":  "Brother-at-Arms",
-                          "description":  "A sworn defender.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.7
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "dodge",
-                                              "weight":  0.15
-                                          },
-                                          {
-                                              "kind":  "fixed_skill",
-                                              "skill":  "block",
-                                              "weight":  0.15
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "wear_armor"
-                       ],
-        "public_threat_referrals":  false
-    },
-    {
-        "id":  "wardens_harz",
-        "name":  "Wardens of the Harz",
-        "description":  "Sworn wardens of forest roads, game, and dangerous beasts.",
-        "starting_role":  {
-                              "profession":  "forester",
-                              "adult_rank_id":  "warden",
-                              "old_rank_id":  "master"
-                          },
-        "historical_fantasy_note":  "An invented body using period-appropriate territorial forest-office language.",
-        "chapters":  [
-                         {
-                             "settlement_id":  "viabundus-2337",
-                             "location_id":  "organization-wardens-harz",
-                             "building_name":  "Harz Warden Lodge",
-                             "building_kind":  "lodge",
-                             "representative_title":  "chief warden",
-                             "representative_profession":  "forester"
-                         }
-                     ],
-        "recognition":  {
-                            "kind":  "settlements",
-                            "settlement_ids":  [
-                                                   "viabundus-2337",
-                                                   "viabundus-0"
-                                               ]
-                        },
-        "admission":  {
-                          "joining_fee":  2,
-                          "requirements":  [
-
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "under_warden",
-                          "name":  "Under-Warden",
-                          "description":  "A probationary forest servant.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  false,
-                          "practice_reward_interval_minutes":  0
-                      },
-                      {
-                          "id":  "warden",
-                          "name":  "Warden",
-                          "description":  "A sworn forest officer.",
-                          "requirements":  [
-                                               {
-                                                   "kind":  "skill_rating",
-                                                   "skill":  "terrain_forest",
-                                                   "minimum":  2.0
-                                               }
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  120
-                      },
-                      {
-                          "id":  "master",
-                          "name":  "Master",
-                          "description":  "A master warden entrusted with the prince\u0027s high game.",
-                          "requirements":  [
-                                               {
-                                                   "kind":  "skill_rating",
-                                                   "skill":  "terrain_forest",
-                                                   "minimum":  4.0
-                                               }
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  120,
-                          "privileges":  [
-                                             "forage_high_game"
-                                         ]
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "terrain",
-                                              "terrain":  "forest",
-                                              "weight":  0.35
-                                          },
-                                          {
-                                              "kind":  "bestiary",
-                                              "category":  "beast",
-                                              "weight":  0.35
-                                          },
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.3
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "forage_low_game",
-                           "forage_fish",
-                           "forage_plants"
-                       ],
-        "public_threat_referrals":  true
-    },
-    {
-        "id":  "keepers_solling",
-        "name":  "Keepers of the Solling",
-        "description":  "Territorial keepers of woods, roads, and game.",
-        "starting_role":  {
-                              "profession":  "forester",
-                              "adult_rank_id":  "keeper",
-                              "old_rank_id":  "master"
-                          },
-        "historical_fantasy_note":  "An invented body using period-appropriate forest-office language.",
-        "chapters":  [
-                         {
-                             "settlement_id":  "viabundus-0",
-                             "location_id":  "organization-keepers-solling",
-                             "building_name":  "Solling Keeper Lodge",
-                             "building_kind":  "lodge",
-                             "representative_title":  "chief keeper",
-                             "representative_profession":  "forester"
-                         }
-                     ],
-        "recognition":  {
-                            "kind":  "settlements",
-                            "settlement_ids":  [
-                                                   "viabundus-0"
-                                               ]
-                        },
-        "admission":  {
-                          "joining_fee":  2,
-                          "requirements":  [
-
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "keeper",
-                          "name":  "Keeper",
-                          "description":  "A sworn forest servant.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      },
-                      {
-                          "id":  "master",
-                          "name":  "Master",
-                          "description":  "A master keeper entrusted with the prince\u0027s high game.",
-                          "requirements":  [
-                                               {
-                                                   "kind":  "skill_rating",
-                                                   "skill":  "terrain_forest",
-                                                   "minimum":  4.0
-                                               }
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  120,
-                          "privileges":  [
-                                             "forage_high_game"
-                                         ]
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "terrain",
-                                              "terrain":  "forest",
-                                              "weight":  0.35
-                                          },
-                                          {
-                                              "kind":  "bestiary",
-                                              "category":  "beast",
-                                              "weight":  0.35
-                                          },
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.3
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "forage_low_game",
-                           "forage_fish",
-                           "forage_plants"
-                       ],
-        "public_threat_referrals":  true
-    },
-    {
-        "id":  "company_green_staff_thuringia",
-        "name":  "Company of the Green Staff of Thuringia",
-        "description":  "A company of sworn foresters and march wardens.",
-        "starting_role":  {
-                              "profession":  "forester",
-                              "adult_rank_id":  "green_staff",
-                              "old_rank_id":  "master"
-                          },
-        "historical_fantasy_note":  "An invented body using period-appropriate forest-office language.",
-        "chapters":  [
-                         {
-                             "settlement_id":  "viabundus-1826",
-                             "location_id":  "organization-company-green-staff-thuringia",
-                             "building_name":  "Green Staff Lodge",
-                             "building_kind":  "lodge",
-                             "representative_title":  "company warden",
-                             "representative_profession":  "forester"
-                         }
-                     ],
-        "recognition":  {
-                            "kind":  "settlements",
-                            "settlement_ids":  [
-                                                   "viabundus-1826"
-                                               ]
-                        },
-        "admission":  {
-                          "joining_fee":  2,
-                          "requirements":  [
-
-                                           ]
-                      },
-        "ranks":  [
-                      {
-                          "id":  "green_staff",
-                          "name":  "Green Staff",
-                          "description":  "A sworn forest servant.",
-                          "requirements":  [
-
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  480
-                      },
-                      {
-                          "id":  "master",
-                          "name":  "Master",
-                          "description":  "A master forester entrusted with the prince\u0027s high game.",
-                          "requirements":  [
-                                               {
-                                                   "kind":  "skill_rating",
-                                                   "skill":  "terrain_hills",
-                                                   "minimum":  4.0
-                                               }
-                                           ],
-                          "practice_allowed":  true,
-                          "practice_reward_interval_minutes":  120,
-                          "privileges":  [
-                                             "forage_high_game"
-                                         ]
-                      }
-                  ],
-        "activity":  {
-                         "training":  [
-                                          {
-                                              "kind":  "terrain",
-                                              "terrain":  "hills",
-                                              "weight":  0.35
-                                          },
-                                          {
-                                              "kind":  "bestiary",
-                                              "category":  "beast",
-                                              "weight":  0.35
-                                          },
-                                          {
-                                              "kind":  "equipped_weapon_skills",
-                                              "weight":  0.3
-                                          }
-                                      ],
-                         "reward":  "gold"
-                     },
-        "privileges":  [
-                           "bear_arms",
-                           "forage_low_game",
-                           "forage_fish",
-                           "forage_plants"
-                       ],
-        "public_threat_referrals":  true
+        "id": "lodge_hart_king",
+        "name": "The Lodge of the Hart King",
+        "description": "Sworn wardens of forests, roads, game, and dangerous beasts.",
+        "historical_fantasy_note": "An invented body using period-appropriate territorial forest-office language.",
+        "starting_role": {
+            "profession": "forester",
+            "adult_rank_id": "warden",
+            "old_rank_id": "master"
+        },
+        "chapters": [
+            {
+                "settlement_id": "viabundus-2337",
+                "location_id": "organization-lodge-hart-king",
+                "building_name": "Hart King Lodge",
+                "building_kind": "lodge",
+                "representative_title": "master warden",
+                "representative_profession": "forester"
+            },
+            {
+                "settlement_id": "viabundus-0",
+                "location_id": "organization-lodge-hart-king",
+                "building_name": "Hart King Lodge",
+                "building_kind": "lodge",
+                "representative_title": "master warden",
+                "representative_profession": "forester"
+            },
+            {
+                "settlement_id": "viabundus-1826",
+                "location_id": "organization-lodge-hart-king",
+                "building_name": "Hart King Lodge",
+                "building_kind": "lodge",
+                "representative_title": "master warden",
+                "representative_profession": "forester"
+            }
+        ],
+        "recognition": {
+            "kind": "universal"
+        },
+        "admission": {
+            "joining_fee": 2,
+            "requirements": []
+        },
+        "ranks": [
+            {
+                "id": "under_warden",
+                "name": "Under-Warden",
+                "description": "A probationary forest servant.",
+                "requirements": [],
+                "practice_allowed": false,
+                "practice_reward_interval_minutes": 0
+            },
+            {
+                "id": "warden",
+                "name": "Warden",
+                "description": "A sworn forest officer.",
+                "requirements": [
+                    {
+                        "kind": "skill_rating",
+                        "skill": "terrain_forest",
+                        "minimum": 2.0
+                    }
+                ],
+                "practice_allowed": true,
+                "practice_reward_interval_minutes": 120
+            },
+            {
+                "id": "master",
+                "name": "Master",
+                "description": "A master warden entrusted with the highest game.",
+                "requirements": [
+                    {
+                        "kind": "skill_rating",
+                        "skill": "terrain_forest",
+                        "minimum": 4.0
+                    }
+                ],
+                "practice_allowed": true,
+                "practice_reward_interval_minutes": 120,
+                "privileges": [
+                    "forage_high_game"
+                ]
+            }
+        ],
+        "activity": {
+            "training": [
+                {
+                    "kind": "terrain",
+                    "terrain": "forest",
+                    "weight": 0.35
+                },
+                {
+                    "kind": "bestiary",
+                    "category": "beast",
+                    "weight": 0.35
+                },
+                {
+                    "kind": "equipped_weapon_skills",
+                    "weight": 0.3
+                }
+            ],
+            "reward": "gold"
+        },
+        "privileges": [
+            "bear_arms",
+            "forage_low_game",
+            "forage_fish",
+            "forage_plants"
+        ],
+        "public_threat_referrals": true
     },
     {
         "id":  "test_catholic_polearm_cooks",

--- a/crates/adventuresim-core/src/organization.rs
+++ b/crates/adventuresim-core/src/organization.rs
@@ -382,19 +382,85 @@ mod tests {
 
     #[test]
     fn ranger_common_licenses_are_inherited_and_high_game_is_master_only() {
-        for id in [
-            "wardens_harz",
-            "keepers_solling",
-            "company_green_staff_thuringia",
+        let definition = organization("lodge_hart_king").unwrap();
+        let first = &definition.ranks[0];
+        assert!(definition.has_privilege_at_rank(&first.id, Privilege::ForageLowGame));
+        assert!(definition.has_privilege_at_rank(&first.id, Privilege::ForageFish));
+        assert!(definition.has_privilege_at_rank(&first.id, Privilege::ForagePlants));
+        assert!(!definition.has_privilege_at_rank(&first.id, Privilege::ForageHighGame));
+        assert!(definition.has_privilege_at_rank("master", Privilege::ForageHighGame));
+    }
+
+    #[test]
+    fn adventurer_professions_each_have_one_neutral_starting_organization() {
+        for (profession, id, name, chapter_count) in [
+            (
+                StartingProfession::WitchHunter,
+                "hunt_pale_lantern",
+                "The Hunt of the Pale Lantern",
+                2,
+            ),
+            (
+                StartingProfession::Knight,
+                "order_saint_george",
+                "The Order of St. George",
+                2,
+            ),
+            (
+                StartingProfession::Forester,
+                "lodge_hart_king",
+                "The Lodge of the Hart King",
+                3,
+            ),
         ] {
-            let definition = organization(id).unwrap();
-            let first = &definition.ranks[0];
-            assert!(definition.has_privilege_at_rank(&first.id, Privilege::ForageLowGame));
-            assert!(definition.has_privilege_at_rank(&first.id, Privilege::ForageFish));
-            assert!(definition.has_privilege_at_rank(&first.id, Privilege::ForagePlants));
-            assert!(!definition.has_privilege_at_rank(&first.id, Privilege::ForageHighGame));
-            assert!(definition.has_privilege_at_rank("master", Privilege::ForageHighGame));
+            let eligible = catalog()
+                .organizations
+                .iter()
+                .filter(|definition| {
+                    definition
+                        .starting_role
+                        .as_ref()
+                        .is_some_and(|role| role.profession == profession)
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(eligible.len(), 1, "{profession:?}");
+            let definition = eligible[0];
+            assert_eq!(definition.id, id);
+            assert_eq!(definition.name, name);
+            assert_eq!(definition.chapters.len(), chapter_count);
+            assert!(definition.admission.requirements.iter().all(|requirement| {
+                !matches!(requirement, Requirement::ProfessedReligion { .. })
+            }));
+            assert!(definition.ranks.iter().all(|rank| {
+                rank.requirements.iter().all(|requirement| {
+                    !matches!(requirement, Requirement::ProfessedReligion { .. })
+                })
+            }));
+            assert!(definition.public_threat_referrals);
         }
+
+        let hunt = organization("hunt_pale_lantern").unwrap();
+        assert!(
+            hunt.activity
+                .training
+                .iter()
+                .all(|entry| { !matches!(&entry.target, TrainingTarget::Religion { .. }) })
+        );
+        assert_eq!(
+            hunt.activity.training,
+            vec![
+                TrainingEntry {
+                    weight: 0.5,
+                    target: TrainingTarget::Bestiary {
+                        category: "spirit".into(),
+                    },
+                },
+                TrainingEntry {
+                    weight: 0.5,
+                    target: TrainingTarget::EquippedWeaponSkills,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/crates/adventuresim-core/src/settlement_economy.rs
+++ b/crates/adventuresim-core/src/settlement_economy.rs
@@ -439,7 +439,7 @@ mod tests {
             &p,
             false,
             "viabundus-0",
-            "organization-brotherhood-saint-peter-martyr"
+            "organization-hunt-pale-lantern"
         ));
     }
 

--- a/crates/adventuresim-core/src/starting_character.rs
+++ b/crates/adventuresim-core/src/starting_character.rs
@@ -1377,6 +1377,44 @@ mod tests {
         }
         let adult = roster(GENERATOR_VERSION, SEED, StartingAgeTier::Adult).unwrap();
         let old = roster(GENERATOR_VERSION, SEED, StartingAgeTier::Old).unwrap();
+        for (profession, id, name, adult_rank, old_rank) in [
+            (
+                StartingProfession::WitchHunter,
+                "hunt_pale_lantern",
+                "The Hunt of the Pale Lantern",
+                "hunter",
+                "huntmaster",
+            ),
+            (
+                StartingProfession::Knight,
+                "order_saint_george",
+                "The Order of St. George",
+                "knight",
+                "commander",
+            ),
+            (
+                StartingProfession::Forester,
+                "lodge_hart_king",
+                "The Lodge of the Hart King",
+                "warden",
+                "master",
+            ),
+        ] {
+            let slot = StartingProfession::ALL
+                .iter()
+                .position(|candidate| *candidate == profession)
+                .unwrap();
+            let adult_organization = adult[slot].organization.as_ref().unwrap();
+            let old_organization = old[slot].organization.as_ref().unwrap();
+            assert_eq!(adult_organization.organization_id, id);
+            assert_eq!(adult_organization.organization_name, name);
+            assert_eq!(adult_organization.rank_id, adult_rank);
+            assert_eq!(old_organization.organization_id, id);
+            assert_eq!(old_organization.organization_name, name);
+            assert_eq!(old_organization.rank_id, old_rank);
+            assert!(adult[slot].religion_id.is_none());
+            assert!(old[slot].religion_id.is_none());
+        }
         assert!(adult.iter().zip(&old).all(|(adult, old)| {
             adult.id != old.id
                 && adult.organization.as_ref().unwrap().rank_id

--- a/crates/adventuresim-stdb-module/src/organization.rs
+++ b/crates/adventuresim-stdb-module/src/organization.rs
@@ -510,7 +510,7 @@ mod tests {
         OrganizationMembership {
             id: 1,
             character_id: 7,
-            organization_id: "wardens_harz".into(),
+            organization_id: "lodge_hart_king".into(),
             rank_id: rank_id.into(),
             joined_minute: 0,
             dues_paid_through_minute: paid_through,
@@ -522,7 +522,7 @@ mod tests {
 
     #[test]
     fn global_license_requires_current_membership_and_right_rank() {
-        let definition = organization("wardens_harz").unwrap();
+        let definition = organization("lodge_hart_king").unwrap();
         let warden = membership_at("warden", MEMBERSHIP_ACTIVE, 100);
         assert!(current_membership_grants(
             definition,

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -2539,9 +2539,9 @@ mod tests {
     fn camp_schedule_excludes_organization_training_and_activity() {
         let schedule = ScheduleAllocation {
             apprenticeship_minutes: 120,
-            apprenticeship_organization_id: Some("wardens_harz".into()),
+            apprenticeship_organization_id: Some("lodge_hart_king".into()),
             profession_practice_minutes: 180,
-            practice_organization_id: Some("wardens_harz".into()),
+            practice_organization_id: Some("lodge_hart_king".into()),
             prayer_minutes: 60,
             ..Default::default()
         };

--- a/crates/strategic-web/src/routes/dialogue.rs
+++ b/crates/strategic-web/src/routes/dialogue.rs
@@ -325,7 +325,7 @@ mod npc_navigation_tests {
             &profile,
             &SettlementCategory::City,
             "viabundus-0",
-            "organization-brotherhood-saint-peter-martyr"
+            "organization-hunt-pale-lantern"
         ));
         assert!(!npc_location_is_navigable(
             &profile,

--- a/crates/strategic-web/src/routes/foraging.rs
+++ b/crates/strategic-web/src/routes/foraging.rs
@@ -645,7 +645,7 @@ mod tests {
         OrganizationMembership {
             id: 1,
             character_id: 7,
-            organization_id: "wardens_harz".into(),
+            organization_id: "lodge_hart_king".into(),
             rank_id: rank_id.into(),
             joined_minute: 0,
             dues_paid_through_minute: paid_through,
@@ -659,7 +659,7 @@ mod tests {
     fn advisory_licenses_require_matching_current_presentation_and_rank() {
         use adventuresim_core::organization::Privilege;
         let warden = ranger_membership("warden", "active", 100);
-        let common = advisory_privileges_for(Some("wardens_harz"), &[warden.clone()], Some(100));
+        let common = advisory_privileges_for(Some("lodge_hart_king"), &[warden.clone()], Some(100));
         assert!(common.contains(&Privilege::ForageLowGame));
         assert!(common.contains(&Privilege::ForageFish));
         assert!(common.contains(&Privilege::ForagePlants));
@@ -667,18 +667,20 @@ mod tests {
 
         let master = ranger_membership("master", "active", 100);
         assert!(
-            advisory_privileges_for(Some("wardens_harz"), &[master], Some(100))
+            advisory_privileges_for(Some("lodge_hart_king"), &[master], Some(100))
                 .contains(&Privilege::ForageHighGame)
         );
         assert!(advisory_privileges_for(None, &[warden.clone()], Some(100)).is_empty());
         assert!(
-            advisory_privileges_for(Some("keepers_solling"), &[warden.clone()], Some(100))
+            advisory_privileges_for(Some("hunt_pale_lantern"), &[warden.clone()], Some(100))
                 .is_empty()
         );
         let lapsed = ranger_membership("master", "active", 99);
-        assert!(advisory_privileges_for(Some("wardens_harz"), &[lapsed], Some(100)).is_empty());
+        assert!(advisory_privileges_for(Some("lodge_hart_king"), &[lapsed], Some(100)).is_empty());
         let suspended = ranger_membership("master", "suspended", 100);
-        assert!(advisory_privileges_for(Some("wardens_harz"), &[suspended], Some(100)).is_empty());
+        assert!(
+            advisory_privileges_for(Some("lodge_hart_king"), &[suspended], Some(100)).is_empty()
+        );
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/character_details.rs
+++ b/crates/strategic-web/src/templates/settlement/character_details.rs
@@ -763,6 +763,12 @@ fn organization_colors(id: &str) -> (&'static str, &'static str) {
 }
 
 fn organization_charge(definition: &OrganizationDefinition) -> &'static str {
+    match definition.id.as_str() {
+        "order_saint_george" => return "mounted-knight",
+        "lodge_hart_king" => return "wood-axe",
+        "hunt_pale_lantern" => return "eye-target",
+        _ => {}
+    }
     match definition.service_id.as_deref() {
         Some("merchants") => "coins",
         Some("weapons") => "anvil",
@@ -1095,6 +1101,21 @@ mod tests {
             assert!(first.contains("organization-crest"));
             assert!(first.contains("/static/icons/game/"));
             assert!(first.contains(&format!("{} heraldry", definition.name)));
+        }
+    }
+
+    #[test]
+    fn consolidated_adventurer_organizations_have_specific_charges() {
+        for (id, charge) in [
+            ("order_saint_george", "mounted-knight"),
+            ("lodge_hart_king", "wood-axe"),
+            ("hunt_pale_lantern", "eye-target"),
+        ] {
+            let definition = organization(id).unwrap();
+            assert_eq!(organization_charge(definition), charge);
+            let crest = organization_crest(definition).into_string();
+            assert!(crest.contains(&format!("/static/icons/game/{charge}.svg")));
+            assert!(!crest.contains("/static/icons/game/shield.svg"));
         }
     }
 

--- a/wiki/reference/foraging.md
+++ b/wiki/reference/foraging.md
@@ -63,8 +63,8 @@ hours, and routes rejected above-cap training into mastery enjoyment.
 Foraging is illegal at a settlement or in a cultivated square. High Game, Low
 Game, Fish, and Plants also require a license granted by the character's
 currently presented, active, dues-current profession; Harmful Beasts requires
-none. Ranger and forester organizations grant the common licenses at every
-rank, while High Game is reserved to Master rank. Licenses are global for now
+none. The Lodge of the Hart King grants the common licenses at every rank,
+while High Game is reserved to Master rank. Licenses are global for now
 and deliberately ignore local recognition and political boundaries.
 
 Unlicensed sources remain selectable as poaching. A completed illegal search

--- a/wiki/reference/organizations.md
+++ b/wiki/reference/organizations.md
@@ -47,15 +47,18 @@ still require persisted presentation plus a matching active, dues-current
 membership and its current rank, but do not require the current settlement to
 recognize the organization. A valid persisted presentation therefore survives
 travel and entry into an unrecognizing settlement. This does not weaken the
-locally recognized equipment privilege rules. The three forester organizations
-grant Low Game, Fish, and Plants throughout their ranks; each has a terrain-4.0
-Master rank that adds High Game.
+locally recognized equipment privilege rules. The Lodge of the Hart King
+grants Low Game, Fish, and Plants throughout its ranks; its Forest-4.0 Master
+rank adds High Game.
 
-The first catalog includes migrated trade and religious bodies, denomination-
-specific witch-hunter and knightly organizations, three regional forester
-organizations, and a deliberately eccentric Catholic cooks test organization.
-These are historically informed fictional institutions rather than claims that
-each exact organization existed in every listed settlement.
+The first catalog includes migrated trade and religious bodies plus three
+universal, denomination-neutral adventurer organizations: The Hunt of the Pale
+Lantern for witch hunters, The Order of St. George for knights, and The Lodge
+of the Hart King for foresters. Their chapters combine the playable footprints
+of the former denominational and regional variants. The catalog also retains a
+deliberately eccentric Catholic cooks test organization. These are historically
+informed fictional institutions rather than claims that each exact organization
+existed in every listed settlement.
 
 The character sheet exposes the presented organization as a compact profession
 picker; it is only a self-presentation control. Joining, dues, reactivation,
@@ -90,8 +93,10 @@ innkeeper.
 
 Organization training and activity require a current membership and local
 chapter. Their skill mix is read from the catalog, including fixed skills,
-denomination-specific Religion, Bestiary and Terrain leaves, and equipped
-weapon skills.
+Bestiary and Terrain leaves, equipped weapon skills, and Religion only where
+an organization explicitly teaches a particular tradition. The Hunt of the
+Pale Lantern instead divides its training evenly between Spirit Bestiary and
+equipped weapon skills.
 
 ### MVP privacy and uniqueness limitation
 

--- a/wiki/strategic/character.md
+++ b/wiki/strategic/character.md
@@ -66,7 +66,10 @@ journeyman-equivalent; old candidates are age 40 and master-equivalent. Adult
 and old rosters each offer one candidate for merchant, weaponsmith, armourer,
 tailor, herbalist, cook, learned religious practitioner, witch hunter, knight,
 and forester. The specific eligible organization is deterministic but random
-from the player's perspective.
+from the player's perspective when a family has multiple options. Witch
+hunters join The Hunt of the Pale Lantern, knights join The Order of St.
+George, and foresters join The Lodge of the Hart King; these three
+organizations have no profession-of-faith requirement.
 
 Professional candidates preview and receive their complete plausible package:
 organization and mapped rank, current dues and presentation, required


### PR DESCRIPTION
## Summary

- consolidate thirteen denomination- and region-specific witch-hunter, knight, and forester bodies into three canonical organizations:
  - The Hunt of the Pale Lantern
  - The Order of St. George
  - The Lodge of the Hart King
- merge their playable chapter footprints while making admission denomination-neutral
- preserve profession privileges, referrals, rewards, appropriate dues, starting ranks, and curricula
- update starting-character and membership fixtures, organization heraldry, and behavior documentation

## Notable choices

- The Hunt trains Spirit Bestiary and equipped weapon skills evenly instead of selecting one denomination's Religion tradition.
- The consolidated organizations are universally recognized and use clean final IDs without compatibility aliases, following the pre-launch schema policy.
- Existing playable chapter coverage is retained: 2 Hunt chapters, 2 Order chapters, and 3 Lodge chapters.

## Verification

- `just fmt`
- `just content-check`
- `cargo test -p adventuresim-core` — 485 passed
- `cargo test -p strategic-web` — 319 passed
- `just check`
- `python scripts/update_project_map.py --check`
- organization world validation — valid against 714 settlements
- two independent read-only reviews; no blocking findings

## Known baseline limitation

`cargo test -p adventuresim-stdb-module organization::tests` cannot currently compile because five pre-existing test-only calls to `dialogue_capable_inn_contact` are unresolved in `local_problem.rs`. Those lines are outside this diff; the workspace's non-test `just check` passes.

## Compatibility

This intentionally removes retired organization IDs. Existing development memberships using them should be recreated or reseeded; no migration or compatibility shim is included under the repository's pre-launch data policy.