### PR TITLE
Harden strategic web error handling

### DIFF
--- a/crates/adventuresim-core/src/durability.rs
+++ b/crates/adventuresim-core/src/durability.rs
@@ -33,6 +33,14 @@ impl RepairService {
         }
     }
 
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Weapons => "weapons",
+            Self::Armor => "armor",
+            Self::Clothing => "clothing",
+        }
+    }
+
     pub const fn matches(self, kind: RepairItemKind) -> bool {
         match self {
             Self::Weapons => matches!(kind, RepairItemKind::Weapon | RepairItemKind::Shield),
@@ -292,6 +300,9 @@ mod tests {
         assert!(clothing.matches(RepairItemKind::Clothing));
         assert!(!clothing.matches(RepairItemKind::Weapon));
         assert_eq!(RepairService::parse("smith"), None);
+        assert_eq!(weapons.as_str(), "weapons");
+        assert_eq!(armor.as_str(), "armor");
+        assert_eq!(clothing.as_str(), "clothing");
     }
     #[test]
     fn ductile_yields_sooner_but_brittle_fails_sooner() {

--- a/crates/strategic-web/src/main.rs
+++ b/crates/strategic-web/src/main.rs
@@ -33,14 +33,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use config::Config;
 use live::LiveState;
 use routes::{AppState, build_router};
-use spacetimedb::SpacetimeClient;
-
-fn sats_option_string(value: Option<&str>) -> serde_json::Value {
-    match value {
-        Some(value) => serde_json::json!({ "some": value }),
-        None => serde_json::json!({ "none": [] }),
-    }
-}
+use spacetimedb::{SpacetimeClient, sats_option};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -64,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     // Create SpacetimeDB client
-    let db = SpacetimeClient::new(&config.spacetimedb_host, &config.spacetimedb_database)
+    let db = SpacetimeClient::new(&config.spacetimedb_host, &config.spacetimedb_database)?
         .with_token(config.spacetimedb_token.clone());
     let measurement_baseline = db.query_metrics();
     let measurement_delta = measurement_baseline.delta(measurement_baseline);
@@ -122,7 +115,7 @@ async fn main() -> anyhow::Result<()> {
     db.call(
         "register_strategic_gateway",
         &[
-            sats_option_string(terrain.as_ref().map(|planner| planner.digest())),
+            sats_option(terrain.as_ref().map(|planner| planner.digest())),
             serde_json::json!(if terrain.is_some() { 3_u32 } else { 0_u32 }),
         ],
     )
@@ -814,14 +807,14 @@ impl Drop for HttpRequestLog {
 
 #[cfg(test)]
 mod tests {
-    use super::sats_option_string;
+    use crate::spacetimedb::sats_option;
 
     #[test]
     fn gateway_registration_uses_spacetimedb_option_sum_json() {
         assert_eq!(
-            sats_option_string(Some("digest")),
+            sats_option(Some("digest")),
             serde_json::json!({ "some": "digest" })
         );
-        assert_eq!(sats_option_string(None), serde_json::json!({ "none": [] }));
+        assert_eq!(sats_option::<&str>(None), serde_json::json!({ "none": [] }));
     }
 }

--- a/crates/strategic-web/src/routes/foraging.rs
+++ b/crates/strategic-web/src/routes/foraging.rs
@@ -456,6 +456,9 @@ pub(crate) async fn activity_dialog(
     let privileges = advisory_privileges(state, character.id).await;
     let illegal =
         environment.is_some_and(|environment| environment.settlement || environment.cultivated);
+    let available_source_rows = environment
+        .as_ref()
+        .map(|environment| source_rows(*environment, &privileges));
     html! {
         div class="character-action-overlay" data-character-action-dialog
             data-initial-focus=(if receipt.is_some() { ".modal-actions .btn" } else { "#forage-targets input:not(:disabled)" }) {
@@ -489,7 +492,9 @@ pub(crate) async fn activity_dialog(
                         p id="forage-source-help" class="text-muted small-copy" { "Choose food sources. Selected categories share one search-time budget." }
                         fieldset id="forage-targets" aria-describedby="forage-source-help" {
                             legend { "Food sources" }
-                            (source_rows(environment.expect("available environment"), &privileges))
+                            @if let Some(rows) = available_source_rows {
+                                (rows)
+                            }
                         }
                         label for="forage-hours" { "Search plan" }
                         input id="forage-hours" name="hours" type="range" min="1" max="24" value="4"

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -1,6 +1,7 @@
 //! Settlement route handlers
 
 use adventuresim_core::{
+    durability::RepairService,
     equipment::{EncumbranceSummary, encumbrance_capacity_kg},
     prelude::{
         PartyProvisioningInputs, STANDARD_TRAVEL_RATION_ID, STANDARD_WATERSKIN_ID,
@@ -389,6 +390,20 @@ fn parse_surgery_limb(slug: &str) -> Option<LimbRegion> {
     })
 }
 
+async fn required_surgery_rows<T>(
+    state: &AppState,
+    sql: &str,
+    data_kind: &'static str,
+) -> Result<Vec<T>, Html<String>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    state.db.query(sql).await.map_err(|error| {
+        tracing::error!(%error, data_kind, "failed to load surgery data");
+        Html("<h1>Strategic medical data is unavailable</h1>".into())
+    })
+}
+
 async fn surgery(
     State(state): State<AppState>,
     Path((kind, id, patient_id, limb)): Path<(String, String, u64, String)>,
@@ -425,32 +440,46 @@ async fn surgery(
     {
         return Html("<h1>Surgeon and patient must be together</h1>".into());
     }
-    let injuries = state
-        .db
-        .query::<LimbInjury>(&format!(
-            "SELECT * FROM limb_injury WHERE character_id = {patient_id}"
-        ))
-        .await
-        .unwrap_or_default();
-    let projectiles = state
-        .db
-        .query::<RetainedProjectile>(&format!(
-            "SELECT * FROM retained_projectile WHERE character_id = {patient_id}"
-        ))
-        .await
-        .unwrap_or_default();
-    let inventory = state
-        .db
-        .query::<InventoryItem>(&format!(
-            "SELECT * FROM inventory_item WHERE character_id = {actor_id}"
-        ))
-        .await
-        .unwrap_or_default();
-    let item_definitions = state
-        .db
-        .query::<ItemDefinition>("SELECT * FROM item")
-        .await
-        .unwrap_or_default();
+    let injuries = match required_surgery_rows::<LimbInjury>(
+        &state,
+        &format!("SELECT * FROM limb_injury WHERE character_id = {patient_id}"),
+        "patient injuries",
+    )
+    .await
+    {
+        Ok(rows) => rows,
+        Err(response) => return response,
+    };
+    let projectiles = match required_surgery_rows::<RetainedProjectile>(
+        &state,
+        &format!("SELECT * FROM retained_projectile WHERE character_id = {patient_id}"),
+        "retained projectiles",
+    )
+    .await
+    {
+        Ok(rows) => rows,
+        Err(response) => return response,
+    };
+    let inventory = match required_surgery_rows::<InventoryItem>(
+        &state,
+        &format!("SELECT * FROM inventory_item WHERE character_id = {actor_id}"),
+        "surgeon inventory",
+    )
+    .await
+    {
+        Ok(rows) => rows,
+        Err(response) => return response,
+    };
+    let item_definitions = match required_surgery_rows::<ItemDefinition>(
+        &state,
+        "SELECT * FROM item",
+        "item definitions",
+    )
+    .await
+    {
+        Ok(rows) => rows,
+        Err(response) => return response,
+    };
     let alcohol_count = inventory
         .iter()
         .filter(|entry| {
@@ -485,13 +514,16 @@ async fn surgery(
     let actor_injuries = if actor_id == patient_id {
         injuries.clone()
     } else {
-        state
-            .db
-            .query::<LimbInjury>(&format!(
-                "SELECT * FROM limb_injury WHERE character_id = {actor_id}"
-            ))
-            .await
-            .unwrap_or_default()
+        match required_surgery_rows::<LimbInjury>(
+            &state,
+            &format!("SELECT * FROM limb_injury WHERE character_id = {actor_id}"),
+            "surgeon injuries",
+        )
+        .await
+        {
+            Ok(rows) => rows,
+            Err(response) => return response,
+        }
     };
     let quantity = |item_id: &str| {
         inventory
@@ -567,43 +599,20 @@ struct SurgeryProcedureForm {
     use_soap: bool,
 }
 
-/// SpacetimeDB's raw HTTP reducer API expects algebraic `Option<T>` values,
-/// not Serde's scalar-or-null representation: `Some(v) = {"some": v}` and
-/// `None = {"none": []}`.
-fn spacetime_option_u64(value: Option<u64>) -> serde_json::Value {
-    match value {
-        Some(value) => json!({ "some": value }),
-        None => json!({ "none": [] }),
-    }
-}
-
-fn spacetime_option_string(value: Option<&str>) -> serde_json::Value {
-    match value {
-        Some(value) => json!({ "some": value }),
-        None => json!({ "none": [] }),
-    }
-}
-
 fn schedule_allocation_reducer_arg(schedule: &ScheduleAllocation) -> serde_json::Value {
     let mut value = json!(schedule);
     value["apprenticeship_organization_id"] =
-        spacetime_option_string(schedule.apprenticeship_organization_id.as_deref());
+        crate::spacetimedb::sats_option(schedule.apprenticeship_organization_id.as_deref());
     value["practice_organization_id"] =
-        spacetime_option_string(schedule.practice_organization_id.as_deref());
+        crate::spacetimedb::sats_option(schedule.practice_organization_id.as_deref());
     value
 }
 
 #[cfg(test)]
 mod surgery_reducer_argument_tests {
-    use super::{schedule_allocation_reducer_arg, spacetime_option_u64};
+    use super::schedule_allocation_reducer_arg;
     use crate::spacetimedb::ScheduleAllocation;
     use serde_json::json;
-
-    #[test]
-    fn projectile_id_uses_spacetime_option_encoding() {
-        assert_eq!(spacetime_option_u64(Some(73)), json!({ "some": 73 }));
-        assert_eq!(spacetime_option_u64(None), json!({ "none": [] }));
-    }
 
     #[test]
     fn schedule_profession_ids_use_spacetime_option_encoding() {
@@ -643,7 +652,7 @@ async fn perform_surgery(
                 json!(patient_id),
                 json!(limb),
                 json!(form.procedure),
-                spacetime_option_u64(form.projectile_id),
+                crate::spacetimedb::sats_option(form.projectile_id),
                 json!(form.use_soap),
             ],
         )
@@ -676,26 +685,23 @@ struct RepairItemForm {
     inventory_item_id: u64,
 }
 
-fn repair_service(shop: &str) -> Option<&'static str> {
-    match shop {
-        "weapons" => Some("weapons"),
-        "armor" => Some("armor"),
-        "clothing" => Some("clothing"),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod repair_route_tests {
-    use super::repair_service;
+    use adventuresim_core::durability::RepairService;
 
     #[test]
     fn repair_routes_dispatch_all_and_only_the_three_authoritative_services() {
-        assert_eq!(repair_service("weapons"), Some("weapons"));
-        assert_eq!(repair_service("armor"), Some("armor"));
-        assert_eq!(repair_service("clothing"), Some("clothing"));
-        assert_eq!(repair_service("merchants"), None);
-        assert_eq!(repair_service("smith"), None);
+        assert_eq!(
+            RepairService::parse("weapons"),
+            Some(RepairService::Weapons)
+        );
+        assert_eq!(RepairService::parse("armor"), Some(RepairService::Armor));
+        assert_eq!(
+            RepairService::parse("clothing"),
+            Some(RepairService::Clothing)
+        );
+        assert_eq!(RepairService::parse("merchants"), None);
+        assert_eq!(RepairService::parse("smith"), None);
     }
 }
 
@@ -705,21 +711,24 @@ async fn submit_repair(
     session: Session,
     Form(form): Form<RepairItemForm>,
 ) -> Redirect {
-    if let Some(service) = repair_service(&shop) {
+    if let Some(service) = RepairService::parse(&shop) {
         if let Some((character, _)) = get_active_character(&state, session.character_id_u64()).await
         {
-            let _ = state
+            if let Err(error) = state
                 .db
                 .call(
                     "submit_item_for_repair",
                     &[
                         json!(character.id),
                         json!(id),
-                        json!(service),
+                        json!(service.as_str()),
                         json!(form.inventory_item_id),
                     ],
                 )
-                .await;
+                .await
+            {
+                tracing::warn!(%error, character_id = character.id, settlement_id = %id, shop = service.as_str(), "failed to submit item for repair");
+            }
         }
     }
     Redirect::to(&format!("/settlements/{id}/{shop}"))
@@ -730,16 +739,19 @@ async fn submit_all_repairs(
     Path((id, shop)): Path<(String, String)>,
     session: Session,
 ) -> Redirect {
-    if let Some(service) = repair_service(&shop) {
+    if let Some(service) = RepairService::parse(&shop) {
         if let Some((character, _)) = get_active_character(&state, session.character_id_u64()).await
         {
-            let _ = state
+            if let Err(error) = state
                 .db
                 .call(
                     "submit_all_repairable_items",
-                    &[json!(character.id), json!(id), json!(service)],
+                    &[json!(character.id), json!(id), json!(service.as_str())],
                 )
-                .await;
+                .await
+            {
+                tracing::warn!(%error, character_id = character.id, settlement_id = %id, shop = service.as_str(), "failed to submit repairable items");
+            }
         }
     }
     Redirect::to(&format!("/settlements/{id}/{shop}"))
@@ -750,16 +762,19 @@ async fn retrieve_repair(
     Path((id, shop, order_id)): Path<(String, String, u64)>,
     session: Session,
 ) -> Redirect {
-    if repair_service(&shop).is_some()
+    if RepairService::parse(&shop).is_some()
         && let Some((character, _)) = get_active_character(&state, session.character_id_u64()).await
     {
-        let _ = state
+        if let Err(error) = state
             .db
             .call(
                 "retrieve_repaired_item",
                 &[json!(character.id), json!(order_id)],
             )
-            .await;
+            .await
+        {
+            tracing::warn!(%error, character_id = character.id, settlement_id = %id, order_id, "failed to retrieve repaired item");
+        }
     }
     Redirect::to(&format!("/settlements/{id}/{shop}"))
 }
@@ -776,22 +791,25 @@ async fn retrieve_repairs(
     session: Session,
     Form(form): Form<RetrieveRepairsForm>,
 ) -> Redirect {
-    if let Some(service) = repair_service(&shop)
+    if let Some(service) = RepairService::parse(&shop)
         && let Some((character, _)) = get_active_character(&state, session.character_id_u64()).await
     {
-        let _ = state
+        if let Err(error) = state
             .db
             .call(
                 "retrieve_repaired_items",
                 &[
                     json!(character.id),
                     json!(id),
-                    json!(service),
+                    json!(service.as_str()),
                     json!(form.item_id),
                     json!(form.limit),
                 ],
             )
-            .await;
+            .await
+        {
+            tracing::warn!(%error, character_id = character.id, settlement_id = %id, shop = service.as_str(), "failed to retrieve repaired items");
+        }
     }
     Redirect::to(&format!("/settlements/{id}/{shop}"))
 }

--- a/crates/strategic-web/src/spacetimedb/client.rs
+++ b/crates/strategic-web/src/spacetimedb/client.rs
@@ -226,18 +226,17 @@ pub struct SpacetimeClient {
 
 impl SpacetimeClient {
     /// Create a new SpacetimeDB client
-    pub fn new(base_url: impl Into<String>, database: impl Into<String>) -> Self {
-        Self {
+    pub fn new(base_url: impl Into<String>, database: impl Into<String>) -> Result<Self> {
+        Ok(Self {
             http: Client::builder()
                 .timeout(Duration::from_secs(10))
                 .connect_timeout(Duration::from_secs(3))
-                .build()
-                .expect("failed to build SpacetimeDB HTTP client"),
+                .build()?,
             base_url: base_url.into(),
             database: database.into(),
             token: None,
             metrics: Arc::new(QueryMetrics::default()),
-        }
+        })
     }
 
     /// Set the auth token
@@ -391,8 +390,8 @@ mod tests {
     }
 
     #[test]
-    fn query_metrics_are_resettable_and_clone_safe() {
-        let client = SpacetimeClient::new("http://localhost:3000", "test");
+    fn query_metrics_are_monotonic_and_clone_safe() {
+        let client = SpacetimeClient::new("http://localhost:3000", "test").unwrap();
         client.metrics.requests.store(3, Ordering::Relaxed);
         client.metrics.elapsed_micros.store(125, Ordering::Relaxed);
         assert_eq!(

--- a/crates/strategic-web/src/spacetimedb/mod.rs
+++ b/crates/strategic-web/src/spacetimedb/mod.rs
@@ -10,12 +10,31 @@ pub(crate) fn sql_string_literal(value: &str) -> String {
     format!("'{}'", value.replace('\'', "''"))
 }
 
+/// SpacetimeDB's raw HTTP reducer API represents algebraic `Option<T>` values
+/// as sum variants rather than Serde's scalar-or-null representation.
+pub(crate) fn sats_option<T: serde::Serialize>(value: Option<T>) -> serde_json::Value {
+    match value {
+        Some(value) => serde_json::json!({ "some": value }),
+        None => serde_json::json!({ "none": [] }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::sql_string_literal;
+    use super::{sats_option, sql_string_literal};
 
     #[test]
     fn sql_string_literals_escape_quotes() {
         assert_eq!(sql_string_literal("St. John's"), "'St. John''s'");
+    }
+
+    #[test]
+    fn reducer_options_use_spacetimedb_sum_encoding() {
+        assert_eq!(
+            sats_option(Some("digest")),
+            serde_json::json!({ "some": "digest" })
+        );
+        assert_eq!(sats_option(Some(73_u64)), serde_json::json!({ "some": 73 }));
+        assert_eq!(sats_option::<u64>(None), serde_json::json!({ "none": [] }));
     }
 }

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -443,7 +443,13 @@ fn normalize_religious_status(value: Value) -> Value {
         return Value::Object(status);
     }
 
-    let (variant, payload) = status.into_iter().next().expect("checked one variant");
+    let Some((variant, payload)) = status
+        .iter()
+        .next()
+        .map(|(variant, payload)| (variant.clone(), payload.clone()))
+    else {
+        return Value::Object(status);
+    };
     let payload = match variant.as_str() {
         "Established" => wrap_single_field(payload, "religion"),
         "LocallyDetermined" => wrap_single_field(payload, "church"),
@@ -464,10 +470,13 @@ fn normalize_western_arrangement(value: Value) -> Value {
         return Value::Object(arrangement);
     }
 
-    let (variant, payload) = arrangement
-        .into_iter()
+    let Some((variant, payload)) = arrangement
+        .iter()
         .next()
-        .expect("checked one arrangement variant");
+        .map(|(variant, payload)| (variant.clone(), payload.clone()))
+    else {
+        return Value::Object(arrangement);
+    };
     arrangement = [(variant, wrap_single_field(payload, "church"))]
         .into_iter()
         .collect();


### PR DESCRIPTION
## What changed

- make SpacetimeDB HTTP client construction fallible instead of panicking
- centralize raw SpacetimeDB `Option<T>` sum encoding
- reuse the shared typed `RepairService` contract in strategic-web
- fail closed when required surgery data cannot be loaded instead of treating transport failures as empty medical state
- log repair reducer failures rather than silently discarding them
- remove avoidable `expect` calls from foraging and religious-status normalization
- correct the query-metrics test name to match its monotonic behavior

## Why

A strategic-layer quality audit found several small but consequential safety issues: backend failures could be presented as empty authoritative state, transport initialization could panic, reducer failures were ignored, and protocol/domain parsing was duplicated with strings. These changes make those paths explicit and typed without changing the database schema or strategic/tactical persistence boundary.

## Impact

Strategic medical and repair flows now surface backend problems through logs or an unavailable-state response instead of silently presenting incomplete data. Startup propagates HTTP client construction failures through the existing `anyhow::Result` boundary. Reducer wire encoding and repair-service names now have single shared implementations.

## Validation

- `cargo check -p strategic-web --tests`
- `cargo fmt --all -- --check`
- `python scripts/update_project_map.py --check`
- `git diff --check`

Full test execution was attempted but blocked by unrelated authored-content validation failures in the shared worktree (missing armor/clothing placement/protection mappings and an unsupported organization activity reward). Those content files are not part of this PR.
