### PR TITLE
Simplify medication administration UI

### DIFF
--- a/crates/adventuresim-core/src/physiology.rs
+++ b/crates/adventuresim-core/src/physiology.rs
@@ -394,6 +394,17 @@ pub fn intervention_profile(id: &str, version: u16) -> Option<&'static Intervent
         .find(|profile| profile.preparation_id == id && profile.version == version)
 }
 
+/// Resolve the latest authored profile for a concrete preparation.
+///
+/// Trusted callers use this when starting a new course. Durable
+/// administrations continue to pin their exact version for replay.
+pub fn current_intervention_profile(id: &str) -> Option<&'static InterventionProfile> {
+    INTERVENTION_PROFILES
+        .iter()
+        .filter(|profile| profile.preparation_id == id)
+        .max_by_key(|profile| profile.version)
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Administration {
     pub id: u64,

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -11194,6 +11194,16 @@ pub fn transfer_party_item(
         return Ok(());
     }
 
+    if item_is_medication(ctx, &source_item.item_id) {
+        if quantity != 1 || source_item.quantity != 1 {
+            return Err("Medication must be transferred as an individual course".into());
+        }
+        let mut transferred = source_item;
+        transferred.character_id = to_character_id;
+        ctx.db.inventory_item().id().update(transferred);
+        return Ok(());
+    }
+
     let durable = item_is_durable(ctx, &source_item.item_id);
     if durable {
         if quantity != 1 || source_item.quantity != 1 {
@@ -11350,6 +11360,14 @@ fn item_is_durable(ctx: &ReducerContext, item_id: &str) -> bool {
         .is_some_and(|definition| definition.repairable)
 }
 
+fn item_is_medication(ctx: &ReducerContext, item_id: &str) -> bool {
+    ctx.db
+        .item()
+        .id()
+        .find(item_id.to_owned())
+        .is_some_and(|definition| definition.kind == crate::ItemKind::Medication)
+}
+
 #[cfg(test)]
 mod durable_custody_tests {
     #[test]
@@ -11398,6 +11416,57 @@ mod durable_custody_tests {
     }
 }
 
+#[cfg(test)]
+mod medication_custody_tests {
+    #[test]
+    fn medication_stays_in_quantity_one_rows_across_custody_paths() {
+        let source = include_str!("strategic.rs");
+        let direct_transfer = source
+            .split("pub fn transfer_party_item")
+            .nth(1)
+            .unwrap()
+            .split("fn objective_item_value")
+            .next()
+            .unwrap();
+        assert!(direct_transfer.contains("item_is_medication"));
+        assert!(direct_transfer.contains("source_item.quantity != 1"));
+        assert!(direct_transfer.contains("transferred.character_id = to_character_id"));
+
+        let party_add = source
+            .rsplit("fn add_to_party_inventory_checked")
+            .next()
+            .unwrap()
+            .split("fn credit_party_stake")
+            .next()
+            .unwrap();
+        assert!(party_add.contains("kind == Some(crate::ItemKind::Medication)"));
+        assert!(party_add.contains("for _ in 0..quantity"));
+        assert!(party_add.contains("quantity: 1"));
+
+        let withdrawal = source
+            .rsplit("pub fn withdraw_party_inventory_item")
+            .next()
+            .unwrap()
+            .split("pub fn liquidate_party_inventory")
+            .next()
+            .unwrap();
+        assert!(withdrawal.contains("item_is_medication"));
+        assert!(withdrawal.contains("Medication must be withdrawn as an individual course"));
+        assert!(withdrawal.contains("crate::add_inventory_item"));
+
+        let deposit = source
+            .rsplit("pub fn deposit_party_inventory_item")
+            .next()
+            .unwrap()
+            .split("pub(crate) fn consume_personal_gold")
+            .next()
+            .unwrap();
+        assert!(deposit.contains("item_is_medication"));
+        assert!(deposit.contains("Medication must be deposited as an individual course"));
+        assert!(deposit.contains("add_to_party_inventory"));
+    }
+}
+
 pub(crate) fn add_to_party_inventory(
     ctx: &ReducerContext,
     party_id: &str,
@@ -11424,6 +11493,17 @@ fn add_to_party_inventory_checked(
         .map(|row| row.kind);
     let food_definition = crate::item::inventory_food_definition(kind, item_id)?;
     let measured = crate::inventory_amount::is_measured_item(ctx, item_id);
+    if kind == Some(crate::ItemKind::Medication) {
+        for _ in 0..quantity {
+            ctx.db.party_inventory_item().insert(PartyInventoryItem {
+                id: 0,
+                party_id: party_id.into(),
+                item_id: item_id.into(),
+                quantity: 1,
+            });
+        }
+        return Ok(());
+    }
     if measured {
         let minute = ctx
             .db
@@ -12257,6 +12337,10 @@ pub fn deposit_party_inventory_item(
     {
         return Err("Unequip an item before depositing it".into());
     }
+    let medication = item_is_medication(ctx, &inventory.item_id);
+    if medication && (quantity != 1 || inventory.quantity != 1) {
+        return Err("Medication must be deposited as an individual course".into());
+    }
     let value = personal_inventory_value(ctx, &inventory, quantity)?;
     let durable = item_is_durable(ctx, &inventory.item_id);
     if durable && (quantity != 1 || inventory.quantity != 1) {
@@ -12514,6 +12598,10 @@ pub fn withdraw_party_inventory_item(
         ctx.db.party_stake().id().update(stake.clone());
     }
     let durable = item_is_durable(ctx, &inventory.item_id);
+    let medication = item_is_medication(ctx, &inventory.item_id);
+    if medication && (quantity != 1 || inventory.quantity != 1) {
+        return Err("Medication must be withdrawn as an individual course".into());
+    }
     if durable && (quantity != 1 || inventory.quantity != 1) {
         return Err("Equipment instances must be withdrawn individually".into());
     }

--- a/crates/strategic-web/src/medical.rs
+++ b/crates/strategic-web/src/medical.rs
@@ -60,6 +60,8 @@ pub struct ChartGapPresentation {
 pub struct AdministrationPresentation {
     pub id: u64,
     pub preparation_id: String,
+    pub display_name: String,
+    pub profile_version: u16,
     pub route: String,
     pub amount_milliunits: u32,
     pub region: Option<String>,
@@ -70,6 +72,7 @@ pub struct AdministrationPresentation {
 pub fn sanitize(
     rows: &[BackendPhysiologyChart],
     administrations: &[BackendPhysiologyAdministration],
+    current_minute: u64,
 ) -> MedicalPresentation {
     let mut readings = rows
         .iter()
@@ -145,6 +148,18 @@ pub fn sanitize(
         .map(|row| AdministrationPresentation {
             id: row.id,
             preparation_id: row.preparation_id.clone(),
+            display_name: adventuresim_core::item_catalog::definition(&row.preparation_id)
+                .map_or_else(
+                    || {
+                        let mut readable = row.preparation_id.replace('_', " ");
+                        if let Some(first) = readable.get_mut(0..1) {
+                            first.make_ascii_uppercase();
+                        }
+                        readable
+                    },
+                    |definition| definition.display_name.clone(),
+                ),
+            profile_version: row.profile_version,
             route: row.route.clone(),
             amount_milliunits: row.amount_milliunits,
             region: row.region.clone(),
@@ -154,7 +169,20 @@ pub fn sanitize(
         .collect::<Vec<_>>();
     let active_administrations = administrations
         .iter()
-        .filter(|row| row.stopped_at.is_none())
+        .filter(|row| {
+            row.stopped_at.is_none()
+                && adventuresim_core::physiology::intervention_profile(
+                    &row.preparation_id,
+                    row.profile_version,
+                )
+                .is_some_and(|profile| {
+                    current_minute >= row.administered_at
+                        && current_minute
+                            < row
+                                .administered_at
+                                .saturating_add(profile.duration_minutes)
+                })
+        })
         .cloned()
         .collect();
     MedicalPresentation {
@@ -296,7 +324,7 @@ mod tests {
                 gap_to: Some(200),
             },
         ];
-        let presentation = sanitize(&rows, &[]);
+        let presentation = sanitize(&rows, &[], 200);
         assert_eq!(presentation.readings.len(), 1);
         assert_eq!(presentation.gaps.len(), 1);
         let regions = presentation.regional_humours.expect("regional readings");
@@ -317,7 +345,7 @@ mod tests {
     }
 
     #[test]
-    fn administration_history_retains_timeline_boundaries_and_active_subset() {
+    fn administration_history_retains_boundaries_and_excludes_stopped_or_expired_courses() {
         let administrations = vec![
             BackendPhysiologyAdministration {
                 id: 1,
@@ -333,7 +361,7 @@ mod tests {
             BackendPhysiologyAdministration {
                 id: 2,
                 patient_id: 2,
-                preparation_id: "active_course".into(),
+                preparation_id: "oral_rehydration_draught".into(),
                 profile_version: 1,
                 route: "oral".into(),
                 amount_milliunits: 1_000,
@@ -341,16 +369,35 @@ mod tests {
                 administered_at: 300,
                 stopped_at: None,
             },
+            BackendPhysiologyAdministration {
+                id: 3,
+                patient_id: 2,
+                preparation_id: "cooling_willow_draught".into(),
+                profile_version: 1,
+                route: "oral".into(),
+                amount_milliunits: 1_000,
+                region: None,
+                administered_at: 100,
+                stopped_at: None,
+            },
         ];
-        let presentation = sanitize(&[], &administrations);
-        assert_eq!(presentation.administrations.len(), 2);
+        let presentation = sanitize(&[], &administrations, 500);
+        assert_eq!(presentation.administrations.len(), 3);
         assert_eq!(presentation.administrations[0].administered_at, 100);
         assert_eq!(presentation.administrations[0].stopped_at, Some(200));
         assert_eq!(presentation.active_administrations.len(), 1);
         assert_eq!(
             presentation.active_administrations[0].preparation_id,
-            "active_course"
+            "oral_rehydration_draught"
         );
+        assert_eq!(
+            presentation.active_administrations[0].display_name,
+            "Oral rehydration draught"
+        );
+
+        let expired = sanitize(&[], &administrations, 1_000);
+        assert!(expired.active_administrations.is_empty());
+        assert_eq!(expired.administrations.len(), 3);
     }
 
     #[test]

--- a/crates/strategic-web/src/medical.rs
+++ b/crates/strategic-web/src/medical.rs
@@ -178,9 +178,7 @@ pub fn sanitize(
                 .is_some_and(|profile| {
                     current_minute >= row.administered_at
                         && current_minute
-                            < row
-                                .administered_at
-                                .saturating_add(profile.duration_minutes)
+                            < row.administered_at.saturating_add(profile.duration_minutes)
                 })
         })
         .cloned()

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -256,10 +256,6 @@ pub fn routes() -> Router<AppState> {
             post(cook_food),
         )
         .route(
-            "/locations/{kind}/{id}/party/{character_id}/physiology/administer",
-            post(administer_preparation),
-        )
-        .route(
             "/locations/{kind}/{id}/party/{character_id}/physiology/{administration_id}/stop",
             post(stop_preparation),
         )
@@ -3624,11 +3620,47 @@ async fn set_equipment(
         return (StatusCode::NOT_FOUND, "Item definition is missing").into_response();
     };
     if definition.kind == crate::spacetimedb::ItemKind::Medication {
-        return (
-            StatusCode::BAD_REQUEST,
-            "Preparations are administered through the Physiology interface.",
-        )
-            .into_response();
+        if !form.equipped {
+            return (
+                StatusCode::BAD_REQUEST,
+                "A preparation cannot be unchecked after it has been administered.",
+            )
+                .into_response();
+        }
+        let Some(profile) =
+            adventuresim_core::physiology::current_intervention_profile(&inventory.item_id)
+        else {
+            return (
+                StatusCode::BAD_REQUEST,
+                "This medication has no current preparation profile.",
+            )
+                .into_response();
+        };
+        if let Err(error) = state
+            .db
+            .call(
+                "administer_preparation",
+                &[
+                    json!(character_id),
+                    json!(character_id),
+                    json!(form.inventory_item_id),
+                    json!(profile.version),
+                    json!(format!("{:?}", profile.route).to_ascii_lowercase()),
+                    json!(1_000u32),
+                    json!(Option::<String>::None),
+                ],
+            )
+            .await
+        {
+            tracing::warn!(
+                %error,
+                character_id,
+                inventory_item_id = form.inventory_item_id,
+                "preparation administration rejected"
+            );
+            return (StatusCode::BAD_REQUEST, error.to_string()).into_response();
+        }
+        return (StatusCode::NO_CONTENT, "").into_response();
     }
     let destination = if form.equipped {
         definition.slot
@@ -3993,7 +4025,10 @@ pub(crate) async fn medical_presentation(
     } else {
         Vec::new()
     };
-    crate::medical::sanitize(&rows, &administrations)
+    let current_minute = query_single::<CharacterTime>(state, "character_time", target_id)
+        .await
+        .map_or(0, |time| time.minutes);
+    crate::medical::sanitize(&rows, &administrations, current_minute)
 }
 
 fn administration_history_visible(
@@ -4014,45 +4049,6 @@ mod physiology_privacy_tests {
         assert!(administration_history_visible(7, 8, true));
         assert!(!administration_history_visible(7, 8, false));
     }
-}
-
-#[derive(Deserialize)]
-struct AdministrationForm {
-    inventory_item_id: u64,
-    route: String,
-    amount_milliunits: u32,
-    region: Option<String>,
-}
-
-async fn administer_preparation(
-    State(state): State<AppState>,
-    Path((kind, id, patient_id)): Path<(String, String, u64)>,
-    Query(building): Query<BuildingQuery>,
-    session: Session,
-    Form(form): Form<AdministrationForm>,
-) -> Redirect {
-    let Some(actor_id) = session.character_id_u64() else {
-        return Redirect::to("/characters");
-    };
-    if let Err(error) = state
-        .db
-        .call(
-            "administer_preparation",
-            &[
-                json!(actor_id),
-                json!(patient_id),
-                json!(form.inventory_item_id),
-                json!(1u16),
-                json!(form.route),
-                json!(form.amount_milliunits),
-                json!(form.region.filter(|value| !value.is_empty())),
-            ],
-        )
-        .await
-    {
-        tracing::warn!(%error, actor_id, patient_id, "preparation administration rejected");
-    }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}/party/{patient_id}")))
 }
 
 async fn stop_preparation(

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -4063,7 +4063,10 @@ pub(crate) async fn medical_presentation(
     {
         Ok(Some(time)) => time.minutes,
         Ok(None) => {
-            tracing::error!(target_id, "patient time missing; medical presentation unavailable");
+            tracing::error!(
+                target_id,
+                "patient time missing; medical presentation unavailable"
+            );
             return crate::medical::MedicalPresentation {
                 unavailable: true,
                 ..Default::default()

--- a/crates/strategic-web/src/routes/settlements.rs
+++ b/crates/strategic-web/src/routes/settlements.rs
@@ -3573,6 +3573,53 @@ struct EquipmentForm {
     equipped: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct StandardMedicationAdministration {
+    actor_id: u64,
+    patient_id: u64,
+    inventory_item_id: u64,
+    profile_version: u16,
+    route: String,
+    amount_milliunits: u32,
+    region: Option<String>,
+}
+
+impl StandardMedicationAdministration {
+    fn reducer_args(&self) -> [serde_json::Value; 7] {
+        [
+            json!(self.actor_id),
+            json!(self.patient_id),
+            json!(self.inventory_item_id),
+            json!(self.profile_version),
+            json!(&self.route),
+            json!(self.amount_milliunits),
+            json!(&self.region),
+        ]
+    }
+}
+
+fn standard_medication_administration(
+    session_character_id: u64,
+    inventory_item_id: u64,
+    preparation_id: &str,
+    checked: bool,
+) -> Result<StandardMedicationAdministration, &'static str> {
+    if !checked {
+        return Err("A preparation cannot be unchecked after it has been administered.");
+    }
+    let profile = adventuresim_core::physiology::current_intervention_profile(preparation_id)
+        .ok_or("This medication has no current preparation profile.")?;
+    Ok(StandardMedicationAdministration {
+        actor_id: session_character_id,
+        patient_id: session_character_id,
+        inventory_item_id,
+        profile_version: profile.version,
+        route: format!("{:?}", profile.route).to_ascii_lowercase(),
+        amount_milliunits: 1_000,
+        region: None,
+    })
+}
+
 async fn set_equipment(
     State(state): State<AppState>,
     session: Session,
@@ -3620,36 +3667,18 @@ async fn set_equipment(
         return (StatusCode::NOT_FOUND, "Item definition is missing").into_response();
     };
     if definition.kind == crate::spacetimedb::ItemKind::Medication {
-        if !form.equipped {
-            return (
-                StatusCode::BAD_REQUEST,
-                "A preparation cannot be unchecked after it has been administered.",
-            )
-                .into_response();
-        }
-        let Some(profile) =
-            adventuresim_core::physiology::current_intervention_profile(&inventory.item_id)
-        else {
-            return (
-                StatusCode::BAD_REQUEST,
-                "This medication has no current preparation profile.",
-            )
-                .into_response();
+        let administration = match standard_medication_administration(
+            character_id,
+            form.inventory_item_id,
+            &inventory.item_id,
+            form.equipped,
+        ) {
+            Ok(administration) => administration,
+            Err(error) => return (StatusCode::BAD_REQUEST, error).into_response(),
         };
         if let Err(error) = state
             .db
-            .call(
-                "administer_preparation",
-                &[
-                    json!(character_id),
-                    json!(character_id),
-                    json!(form.inventory_item_id),
-                    json!(profile.version),
-                    json!(format!("{:?}", profile.route).to_ascii_lowercase()),
-                    json!(1_000u32),
-                    json!(Option::<String>::None),
-                ],
-            )
+            .call("administer_preparation", &administration.reducer_args())
             .await
         {
             tracing::warn!(
@@ -4025,9 +4054,29 @@ pub(crate) async fn medical_presentation(
     } else {
         Vec::new()
     };
-    let current_minute = query_single::<CharacterTime>(state, "character_time", target_id)
+    let current_minute = match state
+        .db
+        .query_one::<CharacterTime>(&format!(
+            "SELECT * FROM character_time WHERE character_id = {target_id}"
+        ))
         .await
-        .map_or(0, |time| time.minutes);
+    {
+        Ok(Some(time)) => time.minutes,
+        Ok(None) => {
+            tracing::error!(target_id, "patient time missing; medical presentation unavailable");
+            return crate::medical::MedicalPresentation {
+                unavailable: true,
+                ..Default::default()
+            };
+        }
+        Err(error) => {
+            tracing::error!(%error, target_id, "patient time query failed; medical presentation unavailable");
+            return crate::medical::MedicalPresentation {
+                unavailable: true,
+                ..Default::default()
+            };
+        }
+    };
     crate::medical::sanitize(&rows, &administrations, current_minute)
 }
 
@@ -4041,13 +4090,51 @@ fn administration_history_visible(
 
 #[cfg(test)]
 mod physiology_privacy_tests {
-    use super::administration_history_visible;
+    use super::{administration_history_visible, standard_medication_administration};
+    use serde_json::json;
 
     #[test]
     fn administration_history_requires_self_or_an_authorized_observation() {
         assert!(administration_history_visible(7, 7, false));
         assert!(administration_history_visible(7, 8, true));
         assert!(!administration_history_visible(7, 8, false));
+    }
+
+    #[test]
+    fn standard_medication_mapping_is_self_only_versioned_and_parameter_free() {
+        let action =
+            standard_medication_administration(7, 42, "oral_rehydration_draught", true).unwrap();
+        assert_eq!(action.actor_id, 7);
+        assert_eq!(action.patient_id, 7);
+        assert_eq!(action.inventory_item_id, 42);
+        assert_eq!(action.profile_version, 1);
+        assert_eq!(action.route, "oral");
+        assert_eq!(action.amount_milliunits, 1_000);
+        assert_eq!(action.region, None);
+        assert_eq!(
+            action.reducer_args(),
+            [
+                json!(7),
+                json!(7),
+                json!(42),
+                json!(1),
+                json!("oral"),
+                json!(1_000),
+                json!(null),
+            ]
+        );
+    }
+
+    #[test]
+    fn standard_medication_mapping_rejects_uncheck_and_unknown_profile() {
+        assert_eq!(
+            standard_medication_administration(7, 42, "oral_rehydration_draught", false),
+            Err("A preparation cannot be unchecked after it has been administered.")
+        );
+        assert_eq!(
+            standard_medication_administration(7, 42, "unknown_medication", true),
+            Err("This medication has no current preparation profile.")
+        );
     }
 }
 

--- a/crates/strategic-web/src/templates/settlement/character_details.rs
+++ b/crates/strategic-web/src/templates/settlement/character_details.rs
@@ -282,8 +282,6 @@ pub fn party_personal_page(
         (physiology_controls(
             medical,
             &format!("{location_path}/party/{}", active_character.id),
-            inventory,
-            item_definitions,
         ))
         @if let Some(demand) = religious_demand {
             (religious_demand_rail(demand, &location_path, active_character.id))

--- a/crates/strategic-web/src/templates/settlement/character_health.rs
+++ b/crates/strategic-web/src/templates/settlement/character_health.rs
@@ -7,8 +7,8 @@ use super::{
 };
 use crate::medical::{ChartGapPresentation, ChartReadingPresentation, MedicalPresentation};
 use crate::spacetimedb::{
-    Character, CharacterAttributes, CharacterLimbs, CharacterStrategicCondition, InventoryItem,
-    ItemDefinition, LimbInjury, LimbRegion, ProjectileKind, RetainedProjectile,
+    Character, CharacterAttributes, CharacterLimbs, CharacterStrategicCondition, LimbInjury,
+    LimbRegion, ProjectileKind, RetainedProjectile,
 };
 use crate::templates::{
     decorative_game_icon, game_icon, item_display_name, sidebar_section, stat_icon_path,
@@ -1129,71 +1129,19 @@ pub(super) fn physiology_dialog(
 pub(super) fn physiology_controls(
     medical: &MedicalPresentation,
     action_base: &str,
-    inventory: &[InventoryItem],
-    definitions: &[ItemDefinition],
 ) -> Markup {
-    let preparations = inventory
-        .iter()
-        .filter_map(|inventory| {
-            let definition = definitions
-                .iter()
-                .find(|item| item.id == inventory.item_id)?;
-            let profile =
-                adventuresim_core::physiology::intervention_profile(&inventory.item_id, 1)?;
-            (definition.kind == crate::spacetimedb::ItemKind::Medication)
-                .then_some((inventory, definition, profile))
-        })
-        .collect::<Vec<_>>();
     html! {
-        (sidebar_section("Administer preparation", html! {
-            p class="small-copy" {
-                "Choose a prepared item, route, amount, and optional region. "
-                "This interface makes no diagnosis or recommendation."
-            }
-            @if preparations.is_empty() {
-                p class="text-muted small-copy" { "No prepared interventions in personal inventory." }
-            } @else {
-                @for (inventory, definition, profile) in preparations {
-                    form method="post" action=(format!("{action_base}/physiology/administer")) {
-                        input type="hidden" name="inventory_item_id" value=(inventory.id);
-                        input type="hidden" name="route"
-                            value=(format!("{:?}", profile.route).to_ascii_lowercase());
-                        label {
-                            (item_display_name(&definition.id))
-                            " amount"
-                            input type="number" name="amount_milliunits"
-                                min="1" max="8000" value="1000" required;
-                        }
-                        label {
-                            "Region"
-                            select name="region" {
-                                option value="" { "Whole body" }
-                                @for region in adventuresim_core::physiology::BodyRegion::ALL {
-                                    option value=(region.as_str()) {
-                                        (region.as_str().replace('_', " "))
-                                    }
-                                }
-                            }
-                        }
-                        button type="submit" class="btn btn-small" {
-                            "Administer by "
-                            (format!("{:?}", profile.route).to_ascii_lowercase())
-                        }
-                    }
-                }
-            }
+        @if !medical.active_administrations.is_empty() {
+        (sidebar_section("Current medication", html! {
             @for administration in &medical.active_administrations {
                 form method="post"
                     action=(format!("{action_base}/physiology/{}/stop", administration.id)) {
-                    span {
-                        (&administration.preparation_id)
-                        " — " (&administration.route)
-                        ", " (administration.amount_milliunits) " milliunits"
-                    }
+                    span { (&administration.display_name) }
                     button type="submit" class="btn btn-small" { "Stop" }
                 }
             }
         }))
+        }
     }
 }
 
@@ -1821,6 +1769,49 @@ mod tests {
     }
 
     #[test]
+    fn physiology_controls_show_only_compact_current_medication() {
+        let empty = physiology_controls(
+            &crate::medical::MedicalPresentation::default(),
+            "/locations/settlement/test/party/1",
+        )
+        .into_string();
+        assert!(empty.is_empty());
+        for removed in [
+            "Administer preparation",
+            "No prepared interventions",
+            "amount_milliunits",
+            "name=\"route\"",
+            "name=\"region\"",
+        ] {
+            assert!(!empty.contains(removed));
+        }
+
+        let presentation = crate::medical::MedicalPresentation {
+            active_administrations: vec![crate::medical::AdministrationPresentation {
+                id: 12,
+                preparation_id: "oral_rehydration_draught".into(),
+                display_name: "Oral rehydration draught".into(),
+                profile_version: 1,
+                route: "oral".into(),
+                amount_milliunits: 1_000,
+                region: None,
+                administered_at: 100,
+                stopped_at: None,
+            }],
+            ..Default::default()
+        };
+        let current =
+            physiology_controls(&presentation, "/locations/settlement/test/party/1").into_string();
+        assert!(current.contains("Current medication"));
+        assert!(current.contains("Oral rehydration draught"));
+        assert!(current.contains(">Stop</button>"));
+        assert!(!current.contains("oral_rehydration_draught"));
+        assert!(!current.contains("milliunits"));
+        assert!(!current.contains("name=\"route\""));
+        assert!(!current.contains("name=\"region\""));
+    }
+
+    #[test]
     fn physician_notebook_uses_visual_readings_with_accessible_values() {
         let presentation = crate::medical::MedicalPresentation {
             readings: vec![
@@ -1860,6 +1851,8 @@ mod tests {
             administrations: vec![crate::medical::AdministrationPresentation {
                 id: 1,
                 preparation_id: "oral_rehydration".into(),
+                display_name: "Oral rehydration draught".into(),
+                profile_version: 1,
                 route: "oral".into(),
                 amount_milliunits: 1_000,
                 region: None,

--- a/crates/strategic-web/src/templates/settlement/character_health.rs
+++ b/crates/strategic-web/src/templates/settlement/character_health.rs
@@ -1126,10 +1126,7 @@ pub(super) fn physiology_dialog(
     }
 }
 
-pub(super) fn physiology_controls(
-    medical: &MedicalPresentation,
-    action_base: &str,
-) -> Markup {
+pub(super) fn physiology_controls(medical: &MedicalPresentation, action_base: &str) -> Markup {
     html! {
         @if !medical.active_administrations.is_empty() {
         (sidebar_section("Current medication", html! {

--- a/crates/strategic-web/src/templates/settlement/trade.rs
+++ b/crates/strategic-web/src/templates/settlement/trade.rs
@@ -2200,9 +2200,7 @@ mod tests {
         let rendered = equipment_checkbox(&inventory, Some(&definition), false, true).into_string();
         assert!(!rendered.contains(" disabled"));
         assert!(rendered.contains("aria-label=\"Administer Oral rehydration draught\""));
-        assert!(rendered.contains(
-            "title=\"Administer one standard course of this preparation\""
-        ));
+        assert!(rendered.contains("title=\"Administer one standard course of this preparation\""));
         assert!(!rendered.contains("Equip Oral rehydration draught"));
     }
 
@@ -2220,14 +2218,16 @@ mod tests {
             kind: crate::spacetimedb::ItemKind::Medication,
             ..Default::default()
         };
-        let rendered = equipment_checkbox(&inventory, Some(&definition), false, false).into_string();
+        let rendered =
+            equipment_checkbox(&inventory, Some(&definition), false, false).into_string();
         assert!(rendered.contains(" disabled"));
-        assert!(rendered.contains(
-            "aria-label=\"Only Oral rehydration draught&#x27;s owner can administer it\""
-        ));
-        assert!(rendered.contains(
-            "title=\"Select this character to administer their preparation\""
-        ));
+        assert!(
+            rendered
+                .contains("aria-label=\"Only Oral rehydration draught's owner can administer it\"")
+        );
+        assert!(
+            rendered.contains("title=\"Select this character to administer their preparation\"")
+        );
         assert!(!rendered.contains("aria-label=\"Administer Oral rehydration draught\""));
     }
 

--- a/crates/strategic-web/src/templates/settlement/trade.rs
+++ b/crates/strategic-web/src/templates/settlement/trade.rs
@@ -217,7 +217,7 @@ pub fn party_inventory_page(
 ) -> Markup {
     let content = html! {
         aside class="left-sidebar" {
-            (party_trade_inventory_rail(selected, selected_inventory, items, food_lots, active_character.id, "right", selected_equip, active_targets, selected_encumbrance))
+            (party_trade_inventory_rail(selected, selected_inventory, items, food_lots, active_character.id, "right", selected_equip, active_targets, selected_encumbrance, false))
         }
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(selected.id), false))
@@ -231,7 +231,7 @@ pub fn party_inventory_page(
             }
         }
         aside class="right-sidebar" {
-            (party_trade_inventory_rail(active_character, active_inventory, items, food_lots, selected.id, "left", active_equip, selected_targets, active_encumbrance))
+            (party_trade_inventory_rail(active_character, active_inventory, items, food_lots, selected.id, "left", active_equip, selected_targets, active_encumbrance, true))
         }
     };
     location.render_layout("Party", content, Some(&active_character.name))
@@ -638,6 +638,7 @@ fn party_trade_inventory_rail(
     equip: Option<&CharacterEquip>,
     recipient_targets: &[InventoryQuantityTarget],
     encumbrance: EncumbranceSummary,
+    medication_is_self: bool,
 ) -> Markup {
     let title = format!("{}'s inventory", character.name);
     html! {
@@ -667,7 +668,7 @@ fn party_trade_inventory_rail(
                                         }
                                     }
                                     td class="inventory-count" { (item.qty) }
-                                    td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) }
+                                    td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped, medication_is_self)) }
                                     td class="inventory-weight" { (item_weight(definition)) }
                                     td class="inventory-gold" { (item_value(definition)) }
                                 }
@@ -721,7 +722,7 @@ fn discard_inventory_rail(
                                     }
                                 }
                                 td class="inventory-count" { (item.qty) }
-                                td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) }
+                                td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped, true)) }
                                 td class="inventory-weight" { (item_weight(definition)) }
                                 td class="inventory-gold" { (item_value(definition)) }
                             }
@@ -863,7 +864,7 @@ pub fn live_merchant_shop_page(
                         @let can_sell = !is_currency && !is_equipped;
                         td class="inventory-item-type" { (item_type_icon(&item.item_id)) }
                         td class="inventory-item-name" { (item_name_with_food_lot(&item.item_id, &food_display_name, definition, food_lot)) @if !matches!(shop, MerchantShop::Herbalist) && (can_sell || service_matches) { (merchant_sell_repair_controls(item.id, &item.item_id, sell_price, item.qty, target, can_sell, service_matches.then(|| repair_submit_control(settlement, service_id, item.id, condition, repair_skill)))) } }
-                        td class="inventory-count" { (quantity_target_control(item.qty, target, &item.item_id, false)) } td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped)) } td class="inventory-durability" { @if durable_item { (condition_bar(condition, service_matches.then_some(repair_skill))) } @else { "—" } } td class="inventory-weight" { (merchant_inventory_weight(definition, food_lot)) } td class="inventory-gold" { (sell_price) }
+                        td class="inventory-count" { (quantity_target_control(item.qty, target, &item.item_id, false)) } td class="inventory-equipped" { (equipment_checkbox(item, definition, is_equipped, true)) } td class="inventory-durability" { @if durable_item { (condition_bar(condition, service_matches.then_some(repair_skill))) } @else { "—" } } td class="inventory-weight" { (merchant_inventory_weight(definition, food_lot)) } td class="inventory-gold" { (sell_price) }
                     }}
                     @for target in personal_targets.iter().filter(|target| target.quantity > 0 && !inventory.iter().any(|item| item.item_id == target.item_id) && items.iter().find(|definition| definition.id == target.item_id).is_some_and(|definition| shop.shows_inventory(definition))) {
                         @let definition = items.iter().find(|definition| definition.id == target.item_id);
@@ -1023,7 +1024,7 @@ pub fn party_pool_page(
                                     }
                                 }
                                 td class="inventory-count" { (quantity_target_control(item.qty, target_quantity(personal_targets, &item.item_id), &item.item_id, false)) }
-                                td class="inventory-equipped" { (equipment_checkbox(item, definition, equipped)) }
+                                td class="inventory-equipped" { (equipment_checkbox(item, definition, equipped, true)) }
                                 td class="inventory-weight" { (item_weight(definition)) }
                                 td class="inventory-gold" { (item_value(definition)) }
                             }
@@ -1119,23 +1120,27 @@ fn equipment_checkbox(
     inventory: &InventoryItem,
     definition: Option<&crate::spacetimedb::ItemDefinition>,
     equipped: bool,
+    medication_is_self: bool,
 ) -> Markup {
-    let equippable = definition.is_some_and(|definition| {
-        definition.slot != ItemSlot::None
-            || definition.kind == crate::spacetimedb::ItemKind::Medication
-    });
     let medication = definition
         .is_some_and(|definition| definition.kind == crate::spacetimedb::ItemKind::Medication);
+    let equippable = definition.is_some_and(|definition| {
+        definition.slot != ItemSlot::None || (medication && medication_is_self)
+    });
     let item_name = item_display_name(&inventory.item_id);
-    let label = if medication {
+    let label = if medication && medication_is_self {
         format!("Administer {item_name}")
+    } else if medication {
+        format!("Only {item_name}'s owner can administer it")
     } else if equipped {
         format!("Unequip {item_name}")
     } else {
         format!("Equip {item_name}")
     };
-    let title = if medication {
+    let title = if medication && medication_is_self {
         "Administer one standard course of this preparation"
+    } else if medication {
+        "Select this character to administer their preparation"
     } else if equippable {
         "Equip or unequip this item"
     } else {
@@ -2170,11 +2175,11 @@ mod tests {
             handling_sensitivity: 0.0,
             ..Default::default()
         };
-        let enabled = equipment_checkbox(&inventory, Some(&definition), false).into_string();
+        let enabled = equipment_checkbox(&inventory, Some(&definition), false, true).into_string();
         assert!(enabled.contains("data-equipment-toggle"));
         assert!(!enabled.contains(" disabled"));
         definition.slot = ItemSlot::None;
-        let disabled = equipment_checkbox(&inventory, Some(&definition), false).into_string();
+        let disabled = equipment_checkbox(&inventory, Some(&definition), false, true).into_string();
         assert!(disabled.contains(" disabled"));
     }
 
@@ -2192,13 +2197,38 @@ mod tests {
             kind: crate::spacetimedb::ItemKind::Medication,
             ..Default::default()
         };
-        let rendered = equipment_checkbox(&inventory, Some(&definition), false).into_string();
+        let rendered = equipment_checkbox(&inventory, Some(&definition), false, true).into_string();
         assert!(!rendered.contains(" disabled"));
         assert!(rendered.contains("aria-label=\"Administer Oral rehydration draught\""));
         assert!(rendered.contains(
             "title=\"Administer one standard course of this preparation\""
         ));
         assert!(!rendered.contains("Equip Oral rehydration draught"));
+    }
+
+    #[test]
+    fn companion_medication_checkbox_is_disabled_with_honest_copy() {
+        let inventory = InventoryItem {
+            id: 7,
+            character_id: 10,
+            item_id: "oral_rehydration_draught".into(),
+            qty: 1,
+        };
+        let definition = crate::spacetimedb::ItemDefinition {
+            id: inventory.item_id.clone(),
+            slot: ItemSlot::None,
+            kind: crate::spacetimedb::ItemKind::Medication,
+            ..Default::default()
+        };
+        let rendered = equipment_checkbox(&inventory, Some(&definition), false, false).into_string();
+        assert!(rendered.contains(" disabled"));
+        assert!(rendered.contains(
+            "aria-label=\"Only Oral rehydration draught&#x27;s owner can administer it\""
+        ));
+        assert!(rendered.contains(
+            "title=\"Select this character to administer their preparation\""
+        ));
+        assert!(!rendered.contains("aria-label=\"Administer Oral rehydration draught\""));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/trade.rs
+++ b/crates/strategic-web/src/templates/settlement/trade.rs
@@ -1124,11 +1124,22 @@ fn equipment_checkbox(
         definition.slot != ItemSlot::None
             || definition.kind == crate::spacetimedb::ItemKind::Medication
     });
+    let medication = definition
+        .is_some_and(|definition| definition.kind == crate::spacetimedb::ItemKind::Medication);
     let item_name = item_display_name(&inventory.item_id);
-    let label = if equipped {
+    let label = if medication {
+        format!("Administer {item_name}")
+    } else if equipped {
         format!("Unequip {item_name}")
     } else {
         format!("Equip {item_name}")
+    };
+    let title = if medication {
+        "Administer one standard course of this preparation"
+    } else if equippable {
+        "Equip or unequip this item"
+    } else {
+        "This item cannot be equipped"
     };
     html! {
         input type="checkbox"
@@ -1138,7 +1149,7 @@ fn equipment_checkbox(
             data-inventory-item-id=(inventory.id)
             aria-describedby=(format!("equipment-status-{}", inventory.id))
             aria-label=(label)
-            title=(if equippable { "Equip or unequip this item" } else { "This item cannot be equipped" });
+            title=(title);
         span id=(format!("equipment-status-{}", inventory.id))
             class="equipment-toggle-status"
             data-equipment-status
@@ -2165,6 +2176,29 @@ mod tests {
         definition.slot = ItemSlot::None;
         let disabled = equipment_checkbox(&inventory, Some(&definition), false).into_string();
         assert!(disabled.contains(" disabled"));
+    }
+
+    #[test]
+    fn medication_checkbox_describes_administration_instead_of_equipping() {
+        let inventory = InventoryItem {
+            id: 7,
+            character_id: 9,
+            item_id: "oral_rehydration_draught".into(),
+            qty: 1,
+        };
+        let definition = crate::spacetimedb::ItemDefinition {
+            id: inventory.item_id.clone(),
+            slot: ItemSlot::None,
+            kind: crate::spacetimedb::ItemKind::Medication,
+            ..Default::default()
+        };
+        let rendered = equipment_checkbox(&inventory, Some(&definition), false).into_string();
+        assert!(!rendered.contains(" disabled"));
+        assert!(rendered.contains("aria-label=\"Administer Oral rehydration draught\""));
+        assert!(rendered.contains(
+            "title=\"Administer one standard course of this preparation\""
+        ));
+        assert!(!rendered.contains("Equip Oral rehydration draught"));
     }
 
     #[test]

--- a/crates/strategic-web/tests/equipment-toggle.test.cjs
+++ b/crates/strategic-web/tests/equipment-toggle.test.cjs
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const { exactEquipmentError } = require('../static/equipment-toggle.js');
 
@@ -22,4 +24,34 @@ test('equipment errors have an HTTP fallback when the reducer body is empty', as
     text: async () => '',
   };
   assert.equal(await exactEquipmentError(response), '503 Service Unavailable');
+});
+
+test('medication checkbox submits no browser-selected medical parameters', () => {
+  const client = fs.readFileSync(
+    path.join(__dirname, '..', 'static', 'equipment-toggle.js'),
+    'utf8',
+  );
+  assert.match(client, /inventory_item_id: checkbox\.dataset\.inventoryItemId/);
+  assert.match(client, /equipped: String\(checkbox\.checked\)/);
+  for (const parameter of ['patient_id', 'route', 'amount_milliunits', 'region']) {
+    assert.doesNotMatch(client, new RegExp(`${parameter}:`));
+  }
+});
+
+test('parameterized preparation form and browser route are absent', () => {
+  const health = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'templates', 'settlement', 'character_health.rs'),
+    'utf8',
+  );
+  const routes = fs.readFileSync(
+    path.join(__dirname, '..', 'src', 'routes', 'settlements.rs'),
+    'utf8',
+  );
+  assert.doesNotMatch(health, /Administer preparation|No prepared interventions/);
+  assert.doesNotMatch(health, /name="(?:route|amount_milliunits|region)"/);
+  assert.doesNotMatch(routes, /physiology\/administer/);
+  assert.match(routes, /json!\(1_000u32\)/);
+  assert.match(routes, /json!\(Option::<String>::None\)/);
+  assert.match(routes, /"equip_item"/);
+  assert.match(routes, /definition\.slot/);
 });

--- a/crates/strategic-web/tests/equipment-toggle.test.cjs
+++ b/crates/strategic-web/tests/equipment-toggle.test.cjs
@@ -47,11 +47,15 @@ test('parameterized preparation form and browser route are absent', () => {
     path.join(__dirname, '..', 'src', 'routes', 'settlements.rs'),
     'utf8',
   );
-  assert.doesNotMatch(health, /Administer preparation|No prepared interventions/);
-  assert.doesNotMatch(health, /name="(?:route|amount_milliunits|region)"/);
-  assert.doesNotMatch(routes, /physiology\/administer/);
-  assert.match(routes, /json!\(1_000u32\)/);
-  assert.match(routes, /json!\(Option::<String>::None\)/);
+  const healthProduction = health.split('#[cfg(test)]')[0];
+  const removedHeading = ['Administer', ' preparation'].join('');
+  const removedEmptyState = ['No prepared', ' interventions'].join('');
+  assert.equal(healthProduction.includes(removedHeading), false);
+  assert.equal(healthProduction.includes(removedEmptyState), false);
+  assert.doesNotMatch(healthProduction, /name="(?:route|amount_milliunits|region)"/);
+  const removedRoute = ['physiology', '/administer'].join('');
+  assert.equal(routes.includes(removedRoute), false);
+  assert.match(routes, /standard_medication_administration/);
   assert.match(routes, /"equip_item"/);
   assert.match(routes, /definition\.slot/);
 });

--- a/wiki/reference/equipment.md
+++ b/wiki/reference/equipment.md
@@ -100,6 +100,11 @@ Demo fixture exercises each color and repair ceiling.
 Equippable personal-inventory rows expose a checkbox backed by the item's catalog slot. Checking
 it equips that exact inventory instance, displacing any item already occupying the selected slot;
 unchecking it unequips the instance. Non-equipment rows keep a disabled checkbox.
+Medication reuses the same familiar checkbox gesture without occupying an
+equipment slot. Checking it administers and consumes the quantity-one
+preparation as a standard course; it cannot be unchecked after administration.
+The checkbox is labeled as administering the preparation rather than equipping
+it. Ordinary equipment behavior is unchanged.
 
 Smithing uses the shared trained-skill curve: 5,000 invested hours is rank 2.5. Database upgrades
 split any legacy durable stack into quantity-one instances while retaining the original row ID for

--- a/wiki/reference/equipment.md
+++ b/wiki/reference/equipment.md
@@ -104,7 +104,10 @@ Medication reuses the same familiar checkbox gesture without occupying an
 equipment slot. Checking it administers and consumes the quantity-one
 preparation as a standard course; it cannot be unchecked after administration.
 The checkbox is labeled as administering the preparation rather than equipping
-it. Ordinary equipment behavior is unchanged.
+it, and is disabled when inspecting a companion because administration through
+this gesture is self-only. Direct member transfers and party-pool
+deposits/withdrawals preserve every preparation as an individual quantity-one
+course. Ordinary equipment behavior is unchanged.
 
 Smithing uses the shared trained-skill curve: 5,000 invested hours is rank 2.5. Database upgrades
 split any legacy durable stack into quantity-one instances while retaining the original row ID for

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1338)
+## Files (1341)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.

--- a/wiki/reference/physiology.md
+++ b/wiki/reference/physiology.md
@@ -32,6 +32,13 @@ Interventions use generic, versioned profiles with meter deltas over time.
 Administration records the patient, concrete preparation and profile version,
 route, amount, optional body region, start and stop minutes, and private
 sensitivity/adverse variation. No effect lookup accepts a disease key.
+The personal inventory presents medication with the familiar checkbox gesture.
+Checking it administers and consumes that concrete quantity-one item as one
+standard 1,000-milliunit, whole-body course. The trusted server selects the
+current profile version and the preparation's intrinsic route; the browser does
+not choose medical parameters. The compact current-medication status retains a
+Stop action and disappears when a course is stopped or reaches its authored
+duration. Durable start and stop markers remain in the physician notebook.
 
 All authoritative personal-time paths evaluate disease and intervention effects
 together. The earliest integer-minute terminal crossing wins, with a stable

--- a/wiki/shared/stats.md
+++ b/wiki/shared/stats.md
@@ -302,10 +302,12 @@ them. Cuts and blunt trauma remain visible without Physiology; private meter
 causes are disclosed only through the deliberately many-to-one four-humour
 projection. The chart never names a disease or recommends a treatment.
 
-Characters may explicitly administer a preparation they possess, choosing its
-amount and optional canonical body region through the preparation's supported
-route, or stop an active administration. These actions operate on generic,
-versioned physiology profiles rather than disease-keyed cures.
+Characters administer a preparation they possess by checking its personal-
+inventory checkbox. The trusted server consumes that concrete item and starts
+one standard 1,000-milliunit whole-body course through the preparation's
+intrinsic route. A compact current-medication status allows an active course to
+be stopped and disappears after a stop or natural expiry. These actions operate
+on generic, versioned physiology profiles rather than disease-keyed cures.
 
 Physiology uses a bounded party-check equation. Individual checks are sorted strongest-first, the leader receives full weight, and successive contributors receive weights of `1/2`, `1/4`, `1/8`, and so on:
 

--- a/wiki/strategic/settlement.md
+++ b/wiki/strategic/settlement.md
@@ -181,9 +181,15 @@ and explicit gaps, but never diagnoses or recommends. The active character's
 Cooking skill icon continues to open cooking.
 
 Herbalists sell concrete prepared interventions into personal inventory.
-The patient or an authorized, co-located party member may administer one with
-an explicit route, amount, and optional body region, and may stop an active
-administration. Physiology does not craft preparations; Herbalism #214 owns
+The active character self-administers a preparation from personal inventory by
+checking its inventory checkbox. This consumes the concrete item as one
+standard course; the trusted server supplies the current profile version,
+intrinsic route, 1,000-milliunit amount, and whole-body scope. Active courses
+appear as compact current-medication status with a Stop action until stopped or
+naturally expired. The generic reducer continues to authorize an eligible,
+co-located party member administering a patient's own preparation, but the
+inventory checkbox intentionally remains self-administration only.
+Physiology does not craft preparations; Herbalism #214 owns
 ingredients, lots, composition, recipes, and crafting, while Chemistry #215
 owns chemical behavior. Foraging remains deferred.
 


### PR DESCRIPTION
## Summary

Restore the familiar personal-inventory checkbox as the medication action while retaining the longitudinal, disease-agnostic physiology backend.

- checking a medication administers one standard 1,000-milliunit whole-body course
- the trusted server derives the current profile version and intrinsic route
- the parameterized route/dose/region form and empty medical panel are removed
- active medication is shown as compact, display-name-based status until stopped or naturally expired
- ordinary equipment behavior remains unchanged

## Implementation notes

- Medication does not occupy a physical equipment slot and the old disease-keyed `EquippedMedication`/`treated_at` behavior is not restored.
- The server binds actor and patient to the session character and sends only typed, server-derived administration arguments to the existing reducer.
- Companion medication checkboxes are disabled because this inventory gesture is intentionally self-only; cooperative administration authority remains available in the underlying reducer.
- Direct member transfers and party-pool custody keep every medication course in an individual quantity-one row so it remains administrable.
- Durable administration history, private sensitivity/adverse variation, notebook markers, and versioned replay remain intact.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p adventuresim-core physiology` — 9 passed
- `cargo test -p strategic-web` — 326 passed
- `node --test crates/strategic-web/tests/equipment-toggle.test.cjs` — 4 passed
- `just check`
- `just build-strategic`
- `python scripts/update_project_map.py --check`

`just test` is currently blocked by a pre-existing `service-quests.test.cjs` expectation that is already inconsistent on `origin/main`. The SpacetimeDB crate's Rust test target is likewise blocked by pre-existing missing test imports on `origin/main`; the module itself passes `cargo check` and the authoritative `just build-strategic` path.

## Compatibility and rollback

No database schema or generated client binding changes are required. Existing administration rows remain compatible because they continue to pin their exact profile version and causal metadata. Rollback is a normal revert of this branch.
