### PR TITLE
Fix baseline test failures

### DIFF
--- a/crates/adventuresim-stdb-module/src/local_problem.rs
+++ b/crates/adventuresim-stdb-module/src/local_problem.rs
@@ -1706,8 +1706,8 @@ fn referral_fragments_json(presentation: lp::ReferralPresentation) -> Result<Str
 mod tests {
     use crate::local_problem::{
         BoundedHearingGraph, MAX_HEARING_DISTANCE_M, MAX_HEARING_GRAPH_EDGES,
-        MAX_HEARING_GRAPH_NODES, public_threat_in_hearing_range, referral_fragments_json,
-        stable_eligible_candidates,
+        MAX_HEARING_GRAPH_NODES, dialogue_capable_inn_contact, public_threat_in_hearing_range,
+        referral_fragments_json, stable_eligible_candidates,
     };
     use adventuresim_core::threat_escalation::{
         MAX_PUBLIC_THREAT_CANDIDATES, bounded_public_threat_candidates as bounded_public_candidates,

--- a/crates/adventuresim-stdb-module/src/strategic.rs
+++ b/crates/adventuresim-stdb-module/src/strategic.rs
@@ -16971,13 +16971,15 @@ fn reconstruct_legacy_journey_coordinates(
 #[cfg(test)]
 mod departure_invariant_tests {
     use super::{
-        CampDurationMode, CaseSiteId, JourneyCaseSiteEndpoint, JourneyEndpoint, JourneyRoutePlan,
-        JourneyRoutePoint, JourneySettlementEndpoint, JourneyTerrainKind, JourneyTerrainSpan,
-        JourneyTerrainWeights, Party, PartyJourneyRoute, common_movement_prefix,
-        core_encounter_terrain, departure_requires_ready_party, departure_snapshot_allows_travel,
-        party_can_continue_travel, pending_incident_allows_departure,
-        reconstruct_legacy_journey_coordinates, route_position_at_minute, set_party_journey_state,
-        straight_line_distance_m, terrain_training_exposure, validate_journey_route_payload,
+        CampDurationMode, CaseSiteId, JourneyCaseSiteEndpoint, JourneyEndpoint,
+        JourneyPrecipitation, JourneyRoutePlan, JourneyRoutePoint, JourneySettlementEndpoint,
+        JourneyTerrainKind, JourneyTerrainSpan, JourneyTerrainWeights, Party, PartyJourneyRoute,
+        common_movement_prefix, core_encounter_terrain, departure_requires_ready_party,
+        departure_snapshot_allows_travel, party_can_continue_travel,
+        pending_incident_allows_departure, reconstruct_legacy_journey_coordinates,
+        route_position_at_minute, set_party_journey_state, straight_line_distance_m,
+        terrain_training_exposure, validate_camp_redirect_weather_interval,
+        validate_journey_route_payload, validate_route_departure_weather_interval,
         zero_boundary_requires_settlement,
     };
 

--- a/crates/strategic-web/static/service-quests.js
+++ b/crates/strategic-web/static/service-quests.js
@@ -1,12 +1,3 @@
-const serviceQuestTabState = (activity) => {
-  if (activity.recruitment?.length) return "recruitment available";
-  if (activity.quests?.some((quest) => quest.state === "ready")) return "quest ready to report";
-  if (activity.quests?.some((quest) => quest.state === "available")) return "quest available";
-  return null;
-};
-
-if (typeof module !== "undefined") module.exports = { serviceQuestTabState };
-
 (() => {
   if (typeof document === "undefined") return;
   const refreshServiceQuests = () => {

--- a/crates/strategic-web/tests/service-quests.test.cjs
+++ b/crates/strategic-web/tests/service-quests.test.cjs
@@ -5,24 +5,16 @@ const test = require("node:test");
 
 const file = path.join(__dirname, "..", "static", "service-quests.js");
 const source = fs.readFileSync(file, "utf8");
-const { serviceQuestTabState } = require(file);
 
-test("service quest script owns notification state and trusted recruitment inspection", () => {
+test("service quest script owns trusted recruitment inspection without quest-marker UI", () => {
   assert.doesNotMatch(source, /dialogueActions|nextDialogueActionId|createDocumentFragment|chat-npc-message/);
   assert.doesNotMatch(source, /beginHerbalistConversation|openProfessionTopic|openQuestOffer/);
-  assert.match(source, /data-service-quest-badge/);
-  assert.match(source, /api\/active-quest-marker/);
+  assert.doesNotMatch(source, /data-service-quest-badge/);
+  assert.doesNotMatch(source, /api\/active-quest-marker/);
   assert.match(source, /data-service-recruitment/);
   assert.match(source, /role\.left_html/);
   assert.match(source, /role\.right_html/);
   assert.match(source, /activity\.recruitment/);
   assert.match(source, /recruiting\.leader_id/);
   assert.doesNotMatch(source, /quest\.recruitment/);
-});
-
-test("service tab state is appended only for actionable quest states", () => {
-  assert.equal(serviceQuestTabState({ quests: [{ state: "ready" }], recruitment: [] }), "quest ready to report");
-  assert.equal(serviceQuestTabState({ quests: [{ state: "available" }], recruitment: [] }), "quest available");
-  assert.equal(serviceQuestTabState({ quests: [], recruitment: [{ offer_id: "offer:1" }] }), "recruitment available");
-  assert.equal(serviceQuestTabState({ quests: [{ state: "underway" }], recruitment: [] }), null);
 });

--- a/scripts/dev_stack.py
+++ b/scripts/dev_stack.py
@@ -490,18 +490,31 @@ def process_snapshot(pid: int) -> dict[str, object] | None:
         kernel32.CloseHandle(handle)
 
 
+def executable_identity_matches(expected: object, actual: object) -> bool:
+    expected_path = str(expected)
+    actual_path = str(actual)
+    if os.path.normcase(expected_path) == os.path.normcase(actual_path):
+        return True
+    expected_name = Path(expected_path).stem.lower()
+    actual_name = Path(actual_path).stem.lower()
+    return (
+        expected_name in {"spacetime", "spacetimedb-cli"}
+        and actual_name in {"spacetime-standalone", "spacetimedb-standalone"}
+    )
+
+
 def identity_matches(expected: dict[str, object]) -> bool:
     actual = process_snapshot(int(expected.get("pid", 0)))
     if actual is None:
         return False
     if actual["start_token"] != expected.get("start_token"):
         return False
-    exe_matches = os.path.normcase(str(actual["executable"])) == os.path.normcase(str(expected.get("executable", "")))
-    if not exe_matches:
+    if not executable_identity_matches(expected.get("executable", ""), actual["executable"]):
         print(
-            f"note: executable path changed (likely exec'd): {expected.get('executable')} -> {actual['executable']}",
+            f"note: unexpected executable path change: {expected.get('executable')} -> {actual['executable']}",
             file=sys.stderr,
         )
+        return False
     return True
 
 

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -262,6 +262,20 @@ class WorkflowTests(unittest.TestCase):
         self.assertFalse(dev_stack.identity_matches(wrong_exe))
         self.assertFalse(dev_stack.identity_matches(wrong_start))
 
+    def test_spacetime_launcher_exec_transition_is_allowed(self):
+        self.assertTrue(dev_stack.executable_identity_matches(
+            "/usr/bin/spacetime",
+            "/usr/bin/spacetimedb-standalone",
+        ))
+        self.assertTrue(dev_stack.executable_identity_matches(
+            r"C:\tools\spacetimedb-cli.exe",
+            r"C:\tools\spacetime-standalone.exe",
+        ))
+        self.assertFalse(dev_stack.executable_identity_matches(
+            "/usr/bin/python",
+            "/usr/bin/spacetimedb-standalone",
+        ))
+
     def test_stop_refuses_identity_mismatch(self):
         with tempfile.TemporaryDirectory() as temp:
             metadata = Path(temp, "process.json")


### PR DESCRIPTION
## Summary

Repair the unrelated baseline failures uncovered while validating the medication UI change.

- restore missing private-item imports in the SpacetimeDB module's test modules so the native test target compiles through code generation
- align the service-quest JavaScript test with the documented diegetic discovery design introduced in #198, which intentionally removed quest/service notification badges
- remove the now-dead test-only `serviceQuestTabState` helper
- reject unexpected executable changes in isolated-process identity checks while retaining an explicit allowlist for the legitimate Spacetime CLI launcher-to-standalone exec transition

## Root causes

The Rust tests referenced sibling-private functions and a type without importing them into their nested test modules. The service-quest test retained assertions for marker UI and an API removed by #198. A later tactical workflow change relaxed executable identity matching globally to accommodate the Spacetime launcher transition, contradicting the existing PID-reuse safety test and allowing unrelated executable paths.

## Impact

No gameplay, database schema, or persistence behavior changes. The supported test workflow is green again, and isolated development process ownership checks regain their intended fail-closed behavior without breaking Spacetime startup.

## Validation

- `just test`
- `just check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node --test crates/strategic-web/tests/service-quests.test.cjs`
- targeted `scripts.tests.test_dev_stack` executable-identity tests
- clean `cargo test -p adventuresim-stdb-module medication_custody_tests --no-run` progressed past all 13 former compile errors; native linking then reaches the expected unavailable Spacetime host symbols, while the supported `just build-strategic` path passes as part of `just test`
- `python scripts/update_project_map.py --check`
