### PR TITLE
Add low-risk Physiology bedside reassurance

### DIFF
--- a/crates/adventuresim-core/src/social.rs
+++ b/crates/adventuresim-core/src/social.rs
@@ -472,6 +472,7 @@ pub enum SocialActionKind {
     Listen,
     Commiserate,
     Pray,
+    Reassure,
     LightenMood,
     Rally,
     Reframe,
@@ -485,6 +486,7 @@ impl SocialActionKind {
             Self::Listen => "listen",
             Self::Commiserate => "commiserate",
             Self::Pray => "pray",
+            Self::Reassure => "reassure",
             Self::LightenMood => "lighten_mood",
             Self::Rally => "command",
             Self::Reframe => "deception",
@@ -499,6 +501,7 @@ impl SocialActionKind {
             Self::Commiserate if shares_concern => "Insight",
             Self::Commiserate => "Deception",
             Self::Pray => "Religion",
+            Self::Reassure => "Physiology",
             Self::LightenMood => "Charm",
             Self::Rally => "Command",
             Self::Reframe => "Deception",
@@ -510,6 +513,10 @@ impl SocialActionKind {
         match self {
             Self::Reflect | Self::Listen | Self::Commiserate => true,
             Self::Pray => !matches!(topic, SocialTopic::Filth),
+            Self::Reassure => matches!(
+                topic,
+                SocialTopic::Injury | SocialTopic::Fatigue | SocialTopic::Hunger
+            ),
             Self::LightenMood => !matches!(topic, SocialTopic::Faith),
             Self::Rally => matches!(
                 topic,
@@ -549,6 +556,15 @@ impl SocialActionKind {
             }
             (Self::Commiserate, SocialTopic::Filth, false) => "Feign sympathy about being filthy",
             (Self::Pray, _, _) => "Offer a prayer in their tradition",
+            (Self::Reassure, SocialTopic::Injury, _) => {
+                "Sit with them and speak calmly about what can be plainly observed"
+            }
+            (Self::Reassure, SocialTopic::Fatigue, _) => {
+                "Attend to their weariness and acknowledge what they are feeling"
+            }
+            (Self::Reassure, SocialTopic::Hunger, _) => {
+                "Stay with them and acknowledge the bodily distress of hunger"
+            }
             (Self::LightenMood, SocialTopic::Defeat, _) => "Joke about bouncing back from defeat",
             (Self::LightenMood, SocialTopic::Injury, _) => "Joke to distract them from the pain",
             (Self::LightenMood, SocialTopic::Fatigue, _) => "Joke to help keep them awake",
@@ -580,12 +596,51 @@ impl SocialActionKind {
             Self::Listen => 0.05,
             Self::Commiserate => 0.2,
             Self::Pray => 0.45,
+            Self::Reassure => 0.12,
             Self::LightenMood => 0.45,
             Self::Rally => 0.55,
             Self::Reframe => 0.65,
             Self::Flirt => 0.85,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BedsideReassuranceApproach {
+    pub counsel: &'static str,
+    pub effectiveness: f32,
+    pub risk: f32,
+}
+
+/// Closed catalog for honest bedside attention. It is deliberately limited to
+/// bodily concerns that a physician can acknowledge without diagnosing,
+/// predicting, triaging, or prescribing treatment.
+pub const fn bedside_reassurance_approach(
+    topic: SocialTopic,
+) -> Option<BedsideReassuranceApproach> {
+    let (counsel, effectiveness, risk) = match topic {
+        SocialTopic::Injury => (
+            "Sit at their bedside, attend to what they describe, and speak calmly about what is plainly visible",
+            0.55,
+            0.12,
+        ),
+        SocialTopic::Fatigue => (
+            "Attend to their weariness and acknowledge the strain they describe",
+            0.42,
+            0.08,
+        ),
+        SocialTopic::Hunger => (
+            "Stay with them and acknowledge the bodily distress they describe",
+            0.25,
+            0.06,
+        ),
+        SocialTopic::Defeat | SocialTopic::Faith | SocialTopic::Filth => return None,
+    };
+    Some(BedsideReassuranceApproach {
+        counsel,
+        effectiveness,
+        risk,
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -662,6 +717,17 @@ impl SocialResolutionProfile {
             chance_modifier: 0.0,
             failure_multiplier: 1.0,
         }
+    }
+}
+
+pub const fn bedside_reassurance_resolution_profile(
+    approach: BedsideReassuranceApproach,
+) -> SocialResolutionProfile {
+    SocialResolutionProfile {
+        risk: approach.risk,
+        effectiveness: approach.effectiveness,
+        chance_modifier: 0.0,
+        failure_multiplier: 1.0,
     }
 }
 
@@ -1863,6 +1929,82 @@ mod tests {
     }
 
     #[test]
+    fn bedside_reassurance_is_authored_only_for_bodily_concerns() {
+        let injury = bedside_reassurance_approach(SocialTopic::Injury).expect("injury reassurance");
+        let fatigue =
+            bedside_reassurance_approach(SocialTopic::Fatigue).expect("fatigue reassurance");
+        let hunger = bedside_reassurance_approach(SocialTopic::Hunger).expect("hunger reassurance");
+
+        assert_eq!(injury.effectiveness, 0.55);
+        assert_eq!(injury.risk, 0.12);
+        assert_eq!(fatigue.effectiveness, 0.42);
+        assert_eq!(fatigue.risk, 0.08);
+        assert_eq!(hunger.effectiveness, 0.25);
+        assert_eq!(hunger.risk, 0.06);
+        assert!(hunger.effectiveness < fatigue.effectiveness);
+        assert!(fatigue.effectiveness < injury.effectiveness);
+        for topic in [SocialTopic::Defeat, SocialTopic::Faith, SocialTopic::Filth] {
+            assert_eq!(bedside_reassurance_approach(topic), None);
+            assert!(!SocialActionKind::Reassure.available_for(topic));
+        }
+        for approach in [injury, fatigue, hunger] {
+            let copy = approach.counsel.to_ascii_lowercase();
+            for unsupported_claim in [
+                "humour", "diagnos", "prognos", "recover", "treat", "cure", "prescri",
+            ] {
+                assert!(
+                    !copy.contains(unsupported_claim),
+                    "bedside copy made unsupported claim: {copy}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bedside_reassurance_is_conservative_beside_riskier_approaches() {
+        let attempt = |topic, action| SocialAttempt {
+            action,
+            topic,
+            skill_check: 5.0,
+            affinity: 0.0,
+            familiarity_hours: 0.0,
+            diagnosis_correct: None,
+            sensitivity: 0.5,
+            roll: 0.0,
+        };
+        for topic in [
+            SocialTopic::Injury,
+            SocialTopic::Fatigue,
+            SocialTopic::Hunger,
+        ] {
+            let approach = bedside_reassurance_approach(topic).unwrap();
+            let profile = bedside_reassurance_resolution_profile(approach);
+            let reassurance = resolve_social_attempt_with_profile(
+                attempt(topic, SocialActionKind::Reassure),
+                profile,
+            );
+            let prayer_approach =
+                prayer_approach(OfficialReligion::Anglican, topic).expect("prayer topic");
+            let prayer_profile = prayer_resolution_profile(prayer_approach, 0);
+            let prayer = resolve_social_attempt_with_profile(
+                attempt(topic, SocialActionKind::Pray),
+                prayer_profile,
+            );
+
+            assert!(profile.risk < prayer_profile.risk);
+            assert!(reassurance.morale_delta < prayer.morale_delta);
+        }
+        assert!(
+            bedside_reassurance_approach(SocialTopic::Hunger)
+                .unwrap()
+                .effectiveness
+                < bedside_reassurance_approach(SocialTopic::Injury)
+                    .unwrap()
+                    .effectiveness
+        );
+    }
+
+    #[test]
     fn target_tradition_study_gates_correlated_religion_knowledge() {
         let mut hours = adventuresim_world_schema::ReligionHours {
             roman_catholic: 1_000.0,
@@ -1911,7 +2053,7 @@ mod tests {
     }
 
     #[test]
-    fn automatic_care_can_select_prayer_but_never_for_filth() {
+    fn automatic_care_can_select_prayer_and_reassurance_only_where_authored() {
         assert_eq!(
             choose_automatic_social_action(
                 SocialTopic::Injury,
@@ -1935,6 +2077,33 @@ mod tests {
                     5.0,
                     2.0,
                     0.3,
+                )],
+            ),
+            None
+        );
+        assert_eq!(
+            choose_automatic_social_action(
+                SocialTopic::Fatigue,
+                [
+                    AutomaticSocialCandidate::ordinary(SocialActionKind::Listen, 2.0, 0.0),
+                    AutomaticSocialCandidate::with_resolved_risk(
+                        SocialActionKind::Reassure,
+                        4.0,
+                        0.0,
+                        0.08,
+                    ),
+                ],
+            ),
+            Some(SocialActionKind::Reassure)
+        );
+        assert_eq!(
+            choose_automatic_social_action(
+                SocialTopic::Defeat,
+                [AutomaticSocialCandidate::with_resolved_risk(
+                    SocialActionKind::Reassure,
+                    5.0,
+                    2.0,
+                    0.06,
                 )],
             ),
             None

--- a/crates/adventuresim-stdb-module/src/social.rs
+++ b/crates/adventuresim-stdb-module/src/social.rs
@@ -9,13 +9,13 @@ use adventuresim_core::social::{
     SOCIAL_RESPONSE_MINUTES, SelfKnowledge as CoreSelfKnowledge, SocialActionKind, SocialAttempt,
     SocialTopic, Transparency as CoreTransparency, actor_allows_social_action,
     actor_allows_social_prayer, affinity_gain, assess_testimony_claim, axis_for_topic,
-    canonical_cooldown_id, canonical_pair, choose_automatic_social_action,
-    command_gravitas_modifier, diagnosed_axis, diagnosis_for_axis, discovery_training_split,
-    flirt_charm_modifier, humor_charm_modifier, incompatible_flirt_outcome, prayer_approach,
-    prayer_resolution_profile, realized_affinity_delta, resolve_casual_chat,
-    resolve_claim_challenge, resolve_social_attempt, resolve_social_attempt_with_profile,
-    self_knowledge_insight_modifier, settle_affinity, should_replace_belief,
-    social_source_eligible, topic_for_source_kind,
+    bedside_reassurance_approach, bedside_reassurance_resolution_profile, canonical_cooldown_id,
+    canonical_pair, choose_automatic_social_action, command_gravitas_modifier, diagnosed_axis,
+    diagnosis_for_axis, discovery_training_split, flirt_charm_modifier, humor_charm_modifier,
+    incompatible_flirt_outcome, prayer_approach, prayer_resolution_profile,
+    realized_affinity_delta, resolve_casual_chat, resolve_claim_challenge, resolve_social_attempt,
+    resolve_social_attempt_with_profile, self_knowledge_insight_modifier, settle_affinity,
+    should_replace_belief, social_source_eligible, topic_for_source_kind,
 };
 use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, reducer, table, view};
 
@@ -2002,6 +2002,7 @@ fn parse_action(value: &str) -> Result<SocialActionKind, String> {
         "listen" => Ok(SocialActionKind::Listen),
         "commiserate" => Ok(SocialActionKind::Commiserate),
         "pray" => Ok(SocialActionKind::Pray),
+        "reassure" => Ok(SocialActionKind::Reassure),
         "lighten_mood" => Ok(SocialActionKind::LightenMood),
         "command" => Ok(SocialActionKind::Rally),
         "deception" => Ok(SocialActionKind::Reframe),
@@ -2017,6 +2018,7 @@ fn social_action_skill(action: SocialActionKind, shares_concern: bool) -> Skill 
         SocialActionKind::Commiserate if shares_concern => Skill::Insight,
         SocialActionKind::Commiserate => Skill::Deception,
         SocialActionKind::Pray => Skill::Religion,
+        SocialActionKind::Reassure => Skill::Physiology,
         SocialActionKind::LightenMood => Skill::Charm,
         SocialActionKind::Rally => Skill::Command,
         SocialActionKind::Reframe => Skill::Deception,
@@ -2223,10 +2225,11 @@ fn automatic_social_action(
     target_id: u64,
     topic: SocialTopic,
 ) -> Result<Option<SocialActionKind>, String> {
-    const ACTIONS: [SocialActionKind; 7] = [
+    const ACTIONS: [SocialActionKind; 8] = [
         SocialActionKind::Listen,
         SocialActionKind::Commiserate,
         SocialActionKind::Pray,
+        SocialActionKind::Reassure,
         SocialActionKind::LightenMood,
         SocialActionKind::Rally,
         SocialActionKind::Reframe,
@@ -2301,6 +2304,15 @@ fn automatic_social_action(
                 personality_fit,
                 prayer_resolution_profile(approach, conviction_code(target_personality.conviction))
                     .risk,
+            )
+        } else if action == SocialActionKind::Reassure {
+            let approach = bedside_reassurance_approach(topic)
+                .expect("Reassurance candidates require an authored health topic");
+            AutomaticSocialCandidate::with_resolved_risk(
+                action,
+                skill_check,
+                personality_fit,
+                bedside_reassurance_resolution_profile(approach).risk,
             )
         } else {
             AutomaticSocialCandidate::ordinary(action, skill_check, personality_fit)
@@ -2507,6 +2519,7 @@ fn discovery_axes(
             vec![PersonalityAxis::Conscience, PersonalityAxis::Sociability]
         }
         SocialActionKind::Pray => vec![PersonalityAxis::Conviction],
+        SocialActionKind::Reassure => Vec::new(),
         SocialActionKind::LightenMood => vec![PersonalityAxis::Mirth],
         SocialActionKind::Rally => vec![
             PersonalityAxis::Nerve,
@@ -2734,6 +2747,14 @@ fn perform_social_action_authoritative(
     } else {
         None
     };
+    let reassurance = if action == SocialActionKind::Reassure {
+        Some(
+            bedside_reassurance_approach(topic)
+                .ok_or("That social approach does not fit this concern")?,
+        )
+    } else {
+        None
+    };
     let now = ctx
         .db
         .character_time()
@@ -2854,6 +2875,11 @@ fn perform_social_action_authoritative(
         resolve_social_attempt_with_profile(
             attempt,
             prayer_resolution_profile(approach, conviction_code(target_personality.conviction)),
+        )
+    } else if let Some(approach) = reassurance {
+        resolve_social_attempt_with_profile(
+            attempt,
+            bedside_reassurance_resolution_profile(approach),
         )
     } else {
         resolve_social_attempt(attempt)
@@ -3451,6 +3477,39 @@ mod contract_tests {
         assert!(check.contains("religion_hours.effective(religion)"));
         assert!(!check.contains("maximum_effective"));
         assert!(!check.contains("aggregate_party_check"));
+    }
+
+    #[test]
+    fn bedside_reassurance_uses_physiology_without_personality_discovery() {
+        assert_eq!(parse_action("reassure"), Ok(SocialActionKind::Reassure));
+        assert_eq!(
+            social_action_skill(SocialActionKind::Reassure, false),
+            Skill::Physiology
+        );
+        assert!(discovery_axes(SocialActionKind::Reassure, SocialTopic::Injury, false).is_empty());
+
+        let source = include_str!("social.rs");
+        let automatic = source
+            .split("fn automatic_social_action")
+            .nth(1)
+            .and_then(|tail| tail.split("fn sensitivity").next())
+            .expect("automatic selector");
+        assert!(automatic.contains("SocialActionKind::Reassure"));
+        assert!(automatic.contains("bedside_reassurance_resolution_profile"));
+
+        let authoritative = source
+            .split("fn perform_social_action_authoritative")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("pub(crate) fn apply_automatic_social_chats")
+                    .next()
+            })
+            .expect("authoritative action");
+        assert!(authoritative.contains("bedside_reassurance_approach(topic)"));
+        assert!(authoritative.contains("language_scaled_effect"));
+        assert!(authoritative.contains("\"social_interaction\""));
+        assert!(!authoritative.contains("physiology_administration"));
+        assert!(!authoritative.contains("record_health"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -334,10 +334,15 @@ pub fn party_social_dialog(
                                        };
                                       @let label = social_action_label(action, action_shares_concern);
                                       @let disabled_reason = if action == adventuresim_core::social::SocialActionKind::Pray { social.prayer_disabled_reason.as_deref() } else { None };
-                                       @let risk = prayer_approach.map_or_else(
-                                           || reassurance_approach.map_or(action.risk(), |approach| approach.risk),
-                                           |approach| approach.risk,
-                                       );
+                                        @let risk = match action {
+                                            adventuresim_core::social::SocialActionKind::Pray => {
+                                                prayer_approach.map_or(action.risk(), |approach| approach.risk)
+                                            }
+                                            adventuresim_core::social::SocialActionKind::Reassure => {
+                                                reassurance_approach.map_or(action.risk(), |approach| approach.risk)
+                                            }
+                                            _ => action.risk(),
+                                        };
                                       @let tooltip = if let Some(reason) = disabled_reason {
                                           format!("{}\nUnavailable: {}", description, reason)
                                       } else {
@@ -711,6 +716,10 @@ mod tests {
         assert!(injury_markup.contains("Physiology"));
         assert!(injury_markup.contains("low risk"));
         assert!(injury_markup.contains("Reassure. Sit at their bedside"));
+        assert!(injury_markup.contains("Physiology Â· low risk"));
+        assert!(injury_markup.contains("value=\"deception\""));
+        assert!(injury_markup.contains("Claim the injury is less serious than it looks"));
+        assert!(injury_markup.contains("Deception Â· high risk"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -61,6 +61,7 @@ fn social_actions(
         ("awareness", Listen, "listen"),
         ("awareness", Commiserate, "commiserate"),
         ("prayer", Pray, "pray"),
+        ("heart-beats", Reassure, "reassure"),
         ("juggler", LightenMood, "lighten_mood"),
         ("crown", Rally, "command"),
         ("conversation", Reframe, "deception"),
@@ -86,6 +87,7 @@ fn social_action_label(
         SocialActionKind::Commiserate if shares_concern => "Commiserate",
         SocialActionKind::Commiserate => "Feign sympathy",
         SocialActionKind::Pray => "Pray",
+        SocialActionKind::Reassure => "Reassure",
         SocialActionKind::LightenMood => "Joke",
         SocialActionKind::Rally => "Rally",
         SocialActionKind::Reframe => "Reframe",
@@ -313,20 +315,29 @@ pub fn party_social_dialog(
                                     @for (default_icon, action, value) in social_actions(is_self, topic, social.joke_blocked, social.flirt_blocked) {
                                       @let action_shares_concern = action != adventuresim_core::social::SocialActionKind::Commiserate || shares_concern;
                                       @let icon = if action == adventuresim_core::social::SocialActionKind::Commiserate && !shares_concern { "conversation" } else { default_icon };
-                                      @let prayer_approach = social.religion_id.as_deref()
-                                          .and_then(adventuresim_world_schema::OfficialReligion::from_id)
-                                          .and_then(|religion| adventuresim_core::social::prayer_approach(religion, topic));
-                                      @let description = if action == adventuresim_core::social::SocialActionKind::Pray {
-                                          prayer_approach.map_or_else(
-                                              || action.description(topic, action_shares_concern).to_owned(),
-                                              |approach| format!("{} {}", approach.devotion, approach.intention),
-                                          )
-                                      } else {
-                                          action.description(topic, action_shares_concern).to_owned()
-                                      };
+                                       @let prayer_approach = social.religion_id.as_deref()
+                                           .and_then(adventuresim_world_schema::OfficialReligion::from_id)
+                                           .and_then(|religion| adventuresim_core::social::prayer_approach(religion, topic));
+                                       @let reassurance_approach = adventuresim_core::social::bedside_reassurance_approach(topic);
+                                       @let description = if action == adventuresim_core::social::SocialActionKind::Pray {
+                                           prayer_approach.map_or_else(
+                                               || action.description(topic, action_shares_concern).to_owned(),
+                                               |approach| format!("{} {}", approach.devotion, approach.intention),
+                                           )
+                                       } else if action == adventuresim_core::social::SocialActionKind::Reassure {
+                                           reassurance_approach.map_or_else(
+                                               || action.description(topic, action_shares_concern).to_owned(),
+                                               |approach| approach.counsel.to_owned(),
+                                           )
+                                       } else {
+                                           action.description(topic, action_shares_concern).to_owned()
+                                       };
                                       @let label = social_action_label(action, action_shares_concern);
                                       @let disabled_reason = if action == adventuresim_core::social::SocialActionKind::Pray { social.prayer_disabled_reason.as_deref() } else { None };
-                                      @let risk = prayer_approach.map_or(action.risk(), |approach| approach.risk);
+                                       @let risk = prayer_approach.map_or_else(
+                                           || reassurance_approach.map_or(action.risk(), |approach| approach.risk),
+                                           |approach| approach.risk,
+                                       );
                                       @let tooltip = if let Some(reason) = disabled_reason {
                                           format!("{}\nUnavailable: {}", description, reason)
                                       } else {
@@ -678,6 +689,28 @@ mod tests {
         assert!(!response_markup.contains(
             "class=\"social-action\" aria-label=\"Ask how they feel about the defeat\" title="
         ));
+
+        let injury_source = CharacterMoraleSource {
+            id: "fresh-injury".into(),
+            character_id: target.id,
+            kind: "injury".into(),
+            label: "Painful injury".into(),
+            magnitude: -2.0,
+        };
+        let injury_markup = party_social_dialog(
+            &location,
+            &target,
+            &actor,
+            &[injury_source],
+            &SocialPresentation::default(),
+        )
+        .into_string();
+        assert!(injury_markup.contains("value=\"reassure\""));
+        assert!(injury_markup.contains("class=\"social-action-label\">Reassure</span>"));
+        assert!(injury_markup.contains("Sit at their bedside"));
+        assert!(injury_markup.contains("Physiology"));
+        assert!(injury_markup.contains("low risk"));
+        assert!(injury_markup.contains("Reassure. Sit at their bedside"));
     }
 
     #[test]
@@ -764,7 +797,7 @@ mod tests {
         );
         assert_eq!(
             social_actions(false, SocialTopic::Hunger, false, false).len(),
-            4
+            5
         );
         assert_eq!(
             social_actions(false, SocialTopic::Faith, false, false).len(),
@@ -782,6 +815,26 @@ mod tests {
                 .any(|(_, action, _)| *action == SocialActionKind::Rally)
         );
         assert_eq!(SocialActionKind::Commiserate.skill_name(false), "Deception");
+        assert_eq!(SocialActionKind::Reassure.skill_name(false), "Physiology");
+        for topic in [
+            SocialTopic::Injury,
+            SocialTopic::Fatigue,
+            SocialTopic::Hunger,
+        ] {
+            assert!(
+                social_actions(false, topic, false, false)
+                    .iter()
+                    .any(|(_, action, value)| *action == SocialActionKind::Reassure
+                        && *value == "reassure")
+            );
+        }
+        for topic in [SocialTopic::Defeat, SocialTopic::Faith, SocialTopic::Filth] {
+            assert!(
+                social_actions(false, topic, false, false)
+                    .iter()
+                    .all(|(_, action, _)| *action != SocialActionKind::Reassure)
+            );
+        }
         assert_eq!(
             SocialActionKind::Flirt.description(SocialTopic::Injury, false),
             "Tell them the scar makes them look striking"

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -713,13 +713,23 @@ mod tests {
         assert!(injury_markup.contains("value=\"reassure\""));
         assert!(injury_markup.contains("class=\"social-action-label\">Reassure</span>"));
         assert!(injury_markup.contains("Sit at their bedside"));
-        assert!(injury_markup.contains("Physiology"));
-        assert!(injury_markup.contains("low risk"));
         assert!(injury_markup.contains("Reassure. Sit at their bedside"));
-        assert!(injury_markup.contains("Physiology Â· low risk"));
+        let reassurance_button = injury_markup
+            .split("value=\"reassure\"")
+            .nth(1)
+            .and_then(|tail| tail.split("</button>").next())
+            .expect("rendered Reassure button");
+        assert!(reassurance_button.contains("Physiology"));
+        assert!(reassurance_button.contains("low risk"));
         assert!(injury_markup.contains("value=\"deception\""));
         assert!(injury_markup.contains("Claim the injury is less serious than it looks"));
-        assert!(injury_markup.contains("Deception Â· high risk"));
+        let reframe_button = injury_markup
+            .split("value=\"deception\"")
+            .nth(1)
+            .and_then(|tail| tail.split("</button>").next())
+            .expect("rendered Injury Reframe button");
+        assert!(reframe_button.contains("Deception"));
+        assert!(reframe_button.contains("high risk"));
     }
 
     #[test]

--- a/wiki/reference/physiology.md
+++ b/wiki/reference/physiology.md
@@ -16,6 +16,16 @@ non-operative treatment. Herbalists prepare remedies through Herbalism, while
 surgeons train Surgery for operative procedures.
 Membership and advancement in one organization never confer a rank in another.
 
+Physiology also supports a narrow bedside **Reassure** response to companions'
+injury or pain, fatigue, and hunger or thirst morale concerns. This is honest,
+period-facing attention to the patient's account and plainly observable
+distress. It is a modest, low-risk morale intervention rather than medical
+success: the action does not identify a condition, predict its course, triage
+the patient, prescribe supportive care, endorse Humour theory, or alter any
+physical state. Hunger or thirst reassurance is intentionally the weakest
+authored case. See [Morale](../shared/morale.md) for the shared social-action,
+relationship, cooldown, history, privacy, and automatic-care rules.
+
 ## Private authority
 
 The authoritative strategic simulation derives ten bounded functional-loss

--- a/wiki/shared/morale.md
+++ b/wiki/shared/morale.md
@@ -32,6 +32,23 @@ social care considers Prayer alongside the other eligible approaches using the
 same target-specific check, personality fit, cooldown, and authoritative
 resolver.
 
+Companion responses also include **Reassure** for injury or pain, fatigue, and
+hunger or thirst concerns. The action uses the actor's Physiology check after
+shared-language scaling. Its closed, topic-specific bedside catalog is
+deliberately conservative: injury reassurance is the strongest of the three,
+fatigue is weaker, and hunger or thirst is materially weakest. All three offer
+less morale reward and less risk than the relevant specialist or riskier social
+approaches; they are not claimed to be safer than simply listening.
+
+Reassurance consists only of honest attention to what the patient reports and
+what is plainly observable. It makes no diagnosis, prognosis, triage decision,
+humoral claim, or prescription. It changes morale and relationship state only,
+never wounds, disease, needs, medication, or any other physical state. It uses
+the same five-minute manual cost, target-specific cooldown, durable interaction
+history, compact successful-address state, affinity rules, privacy boundary,
+and opt-in automatic-care pipeline as other companion responses. Reassurance
+does not reveal personality beliefs.
+
 Living, co-located companions show an observer-specific Party Rail badge for
 each current actionable negative source row that this character has not yet
 successfully addressed. Separate sources count separately even when they share


### PR DESCRIPTION
## What changed

- add an explicitly authored Physiology-based `Reassure` response for injury, fatigue, and hunger morale topics
- give each eligible topic its own conservative effectiveness, risk, and bedside copy
- route manual and automatic reassurance through the existing language, relationship, cooldown, interaction-history, affinity, and morale-address machinery
- expose the action in the social panel with accessible Physiology and risk presentation
- document the action's honest, non-diagnostic boundaries

## Why

Physiology needed a useful expedition and care role that does not make humoral theory authoritative or let physicians diagnose, treat, or physically improve conditions beyond the simulation. Bedside attention provides a low-risk, lower-reward morale option while preserving the stronger niches of specialist social skills and Religion.

## Player impact

Characters with Physiology can reassure companions about selected bodily concerns. Injury is the strongest initial case, fatigue is more modest, and hunger is deliberately weak. Reassurance changes only morale and ordinary relationship state; it does not alter wounds, fatigue, disease state, hidden diagnosis, or private physiological meters.

## Review remediation

Independent review found that the first UI implementation reused reassurance risk labels for unrelated actions on bodily topics. Risk selection is now action-scoped, with a regression test proving Injury Reframe remains high-risk while Reassure is low-risk.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `python scripts/update_project_map.py --check`
- `cargo test -p adventuresim-core social::tests::` (32 passed)
- `cargo test -p strategic-web templates::settlement::social::tests::` (9 passed)
- `cargo check -p adventuresim-stdb-module`
- `cargo check --workspace`

Closes #295.
