### PR TITLE
Add literacy-gated book training and bookstores

### DIFF
--- a/content/items/catalog.yaml
+++ b/content/items/catalog.yaml
@@ -3274,124 +3274,124 @@
       }
     },
     {
-      "id": "primer_german_latin", "display_name": "German-Latin primer",
+      "id": "primer_german_latin", "display_name": "Vocabularius ex quo (German–Latin)",
       "weight_kg": 0.35, "base_value": 18, "tags": ["book"],
       "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "written", "language": "Latin"}, "lower_rank": 0, "upper_rank": 1}}
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "written", "language": "Latin"}, "quality": 1}}
     },
     {
-      "id": "primer_latin_german", "display_name": "Latin-German primer",
+      "id": "primer_latin_german", "display_name": "Vocabularius ex quo (Latin–German)",
       "weight_kg": 0.35, "base_value": 18, "tags": ["book"],
       "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "written", "language": "German"}, "lower_rank": 0, "upper_rank": 1}}
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "written", "language": "German"}, "quality": 1}}
     },
     {
-      "id": "primer_low_german", "display_name": "Low German-German primer",
+      "id": "primer_low_german", "display_name": "Teuthonista (Low German–German)",
       "weight_kg": 0.35, "base_value": 16, "tags": ["book"],
       "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "Low", "target": {"kind": "written", "language": "German"}, "lower_rank": 0, "upper_rank": 1}}
+      "capabilities": {"book": {"medium": "Low", "target": {"kind": "written", "language": "German"}, "quality": 1}}
     },
     {
-      "id": "primer_german_low", "display_name": "German-Low German primer",
+      "id": "primer_german_low", "display_name": "Teuthonista (German–Low German)",
       "weight_kg": 0.35, "base_value": 16, "tags": ["book"],
       "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "written", "language": "Low"}, "lower_rank": 0, "upper_rank": 1}}
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "written", "language": "Low"}, "quality": 1}}
     },
     {
-      "id": "latin_rhetoric_advanced", "display_name": "Advanced Latin rhetoric",
+      "id": "latin_rhetoric_advanced", "display_name": "De oratore",
       "weight_kg": 0.55, "base_value": 75, "tags": ["book"],
       "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "written", "language": "Latin"}, "lower_rank": 4, "upper_rank": 5}}
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "written", "language": "Latin"}, "quality": 5}}
     },
     {
-      "id": "catholic_summa_advanced", "display_name": "Advanced Catholic summa",
+      "id": "catholic_summa_advanced", "display_name": "Summa Theologiae",
       "weight_kg": 0.8, "base_value": 90, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "religion", "religion": "RomanCatholic"}, "lower_rank": 4, "upper_rank": 5}}
+      "presentation": {"icon": "holy-symbol"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "religion", "religion": "RomanCatholic"}, "quality": 5}}
     },
     {
-      "id": "bestiary_beasts_advanced", "display_name": "A compendium of beasts",
+      "id": "bestiary_beasts_advanced", "display_name": "Physiologus",
       "weight_kg": 0.7, "base_value": 70, "tags": ["book"],
       "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "bestiary", "category": "beast"}, "lower_rank": 4, "upper_rank": 5}}
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "bestiary", "category": "beast"}, "quality": 5}}
     },
     {
-      "id": "human_anatomy", "display_name": "On human anatomy",
+      "id": "human_anatomy", "display_name": "De humani corporis fabrica",
       "weight_kg": 0.65, "base_value": 55, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "skill", "skill": "physiology"}, "lower_rank": 3, "upper_rank": 4}}
+      "presentation": {"icon": "caduceus"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "skill", "skill": "physiology"}, "quality": 4}}
     },
     {
-      "id": "german_herbal", "display_name": "A German herbal",
+      "id": "german_herbal", "display_name": "New Kreütter Buch",
       "weight_kg": 0.6, "base_value": 45, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "herbalism"}, "lower_rank": 3, "upper_rank": 4}}
+      "presentation": {"icon": "caduceus"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "herbalism"}, "quality": 4}}
     },
     {
-      "id": "forest_wayfinding", "display_name": "Woodland ways and signs",
+      "id": "forest_wayfinding", "display_name": "Gejaidbuch (woodcraft)",
       "weight_kg": 0.3, "base_value": 22, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "terrain", "terrain": "forest"}, "lower_rank": 1, "upper_rank": 2}}
+      "presentation": {"icon": "treasure-map"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "terrain", "terrain": "forest"}, "quality": 2}}
     },
     {
-      "id": "field_surgery_manual", "display_name": "Field surgery manual",
+      "id": "field_surgery_manual", "display_name": "Feldbuch der Wundarznei",
       "weight_kg": 0.4, "base_value": 32, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "surgery"}, "lower_rank": 1, "upper_rank": 2}}
+      "presentation": {"icon": "scalpel"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "surgery"}, "quality": 2}}
     },
     {
-      "id": "kitchen_book", "display_name": "The good kitchen book",
+      "id": "kitchen_book", "display_name": "Küchenmeisterei",
       "weight_kg": 0.35, "base_value": 24, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "cooking"}, "lower_rank": 1, "upper_rank": 2}}
+      "presentation": {"icon": "meal"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "cooking"}, "quality": 2}}
     },
     {
-      "id": "tailors_pattern_book", "display_name": "A tailor's pattern book",
+      "id": "tailors_pattern_book", "display_name": "Hausbuch der Mendelschen Zwölfbrüderstiftung",
       "weight_kg": 0.4, "base_value": 30, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "tailoring"}, "lower_rank": 1, "upper_rank": 2}}
+      "presentation": {"icon": "clothes"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "tailoring"}, "quality": 2}}
     },
     {
-      "id": "smiths_handbook", "display_name": "The smith's handbook",
+      "id": "smiths_handbook", "display_name": "Probierbüchlein",
       "weight_kg": 0.45, "base_value": 34, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "smithing"}, "lower_rank": 1, "upper_rank": 2}}
+      "presentation": {"icon": "anvil"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "smithing"}, "quality": 2}}
     },
     {
-      "id": "captains_discourses", "display_name": "A captain's discourses",
+      "id": "captains_discourses", "display_name": "De re militari",
       "weight_kg": 0.4, "base_value": 38, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "command"}, "lower_rank": 1, "upper_rank": 2}}
+      "presentation": {"icon": "crown"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "skill", "skill": "command"}, "quality": 2}}
     },
     {
-      "id": "courtly_conversation", "display_name": "Courtly conversation",
+      "id": "courtly_conversation", "display_name": "De civilitate morum puerilium",
       "weight_kg": 0.3, "base_value": 28, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "charm"}, "lower_rank": 1, "upper_rank": 2}}
+      "presentation": {"icon": "rose"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "skill", "skill": "charm"}, "quality": 2}}
     },
     {
-      "id": "fechtbuch_sword", "display_name": "Illustrated sword fechtbuch",
+      "id": "fechtbuch_sword", "display_name": "Fechtbuch von 1467",
       "weight_kg": 0.45, "base_value": 40, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "sword"}, "lower_rank": 0, "upper_rank": 1}}
+      "presentation": {"icon": "sword-brandish"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "sword"}, "quality": 1}}
     },
     {
-      "id": "hunting_with_bows", "display_name": "Hunting with bows",
+      "id": "hunting_with_bows", "display_name": "Gejaidbuch (bow hunting)",
       "weight_kg": 0.35, "base_value": 30, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "bow"}, "lower_rank": 0, "upper_rank": 1}}
+      "presentation": {"icon": "bow-arrow"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "bow"}, "quality": 1}}
     },
     {
-      "id": "manual_of_defence", "display_name": "A manual of defence",
+      "id": "manual_of_defence", "display_name": "Gladiatoria",
       "weight_kg": 0.4, "base_value": 35, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "block"}, "lower_rank": 0, "upper_rank": 1}}
+      "presentation": {"icon": "shield"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "block"}, "quality": 1}}
     },
     {
-      "id": "hunters_concealment", "display_name": "The hunter's concealment",
+      "id": "hunters_concealment", "display_name": "Liber Vagatorum",
       "weight_kg": 0.3, "base_value": 27, "tags": ["book"],
-      "presentation": {"icon": "open-book"}, "kind": "simple",
-      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "stealth"}, "lower_rank": 0, "upper_rank": 1}}
+      "presentation": {"icon": "hood"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "stealth"}, "quality": 1}}
     }
   ]
 }

--- a/content/items/catalog.yaml
+++ b/content/items/catalog.yaml
@@ -3272,6 +3272,126 @@
           "handling_sensitivity": 0.5
         }
       }
+    },
+    {
+      "id": "primer_german_latin", "display_name": "German-Latin primer",
+      "weight_kg": 0.35, "base_value": 18, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "written", "language": "Latin"}, "lower_rank": 0, "upper_rank": 1}}
+    },
+    {
+      "id": "primer_latin_german", "display_name": "Latin-German primer",
+      "weight_kg": 0.35, "base_value": 18, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "written", "language": "German"}, "lower_rank": 0, "upper_rank": 1}}
+    },
+    {
+      "id": "primer_low_german", "display_name": "Low German-German primer",
+      "weight_kg": 0.35, "base_value": 16, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Low", "target": {"kind": "written", "language": "German"}, "lower_rank": 0, "upper_rank": 1}}
+    },
+    {
+      "id": "primer_german_low", "display_name": "German-Low German primer",
+      "weight_kg": 0.35, "base_value": 16, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "written", "language": "Low"}, "lower_rank": 0, "upper_rank": 1}}
+    },
+    {
+      "id": "latin_rhetoric_advanced", "display_name": "Advanced Latin rhetoric",
+      "weight_kg": 0.55, "base_value": 75, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "written", "language": "Latin"}, "lower_rank": 4, "upper_rank": 5}}
+    },
+    {
+      "id": "catholic_summa_advanced", "display_name": "Advanced Catholic summa",
+      "weight_kg": 0.8, "base_value": 90, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "religion", "religion": "RomanCatholic"}, "lower_rank": 4, "upper_rank": 5}}
+    },
+    {
+      "id": "bestiary_beasts_advanced", "display_name": "A compendium of beasts",
+      "weight_kg": 0.7, "base_value": 70, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "bestiary", "category": "beast"}, "lower_rank": 4, "upper_rank": 5}}
+    },
+    {
+      "id": "human_anatomy", "display_name": "On human anatomy",
+      "weight_kg": 0.65, "base_value": 55, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "Latin", "target": {"kind": "skill", "skill": "physiology"}, "lower_rank": 3, "upper_rank": 4}}
+    },
+    {
+      "id": "german_herbal", "display_name": "A German herbal",
+      "weight_kg": 0.6, "base_value": 45, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "herbalism"}, "lower_rank": 3, "upper_rank": 4}}
+    },
+    {
+      "id": "forest_wayfinding", "display_name": "Woodland ways and signs",
+      "weight_kg": 0.3, "base_value": 22, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "terrain", "terrain": "forest"}, "lower_rank": 1, "upper_rank": 2}}
+    },
+    {
+      "id": "field_surgery_manual", "display_name": "Field surgery manual",
+      "weight_kg": 0.4, "base_value": 32, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "surgery"}, "lower_rank": 1, "upper_rank": 2}}
+    },
+    {
+      "id": "kitchen_book", "display_name": "The good kitchen book",
+      "weight_kg": 0.35, "base_value": 24, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "cooking"}, "lower_rank": 1, "upper_rank": 2}}
+    },
+    {
+      "id": "tailors_pattern_book", "display_name": "A tailor's pattern book",
+      "weight_kg": 0.4, "base_value": 30, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "tailoring"}, "lower_rank": 1, "upper_rank": 2}}
+    },
+    {
+      "id": "smiths_handbook", "display_name": "The smith's handbook",
+      "weight_kg": 0.45, "base_value": 34, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "smithing"}, "lower_rank": 1, "upper_rank": 2}}
+    },
+    {
+      "id": "captains_discourses", "display_name": "A captain's discourses",
+      "weight_kg": 0.4, "base_value": 38, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "command"}, "lower_rank": 1, "upper_rank": 2}}
+    },
+    {
+      "id": "courtly_conversation", "display_name": "Courtly conversation",
+      "weight_kg": 0.3, "base_value": 28, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "charm"}, "lower_rank": 1, "upper_rank": 2}}
+    },
+    {
+      "id": "fechtbuch_sword", "display_name": "Illustrated sword fechtbuch",
+      "weight_kg": 0.45, "base_value": 40, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "sword"}, "lower_rank": 0, "upper_rank": 1}}
+    },
+    {
+      "id": "hunting_with_bows", "display_name": "Hunting with bows",
+      "weight_kg": 0.35, "base_value": 30, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "bow"}, "lower_rank": 0, "upper_rank": 1}}
+    },
+    {
+      "id": "manual_of_defence", "display_name": "A manual of defence",
+      "weight_kg": 0.4, "base_value": 35, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "block"}, "lower_rank": 0, "upper_rank": 1}}
+    },
+    {
+      "id": "hunters_concealment", "display_name": "The hunter's concealment",
+      "weight_kg": 0.3, "base_value": 27, "tags": ["book"],
+      "presentation": {"icon": "open-book"}, "kind": "simple",
+      "capabilities": {"book": {"medium": "German", "target": {"kind": "skill", "skill": "stealth"}, "lower_rank": 0, "upper_rank": 1}}
     }
   ]
 }

--- a/content/organizations/catalog.yaml
+++ b/content/organizations/catalog.yaml
@@ -100,7 +100,12 @@
                                           {
                                               "kind":  "fixed_skill",
                                               "skill":  "command",
-                                              "weight":  1.0
+                                              "weight":  0.75
+                                          },
+                                          {
+                                              "kind":  "written",
+                                              "language":  "German",
+                                              "weight":  0.25
                                           }
                                       ],
                          "reward":  "gold"
@@ -937,7 +942,17 @@
                                           {
                                               "kind":  "religion",
                                               "religion":  "roman_catholic",
-                                              "weight":  1.0
+                                              "weight":  0.5
+                                          },
+                                          {
+                                              "kind":  "written",
+                                              "language":  "Latin",
+                                              "weight":  0.35
+                                          },
+                                          {
+                                              "kind":  "written",
+                                              "language":  "German",
+                                              "weight":  0.15
                                           }
                                       ],
                          "reward":  "fame"
@@ -1205,7 +1220,17 @@
                                           {
                                               "kind":  "religion",
                                               "religion":  "lutheran",
-                                              "weight":  1.0
+                                              "weight":  0.5
+                                          },
+                                          {
+                                              "kind":  "written",
+                                              "language":  "German",
+                                              "weight":  0.35
+                                          },
+                                          {
+                                              "kind":  "written",
+                                              "language":  "Latin",
+                                              "weight":  0.15
                                           }
                                       ],
                          "reward":  "fame"
@@ -1375,7 +1400,22 @@
                                           {
                                               "kind":  "religion",
                                               "religion":  "judaism",
-                                              "weight":  1.0
+                                              "weight":  0.5
+                                          },
+                                          {
+                                              "kind":  "written",
+                                              "language":  "Hebrew",
+                                              "weight":  0.25
+                                          },
+                                          {
+                                              "kind":  "written",
+                                              "language":  "Yiddish",
+                                              "weight":  0.15
+                                          },
+                                          {
+                                              "kind":  "written",
+                                              "language":  "German",
+                                              "weight":  0.1
                                           }
                                       ],
                          "reward":  "fame"

--- a/crates/adventuresim-core/Cargo.toml
+++ b/crates/adventuresim-core/Cargo.toml
@@ -21,6 +21,7 @@ adventuresim-dialogue.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sha2.workspace = true
+adventuresim-world-schema.workspace = true
 
 [lints]
 workspace = true

--- a/crates/adventuresim-core/src/book.rs
+++ b/crates/adventuresim-core/src/book.rs
@@ -5,6 +5,10 @@ use crate::skill::Skill;
 
 pub const READABLE_WRITTEN_RANK: f32 = 1.0;
 
+pub const fn rank_band(book: &Book) -> (u8, u8) {
+    (book.quality.saturating_sub(1), book.quality)
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct BoundedBookGain {
     pub accepted_effective_hours: f32,
@@ -50,8 +54,7 @@ pub fn maximum_book_rank(target: &BookTarget) -> Option<u8> {
 }
 
 pub fn book_shape_is_valid(book: &Book) -> bool {
-    book.upper_rank == book.lower_rank.saturating_add(1)
-        && book.upper_rank <= maximum_book_rank(&book.target).unwrap_or(0)
+    (1..=maximum_book_rank(&book.target).unwrap_or(0)).contains(&book.quality)
         && match &book.target {
             BookTarget::Terrain { terrain } => matches!(
                 terrain.as_str(),
@@ -264,7 +267,7 @@ pub fn select_candidate<'a>(
         right
             .personal
             .cmp(&left.personal)
-            .then(left.book.lower_rank.cmp(&right.book.lower_rank))
+            .then(left.book.quality.cmp(&right.book.quality))
             .then(left.item_id.cmp(right.item_id))
     });
     values.dedup_by(|left, right| left.item_id == right.item_id);
@@ -313,8 +316,7 @@ mod tests {
             target: BookTarget::Skill {
                 skill: "cooking".into(),
             },
-            lower_rank: lower,
-            upper_rank: lower + 1,
+            quality: lower + 1,
             settlement_allowlist: Vec::new(),
         }
     }
@@ -508,5 +510,12 @@ mod tests {
             }),
             Some(1)
         );
+        let cooking = book(1);
+        assert_eq!(cooking.quality, 2);
+        assert_eq!(rank_band(&cooking), (1, 2));
+        assert!(book_shape_is_valid(&cooking));
+        let mut excessive = cooking;
+        excessive.quality = 3;
+        assert!(!book_shape_is_valid(&excessive));
     }
 }

--- a/crates/adventuresim-core/src/book.rs
+++ b/crates/adventuresim-core/src/book.rs
@@ -1,0 +1,512 @@
+//! Pure, deterministic mechanics for language-gated book study.
+
+use crate::item_catalog_schema::{Book, BookTarget};
+use crate::skill::Skill;
+
+pub const READABLE_WRITTEN_RANK: f32 = 1.0;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct BoundedBookGain {
+    pub accepted_effective_hours: f32,
+    pub unused_real_hours: f32,
+}
+
+/// Return the authored ceiling for a target family.
+pub fn maximum_book_rank(target: &BookTarget) -> Option<u8> {
+    Some(match target {
+        BookTarget::Written { .. } | BookTarget::Religion { .. } | BookTarget::Bestiary { .. } => 5,
+        BookTarget::Skill { skill } if matches!(skill.as_str(), "physiology" | "herbalism") => 4,
+        BookTarget::Terrain { .. } => 2,
+        BookTarget::Skill { skill }
+            if matches!(
+                skill.as_str(),
+                "surgery" | "cooking" | "tailoring" | "smithing" | "command" | "charm"
+            ) =>
+        {
+            2
+        }
+        BookTarget::Skill { skill }
+            if matches!(
+                skill.as_str(),
+                "polearm"
+                    | "axe"
+                    | "bludgeon"
+                    | "sword"
+                    | "knife"
+                    | "bow"
+                    | "crossbow"
+                    | "firearm"
+                    | "throw"
+                    | "dodge"
+                    | "block"
+                    | "balance"
+                    | "stealth"
+            ) =>
+        {
+            1
+        }
+        _ => return None,
+    })
+}
+
+pub fn book_shape_is_valid(book: &Book) -> bool {
+    book.upper_rank == book.lower_rank.saturating_add(1)
+        && book.upper_rank <= maximum_book_rank(&book.target).unwrap_or(0)
+        && match &book.target {
+            BookTarget::Terrain { terrain } => matches!(
+                terrain.as_str(),
+                "plains" | "forest" | "hills" | "wetlands" | "urban" | "snow"
+            ),
+            _ => true,
+        }
+}
+
+pub fn written_rank(hours: f32, intelligence: f32) -> f32 {
+    (hours.max(0.0) / 1_000.0).min(intelligence.clamp(0.0, 5.0))
+}
+
+pub fn reading_rate(medium_effective_rank: f32) -> f32 {
+    (medium_effective_rank / 5.0).clamp(0.0, 1.0)
+}
+
+/// Award direct effective hours without applying the target aptitude's
+/// training-speed multiplier. Aptitude remains an effective-rank cap.
+///
+/// `hours_for_rank` must describe the target leaf's direct-hours curve.
+pub fn apply_bounded_book_training(
+    direct_hours: &mut f32,
+    effective_target_rank: f32,
+    target_aptitude: f32,
+    lower_rank: u8,
+    upper_rank: u8,
+    real_reading_hours: f32,
+    medium_effective_rank: f32,
+    hours_for_rank: impl Fn(f32) -> f32,
+    project_effective_hours: impl Fn(f32) -> f32,
+) -> BoundedBookGain {
+    if !real_reading_hours.is_finite()
+        || real_reading_hours <= 0.0
+        || !effective_target_rank.is_finite()
+        || !target_aptitude.is_finite()
+        || !medium_effective_rank.is_finite()
+        || medium_effective_rank < READABLE_WRITTEN_RANK
+        || effective_target_rank + 0.000_01 < f32::from(lower_rank)
+        || effective_target_rank >= f32::from(upper_rank)
+        || target_aptitude <= f32::from(lower_rank)
+    {
+        return BoundedBookGain {
+            unused_real_hours: real_reading_hours.max(0.0),
+            ..Default::default()
+        };
+    }
+    let rate = reading_rate(medium_effective_rank);
+    let upper = f32::from(upper_rank).min(target_aptitude.clamp(0.0, 5.0));
+    let effective_ceiling = hours_for_rank(upper);
+    let current = direct_hours.max(0.0);
+    if rate <= 0.0 || project_effective_hours(current) > effective_ceiling {
+        return BoundedBookGain {
+            unused_real_hours: real_reading_hours,
+            ..Default::default()
+        };
+    }
+    let desired = (current + real_reading_hours * rate).min(effective_ceiling.max(current));
+    let accepted_direct = if project_effective_hours(desired) <= effective_ceiling {
+        desired
+    } else {
+        let mut low = current;
+        let mut high = desired;
+        for _ in 0..64 {
+            let middle = low + (high - low) * 0.5;
+            if project_effective_hours(middle) <= effective_ceiling {
+                low = middle;
+            } else {
+                high = middle;
+            }
+        }
+        low
+    };
+    let accepted = (accepted_direct - current).max(0.0);
+    *direct_hours = current + accepted;
+    BoundedBookGain {
+        accepted_effective_hours: accepted,
+        unused_real_hours: if rate > 0.0 {
+            (real_reading_hours - accepted / rate).max(0.0)
+        } else {
+            real_reading_hours
+        },
+    }
+}
+
+/// Integrate Written study with its changing correlated medium literacy and
+/// its direct-zero target gate.
+pub fn apply_written_book_training(
+    hours: &mut adventuresim_world_schema::WrittenLanguageHours,
+    medium: adventuresim_world_schema::WrittenLanguage,
+    target: adventuresim_world_schema::WrittenLanguage,
+    effective_target_rank: f32,
+    intelligence: f32,
+    lower_rank: u8,
+    upper_rank: u8,
+    real_reading_hours: f32,
+) -> BoundedBookGain {
+    let medium_effective = hours.effective(medium);
+    let medium_rank = written_rank(medium_effective, intelligence);
+    if !real_reading_hours.is_finite()
+        || real_reading_hours <= 0.0
+        || !effective_target_rank.is_finite()
+        || !intelligence.is_finite()
+        || medium_rank < READABLE_WRITTEN_RANK
+        || effective_target_rank + 0.000_01 < f32::from(lower_rank)
+        || effective_target_rank >= f32::from(upper_rank)
+        || intelligence <= f32::from(lower_rank)
+    {
+        return BoundedBookGain {
+            unused_real_hours: real_reading_hours.max(0.0),
+            ..Default::default()
+        };
+    }
+    let upper = f32::from(upper_rank).min(intelligence.clamp(0.0, 5.0));
+    let effective_ceiling = upper * 1_000.0;
+    let current = hours.direct(target).max(0.0);
+    let baseline = *hours;
+    let target_effective = |direct: f32| {
+        let mut projected = baseline;
+        *projected.direct_mut(target) = direct;
+        projected.effective(target)
+    };
+    if target_effective(current) > effective_ceiling {
+        return BoundedBookGain {
+            unused_real_hours: real_reading_hours,
+            ..Default::default()
+        };
+    }
+
+    let coefficient = medium.correlation(target);
+    let base = adventuresim_world_schema::WrittenLanguage::ALL
+        .into_iter()
+        .filter(|source| *source != target)
+        .map(|source| hours.direct(source).max(0.0) * medium.correlation(source))
+        .sum::<f32>();
+    let medium_cap = intelligence.clamp(0.0, 5.0) * 1_000.0;
+    let time_to_direct = |end: f32| {
+        if end <= current {
+            return 0.0;
+        }
+        let start_effective = (base + coefficient * current).min(medium_cap);
+        if coefficient <= f32::EPSILON || start_effective >= medium_cap {
+            return (end - current) * 5_000.0 / start_effective;
+        }
+        let saturation = ((medium_cap - base) / coefficient).max(current);
+        let curved_end = end.min(saturation);
+        let curved_delta = coefficient * (curved_end - current) / start_effective;
+        let mut elapsed = 5_000.0 / coefficient * curved_delta.ln_1p();
+        if end > saturation {
+            elapsed += (end - saturation) * 5_000.0 / medium_cap;
+        }
+        elapsed
+    };
+    let direct_after_time = |elapsed: f32| {
+        let start_effective = (base + coefficient * current).min(medium_cap);
+        if coefficient <= f32::EPSILON || start_effective >= medium_cap {
+            return current + elapsed * start_effective / 5_000.0;
+        }
+        let saturation = ((medium_cap - base) / coefficient).max(current);
+        let curved_time = time_to_direct(saturation);
+        if elapsed <= curved_time {
+            current + start_effective / coefficient * (coefficient * elapsed / 5_000.0).exp_m1()
+        } else {
+            saturation + (elapsed - curved_time) * medium_cap / 5_000.0
+        }
+    };
+    let desired = direct_after_time(real_reading_hours).min(effective_ceiling.max(current));
+    let accepted_direct = if target_effective(desired) <= effective_ceiling {
+        desired
+    } else {
+        let mut low = current;
+        let mut high = desired;
+        for _ in 0..64 {
+            let middle = low + (high - low) * 0.5;
+            if target_effective(middle) <= effective_ceiling {
+                low = middle;
+            } else {
+                high = middle;
+            }
+        }
+        low
+    };
+    let accepted = (accepted_direct - current).max(0.0);
+    *hours.direct_mut(target) = current + accepted;
+    let used_real_hours = time_to_direct(current + accepted);
+    BoundedBookGain {
+        accepted_effective_hours: accepted,
+        unused_real_hours: (real_reading_hours - used_real_hours).max(0.0),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct BookCandidate<'a> {
+    pub item_id: &'a str,
+    pub book: &'a Book,
+    pub personal: bool,
+}
+
+/// Personal books are considered before bookstore books. Duplicate inventory
+/// copies are naturally collapsed by stable item ID.
+pub fn select_candidate<'a>(
+    candidates: impl IntoIterator<Item = BookCandidate<'a>>,
+    useful: impl Fn(&Book) -> bool,
+) -> Option<BookCandidate<'a>> {
+    let mut values = candidates
+        .into_iter()
+        .filter(|candidate| useful(candidate.book))
+        .collect::<Vec<_>>();
+    values.sort_by(|left, right| {
+        right
+            .personal
+            .cmp(&left.personal)
+            .then(left.book.lower_rank.cmp(&right.book.lower_rank))
+            .then(left.item_id.cmp(right.item_id))
+    });
+    values.dedup_by(|left, right| left.item_id == right.item_id);
+    values.into_iter().next()
+}
+
+pub fn ordinary_skill(target: &BookTarget) -> Option<Skill> {
+    let BookTarget::Skill { skill } = target else {
+        return None;
+    };
+    Some(match skill.as_str() {
+        "physiology" => Skill::Physiology,
+        "herbalism" => Skill::Herbalism,
+        "surgery" => Skill::Surgery,
+        "cooking" => Skill::Cooking,
+        "tailoring" => Skill::Tailoring,
+        "smithing" => Skill::Smithing,
+        "command" => Skill::Command,
+        "charm" => Skill::Charm,
+        "polearm" => Skill::Polearm,
+        "axe" => Skill::Axe,
+        "bludgeon" => Skill::Bludgeon,
+        "sword" => Skill::Sword,
+        "knife" => Skill::Knife,
+        "bow" => Skill::Bow,
+        "crossbow" => Skill::Crossbow,
+        "firearm" => Skill::Firearm,
+        "throw" => Skill::Throw,
+        "dodge" => Skill::Dodge,
+        "block" => Skill::Block,
+        "balance" => Skill::Balance,
+        "stealth" => Skill::Stealth,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::item_catalog_schema::{Book, BookTarget};
+    use adventuresim_world_schema::WrittenLanguage;
+
+    fn book(lower: u8) -> Book {
+        Book {
+            medium: WrittenLanguage::German,
+            target: BookTarget::Skill {
+                skill: "cooking".into(),
+            },
+            lower_rank: lower,
+            upper_rank: lower + 1,
+            settlement_allowlist: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn bounded_gain_requires_exact_prerequisite_clips_and_uses_literacy_rate() {
+        let curve = |rank: f32| rank * 100.0;
+        let mut hours = 100.0;
+        let blocked =
+            apply_bounded_book_training(&mut hours, 1.0, 5.0, 2, 3, 10.0, 5.0, curve, |d| d);
+        assert_eq!(blocked.accepted_effective_hours, 0.0);
+        let gain =
+            apply_bounded_book_training(&mut hours, 1.0, 5.0, 1, 2, 1_000.0, 2.5, curve, |d| d);
+        assert_eq!(hours, 200.0);
+        assert_eq!(gain.accepted_effective_hours, 100.0);
+        assert_eq!(gain.unused_real_hours, 800.0);
+    }
+
+    #[test]
+    fn candidate_order_is_personal_then_band_then_stable_id_and_dedupes() {
+        let one = book(0);
+        let two = book(1);
+        let selected = select_candidate(
+            [
+                BookCandidate {
+                    item_id: "b",
+                    book: &one,
+                    personal: false,
+                },
+                BookCandidate {
+                    item_id: "a",
+                    book: &one,
+                    personal: false,
+                },
+                BookCandidate {
+                    item_id: "z",
+                    book: &two,
+                    personal: true,
+                },
+                BookCandidate {
+                    item_id: "z",
+                    book: &two,
+                    personal: true,
+                },
+            ],
+            |_| true,
+        )
+        .unwrap();
+        assert_eq!(selected.item_id, "z");
+    }
+
+    #[test]
+    fn correlated_effective_rank_counts_toward_the_books_upper_boundary() {
+        let projection = |direct: f32| direct + 80.0_f32.min(direct);
+        let mut bulk = 60.0;
+        apply_bounded_book_training(
+            &mut bulk,
+            1.2,
+            5.0,
+            1,
+            2,
+            100.0,
+            5.0,
+            |rank| rank * 100.0,
+            projection,
+        );
+        let mut partitioned = 60.0;
+        for _ in 0..4 {
+            let rank = projection(partitioned) / 100.0;
+            apply_bounded_book_training(
+                &mut partitioned,
+                rank,
+                5.0,
+                1,
+                2,
+                25.0,
+                5.0,
+                |rank| rank * 100.0,
+                projection,
+            );
+        }
+        assert!((bulk - 120.0).abs() < 0.001);
+        assert!((bulk - partitioned).abs() < 0.001);
+        assert!(projection(bulk) <= 200.001);
+    }
+
+    #[test]
+    fn written_bridges_are_bulk_chunk_equivalent_and_never_overshoot() {
+        for target in [WrittenLanguage::Low, WrittenLanguage::Latin] {
+            let initial = adventuresim_world_schema::WrittenLanguageHours {
+                german: 1_000.0,
+                ..Default::default()
+            };
+            let mut bulk_short = initial;
+            apply_written_book_training(
+                &mut bulk_short,
+                WrittenLanguage::German,
+                target,
+                0.0,
+                5.0,
+                0,
+                1,
+                400.0,
+            );
+            let mut partitioned_short = initial;
+            for _ in 0..4 {
+                let rank = written_rank(partitioned_short.effective(target), 5.0);
+                apply_written_book_training(
+                    &mut partitioned_short,
+                    WrittenLanguage::German,
+                    target,
+                    rank,
+                    5.0,
+                    0,
+                    1,
+                    100.0,
+                );
+            }
+            assert!(
+                (bulk_short.direct(target) - partitioned_short.direct(target)).abs() < 0.001,
+                "{target:?}"
+            );
+
+            let mut bulk = initial;
+            apply_written_book_training(
+                &mut bulk,
+                WrittenLanguage::German,
+                target,
+                0.0,
+                5.0,
+                0,
+                1,
+                10_000.0,
+            );
+            assert!(bulk.effective(target) <= 1_000.001, "{target:?}");
+            assert!(
+                (bulk.effective(target) - 1_000.0).abs() < 0.001,
+                "{target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn direct_zero_correlation_gate_cannot_jump_over_a_band() {
+        let mut direct = 0.0;
+        let gain = apply_bounded_book_training(
+            &mut direct,
+            0.0,
+            5.0,
+            0,
+            1,
+            100.0,
+            5.0,
+            |rank| rank * 100.0,
+            |candidate| {
+                if candidate <= 0.0 {
+                    0.0
+                } else {
+                    candidate + 150.0
+                }
+            },
+        );
+        assert_eq!(direct, 0.0);
+        assert_eq!(gain.accepted_effective_hours, 0.0);
+        assert_eq!(gain.unused_real_hours, 100.0);
+    }
+
+    #[test]
+    fn authored_family_caps_are_exact() {
+        assert_eq!(
+            maximum_book_rank(&BookTarget::Written {
+                language: WrittenLanguage::Latin
+            }),
+            Some(5)
+        );
+        assert_eq!(
+            maximum_book_rank(&BookTarget::Skill {
+                skill: "physiology".into()
+            }),
+            Some(4)
+        );
+        assert_eq!(
+            maximum_book_rank(&BookTarget::Skill {
+                skill: "command".into()
+            }),
+            Some(2)
+        );
+        assert_eq!(
+            maximum_book_rank(&BookTarget::Skill {
+                skill: "sword".into()
+            }),
+            Some(1)
+        );
+    }
+}

--- a/crates/adventuresim-core/src/item_catalog.rs
+++ b/crates/adventuresim-core/src/item_catalog.rs
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn embedded_catalog_is_sorted_unique_complete_and_revisioned() {
-        assert_eq!(catalog().len(), 134);
+        assert_eq!(catalog().len(), 154);
         assert!(revision().len() == 64 && revision().bytes().all(|b| b.is_ascii_hexdigit()));
         assert!(
             catalog()
@@ -121,7 +121,7 @@ mod tests {
             + "\n";
         assert_eq!(
             format!("{:x}", Sha256::digest(stable_ids.as_bytes())),
-            "e7f25366ee7c6b5f3e5c1da889b6b600c0dc01883ce858cd0decf8f445d68056",
+            "67ddadf56fd2695d8bb39c8559cd412238e79184558b20afc270fb0a3070f7b0",
             "stable-ID golden changed; review persistence and reseed impact"
         );
 
@@ -141,7 +141,7 @@ mod tests {
             counts[index] += 1;
             counts
         });
-        assert_eq!(counts, [13, 6, 20, 14, 1, 1, 5, 24, 29, 21]);
+        assert_eq!(counts, [33, 6, 20, 14, 1, 1, 5, 24, 29, 21]);
     }
 
     #[test]

--- a/crates/adventuresim-core/src/item_catalog_schema.rs
+++ b/crates/adventuresim-core/src/item_catalog_schema.rs
@@ -124,6 +124,41 @@ pub struct Capabilities {
     pub food: Option<Food>,
     pub alcohol: Option<Alcohol>,
     pub container: Option<Container>,
+    pub book: Option<Book>,
+}
+
+/// Authored teaching metadata. Books remain ordinary `simple` items; this
+/// capability is resolved from the embedded catalog and is never flattened
+/// into a persisted inventory row.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Book {
+    pub medium: adventuresim_world_schema::WrittenLanguage,
+    pub target: BookTarget,
+    pub lower_rank: u8,
+    pub upper_rank: u8,
+    #[serde(default)]
+    pub settlement_allowlist: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum BookTarget {
+    Written {
+        language: adventuresim_world_schema::WrittenLanguage,
+    },
+    Religion {
+        religion: adventuresim_world_schema::OfficialReligion,
+    },
+    Bestiary {
+        category: adventuresim_world_schema::BestiaryCategory,
+    },
+    Terrain {
+        terrain: String,
+    },
+    Skill {
+        skill: String,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]

--- a/crates/adventuresim-core/src/item_catalog_schema.rs
+++ b/crates/adventuresim-core/src/item_catalog_schema.rs
@@ -135,8 +135,8 @@ pub struct Capabilities {
 pub struct Book {
     pub medium: adventuresim_world_schema::WrittenLanguage,
     pub target: BookTarget,
-    pub lower_rank: u8,
-    pub upper_rank: u8,
+    /// Shared 1..=5 item quality. A quality-N book teaches rank N-1 to N.
+    pub quality: u8,
     #[serde(default)]
     pub settlement_allowlist: Vec<String>,
 }

--- a/crates/adventuresim-core/src/item_catalog_validation.rs
+++ b/crates/adventuresim-core/src/item_catalog_validation.rs
@@ -709,13 +709,7 @@ fn validate_capabilities(
     if let Some(book) = capabilities.get("book").and_then(Value::as_object) {
         reject_unknown(
             book,
-            &[
-                "medium",
-                "target",
-                "lower_rank",
-                "upper_rank",
-                "settlement_allowlist",
-            ],
+            &["medium", "target", "quality", "settlement_allowlist"],
             file,
             &format!("{path}.capabilities.book"),
             errors,
@@ -730,7 +724,7 @@ fn validate_capabilities(
         match parsed {
             Ok(book) if valid_book_shape(&book) => {}
             Ok(_) => errors.push(format!(
-                "{file}: {path}.capabilities.book: target must be a supported leaf with an adjacent legal rank band"
+                "{file}: {path}.capabilities.book: target must be a supported leaf with a legal quality"
             )),
             Err(error) => errors.push(format!(
                 "{file}: {path}.capabilities.book: {error}"
@@ -797,7 +791,7 @@ fn valid_book_shape(book: &crate::item_catalog_schema::Book) -> bool {
         }
         _ => return false,
     };
-    book.upper_rank == book.lower_rank.saturating_add(1) && book.upper_rank <= maximum
+    (1..=maximum).contains(&book.quality)
 }
 
 fn valid_id(id: &str) -> bool {
@@ -992,13 +986,12 @@ mod tests {
     }
 
     #[test]
-    fn book_capabilities_require_supported_adjacent_bands() {
+    fn book_capabilities_require_supported_quality() {
         let valid = json!({
             "book": {
                 "medium": "German",
                 "target": {"kind": "written", "language": "Latin"},
-                "lower_rank": 0,
-                "upper_rank": 1
+                "quality": 1
             }
         });
         let mut errors = Vec::new();
@@ -1015,8 +1008,7 @@ mod tests {
             "book": {
                 "medium": "German",
                 "target": {"kind": "skill", "skill": "sword"},
-                "lower_rank": 1,
-                "upper_rank": 2
+                "quality": 2
             }
         });
         let mut errors = Vec::new();
@@ -1027,10 +1019,6 @@ mod tests {
             "simple",
             &mut errors,
         );
-        assert!(
-            errors
-                .iter()
-                .any(|error| error.contains("adjacent legal rank band"))
-        );
+        assert!(errors.iter().any(|error| error.contains("legal quality")));
     }
 }

--- a/crates/adventuresim-core/src/item_catalog_validation.rs
+++ b/crates/adventuresim-core/src/item_catalog_validation.rs
@@ -508,7 +508,7 @@ fn validate_capabilities(
 ) {
     reject_unknown(
         capabilities,
-        &["durability", "food", "alcohol", "container"],
+        &["durability", "food", "alcohol", "container", "book"],
         file,
         &format!("{path}.capabilities"),
         errors,
@@ -706,6 +706,98 @@ fn validate_capabilities(
             "{file}: {path}.capabilities.container: container kind requires capacity metadata"
         ));
     }
+    if let Some(book) = capabilities.get("book").and_then(Value::as_object) {
+        reject_unknown(
+            book,
+            &[
+                "medium",
+                "target",
+                "lower_rank",
+                "upper_rank",
+                "settlement_allowlist",
+            ],
+            file,
+            &format!("{path}.capabilities.book"),
+            errors,
+        );
+        if kind != "simple" {
+            errors.push(format!(
+                "{file}: {path}.capabilities.book: books must use kind simple"
+            ));
+        }
+        let parsed =
+            serde_json::from_value::<crate::item_catalog_schema::Book>(Value::Object(book.clone()));
+        match parsed {
+            Ok(book) if valid_book_shape(&book) => {}
+            Ok(_) => errors.push(format!(
+                "{file}: {path}.capabilities.book: target must be a supported leaf with an adjacent legal rank band"
+            )),
+            Err(error) => errors.push(format!(
+                "{file}: {path}.capabilities.book: {error}"
+            )),
+        }
+    }
+}
+
+fn valid_book_shape(book: &crate::item_catalog_schema::Book) -> bool {
+    use crate::item_catalog_schema::BookTarget;
+    let mut settlements = BTreeSet::new();
+    if book.settlement_allowlist.len() > 64
+        || book.settlement_allowlist.iter().any(|id| {
+            id.is_empty()
+                || id.len() > 96
+                || !id.bytes().all(|byte| {
+                    byte.is_ascii_lowercase()
+                        || byte.is_ascii_digit()
+                        || matches!(byte, b'_' | b'-')
+                })
+                || !settlements.insert(id)
+        })
+    {
+        return false;
+    }
+    let maximum = match &book.target {
+        BookTarget::Written { .. } | BookTarget::Religion { .. } | BookTarget::Bestiary { .. } => 5,
+        BookTarget::Skill { skill } if matches!(skill.as_str(), "physiology" | "herbalism") => 4,
+        BookTarget::Terrain { terrain }
+            if matches!(
+                terrain.as_str(),
+                "plains" | "forest" | "hills" | "wetlands" | "urban" | "snow"
+            ) =>
+        {
+            2
+        }
+        BookTarget::Skill { skill }
+            if matches!(
+                skill.as_str(),
+                "surgery" | "cooking" | "tailoring" | "smithing" | "command" | "charm"
+            ) =>
+        {
+            2
+        }
+        BookTarget::Skill { skill }
+            if matches!(
+                skill.as_str(),
+                "polearm"
+                    | "axe"
+                    | "bludgeon"
+                    | "sword"
+                    | "knife"
+                    | "bow"
+                    | "crossbow"
+                    | "firearm"
+                    | "throw"
+                    | "dodge"
+                    | "block"
+                    | "balance"
+                    | "stealth"
+            ) =>
+        {
+            1
+        }
+        _ => return false,
+    };
+    book.upper_rank == book.lower_rank.saturating_add(1) && book.upper_rank <= maximum
 }
 
 fn valid_id(id: &str) -> bool {
@@ -897,5 +989,48 @@ mod tests {
         let error =
             validate_documents(&[document(vec![item])], &["currency.yaml".into()]).unwrap_err();
         assert!(error.contains("currency IDs must match the supported gameplay registry"));
+    }
+
+    #[test]
+    fn book_capabilities_require_supported_adjacent_bands() {
+        let valid = json!({
+            "book": {
+                "medium": "German",
+                "target": {"kind": "written", "language": "Latin"},
+                "lower_rank": 0,
+                "upper_rank": 1
+            }
+        });
+        let mut errors = Vec::new();
+        validate_capabilities(
+            valid.as_object().unwrap(),
+            "books.yaml",
+            "item latin_primer",
+            "simple",
+            &mut errors,
+        );
+        assert!(errors.is_empty(), "{errors:?}");
+
+        let excessive = json!({
+            "book": {
+                "medium": "German",
+                "target": {"kind": "skill", "skill": "sword"},
+                "lower_rank": 1,
+                "upper_rank": 2
+            }
+        });
+        let mut errors = Vec::new();
+        validate_capabilities(
+            excessive.as_object().unwrap(),
+            "books.yaml",
+            "item master_sword_book",
+            "simple",
+            &mut errors,
+        );
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("adjacent legal rank band"))
+        );
     }
 }

--- a/crates/adventuresim-core/src/lib.rs
+++ b/crates/adventuresim-core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod autoresolve;
 pub mod battle_rewards;
 pub mod bestiary;
 pub mod body;
+pub mod book;
 pub mod capability;
 pub mod case;
 pub mod combat;

--- a/crates/adventuresim-core/src/organization.rs
+++ b/crates/adventuresim-core/src/organization.rs
@@ -312,10 +312,21 @@ pub struct TrainingEntry {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum TrainingTarget {
-    FixedSkill { skill: String },
-    Religion { religion: String },
-    Bestiary { category: String },
-    Terrain { terrain: String },
+    FixedSkill {
+        skill: String,
+    },
+    Religion {
+        religion: String,
+    },
+    Bestiary {
+        category: String,
+    },
+    Terrain {
+        terrain: String,
+    },
+    Written {
+        language: adventuresim_world_schema::WrittenLanguage,
+    },
     EquippedWeaponSkills,
 }
 
@@ -452,6 +463,7 @@ pub fn service_npc_location_id(service_id: &str) -> Option<&'static str> {
         "weapons" => Some("forge"),
         "armor" => Some("armoury"),
         "clothing" => Some("tailor"),
+        "books" => Some("bookstore"),
         "herbalist" => Some("herbalist"),
         "inn" => Some("inn"),
         "religion" => Some("church"),
@@ -471,6 +483,7 @@ pub fn service_npc_location_available(
         "weapons" => storefront_available(profile, Storefront::Weapons),
         "armor" => storefront_available(profile, Storefront::Armor),
         "clothing" => storefront_available(profile, Storefront::Clothing),
+        "books" => storefront_available(profile, Storefront::Books),
         "herbalist" => storefront_available(profile, Storefront::Herbalist),
         "inn" => action_service_available(profile, SettlementActionService::Inn),
         "religion" => action_service_available(profile, SettlementActionService::Temple),
@@ -1000,6 +1013,7 @@ mod tests {
         assert_eq!(service_npc_location_id("weapons"), Some("forge"));
         assert_eq!(service_npc_location_id("armor"), Some("armoury"));
         assert_eq!(service_npc_location_id("clothing"), Some("tailor"));
+        assert_eq!(service_npc_location_id("books"), Some("bookstore"));
         assert_eq!(service_npc_location_id("herbalist"), Some("herbalist"));
         assert_eq!(service_npc_location_id("inn"), Some("inn"));
         assert_eq!(service_npc_location_id("religion"), Some("church"));

--- a/crates/adventuresim-core/src/organization_catalog_validation.rs
+++ b/crates/adventuresim-core/src/organization_catalog_validation.rs
@@ -60,6 +60,9 @@ const BESTIARY: &[&str] = &[
     "wildmen",
 ];
 const TERRAINS: &[&str] = &["plains", "forest", "hills", "urban"];
+const WRITTEN_LANGUAGES: &[&str] = &[
+    "German", "Low", "Latin", "Hebrew", "Yiddish", "Elven", "Dwarfish",
+];
 
 fn object<'a>(
     value: &'a Value,
@@ -614,6 +617,12 @@ pub fn validate_documents(
                         return Err(format!("{source}: {at}.terrain is unknown"));
                     }
                 }
+                "written" => {
+                    keys(entry, &["kind", "language", "weight"], source, &at)?;
+                    if !WRITTEN_LANGUAGES.contains(&text(entry, source, "language")?) {
+                        return Err(format!("{source}: {at}.language is unknown"));
+                    }
+                }
                 "equipped_weapon_skills" => keys(entry, &["kind", "weight"], source, &at)?,
                 _ => {
                     return Err(format!(
@@ -763,6 +772,23 @@ mod tests {
             validate(forbidden, json!([]))
                 .unwrap_err()
                 .contains("leaf is forbidden")
+        );
+    }
+
+    #[test]
+    fn accepts_written_training_and_rejects_unknown_written_language() {
+        let mut written = valid_organization();
+        written["activity"]["training"] =
+            json!([{"kind": "written", "language": "Latin", "weight": 1.0}]);
+        assert!(validate(written, json!([])).is_ok());
+
+        let mut unknown = valid_organization();
+        unknown["activity"]["training"] =
+            json!([{"kind": "written", "language": "atlantean", "weight": 1.0}]);
+        assert!(
+            validate(unknown, json!([]))
+                .unwrap_err()
+                .contains("language is unknown")
         );
     }
 

--- a/crates/adventuresim-core/src/settlement_economy.rs
+++ b/crates/adventuresim-core/src/settlement_economy.rs
@@ -12,6 +12,7 @@ pub enum Storefront {
     Clothing,
     Herbalist,
     Inn,
+    Books,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -150,6 +151,11 @@ pub fn player_visible_npc_tabs(
             action_service_location_id(SettlementActionService::Temple),
             "Church",
         ),
+        (
+            storefront_available(profile, Storefront::Books),
+            "bookstore",
+            "Bookstore",
+        ),
     ] {
         if available {
             tabs.push(SettlementNpcTab { location_id, label });
@@ -215,6 +221,12 @@ pub fn item_stock_category(id: &str, kind: CatalogKind) -> Option<Stock> {
         {
             Stock::Metalwares
         }
+        CatalogKind::Simple
+            if crate::item_catalog::definition(id)
+                .is_some_and(|item| item.capabilities.book.is_some()) =>
+        {
+            Stock::Books
+        }
         CatalogKind::Simple => Stock::GeneralGoods,
         CatalogKind::Food => crate::item_catalog::definition(id)
             .and_then(|item| {
@@ -248,6 +260,7 @@ pub fn storefront_available(profile: &SettlementEconomyProfile, storefront: Stor
         Storefront::Clothing => profile.has_service(Service::Tailor),
         Storefront::Herbalist => profile.has_service(Service::Herbalist),
         Storefront::Inn => profile.has_service(Service::Inn),
+        Storefront::Books => profile.has_service(Service::Bookstore),
     }
 }
 
@@ -276,16 +289,19 @@ pub fn storefront_stocks(
     let category_available = profile.stock.iter().any(|entry| entry.category == category);
     category_available
         && match storefront {
-            Storefront::General => !matches!(
-                kind,
-                CatalogKind::Ingredient
-                    | CatalogKind::Medication
-                    | CatalogKind::Weapon
-                    | CatalogKind::Shield
-                    | CatalogKind::Armor
-                    | CatalogKind::Clothing
-                    | CatalogKind::Food
-            ),
+            Storefront::General => {
+                !matches!(
+                    kind,
+                    CatalogKind::Ingredient
+                        | CatalogKind::Medication
+                        | CatalogKind::Weapon
+                        | CatalogKind::Shield
+                        | CatalogKind::Armor
+                        | CatalogKind::Clothing
+                        | CatalogKind::Food
+                ) && crate::item_catalog::definition(id)
+                    .is_none_or(|item| item.capabilities.book.is_none())
+            }
             Storefront::Weapons => matches!(kind, CatalogKind::Weapon | CatalogKind::Shield),
             Storefront::Armor => kind == CatalogKind::Armor,
             Storefront::Clothing => kind == CatalogKind::Clothing,
@@ -297,6 +313,11 @@ pub fn storefront_stocks(
                 (matches!(kind, CatalogKind::Food) || crate::food::definition(id).is_some())
                     || crate::item_catalog::definition(id)
                         .is_some_and(|item| item.tags.iter().any(|tag| tag == "cooking_tool"))
+            }
+            Storefront::Books => {
+                kind == CatalogKind::Simple
+                    && crate::item_catalog::definition(id)
+                        .is_some_and(|item| item.capabilities.book.is_some())
             }
         }
 }
@@ -328,6 +349,29 @@ mod tests {
             Storefront::Weapons,
             "club",
             CatalogKind::Weapon
+        ));
+    }
+
+    #[test]
+    fn books_are_exclusive_to_bookstores_with_books_stock() {
+        let bookstore = profile(vec![Service::Bookstore], vec![Stock::Books]);
+        assert!(storefront_stocks(
+            &bookstore,
+            Storefront::Books,
+            "primer_german_latin",
+            CatalogKind::Simple,
+        ));
+        assert!(!storefront_stocks(
+            &bookstore,
+            Storefront::General,
+            "primer_german_latin",
+            CatalogKind::Simple,
+        ));
+        assert!(!storefront_stocks(
+            &profile(vec![Service::Bookstore], vec![Stock::GeneralGoods]),
+            Storefront::Books,
+            "primer_german_latin",
+            CatalogKind::Simple,
         ));
     }
 

--- a/crates/adventuresim-core/src/skill.rs
+++ b/crates/adventuresim-core/src/skill.rs
@@ -198,6 +198,10 @@ mod tests {
             Skill::Physiology.governing_aptitude_kind().label(),
             "Intelligence"
         );
+        assert_eq!(
+            Skill::TerrainForest.governing_aptitude_kind().label(),
+            "Instinct"
+        );
         assert_eq!(Skill::Knife.governing_aptitude_kind().label(), "Agility");
     }
 
@@ -593,21 +597,23 @@ impl Skill {
 
     pub const fn governing_aptitude_kind(self) -> GoverningAptitude {
         match self {
-            Self::Will | Self::Insight | Self::Charm | Self::Command | Self::Deception => {
-                GoverningAptitude::Instinct
-            }
-            Self::Physiology
-            | Self::Surgery
-            | Self::Cooking
-            | Self::Herbalism
-            | Self::Religion
-            | Self::Bestiary
+            Self::Will
+            | Self::Insight
+            | Self::Charm
+            | Self::Command
+            | Self::Deception
             | Self::TerrainPlains
             | Self::TerrainForest
             | Self::TerrainHills
             | Self::TerrainWetlands
             | Self::TerrainUrban
-            | Self::TerrainSnow => GoverningAptitude::Intelligence,
+            | Self::TerrainSnow => GoverningAptitude::Instinct,
+            Self::Physiology
+            | Self::Surgery
+            | Self::Cooking
+            | Self::Herbalism
+            | Self::Religion
+            | Self::Bestiary => GoverningAptitude::Intelligence,
             Self::Dodge | Self::Balance => GoverningAptitude::Agility(LimbWeights::both_legs()),
             Self::Stealth => GoverningAptitude::Agility(LimbWeights::all_equal()),
             Self::Polearm

--- a/crates/adventuresim-core/src/starting_character.rs
+++ b/crates/adventuresim-core/src/starting_character.rs
@@ -83,6 +83,7 @@ pub struct StartingAttributes {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StartingSkills {
+    pub written: adventuresim_world_schema::WrittenLanguageHours,
     pub polearm: f32,
     pub axe: f32,
     pub bludgeon: f32,
@@ -401,6 +402,7 @@ pub fn generate(
     let primary_hours = 2600.0 + (hash("training", seed, slot) % 1800) as f32;
     let defense_hours = 1400.0 + (hash("defense", seed, slot) % 1400) as f32;
     let mut skills = StartingSkills {
+        written: adventuresim_world_schema::WrittenLanguageHours::default(),
         polearm: 120.0,
         axe: 120.0,
         bludgeon: 120.0,
@@ -774,6 +776,9 @@ fn apply_training_target(
             "snow" => skills.terrain_snow = hours,
             _ => return Err("unknown terrain in starting package"),
         },
+        TrainingTarget::Written { language } => {
+            *skills.written.direct_mut(*language) = hours.min(5_000.0);
+        }
         TrainingTarget::EquippedWeaponSkills => {
             return Err("equipped weapon training requires a starting loadout");
         }
@@ -1470,6 +1475,9 @@ mod tests {
                     assert_eq!(candidate.skills.surgery, 0.0);
                 }
                 StartingProfession::Cook => assert!(candidate.skills.cooking >= 30_000.0),
+                StartingProfession::Merchant => {
+                    assert!(candidate.skills.written.german > 0.0)
+                }
                 StartingProfession::WitchHunter => {
                     assert!(candidate.skills.bestiary.spirit >= 30_000.0)
                 }

--- a/crates/adventuresim-core/src/strategic_schedule.rs
+++ b/crates/adventuresim-core/src/strategic_schedule.rs
@@ -115,6 +115,8 @@ impl SkillHours {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DailySchedule {
+    /// Quiet study from a personally carried book or an on-site bookstore.
+    pub reading_minutes: u16,
     /// Structured combat practice, including weapon drills, will, and balance.
     pub combat_training_minutes: u16,
     /// Social recreation which trains Charm at the activity rate.
@@ -140,6 +142,7 @@ impl DailySchedule {
             self.carousing_minutes,
             self.apprenticeship_minutes,
             self.profession_practice_minutes,
+            self.reading_minutes,
         ]
         .into_iter()
         .map(u64::from)

--- a/crates/adventuresim-stdb-client/src/immediate_activity_type.rs
+++ b/crates/adventuresim-stdb-client/src/immediate_activity_type.rs
@@ -8,6 +8,8 @@ use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 #[sats(crate = __lib)]
 #[derive(Copy, Eq, Hash)]
 pub enum ImmediateActivity {
+    Reading,
+
     Prayer,
 
     CombatTraining,

--- a/crates/adventuresim-stdb-client/src/schedule_allocation_type.rs
+++ b/crates/adventuresim-stdb-client/src/schedule_allocation_type.rs
@@ -7,6 +7,7 @@ use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
 pub struct ScheduleAllocation {
+    pub reading_minutes: u16,
     pub combat_training_minutes: u16,
     pub carousing_minutes: u16,
     pub apprenticeship_minutes: u16,

--- a/crates/adventuresim-stdb-client/src/settlement_service_type.rs
+++ b/crates/adventuresim-stdb-client/src/settlement_service_type.rs
@@ -25,6 +25,8 @@ pub enum SettlementService {
     Herbalist,
 
     Temple,
+
+    Bookstore,
 }
 
 impl __sdk::InModule for SettlementService {

--- a/crates/adventuresim-stdb-client/src/stock_category_type.rs
+++ b/crates/adventuresim-stdb-client/src/stock_category_type.rs
@@ -39,6 +39,8 @@ pub enum StockCategory {
     Herbs,
 
     GeneralGoods,
+
+    Books,
 }
 
 impl __sdk::InModule for StockCategory {

--- a/crates/adventuresim-stdb-module/src/character.rs
+++ b/crates/adventuresim-stdb-module/src/character.rs
@@ -1265,13 +1265,15 @@ pub(crate) fn set_character_languages_for_settlement(
         .character_id()
         .find(character_id)
         .ok_or_else(|| format!("Character {character_id} has no skills"))?;
-    let (oral, written) = adventuresim_world_schema::initial_character_languages(
+    let (oral, _) = adventuresim_world_schema::initial_character_languages(
         settlement.languages,
         character_id,
         npc,
     );
     skills.oral_languages = oral;
-    skills.written_languages = written;
+    // Relocating a character can replace their authored vernacular identity
+    // during bootstrap, but literacy comes from estate and institutional
+    // training and must not be erased by a change of settlement.
     ctx.db.character_skills().character_id().update(skills);
     Ok(())
 }
@@ -1391,9 +1393,25 @@ fn insert_character_with_origin(
         calories_used: 0.0,
         focus: 1.0,
     });
-    let (oral_languages, written_languages) =
+    let (oral_languages, mut written_languages) =
         adventuresim_world_schema::initial_character_languages(start_settlement.languages, id, npc);
     let generated_skills = starting.map(|spec| &spec.skills);
+    if let Some(generated) = generated_skills {
+        written_languages = generated.written;
+    }
+    if !temporary
+        && crate::social_estate::character_estate(ctx, id)
+            .is_ok_and(|estate| estate == adventuresim_core::organization::Estate::Noble)
+    {
+        let local = if start_settlement.languages.dominant_german()
+            == adventuresim_world_schema::OralLanguage::Low
+        {
+            adventuresim_world_schema::WrittenLanguage::Low
+        } else {
+            adventuresim_world_schema::WrittenLanguage::German
+        };
+        *written_languages.direct_mut(local) = written_languages.direct(local).max(1_000.0);
+    }
     let _character_skills = ctx.db.character_skills().insert(CharacterSkills {
         character_id: id,
         polearm_hours: generated_skills.map_or(2000.0, |s| s.polearm),

--- a/crates/adventuresim-stdb-module/src/item.rs
+++ b/crates/adventuresim-stdb-module/src/item.rs
@@ -286,6 +286,9 @@ fn project_definition(definition: &adventuresim_core::item_catalog::ItemDefiniti
         item.nutrition_kcal = food.nutrition_kcal;
         item.quality = food.quality;
     }
+    if let Some(book) = &definition.capabilities.book {
+        item.quality = book.quality;
+    }
     if let Some(container) = definition.capabilities.container {
         item.water_capacity_ml = container.capacity_ml;
     }
@@ -881,6 +884,16 @@ mod tests {
             adventuresim_core::item_catalog::definition("arming_sword").unwrap(),
         );
         assert!(sword.repairable);
+    }
+
+    #[test]
+    fn projection_exposes_book_quality_for_inventory_presentation() {
+        let book = project_definition(
+            adventuresim_core::item_catalog::definition("human_anatomy").unwrap(),
+        );
+        assert_eq!(book.kind, ItemKind::Simple);
+        assert_eq!(book.quality, 4);
+        assert!(!book.repairable);
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/settlement_population.rs
+++ b/crates/adventuresim-stdb-module/src/settlement_population.rs
@@ -171,7 +171,7 @@ struct PersistedGenerationExplanation {
     profile: population::GeneratedPopulationProfile,
 }
 
-const SERVICES: [(&str, &str, &str, &str); 7] = [
+const SERVICES: [(&str, &str, &str, &str); 8] = [
     ("merchants", "market", "merchant", "market steward"),
     ("weapons", "forge", "weaponsmith", "master weaponsmith"),
     ("armor", "armoury", "armourer", "master armourer"),
@@ -179,6 +179,7 @@ const SERVICES: [(&str, &str, &str, &str); 7] = [
     ("herbalist", "herbalist", "herbalist", "local healer"),
     ("inn", "inn", "innkeeper", "innkeeper"),
     ("religion", "church", "cleric", "parish priest"),
+    ("books", "bookstore", "merchant", "bookseller"),
 ];
 const FEMALE_NAMES: [&str; 10] = [
     "Anna",
@@ -209,6 +210,7 @@ fn location_context(location: &str) -> Result<LocationContext, String> {
         "armoury" => LocationContext::Armoury,
         "tailor" => LocationContext::Tailor,
         "herbalist" => LocationContext::Herbalist,
+        "bookstore" => LocationContext::Market,
         "inn" => LocationContext::Inn,
         "church" => LocationContext::Church,
         "residences" => LocationContext::Residences,

--- a/crates/adventuresim-stdb-module/src/strategic/inventory_trade.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/inventory_trade.rs
@@ -1798,6 +1798,7 @@ fn merchant_storefront(
         "armor" => Ok((Storefront::Armor, "armoury")),
         "clothing" => Ok((Storefront::Clothing, "tailor")),
         "inn" => Ok((Storefront::Inn, "inn")),
+        "books" => Ok((Storefront::Books, "bookstore")),
         _ => Err("Unknown merchant storefront".into()),
     }
 }
@@ -1961,7 +1962,14 @@ fn finalize_storefront_trade_impl(
             storefront,
             item_id,
             catalog_kind,
-        ) {
+        ) || (storefront == adventuresim_core::settlement_economy::Storefront::Books
+            && adventuresim_core::item_catalog::definition(item_id)
+                .and_then(|definition| definition.capabilities.book.as_ref())
+                .is_none_or(|book| {
+                    !book.settlement_allowlist.is_empty()
+                        && !book.settlement_allowlist.contains(&settlement_id)
+                }))
+        {
             return Err("This settlement does not stock that merchant item".into());
         }
         let quoted = adventuresim_core::strategic_economy::language_adjusted_buy_price(

--- a/crates/adventuresim-stdb-module/src/strategic/tests/authority_trade_dialogue.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/tests/authority_trade_dialogue.rs
@@ -517,6 +517,7 @@
             "npc_is_present(&provider_presence, problem_minute)",
             "default_merchant_provider(ctx, &settlement_id, &service_id, location_id)?",
             "storefront_stocks(",
+            "settlement_allowlist",
             "inventory_food_definition(Some(item.kind), item_id)?",
             "add_to_party_inventory_checked(",
             "add_inventory_item_checked(",

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -67,6 +67,7 @@ pub struct CharacterTime {
 /// One 24-hour daily budget. Leisure is always the unallocated remainder.
 #[derive(Clone, Debug, Default, SpacetimeType)]
 pub struct ScheduleAllocation {
+    pub reading_minutes: u16,
     pub combat_training_minutes: u16,
     pub carousing_minutes: u16,
     pub apprenticeship_minutes: u16,
@@ -85,6 +86,7 @@ pub struct ScheduleAllocation {
 /// small, stable discriminator in generated clients.
 #[derive(Clone, Copy, Debug, SpacetimeType)]
 pub enum ImmediateActivity {
+    Reading,
     Prayer,
     CombatTraining,
     Carousing,
@@ -118,6 +120,7 @@ impl ScheduleAllocation {
             self.carousing_minutes,
             self.apprenticeship_minutes,
             self.profession_practice_minutes,
+            self.reading_minutes,
         ])
     }
 
@@ -131,6 +134,7 @@ impl ScheduleAllocation {
             self.carousing_minutes,
             self.apprenticeship_minutes,
             self.profession_practice_minutes,
+            self.reading_minutes,
         ];
         values.into_iter().all(|minutes| minutes % 15 == 0)
     }
@@ -781,6 +785,18 @@ fn apply_training(
                 activities,
                 &attributes,
             );
+            for entry in &definition.activity.training {
+                if let adventuresim_core::organization::TrainingTarget::Written { language } =
+                    &entry.target
+                {
+                    excess += adventuresim_core::skill::apply_language_training(
+                        skills.written_languages.direct_mut(*language),
+                        work_hours * entry.weight,
+                        attributes.intelligence,
+                    )
+                    .excess_effective_hours;
+                }
+            }
         }
     }
     skills.polearm_hours = hours.polearm;
@@ -815,11 +831,311 @@ fn apply_training(
     skills.terrain_snow_hours = hours.terrain_snow;
     skills.tailoring_hours = hours.tailoring;
     skills.smithing_hours = hours.smithing;
+    if schedule.reading_minutes > 0 {
+        let reading_hours =
+            elapsed as f32 / MINUTES_PER_DAY as f32 * f32::from(schedule.reading_minutes) / 60.0;
+        excess += apply_reading_training(ctx, character_id, skills, reading_hours, &attributes);
+    }
+    excess
+}
+
+fn terrain_book_skill(terrain: &str) -> Option<Skill> {
+    Some(match terrain {
+        "plains" => Skill::TerrainPlains,
+        "forest" => Skill::TerrainForest,
+        "hills" => Skill::TerrainHills,
+        "wetlands" => Skill::TerrainWetlands,
+        "urban" => Skill::TerrainUrban,
+        "snow" => Skill::TerrainSnow,
+        _ => return None,
+    })
+}
+
+fn direct_skill_hours_mut(skills: &mut CharacterSkills, skill: Skill) -> &mut f32 {
+    match skill {
+        Skill::Polearm => &mut skills.polearm_hours,
+        Skill::Axe => &mut skills.axe_hours,
+        Skill::Bludgeon => &mut skills.bludgeon_hours,
+        Skill::Sword => &mut skills.sword_hours,
+        Skill::Knife => &mut skills.knife_hours,
+        Skill::Dodge => &mut skills.dodge_hours,
+        Skill::Block => &mut skills.block_hours,
+        Skill::Bow => &mut skills.bow_hours,
+        Skill::Crossbow => &mut skills.crossbow_hours,
+        Skill::Firearm => &mut skills.firearm_hours,
+        Skill::Throw => &mut skills.throw_hours,
+        Skill::Will => &mut skills.will_hours,
+        Skill::Insight => &mut skills.insight_hours,
+        Skill::Charm => &mut skills.charm_hours,
+        Skill::Command => &mut skills.command_hours,
+        Skill::Deception => &mut skills.deception_hours,
+        Skill::Physiology => &mut skills.physiology_hours,
+        Skill::Cooking => &mut skills.cooking_hours,
+        Skill::Herbalism => &mut skills.herbalism_hours,
+        Skill::Stealth => &mut skills.stealth_hours,
+        Skill::Balance => &mut skills.balance_hours,
+        Skill::Surgery => &mut skills.surgery_hours,
+        Skill::TerrainPlains => &mut skills.terrain_plains_hours,
+        Skill::TerrainForest => &mut skills.terrain_forest_hours,
+        Skill::TerrainHills => &mut skills.terrain_hills_hours,
+        Skill::TerrainWetlands => &mut skills.terrain_wetlands_hours,
+        Skill::TerrainUrban => &mut skills.terrain_urban_hours,
+        Skill::TerrainSnow => &mut skills.terrain_snow_hours,
+        Skill::Tailoring => &mut skills.tailoring_hours,
+        Skill::Smithing => &mut skills.smithing_hours,
+        Skill::Religion | Skill::Bestiary => unreachable!("family leaves have separate storage"),
+    }
+}
+
+fn target_snapshot(
+    skills: &CharacterSkills,
+    target: &adventuresim_core::item_catalog_schema::BookTarget,
+    attributes: &CharacterAttributes,
+) -> Option<(f32, f32)> {
+    use adventuresim_core::item_catalog_schema::BookTarget;
+    match target {
+        BookTarget::Written { language } => Some((
+            adventuresim_core::book::written_rank(
+                skills.written_languages.effective(*language),
+                attributes.intelligence,
+            ),
+            attributes.intelligence,
+        )),
+        BookTarget::Religion { religion } => Some((
+            Skill::Religion
+                .capped_training_rank(skills.religion_hours.effective(*religion), attributes),
+            Skill::Religion.governing_aptitude(attributes),
+        )),
+        BookTarget::Bestiary { category } => Some((
+            Skill::Bestiary
+                .capped_training_rank(skills.bestiary_hours.effective(*category), attributes),
+            Skill::Bestiary.governing_aptitude(attributes),
+        )),
+        BookTarget::Terrain { terrain } => {
+            let skill = terrain_book_skill(terrain)?;
+            Some((
+                skill.capped_training_rank(skills.effective_skill_hours(skill), attributes),
+                skill.governing_aptitude(attributes),
+            ))
+        }
+        BookTarget::Skill { .. } => {
+            let skill = adventuresim_core::book::ordinary_skill(target)?;
+            Some((
+                skill.capped_training_rank(skills.effective_skill_hours(skill), attributes),
+                skill.governing_aptitude(attributes),
+            ))
+        }
+    }
+}
+
+fn apply_selected_book(
+    skills: &mut CharacterSkills,
+    book: &adventuresim_core::item_catalog_schema::Book,
+    real_hours: f32,
+    attributes: &CharacterAttributes,
+) -> adventuresim_core::book::BoundedBookGain {
+    use adventuresim_core::item_catalog_schema::BookTarget;
+    let medium_rank = adventuresim_core::book::written_rank(
+        skills.written_languages.effective(book.medium),
+        attributes.intelligence,
+    );
+    let Some((rank, aptitude)) = target_snapshot(skills, &book.target, attributes) else {
+        return Default::default();
+    };
+    let lower = book.lower_rank;
+    let upper = book.upper_rank;
+    match &book.target {
+        BookTarget::Written { language } => adventuresim_core::book::apply_written_book_training(
+            &mut skills.written_languages,
+            book.medium,
+            *language,
+            rank,
+            attributes.intelligence,
+            lower,
+            upper,
+            real_hours,
+        ),
+        BookTarget::Religion { religion } => {
+            let baseline = skills.religion_hours;
+            let direct = skills.religion_hours.direct_mut(*religion);
+            adventuresim_core::book::apply_bounded_book_training(
+                direct,
+                rank,
+                aptitude,
+                lower,
+                upper,
+                real_hours,
+                medium_rank,
+                |rank| Skill::Religion.hours_for_rank(rank),
+                |candidate| {
+                    let mut projected = baseline;
+                    *projected.direct_mut(*religion) = candidate;
+                    projected.effective(*religion)
+                },
+            )
+        }
+        BookTarget::Bestiary { category } => {
+            let baseline = skills.bestiary_hours;
+            let direct = skills.bestiary_hours.direct_mut(*category);
+            adventuresim_core::book::apply_bounded_book_training(
+                direct,
+                rank,
+                aptitude,
+                lower,
+                upper,
+                real_hours,
+                medium_rank,
+                |rank| Skill::Bestiary.hours_for_rank(rank),
+                |candidate| {
+                    let mut projected = baseline;
+                    *projected.direct_mut(*category) = candidate;
+                    projected.effective(*category)
+                },
+            )
+        }
+        BookTarget::Terrain { terrain } => {
+            let skill = terrain_book_skill(terrain).expect("validated terrain book");
+            let transferred = skill
+                .ordinary_correlations()
+                .iter()
+                .map(|(source, coefficient)| {
+                    skills.skill_hours_trained(*source).max(0.0) * coefficient
+                })
+                .sum::<f32>()
+                .max(0.0);
+            adventuresim_core::book::apply_bounded_book_training(
+                direct_skill_hours_mut(skills, skill),
+                rank,
+                aptitude,
+                lower,
+                upper,
+                real_hours,
+                medium_rank,
+                |rank| skill.hours_for_rank(rank),
+                |candidate| candidate.max(0.0) + transferred,
+            )
+        }
+        BookTarget::Skill { .. } => {
+            let skill = adventuresim_core::book::ordinary_skill(&book.target)
+                .expect("validated ordinary book target");
+            let transferred = skill
+                .ordinary_correlations()
+                .iter()
+                .map(|(source, coefficient)| {
+                    skills.skill_hours_trained(*source).max(0.0) * coefficient
+                })
+                .sum::<f32>()
+                .max(0.0);
+            adventuresim_core::book::apply_bounded_book_training(
+                direct_skill_hours_mut(skills, skill),
+                rank,
+                aptitude,
+                lower,
+                upper,
+                real_hours,
+                medium_rank,
+                |rank| skill.hours_for_rank(rank),
+                |candidate| {
+                    let candidate = candidate.max(0.0);
+                    if skill.is_trained() && candidate <= 0.0 {
+                        0.0
+                    } else if skill.is_trained() {
+                        candidate + transferred.min(candidate)
+                    } else {
+                        candidate + transferred
+                    }
+                },
+            )
+        }
+    }
+}
+
+fn apply_reading_training(
+    ctx: &ReducerContext,
+    character_id: u64,
+    skills: &mut CharacterSkills,
+    mut real_hours: f32,
+    attributes: &CharacterAttributes,
+) -> f32 {
+    use crate::item::inventory_item;
+    use adventuresim_core::book::{BookCandidate, select_candidate};
+    let Some(character) = ctx.db.character().id().find(character_id) else {
+        return 0.0;
+    };
+    let personal = ctx
+        .db
+        .inventory_item()
+        .character_id()
+        .filter(character_id)
+        .filter(|row| row.quantity > 0)
+        .map(|row| row.item_id)
+        .collect::<std::collections::BTreeSet<_>>();
+    let bookstore = character
+        .current_settlement_id
+        .as_ref()
+        .and_then(|id| ctx.db.settlement().id().find(id))
+        .filter(|settlement| {
+            settlement
+                .economy
+                .has_service(adventuresim_world_schema::SettlementService::Bookstore)
+        });
+    let mut excess = 0.0;
+    let mut unusable = std::collections::BTreeSet::new();
+    // A bounded title can finish mid-interval; immediately continue with the
+    // next eligible title. The catalog and item IDs give a stable order.
+    while real_hours > 0.000_01 {
+        let candidates = adventuresim_core::item_catalog::catalog()
+            .iter()
+            .filter_map(|item| {
+                if unusable.contains(&item.id) {
+                    return None;
+                }
+                let book = item.capabilities.book.as_ref()?;
+                let owned = personal.contains(&item.id);
+                let on_site = bookstore.as_ref().is_some_and(|settlement| {
+                    book.settlement_allowlist.is_empty()
+                        || book
+                            .settlement_allowlist
+                            .iter()
+                            .any(|id| id == &settlement.id)
+                });
+                (owned || on_site).then_some(BookCandidate {
+                    item_id: &item.id,
+                    book,
+                    personal: owned,
+                })
+            });
+        let Some(selected) = select_candidate(candidates, |book| {
+            let medium_rank = adventuresim_core::book::written_rank(
+                skills.written_languages.effective(book.medium),
+                attributes.intelligence,
+            );
+            target_snapshot(skills, &book.target, attributes).is_some_and(|(rank, aptitude)| {
+                medium_rank >= adventuresim_core::book::READABLE_WRITTEN_RANK
+                    && rank + 0.000_01 >= f32::from(book.lower_rank)
+                    && rank < f32::from(book.upper_rank).min(aptitude)
+                    && aptitude > f32::from(book.lower_rank)
+            })
+        }) else {
+            break;
+        };
+        let gain = apply_selected_book(skills, selected.book, real_hours, attributes);
+        if gain.accepted_effective_hours <= 0.0 {
+            unusable.insert(selected.item_id.to_owned());
+            continue;
+        }
+        excess += 0.0;
+        if gain.unused_real_hours >= real_hours - 0.000_01 {
+            break;
+        }
+        real_hours = gain.unused_real_hours;
+    }
     excess
 }
 
 pub(crate) fn core_schedule(schedule: &ScheduleAllocation) -> DailySchedule {
     DailySchedule {
+        reading_minutes: schedule.reading_minutes,
         combat_training_minutes: schedule.combat_training_minutes,
         carousing_minutes: schedule.carousing_minutes,
         apprenticeship_minutes: schedule.apprenticeship_minutes,
@@ -936,6 +1252,10 @@ fn apply_organization_training(
                         award_direct(skill, target, award * weight / total);
                     }
                 }
+            }
+            TrainingTarget::Written { .. } => {
+                // Written leaves live beside the ordinary SkillHours structure
+                // and are applied by the caller.
             }
         }
     }
@@ -1129,6 +1449,7 @@ fn immediate_activity_schedule(
     let mut schedule = ScheduleAllocation::default();
     match activity {
         ImmediateActivity::Prayer => schedule.prayer_minutes = minutes,
+        ImmediateActivity::Reading => schedule.reading_minutes = minutes,
         ImmediateActivity::CombatTraining => schedule.combat_training_minutes = minutes,
         ImmediateActivity::Carousing => schedule.carousing_minutes = minutes,
         ImmediateActivity::Apprenticeship => {
@@ -1913,6 +2234,7 @@ pub(crate) fn synchronize_party_departure_time(
 
 pub(crate) fn allowed_camp_schedule(schedule: &ScheduleAllocation) -> ScheduleAllocation {
     let mut allowed = schedule.clone();
+    allowed.reading_minutes = 0;
     allowed.apprenticeship_minutes = 0;
     allowed.apprenticeship_organization_id = None;
     allowed.profession_practice_minutes = 0;

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -942,8 +942,7 @@ fn apply_selected_book(
     let Some((rank, aptitude)) = target_snapshot(skills, &book.target, attributes) else {
         return Default::default();
     };
-    let lower = book.lower_rank;
-    let upper = book.upper_rank;
+    let (lower, upper) = adventuresim_core::book::rank_band(book);
     match &book.target {
         BookTarget::Written { language } => adventuresim_core::book::apply_written_book_training(
             &mut skills.written_languages,
@@ -1111,10 +1110,11 @@ fn apply_reading_training(
                 attributes.intelligence,
             );
             target_snapshot(skills, &book.target, attributes).is_some_and(|(rank, aptitude)| {
+                let (lower, upper) = adventuresim_core::book::rank_band(book);
                 medium_rank >= adventuresim_core::book::READABLE_WRITTEN_RANK
-                    && rank + 0.000_01 >= f32::from(book.lower_rank)
-                    && rank < f32::from(book.upper_rank).min(aptitude)
-                    && aptitude > f32::from(book.lower_rank)
+                    && rank + 0.000_01 >= f32::from(lower)
+                    && rank < f32::from(upper).min(aptitude)
+                    && aptitude > f32::from(lower)
             })
         }) else {
             break;

--- a/crates/adventuresim-strategic-sim/src/live_core/policy.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/policy.rs
@@ -194,7 +194,7 @@ fn live_skills(character_id: u64, profile: &AgentProfile) -> CharacterSkills {
             dwarfish: 0.0,
         },
         written_languages: adventuresim_stdb_client::WrittenLanguageHours {
-            german: 1_000.0,
+            german: 0.0,
             low: 0.0,
             latin: 0.0,
             hebrew: 0.0,
@@ -236,6 +236,7 @@ fn live_schedule(profile: &AgentProfile) -> ScheduleAllocation {
     // leave the remainder as leisure instead of failing after medical rest.
     let quarter_hour = |minutes: u16| minutes / 15 * 15;
     reallocate_disabled_crime_to_labor(ScheduleAllocation {
+        reading_minutes: 0,
         combat_training_minutes: quarter_hour(s.combat_training_minutes),
         carousing_minutes: quarter_hour(s.carousing_minutes),
         // Simulation profiles may express future profession preferences that
@@ -266,6 +267,7 @@ fn schedule_allocated_minutes(schedule: &ScheduleAllocation) -> u16 {
         schedule.prayer_minutes,
         schedule.thievery_minutes,
         schedule.raiding_minutes,
+        schedule.reading_minutes,
     ]
     .into_iter()
     .sum()
@@ -318,6 +320,7 @@ fn activity_schedule_plan(
 
 fn medical_rest_schedule() -> ScheduleAllocation {
     ScheduleAllocation {
+        reading_minutes: 0,
         combat_training_minutes: 0,
         carousing_minutes: 0,
         apprenticeship_minutes: 0,

--- a/crates/adventuresim-strategic-sim/tests/simulation.rs
+++ b/crates/adventuresim-strategic-sim/tests/simulation.rs
@@ -205,6 +205,7 @@ fn bounded_skill_state_remains_finite_for_maximum_duration() {
         command: MAX_INITIAL_SKILL_HOURS,
         deception: MAX_INITIAL_SKILL_HOURS,
         physiology: MAX_INITIAL_SKILL_HOURS,
+        herbalism: MAX_INITIAL_SKILL_HOURS,
         religion: adventuresim_world_schema::ReligionHours {
             roman_catholic: MAX_INITIAL_SKILL_HOURS,
             ..Default::default()

--- a/crates/adventuresim-world-import/src/main.rs
+++ b/crates/adventuresim-world-import/src/main.rs
@@ -602,6 +602,7 @@ fn encode_economy(profile: &adventuresim_world_schema::SettlementEconomyProfile)
             S::Tailor => "Tailor",
             S::Herbalist => "Herbalist",
             S::Temple => "Temple",
+            S::Bookstore => "Bookstore",
         })
     };
     let stock = |v| {
@@ -622,6 +623,7 @@ fn encode_economy(profile: &adventuresim_world_schema::SettlementEconomyProfile)
             C::Armor => "Armor",
             C::Herbs => "Herbs",
             C::GeneralGoods => "GeneralGoods",
+            C::Books => "Books",
         })
     };
     json!({

--- a/crates/adventuresim-world-import/src/manifest.rs
+++ b/crates/adventuresim-world-import/src/manifest.rs
@@ -1018,7 +1018,7 @@ mod tests {
     fn fixture_digest_is_stable() {
         assert_eq!(
             digest(1544, SpatialGridSpec::default(), &[fixture()]).unwrap(),
-            "15a7e55b24a287a50439cd773aa64a7c2bed6faac72714fc0896697853cd5db6"
+            "4173eb5d011b980a9f6e9bdfab0b2038249c5a7d9418a0e5348171d8b134aed4"
         );
     }
 

--- a/crates/adventuresim-world-schema/src/language.rs
+++ b/crates/adventuresim-world-schema/src/language.rs
@@ -567,7 +567,7 @@ pub fn initial_oral_languages(
         OralLanguage::Low
     };
     let yiddish = npc
-        && (stable_mix(character_id ^ 0x5949_4444_4953_48) % 10_000)
+        && (stable_mix(character_id ^ 0x0059_4944_4449_5348) % 10_000)
             < u64::from(profile.yiddish_incidence_bp);
     let mut hours = OralLanguageHours::default();
     *hours.direct_mut(german) = if yiddish {
@@ -588,19 +588,11 @@ pub fn initial_character_languages(
     npc: bool,
 ) -> (OralLanguageHours, WrittenLanguageHours) {
     let oral = initial_oral_languages(profile, character_id, npc);
-    let written = if oral.yiddish > 0.0 {
-        WrittenLanguageHours {
-            yiddish: 1_000.0,
-            hebrew: 500.0,
-            german: 500.0,
-            ..Default::default()
-        }
-    } else {
-        WrittenLanguageHours {
-            german: 1_000.0,
-            ..Default::default()
-        }
-    };
+    // Literacy is social and institutional, never a universal consequence of
+    // speaking the local language. Noble estate and authored professional
+    // curricula are applied by character authority after relational roles are
+    // established.
+    let written = WrittenLanguageHours::default();
     (oral, written)
 }
 
@@ -767,7 +759,7 @@ mod tests {
         }
     }
     #[test]
-    fn final_location_reinitializes_complete_bilingual_identity() {
+    fn final_location_reinitializes_oral_identity_without_granting_literacy() {
         let origin = SettlementLanguageProfile {
             east_central_bp: 0,
             west_central_bp: 10_000,
@@ -792,7 +784,7 @@ mod tests {
         assert_eq!(origin_written.yiddish, 0.0);
         let (oral, written) = initial_character_languages(final_place, id, true);
         assert!(oral.east_central > 0.0 && oral.yiddish > 0.0);
-        assert!(written.yiddish > 0.0 && written.hebrew > 0.0);
+        assert_eq!(written, WrittenLanguageHours::default());
         assert_eq!(oral.west_central, 0.0);
     }
 }

--- a/crates/adventuresim-world-schema/src/lib.rs
+++ b/crates/adventuresim-world-schema/src/lib.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 
 mod language;
 pub use language::*;
-pub const WORLD_SCHEMA_VERSION: u32 = 25;
-pub const CURRENT_INFERENCE_RULES_VERSION: u32 = 9;
+pub const WORLD_SCHEMA_VERSION: u32 = 26;
+pub const CURRENT_INFERENCE_RULES_VERSION: u32 = 10;
 pub const MAX_EDGE_GEOMETRY_POINTS: usize = 512;
 pub const MAX_WORLD_GEOMETRY_POINTS: usize = 200_000;
 pub const MAX_SOURCES_MARKDOWN_CHARS: usize = 32_768;
@@ -3031,6 +3031,7 @@ pub enum SettlementService {
     Tailor,
     Herbalist,
     Temple,
+    Bookstore,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3052,6 +3053,7 @@ pub enum StockCategory {
     Armor,
     Herbs,
     GeneralGoods,
+    Books,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
@@ -3083,9 +3085,9 @@ pub struct SettlementEconomyProfile {
 }
 
 impl SettlementEconomyProfile {
-    pub const MAX_SERVICES: usize = 9;
+    pub const MAX_SERVICES: usize = 10;
     pub const MAX_SPECIALIZATIONS: usize = 8;
-    pub const MAX_STOCK: usize = 16;
+    pub const MAX_STOCK: usize = 17;
 
     pub fn stage_placeholder() -> Self {
         Self {
@@ -3129,7 +3131,7 @@ impl SettlementEconomyProfile {
     }
 }
 
-/// Single canonical rules-v8 economy projection used by import and database
+/// Single canonical economy projection used by import and database
 /// finalization. `documented_town` is direct Viabundus evidence; route count is
 /// taken from the finalized graph.
 pub fn infer_settlement_economy(
@@ -3186,6 +3188,9 @@ pub fn infer_settlement_economy(
         }
         if population_level >= 3 || industries.outputs().iter().any(forest_or_peat) {
             services.insert(SettlementService::Herbalist);
+        }
+        if population_level >= 4 {
+            services.insert(SettlementService::Bookstore);
         }
     }
     let mut stock = BTreeMap::<StockCategory, SettlementStock>::new();
@@ -3279,6 +3284,13 @@ pub fn infer_settlement_economy(
         add(
             StockCategory::Herbs,
             2 + u8::from(industries.outputs().iter().any(forest_or_peat)),
+            gap,
+        );
+    }
+    if services.contains(&SettlementService::Bookstore) {
+        add(
+            StockCategory::Books,
+            if population_level >= 5 { 4 } else { 2 },
             gap,
         );
     }
@@ -4693,6 +4705,13 @@ mod tests {
 
         let profile = infer_settlement_economy(5, 50_000, 8, true, &industries).unwrap();
 
+        assert!(profile.has_service(crate::SettlementService::Bookstore));
+        assert!(
+            profile
+                .stock
+                .iter()
+                .any(|entry| entry.category == StockCategory::Books && entry.abundance == 4)
+        );
         assert_eq!(
             profile.specializations.len(),
             SettlementEconomyProfile::MAX_SPECIALIZATIONS

--- a/crates/strategic-web/src/routes/settlements/commerce.rs
+++ b/crates/strategic-web/src/routes/settlements/commerce.rs
@@ -5,6 +5,7 @@ pub(super) fn merchant_service_location(service_id: &str) -> Option<&'static str
         "armor" => Some("armoury"),
         "clothing" => Some("tailor"),
         "inn" => Some("inn"),
+        "books" => Some("bookstore"),
         _ => None,
     }
 }

--- a/crates/strategic-web/src/routes/settlements/mod.rs
+++ b/crates/strategic-web/src/routes/settlements/mod.rs
@@ -122,8 +122,8 @@ use rendering::{
     inventory_trade_context, merchant_shop, personal_inventory_targets, render_service_page,
 };
 use rest::{
-    armor, clothing, herbalist, purchase_from_herbalist, query_local_reputation, query_single,
-    religion, rest, settlement_action_service_available, travel, weapons,
+    armor, bookstore, clothing, herbalist, purchase_from_herbalist, query_local_reputation,
+    query_single, religion, rest, settlement_action_service_available, travel, weapons,
 };
 #[cfg(test)]
 use rest_preview::{calculate_rest_supply_availability, calculate_soap_rest_preview};

--- a/crates/strategic-web/src/routes/settlements/party/location_personal.rs
+++ b/crates/strategic-web/src/routes/settlements/party/location_personal.rs
@@ -215,6 +215,12 @@ pub(super) async fn render_party_personal(
         &apprenticeships,
         &location.id,
         character_minute,
+    )
+    .with_reading(
+        attributes.first(),
+        skills.first(),
+        settlement.as_ref(),
+        active_inventory.iter().filter(|item| item.qty > 0).map(|item| item.item_id.as_str()),
     );
     let activity_location = match location.kind {
         LocationKind::Settlement => adventuresim_core::activity::ActivityLocation::Settlement {

--- a/crates/strategic-web/src/routes/settlements/party/training_activity.rs
+++ b/crates/strategic-web/src/routes/settlements/party/training_activity.rs
@@ -1,6 +1,7 @@
 #[derive(Default, Deserialize)]
 #[serde(default)]
 pub(super) struct TrainingScheduleForm {
+    reading_minutes: u16,
     combat_training_minutes: u16,
     carousing_minutes: u16,
     apprenticeship_minutes: u16,
@@ -60,6 +61,7 @@ pub(super) async fn update_training_schedule(
             .into_response();
     }
     let downtime = ScheduleAllocation {
+        reading_minutes: form.reading_minutes,
         combat_training_minutes: form.combat_training_minutes,
         carousing_minutes: form.carousing_minutes,
         apprenticeship_minutes: form.apprenticeship_minutes,
@@ -104,6 +106,7 @@ pub(super) struct ImmediateActivityForm {
 
 pub(super) fn immediate_activity_arg(activity: &str) -> Option<serde_json::Value> {
     let tag = match activity {
+        "reading" => "reading",
         "prayer" => "prayer",
         "combat_training" => "combatTraining",
         "carousing" => "carousing",

--- a/crates/strategic-web/src/routes/settlements/rest.rs
+++ b/crates/strategic-web/src/routes/settlements/rest.rs
@@ -557,6 +557,14 @@ pub(super) async fn herbalist(
     merchant_shop(state, id, session, MerchantShop::Herbalist).await
 }
 
+pub(super) async fn bookstore(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    session: Session,
+) -> Html<String> {
+    merchant_shop(state, id, session, MerchantShop::Books).await
+}
+
 pub(super) async fn purchase_from_herbalist(
     State(state): State<AppState>,
     Path(id): Path<String>,

--- a/crates/strategic-web/src/routes/settlements/router.rs
+++ b/crates/strategic-web/src/routes/settlements/router.rs
@@ -368,6 +368,7 @@ pub fn routes() -> Router<AppState> {
             post(retrieve_repairs),
         )
         .route("/settlements/{id}/clothing", get(clothing))
+        .route("/settlements/{id}/books", get(bookstore))
         .route("/settlements/{id}/herbalist", get(herbalist))
         .route(
             "/settlements/{id}/herbalist/purchase",

--- a/crates/strategic-web/src/routes/travel.rs
+++ b/crates/strategic-web/src/routes/travel.rs
@@ -395,6 +395,7 @@ pub(crate) async fn apply_terrain_route(
 /// the leader takes the recommended full-fatigue camp rest.
 fn camp_schedule(allocation: &ScheduleAllocation) -> DailySchedule {
     DailySchedule {
+        reading_minutes: 0,
         combat_training_minutes: allocation.combat_training_minutes,
         carousing_minutes: allocation.carousing_minutes,
         apprenticeship_minutes: allocation.apprenticeship_minutes,

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -1492,6 +1492,7 @@ pub struct CharacterStats {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ScheduleAllocation {
+    pub reading_minutes: u16,
     pub combat_training_minutes: u16,
     pub carousing_minutes: u16,
     pub apprenticeship_minutes: u16,

--- a/crates/strategic-web/src/templates/components.rs
+++ b/crates/strategic-web/src/templates/components.rs
@@ -35,7 +35,86 @@ pub fn item_icon_name(item_id: &str) -> &'static str {
 
 pub fn item_type_icon(item_id: &str) -> Markup {
     let readable = item_display_name(item_id);
+    if let Some(book) = adventuresim_core::item_catalog::definition(item_id)
+        .and_then(|item| item.capabilities.book.as_ref())
+    {
+        return book_target_icon(&readable, &book.target);
+    }
     game_icon(&format!("Item type: {readable}"), item_icon_name(item_id))
+}
+
+fn path_icon(label: &str, path: &str) -> Markup {
+    html! {
+        span class="game-icon" style=(format!("--game-icon: url('{path}')"))
+            role="img" aria-label=(label) title=(label) {}
+    }
+}
+
+/// Books use the exact leaf icon from the character skill rail, not a generic
+/// book glyph. The authored presentation icon remains a portable fallback for
+/// clients that do not understand typed book targets.
+fn book_target_icon(
+    title: &str,
+    target: &adventuresim_core::item_catalog_schema::BookTarget,
+) -> Markup {
+    use adventuresim_core::item_catalog_schema::BookTarget;
+    match target {
+        BookTarget::Written { language } => {
+            let descriptor = language.descriptor();
+            let label = format!("Item type: {title} — {} Written", descriptor.english);
+            html! {
+                span class=(if descriptor.germanic_style {
+                    "language-monogram language-written language-blackletter"
+                } else {
+                    "language-monogram language-written"
+                }) role="img" aria-label=(&label) title=(label) {
+                    (descriptor.monogram)
+                }
+            }
+        }
+        BookTarget::Religion { religion } => {
+            let label = format!("Item type: {title} — {} Religion", religion.label());
+            path_icon(&label, religion_icon_path(Some(religion.religion_id())))
+        }
+        BookTarget::Bestiary { category } => {
+            let label = format!("Item type: {title} — {} Bestiary", category.label());
+            path_icon(&label, &stat_icon_path("bestiary", category.id()))
+        }
+        BookTarget::Terrain { terrain } => {
+            let label = format!("Item type: {title} — {terrain} Terrain");
+            path_icon(&label, &stat_icon_path("terrain", terrain))
+        }
+        BookTarget::Skill { skill } => {
+            let (label, icon) = match skill.as_str() {
+                "physiology" => ("Physiology", "physiology"),
+                "herbalism" => ("Herbalism", "herbalism"),
+                "surgery" => ("Surgery", "surgeon"),
+                "cooking" => ("Cooking", "cooking"),
+                "tailoring" => ("Tailoring", "sewing-needle"),
+                "smithing" => ("Smithing", "smithing"),
+                "command" => ("Command", "command"),
+                "charm" => ("Charm", "charm"),
+                "polearm" => ("Polearm", "spear-hook"),
+                "axe" => ("Axe", "battle-axe"),
+                "bludgeon" => ("Bludgeon", "flanged-mace"),
+                "sword" => ("Sword", "sword"),
+                "knife" => ("Knife", "bowie-knife"),
+                "bow" => ("Bow", "bow-arrow"),
+                "crossbow" => ("Crossbow", "crossbow"),
+                "firearm" => ("Firearm", "musket"),
+                "throw" => ("Throw", "throwing-ball"),
+                "dodge" => ("Dodge", "dodge"),
+                "block" => ("Block", "block"),
+                "balance" => ("Balance", "balance"),
+                "stealth" => ("Stealth", "stealth"),
+                _ => ("Unknown skill", "help"),
+            };
+            path_icon(
+                &format!("Item type: {title} — {label}"),
+                &stat_icon_path("skills", icon),
+            )
+        }
+    }
 }
 
 /// Turn a stable snake-case item identifier into player-facing copy without
@@ -81,6 +160,7 @@ pub fn stat_game_icon_name(icon: &str) -> &'static str {
         "command" => "crown",
         "deception" => "conversation",
         "physiology" => "caduceus",
+        "herbalism" => "caduceus",
         "cooking" => "meal",
         "faith" => "holy-symbol",
         "religion" => "holy-symbol",
@@ -413,6 +493,32 @@ mod icon_tests {
         let decorative = decorative_game_icon("sun").into_string();
         assert!(decorative.contains("aria-hidden=\"true\""));
         assert!(!decorative.contains("role=\"img\""));
+    }
+
+    #[test]
+    fn books_render_their_trained_skill_leaf_icons() {
+        for (item, expected) in [
+            ("primer_latin_german", "language-monogram language-written"),
+            (
+                "catholic_summa_advanced",
+                "/static/icons/religion/catholic-cross-bottony.png",
+            ),
+            (
+                "bestiary_beasts_advanced",
+                "/static/icons/stats/bestiary/beast.png",
+            ),
+            (
+                "forest_wayfinding",
+                "/static/icons/stats/terrain/forest.png",
+            ),
+            ("human_anatomy", "/static/icons/game/caduceus.svg"),
+            ("field_surgery_manual", "/static/icons/game/scalpel.svg"),
+            ("fechtbuch_sword", "/static/icons/game/sword-brandish.svg"),
+        ] {
+            let rendered = item_type_icon(item).into_string();
+            assert!(rendered.contains(expected), "{item}: {rendered}");
+            assert!(!rendered.contains("/help.svg"), "{item}: {rendered}");
+        }
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -264,6 +264,7 @@ fn settlement_top_bar(
         ("armor", "armor", "Armour", "armor"),
         ("clothing", "clothing", "Clothing", "clothing"),
         ("herbalist", "herbalist", "Herbalist", "medical-pack"),
+        ("books", "books", "Bookstore", "open-book"),
         ("inn", "inn", "Inn", "inn"),
         ("religion", "religion", "Church", "church"),
     ];
@@ -424,6 +425,7 @@ fn service_tab_available(
         "armor" => "armoury",
         "clothing" => "tailor",
         "herbalist" => "herbalist",
+        "books" => "bookstore",
         "inn" => "inn",
         "religion" => "church",
         _ => return false,
@@ -598,15 +600,16 @@ fn building_tint(settlement: &str, service: &str, material: &str) -> String {
         "armor" => 6,
         "clothing" => 7,
         "herbalist" => 8,
-        "inn" => 9,
-        "religion" => 10,
-        _ => (hash % 11) as usize,
+        "books" => 9,
+        "inn" => 10,
+        "religion" => 11,
+        _ => (hash % 12) as usize,
     };
     let settlement_shift = ((hash >> 24) % 9) as u64;
     let hue = if material == "stone" {
-        [46, 198, 218, 205, 224, 252, 282, 164, 128, 36, 214][service_slot] + settlement_shift
+        [46, 198, 218, 205, 224, 252, 282, 164, 128, 68, 36, 214][service_slot] + settlement_shift
     } else {
-        [35, 58, 16, 8, 20, 31, 43, 56, 104, 72, 350][service_slot] + settlement_shift
+        [35, 58, 16, 8, 20, 31, 43, 56, 104, 48, 72, 350][service_slot] + settlement_shift
     };
     let saturation = if material == "stone" {
         12 + (hash >> 8) % 13
@@ -795,6 +798,7 @@ mod tests {
             "armor",
             "clothing",
             "herbalist",
+            "books",
             "inn",
             "religion",
         ]
@@ -826,6 +830,27 @@ mod tests {
                 settlement_top_bar("Place", "p", &category, "map", None, None, None).into_string();
             assert!(markup.contains(&format!("data-building-tier=\"{tier}\"")));
         }
+    }
+
+    #[test]
+    fn bookstore_service_renders_a_navigable_books_tab() {
+        let mut economy = adventuresim_world_schema::SettlementEconomyProfile::stage_placeholder();
+        economy
+            .services
+            .push(adventuresim_world_schema::SettlementService::Bookstore);
+        let markup = settlement_top_bar(
+            "Place",
+            "p",
+            &SettlementCategory::City,
+            "books",
+            None,
+            Some(&economy),
+            None,
+        )
+        .into_string();
+        assert!(markup.contains("href=\"/settlements/p/books\""));
+        assert!(markup.contains("data-service-label=\"Bookstore\""));
+        assert!(markup.contains("nav-tab active"));
     }
 
     #[test]
@@ -893,8 +918,8 @@ mod tests {
             None,
         )
         .into_string();
-        assert_eq!(markup.matches("class=\"service-tab-building\"").count(), 10);
-        assert_eq!(markup.matches("class=\"service-tab-icon ").count(), 10);
+        assert_eq!(markup.matches("class=\"service-tab-building\"").count(), 11);
+        assert_eq!(markup.matches("class=\"service-tab-icon ").count(), 11);
         assert!(markup.contains("aria-label=\"Public square\""));
         assert!(markup.contains("href=\"/locations/settlement/s\""));
         assert!(markup.contains("data-service-id=\"public-square\""));
@@ -932,6 +957,7 @@ mod tests {
         assert!(css.contains("data-service-id=\"public-square\"].active"));
         assert!(css.contains("data-service-id=\"residences\"].active"));
         assert!(css.contains("data-service-id=\"keep\"].active"));
+        assert!(css.contains(".nav-tab[data-service-id=\"books\"]"));
 
         let town = settlement_top_bar(
             "Larger Place",
@@ -943,7 +969,7 @@ mod tests {
             None,
         )
         .into_string();
-        assert_eq!(town.matches("class=\"service-tab-building\"").count(), 11);
+        assert_eq!(town.matches("class=\"service-tab-building\"").count(), 12);
         assert!(town.contains("aria-label=\"Keep\""));
         assert!(town.contains("href=\"/settlements/t/places/keep\" class=\"nav-tab active\""));
         assert!(town.contains("service-tab-icon-castle"));
@@ -1169,7 +1195,7 @@ mod tests {
         .into_string();
         assert_eq!(markup.matches("building-chimney-smoke").count(), 1);
         assert!(markup.contains("aria-hidden=\"true\""));
-        assert_eq!(markup.matches("class=\"nav-tab").count(), 10);
+        assert_eq!(markup.matches("class=\"nav-tab").count(), 11);
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/character_skills.rs
+++ b/crates/strategic-web/src/templates/settlement/character_skills.rs
@@ -743,10 +743,11 @@ impl ActivityPreviewRates {
                     attributes.intelligence,
                 );
                 rank_and_aptitude(&book.target).is_some_and(|(rank, aptitude)| {
+                    let (lower, upper) = adventuresim_core::book::rank_band(book);
                     medium_rank >= READABLE_WRITTEN_RANK
-                        && rank + 0.000_01 >= f32::from(book.lower_rank)
-                        && rank < f32::from(book.upper_rank).min(aptitude)
-                        && aptitude > f32::from(book.lower_rank)
+                        && rank + 0.000_01 >= f32::from(lower)
+                        && rank < f32::from(upper).min(aptitude)
+                        && aptitude > f32::from(lower)
                 })
             },
         );
@@ -757,13 +758,14 @@ impl ActivityPreviewRates {
             );
             let title = adventuresim_core::item_catalog::definition(selected.item_id)
                 .map_or(selected.item_id, |item| item.display_name.as_str());
+            let (lower, upper) = adventuresim_core::book::rank_band(selected.book);
             self.reading = Some(ReadingPreview {
                 rate: adventuresim_core::book::reading_rate(medium_rank),
                 description: format!(
                     "Read {title} ({:?}, ranks {}→{}). Literacy converts each reading hour into {:.0}% of an effective training hour.",
                     selected.book.medium,
-                    selected.book.lower_rank,
-                    selected.book.upper_rank,
+                    lower,
+                    upper,
                     adventuresim_core::book::reading_rate(medium_rank) * 100.0,
                 ),
             });
@@ -3315,7 +3317,11 @@ mod tests {
             .reading
             .expect("German primer is readable and useful");
         assert!((reading.rate - 0.5).abs() < f32::EPSILON);
-        assert!(reading.description.contains("German-Latin primer"));
+        assert!(
+            reading
+                .description
+                .contains("Vocabularius ex quo (German–Latin)")
+        );
         assert!(reading.description.contains("50%"));
     }
 

--- a/crates/strategic-web/src/templates/settlement/character_skills.rs
+++ b/crates/strategic-web/src/templates/settlement/character_skills.rs
@@ -457,14 +457,14 @@ pub(super) fn character_summary_icons(
         (
             label,
             finite_rank(
-                skill.capped_rank_for_aptitude(view.effective_skill_hours(skill), intelligence),
+                skill.capped_rank_for_aptitude(view.effective_skill_hours(skill), instinct),
             ),
         )
     })
     .filter(|(_, rank)| *rank >= SUMMARY_SKILL_THRESHOLD)
     .collect::<Vec<_>>();
     if !terrain_entries.is_empty() {
-        let rank = finite_rank(terrain_family_rank(skills, intelligence));
+        let rank = finite_rank(terrain_family_rank(skills, instinct));
         icons.push(summary_mask_icon(
             format!("Terrain — {rank:.1}"),
             qualifying_tooltip("Terrain", &terrain_entries),
@@ -510,7 +510,14 @@ pub struct ActivityPreviewRates {
     raiding_reputation_per_hour: f32,
     reputation_multiplier: f32,
     current_fatigue: f32,
+    reading: Option<ReadingPreview>,
     profession: std::collections::BTreeMap<String, ProfessionActivityPreview>,
+}
+
+#[derive(Clone, Debug)]
+struct ReadingPreview {
+    rate: f32,
+    description: String,
 }
 
 #[derive(Clone, Debug)]
@@ -631,8 +638,137 @@ impl ActivityPreviewRates {
             raiding_reputation_per_hour: -1.5 * reputation_multiplier,
             reputation_multiplier,
             current_fatigue,
+            reading: None,
             profession: Default::default(),
         }
+    }
+
+    pub fn with_reading<'a>(
+        mut self,
+        attributes: Option<&CharacterAttributes>,
+        skills: Option<&CharacterSkills>,
+        settlement: Option<&Settlement>,
+        owned_item_ids: impl IntoIterator<Item = &'a str>,
+    ) -> Self {
+        use adventuresim_core::{
+            book::{BookCandidate, READABLE_WRITTEN_RANK, ordinary_skill, select_candidate},
+            item_catalog_schema::BookTarget,
+        };
+        let (Some(attributes), Some(skills)) = (attributes, skills) else {
+            return self;
+        };
+        let owned = owned_item_ids
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
+        let bookstore = settlement.is_some_and(|settlement| {
+            settlement
+                .economy
+                .has_service(adventuresim_world_schema::SettlementService::Bookstore)
+        });
+        let rank_and_aptitude = |target: &BookTarget| -> Option<(f32, f32)> {
+            match target {
+                BookTarget::Written { language } => Some((
+                    adventuresim_core::book::written_rank(
+                        skills.written_languages.effective(*language),
+                        attributes.intelligence,
+                    ),
+                    attributes.intelligence,
+                )),
+                BookTarget::Religion { religion } => Some((
+                    Skill::Religion.capped_rank_for_aptitude(
+                        skills.religion_hours.effective(*religion),
+                        attributes.intelligence,
+                    ),
+                    attributes.intelligence,
+                )),
+                BookTarget::Bestiary { category } => Some((
+                    Skill::Bestiary.capped_rank_for_aptitude(
+                        skills.bestiary_hours.effective(*category),
+                        attributes.intelligence,
+                    ),
+                    attributes.intelligence,
+                )),
+                BookTarget::Terrain { terrain } => {
+                    let skill = match terrain.as_str() {
+                        "plains" => Skill::TerrainPlains,
+                        "forest" => Skill::TerrainForest,
+                        "hills" => Skill::TerrainHills,
+                        "wetlands" => Skill::TerrainWetlands,
+                        "urban" => Skill::TerrainUrban,
+                        "snow" => Skill::TerrainSnow,
+                        _ => return None,
+                    };
+                    let aptitude = character_aptitude(attributes, skill);
+                    Some((
+                        skill.capped_rank_for_aptitude(
+                            CharacterSkillHours(skills).effective_skill_hours(skill),
+                            aptitude,
+                        ),
+                        aptitude,
+                    ))
+                }
+                BookTarget::Skill { .. } => {
+                    let skill = ordinary_skill(target)?;
+                    let aptitude = character_aptitude(attributes, skill);
+                    Some((
+                        skill.capped_rank_for_aptitude(
+                            CharacterSkillHours(skills).effective_skill_hours(skill),
+                            aptitude,
+                        ),
+                        aptitude,
+                    ))
+                }
+            }
+        };
+        let selected = select_candidate(
+            adventuresim_core::item_catalog::catalog()
+                .iter()
+                .filter_map(|item| {
+                    let book = item.capabilities.book.as_ref()?;
+                    let personal = owned.contains(item.id.as_str());
+                    let stocked = bookstore
+                        && (book.settlement_allowlist.is_empty()
+                            || settlement.is_some_and(|settlement| {
+                                book.settlement_allowlist.contains(&settlement.id)
+                            }));
+                    (personal || stocked).then_some(BookCandidate {
+                        item_id: &item.id,
+                        book,
+                        personal,
+                    })
+                }),
+            |book| {
+                let medium_rank = adventuresim_core::book::written_rank(
+                    skills.written_languages.effective(book.medium),
+                    attributes.intelligence,
+                );
+                rank_and_aptitude(&book.target).is_some_and(|(rank, aptitude)| {
+                    medium_rank >= READABLE_WRITTEN_RANK
+                        && rank + 0.000_01 >= f32::from(book.lower_rank)
+                        && rank < f32::from(book.upper_rank).min(aptitude)
+                        && aptitude > f32::from(book.lower_rank)
+                })
+            },
+        );
+        if let Some(selected) = selected {
+            let medium_rank = adventuresim_core::book::written_rank(
+                skills.written_languages.effective(selected.book.medium),
+                attributes.intelligence,
+            );
+            let title = adventuresim_core::item_catalog::definition(selected.item_id)
+                .map_or(selected.item_id, |item| item.display_name.as_str());
+            self.reading = Some(ReadingPreview {
+                rate: adventuresim_core::book::reading_rate(medium_rank),
+                description: format!(
+                    "Read {title} ({:?}, ranks {}→{}). Literacy converts each reading hour into {:.0}% of an effective training hour.",
+                    selected.book.medium,
+                    selected.book.lower_rank,
+                    selected.book.upper_rank,
+                    adventuresim_core::book::reading_rate(medium_rank) * 100.0,
+                ),
+            });
+        }
+        self
     }
 
     pub fn with_professions(
@@ -712,6 +848,7 @@ fn training_target_label(target: &adventuresim_core::organization::TrainingTarge
         TrainingTarget::Religion { religion } => format!("{religion} Religion"),
         TrainingTarget::Bestiary { category } => format!("{category} Bestiary"),
         TrainingTarget::Terrain { terrain } => format!("{terrain} Terrain"),
+        TrainingTarget::Written { language } => format!("{language:?} literacy"),
         TrainingTarget::EquippedWeaponSkills => "equipped weapon skills".into(),
     }
 }
@@ -765,6 +902,7 @@ fn training_target_skill(
             "snow" => Some(Skill::TerrainSnow),
             _ => None,
         },
+        TrainingTarget::Written { .. } => None,
         TrainingTarget::EquippedWeaponSkills => Some(Skill::Polearm),
     }
 }
@@ -1002,7 +1140,7 @@ fn skills_table(
                     @if skills.stealth_hours > 0.0 { (party_skill_row(skills, "Stealth", "stealth", Skill::Stealth, all_agility, (upper_health + lower_health) * 0.5, schedule.is_some(), None)) }
                     (terrain_skill_rows(
                         skills,
-                        intelligence,
+                        instinct,
                         schedule.is_some(),
                         actions.foraging_href.map(|href| SkillAction::Get {
                             href,
@@ -1044,6 +1182,11 @@ fn skills_table(
                                 "Meditation gives modest morale independently of party Religion knowledge and does not train Religion or create Fervor."
                             },
                         ))
+                        @let reading_description = preview.reading.as_ref().map_or(
+                            "No readable carried or bookstore book can currently advance this character.",
+                            |reading| reading.description.as_str(),
+                        );
+                        (schedule_special_row("Reading", "open-book", "reading_minutes", schedule.downtime.reading_minutes, effective.reading_minutes, true, immediate_actions && preview.reading.is_some(), ActivityEffectRates::default(), None, None, preview.reading.as_ref().map_or(0.0, |reading| reading.rate), reading_description))
                         (schedule_special_row("Combat Training", "crossed-swords", "combat_training_minutes", schedule.downtime.combat_training_minutes, effective.combat_training_minutes, true, immediate_actions, ActivityEffectRates::default(), None, None, combat_training, "Sparring and target practice train equipped Combat skills together with Will and Balance."))
                         (schedule_special_row("Carousing", "beer-stein", "carousing_minutes", schedule.downtime.carousing_minutes, effective.carousing_minutes, true, carousing_action, ActivityEffectRates::carousing(), None, None, instinct_training, "Drink and socialize to improve morale and train Charm at 25% speed. Ordinary carousing changes no reputation, but a disorder incident can add Infamy; Drunkards are at substantially higher risk."))
                         @let apprenticeship_id = schedule.downtime.apprenticeship_organization_id.as_deref().filter(|id| preview.profession.contains_key(*id)).or_else(|| preview.profession.keys().next().map(String::as_str));
@@ -1954,6 +2097,7 @@ struct LeisurePreview {
 
 fn core_daily_schedule(schedule: &ScheduleAllocation) -> DailySchedule {
     DailySchedule {
+        reading_minutes: schedule.reading_minutes,
         combat_training_minutes: schedule.combat_training_minutes,
         carousing_minutes: schedule.carousing_minutes,
         apprenticeship_minutes: schedule.apprenticeship_minutes,
@@ -3150,6 +3294,29 @@ mod tests {
         assert!(rendered.contains("data-activity-location-unavailable=\"true\""));
         assert!(!rendered.contains(">+6</td>"));
         assert!(!rendered.contains(">-3.0</td>"));
+    }
+
+    #[test]
+    fn reading_preview_names_the_selected_title_and_uses_medium_literacy() {
+        let skills = CharacterSkills {
+            written_languages: adventuresim_world_schema::WrittenLanguageHours {
+                german: 2_500.0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let preview = ActivityPreviewRates::default().with_reading(
+            Some(&test_attributes(5.0)),
+            Some(&skills),
+            None,
+            ["primer_german_latin"],
+        );
+        let reading = preview
+            .reading
+            .expect("German primer is readable and useful");
+        assert!((reading.rate - 0.5).abs() < f32::EPSILON);
+        assert!(reading.description.contains("German-Latin primer"));
+        assert!(reading.description.contains("50%"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -932,6 +932,7 @@ mod tests {
         assert!(!chat.contains("lubeck:merchants"));
         assert_eq!(npc_location_id("religion"), "church");
         assert_eq!(npc_location_id("inn"), "inn");
+        assert_eq!(npc_location_id("books"), "bookstore");
         let church_strip = npc_portrait_strip("lubeck", "church").into_string();
         assert!(church_strip.contains("Finding the people here…"));
         assert!(!church_strip.contains("â"));

--- a/crates/strategic-web/src/templates/settlement/trade.rs
+++ b/crates/strategic-web/src/templates/settlement/trade.rs
@@ -1377,6 +1377,8 @@ fn item_name_with_display_quality(
         .map(|_| "alcohol");
     let food_quality =
         quality_override.is_some() || adventuresim_core::food::definition(item_id).is_some();
+    let book_quality = adventuresim_core::item_catalog::definition(item_id)
+        .is_some_and(|item| item.capabilities.book.is_some());
     let quality = quality_override.or_else(|| {
         definition
             .filter(|item| {
@@ -1387,11 +1389,12 @@ fn item_name_with_display_quality(
                         | crate::spacetimedb::ItemKind::Shield
                         | crate::spacetimedb::ItemKind::Food
                 ) || adventuresim_core::food::definition(item_id).is_some()
+                    || book_quality
             })
             .map(|item| item.quality.clamp(1, 5))
     });
     let label = quality.map(|quality| {
-        if food_quality {
+        if food_quality || book_quality {
             format!("Quality {quality}")
         } else {
             match quality {
@@ -2253,6 +2256,21 @@ mod tests {
         let rendered = item_name_with_quality(&definition.id, Some(&definition)).into_string();
         assert!(rendered.contains("item-quality-4"));
         assert!(rendered.contains("knightly commission"));
+    }
+
+    #[test]
+    fn book_names_use_shared_quality_color_without_equipment_copy() {
+        let definition = crate::spacetimedb::ItemDefinition {
+            id: "human_anatomy".into(),
+            kind: crate::spacetimedb::ItemKind::Simple,
+            quality: 4,
+            ..Default::default()
+        };
+
+        let rendered = item_name_with_quality(&definition.id, Some(&definition)).into_string();
+        assert!(rendered.contains("item-quality-4"));
+        assert!(rendered.contains("title=\"Quality 4\""));
+        assert!(!rendered.contains("knightly commission"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/trade.rs
+++ b/crates/strategic-web/src/templates/settlement/trade.rs
@@ -38,6 +38,7 @@ pub enum MerchantShop {
     Clothing,
     Herbalist,
     Inn,
+    Books,
 }
 impl MerchantShop {
     pub fn storefront(self) -> adventuresim_core::settlement_economy::Storefront {
@@ -49,6 +50,7 @@ impl MerchantShop {
             Self::Clothing => S::Clothing,
             Self::Herbalist => S::Herbalist,
             Self::Inn => S::Inn,
+            Self::Books => S::Books,
         }
     }
 
@@ -73,12 +75,22 @@ impl MerchantShop {
             crate::spacetimedb::ItemKind::Medication => C::Medication,
             crate::spacetimedb::ItemKind::Food => C::Food,
         };
-        adventuresim_core::settlement_economy::storefront_stocks(
+        let stocked = adventuresim_core::settlement_economy::storefront_stocks(
             &settlement.economy,
             self.storefront(),
             &item.id,
             kind,
-        )
+        );
+        stocked
+            && (!matches!(self, Self::Books)
+                || adventuresim_core::item_catalog::definition(&item.id).is_some_and(
+                    |definition| {
+                        definition.capabilities.book.as_ref().is_some_and(|book| {
+                            book.settlement_allowlist.is_empty()
+                                || book.settlement_allowlist.contains(&settlement.id)
+                        })
+                    },
+                ))
     }
     pub fn service_id(self) -> &'static str {
         match self {
@@ -88,6 +100,7 @@ impl MerchantShop {
             Self::Clothing => "clothing",
             Self::Herbalist => "herbalist",
             Self::Inn => "inn",
+            Self::Books => "books",
         }
     }
 
@@ -99,6 +112,7 @@ impl MerchantShop {
             Self::Clothing => "Tailor",
             Self::Herbalist => "Herbalist",
             Self::Inn => "The Inn",
+            Self::Books => "Bookstore",
         }
     }
 
@@ -128,6 +142,8 @@ impl MerchantShop {
                         "cooking_pan" | "cooking_pot" | "portable_oven"
                     )
             }
+            Self::Books => adventuresim_core::item_catalog::definition(&item.id)
+                .is_some_and(|definition| definition.capabilities.book.is_some()),
         }
     }
 

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -832,6 +832,10 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
   --service-building-image: url("/static/styles/timber-framed/building/village/herbalist.png");
 }
 .settlement-top-bar:is([data-building-tier="village"], [data-building-tier="town"], [data-building-tier="city"])
+  .nav-tab[data-service-id="books"] {
+  --service-building-image: url("/static/styles/timber-framed/building/village/merchants.png?v=facade-2");
+}
+.settlement-top-bar:is([data-building-tier="village"], [data-building-tier="town"], [data-building-tier="city"])
   .nav-tab[data-service-id="inn"] {
   --service-building-image: url("/static/styles/timber-framed/building/village/inn.png?v=facade-2");
 }
@@ -854,6 +858,7 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="armor"] { --service-building-image: url("/static/styles/timber-framed/building/town/armor.png"); }
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="clothing"] { --service-building-image: url("/static/styles/timber-framed/building/town/clothing.png"); }
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="herbalist"] { --service-building-image: url("/static/styles/timber-framed/building/town/herbalist.png"); }
+.settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="books"] { --service-building-image: url("/static/styles/timber-framed/building/town/merchants.png"); }
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="inn"] { --service-building-image: url("/static/styles/timber-framed/building/town/inn.png"); }
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="religion"] { --service-building-image: url("/static/styles/timber-framed/building/town/religion.png"); }
 .settlement-top-bar[data-building-tier="town"] .nav-tab[data-service-id="organization"] { --service-building-image: url("/static/styles/timber-framed/building/town/residences.png"); }
@@ -867,6 +872,7 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="armor"] { --service-building-image: url("/static/styles/timber-framed/building/city/armor.png"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="clothing"] { --service-building-image: url("/static/styles/timber-framed/building/city/clothing.png"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="herbalist"] { --service-building-image: url("/static/styles/timber-framed/building/city/herbalist.png"); }
+.settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="books"] { --service-building-image: url("/static/styles/timber-framed/building/city/merchants.png"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="inn"] { --service-building-image: url("/static/styles/timber-framed/building/city/inn.png"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="religion"] { --service-building-image: url("/static/styles/timber-framed/building/city/religion.png"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="organization"] { --service-building-image: url("/static/styles/timber-framed/building/city/residences.png"); }
@@ -962,6 +968,7 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
 .service-tab-icon-armor { --service-tab-icon: url("/static/icons/settlement-services/armor.png"); }
 .service-tab-icon-clothing { --service-tab-icon: url("/static/icons/settlement-services/clothing.png"); }
 .service-tab-icon-medical-pack { --service-tab-icon: url("/static/icons/settlement-services/herbalist.png"); }
+.service-tab-icon-open-book { --service-tab-icon: url("/static/icons/game/open-book.svg"); }
 .service-tab-icon-inn { --service-tab-icon: url("/static/icons/settlement-services/inn.png"); }
 .service-tab-icon-church { --service-tab-icon: url("/static/icons/game/church.svg"); }
 .service-tab-icon-organization { --service-tab-icon: url("/static/icons/game/templar-shield.svg"); }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -1323,6 +1323,11 @@
 .inventory-column-type { width: 1.45rem; min-width: 1.45rem; }
 .inventory-item-type { width: 1.45rem; padding-inline: 0.18rem !important; text-align: center; }
 .inventory-item-type .game-icon { width: 0.95rem; height: 0.95rem; }
+.inventory-item-type .language-monogram {
+  width: 0.95rem;
+  height: 0.95rem;
+  font-size: 0.72rem;
+}
 
 /* Smith inventories retain compact fixed-purpose columns while the rail grows
    to accommodate them and any enabled optional statistics. */

--- a/wiki/reference/item-authoring.md
+++ b/wiki/reference/item-authoring.md
@@ -39,11 +39,28 @@ custody, condition, and market state do not belong in definitions.
 
 Books remain ordinary `kind: simple` items and add `capabilities.book`. The
 capability authors a `medium` Written language, exactly one typed leaf target,
-adjacent `lower_rank`/`upper_rank` integers, and an optional
-`settlement_allowlist` for culturally rare stock. Validation rejects aggregate
-or unknown targets, non-adjacent bands, and bands beyond the target-family
-limit. Runtime resolves embedded metadata by stable item ID rather than
-widening the persisted item table.
+a shared `quality` from 1 through 5, and an optional `settlement_allowlist` for
+culturally rare stock. Quality is the teaching band: quality 1 teaches rank
+0→1, quality 2 teaches 1→2, and so on. Validation rejects aggregate or unknown
+targets and quality above the target-family limit. Runtime resolves embedded
+metadata by stable item ID rather than widening the persisted inventory row;
+the existing flattened item quality field carries the value needed for the
+standard five inventory-name colors.
+
+The starter catalog uses real works available by the 1544 setting wherever a
+reasonable match exists. Examples include the bilingual *Vocabularius ex quo*,
+Hans von Gersdorff's *Feldbuch der Wundarznei* (1517), *Küchenmeisterei*
+(1485), Erasmus's *De civilitate morum puerilium* (1530), Vesalius's *De
+humani corporis fabrica* (1543), Bock's *New Kreütter Buch* (1539), and the
+German *Fechtbuch* tradition. A work's assignment to a single game skill is a
+gameplay abstraction rather than a claim that the historical text was a modern
+coursebook. Useful collection records include the
+[Bodleian copy of *Vocabularius ex quo*](https://textinc7.bodleian.ox.ac.uk/catalog/tiv00363000),
+[National Library of Medicine records for Gersdorff](https://www.nlm.nih.gov/exhibition/historicalanatomies/gersdorff_bio.html)
+and [Vesalius](https://www.nlm.nih.gov/exhibition/historicalanatomies/vesalius_biblio.html),
+the [Bibliothèque nationale de France record for Erasmus](https://catalogue.bnf.fr/ark:/12148/cb30402412n),
+the [Metropolitan Museum's Talhoffer *Fechtbuch*](https://www.metmuseum.org/art/collection/search/32426),
+and the [Nuremberg Mendel Housebook](https://online-service.nuernberg.de/viewer/!toc/5d64f831-7a9d-47b4-9a01-d6a28f29ad99/307/-/).
 
 Every item requires `id`, `display_name`, `weight_kg`, `base_value`, `tags`,
 `presentation.icon`, and a tagged `kind`. Physical units are part of field
@@ -59,7 +76,7 @@ quality 1--5 and explicit physical/handling inputs.
 Capabilities compose independently of kind. Garlic remains an `ingredient`
 while carrying `capabilities.food`; alcohol remains a simple serving while
 carrying `capabilities.alcohol`. Food, alcohol, container, and durability are
-the supported capabilities. Executable effects, physiology profile versions,
+supported alongside books. Executable effects, physiology profile versions,
 currency assignment, and other mechanics remain typed Rust and are
 cross-validated against catalog membership.
 

--- a/wiki/reference/item-authoring.md
+++ b/wiki/reference/item-authoring.md
@@ -37,6 +37,14 @@ custody, condition, and market state do not belong in definitions.
 
 ## Shape
 
+Books remain ordinary `kind: simple` items and add `capabilities.book`. The
+capability authors a `medium` Written language, exactly one typed leaf target,
+adjacent `lower_rank`/`upper_rank` integers, and an optional
+`settlement_allowlist` for culturally rare stock. Validation rejects aggregate
+or unknown targets, non-adjacent bands, and bands beyond the target-family
+limit. Runtime resolves embedded metadata by stable item ID rather than
+widening the persisted item table.
+
 Every item requires `id`, `display_name`, `weight_kg`, `base_value`, `tags`,
 `presentation.icon`, and a tagged `kind`. Physical units are part of field
 names. Kinds are `simple`, `currency`, `ingredient`, `medication`, `clothing`,

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1444)
+## Files (1445)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -58,6 +58,7 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-core/src/bin/content-check.rs` — Rust source module.
 - `crates/adventuresim-core/src/bin/questgen-check.rs` — Rust source module.
 - `crates/adventuresim-core/src/body.rs` — Rust source module for this component.
+- `crates/adventuresim-core/src/book.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/capability.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/case.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/combat.rs` — Rust source module for this component.

--- a/wiki/reference/organizations.md
+++ b/wiki/reference/organizations.md
@@ -7,6 +7,10 @@ currently asserting.
 
 ## Content
 
+Training entries may use `kind: written` with a typed Written language. These
+entries use normal Intelligence-governed language training and apply both to
+generated starting professionals and later scheduled organization training.
+
 `content/organizations/*.yaml` is compiled into `adventuresim-core`. Definitions
 declare stable IDs, names, chapters, recognition, admission requirements and
 fees, arbitrary ordered ranks, recurring dues, activity training and rewards,

--- a/wiki/reference/potential-vegetation.md
+++ b/wiki/reference/potential-vegetation.md
@@ -36,7 +36,7 @@ non-unknown class inferred from already typed forest, elevation, latitude, and
 HYDE 3.5 context. Reports reconcile posterior, categorical, and inferred outcomes
 exactly to settlement count.
 
-Inference-rules version 9 and world schema version 25 identify the complete
+Inference-rules version 10 and world schema version 26 identify the complete
 post-hydrology synthesis contract. Older artifacts or caches cannot share
 identity with Jung-derived or reconstructed historical results.
 

--- a/wiki/reference/route-terrain.md
+++ b/wiki/reference/route-terrain.md
@@ -1,6 +1,6 @@
 # Strategic route terrain
 
-World schema v25 and inference rules v9 attach a required `RouteTerrain` to
+World schema v26 and inference rules v10 attach a required `RouteTerrain` to
 every imported travel edge. The record is a static strategic fact used for
 travel planning and encounter selection. It never persists tactical positions,
 damage, HP, enemies, or simulation ticks.

--- a/wiki/reference/strategic-simulation.md
+++ b/wiki/reference/strategic-simulation.md
@@ -44,6 +44,10 @@ sinks; the runner therefore does not assert naive currency conservation.
 
 ## Profiles and results
 
+Simulator-authored schedules currently allocate zero Reading minutes, keeping
+existing policy behavior stable. Camp and travel policy explicitly mask the
+player-facing Reading allocation.
+
 Profiles retain their seed and all inputs needed for inspection: a deterministic sparse personality
 (two through four non-neutral axes across thirteen behavioral axes), plus
 always-assigned Sex, Presentation, and Inclination; correlated, bounded attributes; an explicit personality-by-attribute

--- a/wiki/shared/stats.md
+++ b/wiki/shared/stats.md
@@ -136,13 +136,15 @@ Melee, ranged, Defense, and Stealth manuals only provide the 0→1 introduction.
 Advancement above the bounded practical and embodied bands is reserved for
 metis rather than book study.
 
-Each title teaches one adjacent integer band. Its lower rank is a hard
-prerequisite and progress clips at its upper rank. A readable medium requires
-rank 1 in that Written language. Reading converts real hours to effective
-target hours at `written rank / 5`, without applying the target aptitude's
-learning-speed multiplier again. Aptitude still caps the effective target
-rank. Terrain is governed by Instinct; its correlations and exposure sources
-are unchanged.
+Each title has the same 1–5 quality used by other items. Quality `N` teaches
+the adjacent `N-1→N` rank band: the lower rank is a hard prerequisite and
+progress clips at the quality rank. The inventory renders book names with the
+existing quality colors, while the item-type column uses the icon of the exact
+skill leaf the book trains. A readable medium requires rank 1 in that Written
+language. Reading converts real hours to effective target hours at `written
+rank / 5`, without applying the target aptitude's learning-speed multiplier
+again. Aptitude still caps the effective target rank. Terrain is governed by
+Instinct; its correlations and exposure sources are unchanged.
 Every skill has exactly one governing aptitude: Intelligence, Instinct, or
 Agility. Aptitude controls training speed and the effective-rank limit; trained
 skill rank supplies the check itself.

--- a/wiki/shared/stats.md
+++ b/wiki/shared/stats.md
@@ -126,6 +126,23 @@ not add to their final checks.
 5. Blind monk
 
 # Skills
+
+## Book study
+
+Written language, Religion, and Bestiary leaves can be studied from books
+through rank 5. Physiology and Herbalism books stop at rank 4. Terrain,
+Surgery, Cooking, Tailoring, Smithing, Command, and Charm books stop at rank 2.
+Melee, ranged, Defense, and Stealth manuals only provide the 0→1 introduction.
+Advancement above the bounded practical and embodied bands is reserved for
+metis rather than book study.
+
+Each title teaches one adjacent integer band. Its lower rank is a hard
+prerequisite and progress clips at its upper rank. A readable medium requires
+rank 1 in that Written language. Reading converts real hours to effective
+target hours at `written rank / 5`, without applying the target aptitude's
+learning-speed multiplier again. Aptitude still caps the effective target
+rank. Terrain is governed by Instinct; its correlations and exposure sources
+are unchanged.
 Every skill has exactly one governing aptitude: Intelligence, Instinct, or
 Agility. Aptitude controls training speed and the effective-rank limit; trained
 skill rank supplies the check itself.

--- a/wiki/strategic/character.md
+++ b/wiki/strategic/character.md
@@ -1,4 +1,14 @@
 # Character
+
+Literacy is not universal. A character whose authoritative relational estate
+is Noble begins with rank-1 literacy in local written German or Low German;
+Burgher estate alone grants nothing. Merchant-family literacy is represented
+by the merchant starting profession. Learned religious curricula teach their
+authored languages over time (Latin and German for Catholic and Lutheran
+organizations; Hebrew, Yiddish, and German for the Jewish organization).
+Professing a religion or merely joining an organization grants no instant
+literacy. Bidirectional German–Latin and German–Low German primers let each
+currently authored literate upbringing enter the wider book catalog.
 Characters are created by investing some amount of [favor](../shared/magic.md) into them. The more powerful the character, as determined by their [stats](../shared/stats.md), the more favor you need to invest. The exact kind of favor you need also depends on what character you want. If you want an elf character, you need to go do some quests with the elves.
 
 You aren't exactly spawning a character into the world; ostensibly, you are obtaining control over a character who already exists! This means you don't always have to start "fresh" with a young, untrained character with no background. You can create a wealthy, skilled character simply by spending a lot of favor on him.

--- a/wiki/strategic/settlement.md
+++ b/wiki/strategic/settlement.md
@@ -1,5 +1,10 @@
 # Services
 
+City- and Capital-scale settlements infer a Bookstore service and Books stock.
+The bookseller uses ordinary merchant purchase authority and also supplies the
+free on-site fallback catalog for Reading. Book-capability items are excluded
+from General Goods stock.
+
 At strategic locations, characters raise the Herbalism Stage Modal from their
 skill rail. Herbalist storefronts remain sources and exchange counterparties
 for medicinal ingredients and finished remedies.

--- a/wiki/strategic/time.md
+++ b/wiki/strategic/time.md
@@ -2,6 +2,13 @@ Time between players is kept *somewhat* in-sync. The idea is that generally, tim
 
 ## Current implementation
 
+Reading is a saved settlement allocation and immediate activity. It selects
+useful personal books first, deduplicated by stable item ID. If none can teach
+the character, a City or Capital bookstore supplies free on-site study. The
+lowest applicable band and then stable item ID determine selection; finishing a
+band during a long interval cascades into the next eligible title. Reading is
+allocated time rather than Leisure, and is disabled during travel and camp.
+
 Disease is evaluated in the patient's personal character time. Travel, camp
 rest, settlement rest, and lazy catch-up check every disease boundary crossed
 by the interval. If terminal physiological failure occurs, the clock and all

--- a/wiki/strategic/trade.md
+++ b/wiki/strategic/trade.md
@@ -1,5 +1,10 @@
 # Trade
 
+Bookstores reuse ordinary merchant purchase authority. Buying supplies portable
+inventory access; characters may instead read useful bookstore titles free
+while in that city. Explicit title settlement allowlists constrain culturally
+rare catalogs.
+
 Local-problem pressure uses the same checked basis-point adjustment after base
 and language pricing for displayed quotes and reducer transfers, including food.
 


### PR DESCRIPTION
## Summary

- add typed physical books whose shared quality 1–5 derives the exact adjacent skill-rank interval (`quality N` teaches `N-1→N`)
- add deterministic Reading schedule/immediate activity resolution: inventory first, then local bookstore; literacy-gated language access; exact bounded/correlated progress; aptitude caps without target-aptitude speed multipliers
- add Bookstore/Books economy, storefront, navigation, generated ABI bindings, and user-facing Reading skill previews
- render each book with the exact trained skill-leaf icon and the existing quality color in inventory lists
- replace generic starter titles with historically attested works available by 1544, while preserving stable persisted item IDs
- add literacy from noble birth, merchant upbringing, and authored clergy curricula; remap Terrain aptitude to Instinct
- document authoring, training, settlement, trade, organization, and simulation behavior

## Skill coverage

- Written, Religion, Bestiary: ranks 0–5
- Physiology, Herbalism: ranks 0–4
- Terrain, Surgery, Cooking, Tailoring, Smithing, Command, Charm: ranks 0–2
- Melee, Ranged, Defense, Stealth: ranks 0–1

## Independent review

Two independent review passes identified changing-literacy and correlated-effective-skill bulk/chunk overshoot risks. The reading solver was remediated with projection-based bounded integration, direct-zero gates, band/aptitude clipping, deterministic unused-time cascading, and regression tests covering cross-language literacy and correlated skill thresholds.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- focused Rust suites: core (528), world schema (42), strategic web (332), strategic simulation, and doctests
- `just content-check all`
- `just test-schedule` (14 passed)
- `just verify-db-client`
- `python scripts/update_project_map.py --check`
- `git diff --check`
- comprehensive `just test` passed through the workspace except for the intentionally changed world-import manifest digest golden; after refreshing that digest, its targeted test passed
- local isolated UI demo verified the Reading row and daily-allocation editor; imported population-level-4 cities use the tested Bookstore inference path

`cargo clippy --workspace -- -D warnings` remains blocked by unrelated pre-existing warnings in terrain, dialogue, and core; the feature-owned warning encountered during review was fixed.

Closes #299
