### PR TITLE
Co-locate guild representatives with service buildings

### DIFF
--- a/content/dialogue/services.yaml
+++ b/content/dialogue/services.yaml
@@ -18,6 +18,26 @@
       "topics": [
         { "id": "profession", "label": "Profession", "initially_known": true,
           "responses": [
+          { "id": "merchant-profession-referral", "priority": 20, "conditions": { "op": "all", "conditions": [
+              { "op": "fact", "key": { "kind": "service", "role": "professional" }, "equals": "merchants" },
+              { "op": "fact", "key": { "kind": "local_organization_representative", "role": "professional" }, "equals": true }
+            ] }, "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "We learn to judge goods, bargain fairly, and keep trade moving between towns. Talk to " }, { "kind": "runtime", "slot": "organization_representative_name" }, { "kind": "text", "value": " if you're interested in becoming an apprentice." }] }], "effects": [], "prompt": null },
+          { "id": "weaponsmith-profession-referral", "priority": 20, "conditions": { "op": "all", "conditions": [
+              { "op": "fact", "key": { "kind": "service", "role": "professional" }, "equals": "weapons" },
+              { "op": "fact", "key": { "kind": "local_organization_representative", "role": "professional" }, "equals": true }
+            ] }, "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "A weaponsmith forges, fits, and maintains the tools a fighting company depends upon. Talk to " }, { "kind": "runtime", "slot": "organization_representative_name" }, { "kind": "text", "value": " if you're interested in becoming an apprentice." }] }], "effects": [], "prompt": null },
+          { "id": "armourer-profession-referral", "priority": 20, "conditions": { "op": "all", "conditions": [
+              { "op": "fact", "key": { "kind": "service", "role": "professional" }, "equals": "armor" },
+              { "op": "fact", "key": { "kind": "local_organization_representative", "role": "professional" }, "equals": true }
+            ] }, "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "An armourer shapes and repairs protection that must move with its wearer and endure hard blows. Talk to " }, { "kind": "runtime", "slot": "organization_representative_name" }, { "kind": "text", "value": " if you're interested in becoming an apprentice." }] }], "effects": [], "prompt": null },
+          { "id": "tailor-profession-referral", "priority": 20, "conditions": { "op": "all", "conditions": [
+              { "op": "fact", "key": { "kind": "service", "role": "professional" }, "equals": "clothing" },
+              { "op": "fact", "key": { "kind": "local_organization_representative", "role": "professional" }, "equals": true }
+            ] }, "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "A tailor turns cloth into durable, well-fitted garments and learns the trade of the needle. Talk to " }, { "kind": "runtime", "slot": "organization_representative_name" }, { "kind": "text", "value": " if you're interested in becoming an apprentice." }] }], "effects": [], "prompt": null },
+          { "id": "innkeeper-profession-referral", "priority": 20, "conditions": { "op": "all", "conditions": [
+              { "op": "fact", "key": { "kind": "service", "role": "professional" }, "equals": "inn" },
+              { "op": "fact", "key": { "kind": "local_organization_representative", "role": "professional" }, "equals": true }
+            ] }, "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "An innkeeper makes a living through hospitality, good judgment, and knowing how to speak with every sort of traveler. Talk to " }, { "kind": "runtime", "slot": "organization_representative_name" }, { "kind": "text", "value": " if you're interested in becoming an apprentice." }] }], "effects": [], "prompt": null },
           { "id": "merchant-profession", "priority": 10, "conditions": { "op": "fact", "key": { "kind": "service", "role": "professional" }, "equals": "merchants" }, "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "Welcome! We learn to judge goods, bargain fairly, and keep trade moving between towns. Ask if you wish to become an " }, { "kind": "topic", "topic": "apprenticeship", "label": "apprentice" }] }], "effects": [{ "kind": "learn_topic", "topic": "apprenticeship" }], "prompt": null },
           { "id": "weaponsmith-profession", "priority": 10, "conditions": { "op": "fact", "key": { "kind": "service", "role": "professional" }, "equals": "weapons" }, "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "Welcome! A weaponsmith learns to forge, fit, and maintain the tools a fighting company depends upon. Ask if you wish to become an " }, { "kind": "topic", "topic": "apprenticeship", "label": "apprentice" }] }], "effects": [{ "kind": "learn_topic", "topic": "apprenticeship" }], "prompt": null },
           { "id": "armourer-profession", "priority": 10, "conditions": { "op": "fact", "key": { "kind": "service", "role": "professional" }, "equals": "armor" }, "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "Welcome! An armourer shapes and repairs protection that must move with its wearer and endure hard blows. Ask if you wish to become an " }, { "kind": "topic", "topic": "apprenticeship", "label": "apprentice" }] }], "effects": [{ "kind": "learn_topic", "topic": "apprenticeship" }], "prompt": null },
@@ -54,6 +74,7 @@
             "effects": [{ "kind": "learn_topic", "topic": "apprenticeship" }], "prompt": null }]
         },
         { "id": "apprenticeship", "label": "Apprenticeship",
+          "conditions": { "op": "not", "condition": { "op": "fact", "key": { "kind": "local_organization_representative", "role": "professional" }, "equals": true } },
           "responses": [{ "id": "offer-apprenticeship", "priority": 0,
             "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "Are you interested in becoming my apprentice?" }] }],
             "effects": [],
@@ -106,7 +127,20 @@
     },
     { "id": "herbalist-examination", "roles": { "patient": { "kind": "player" }, "herbalist": { "kind": "npc" } },
       "on_start": [{ "id": "physician-greeting", "priority": 0, "turns": [{ "speaker": "herbalist", "fragments": [{ "kind": "text", "value": "Welcome. I can explain how a physician keeps a " }, { "kind": "topic", "topic": "notebook", "label": "notebook" }, { "kind": "text", "value": "." }] }], "effects": [], "prompt": null }],
-      "topics": [{ "id": "notebook", "label": "Physician notebook", "initially_known": true,
+      "topics": [{ "id": "profession", "label": "Profession", "initially_known": true,
+        "responses": [
+          { "id": "herbalist-profession-referral", "priority": 10,
+            "conditions": { "op": "fact", "key": { "kind": "local_organization_representative", "role": "herbalist" }, "equals": true },
+            "turns": [{ "speaker": "herbalist", "fragments": [
+              { "kind": "text", "value": "An herbalist identifies, grades, and prepares plants without claiming to diagnose the patient. Talk to " },
+              { "kind": "runtime", "slot": "organization_representative_name" },
+              { "kind": "text", "value": " if you're interested in becoming an apprentice." }
+            ] }], "effects": [], "prompt": null },
+          { "id": "herbalist-profession-fallback", "priority": 0,
+            "turns": [{ "speaker": "herbalist", "fragments": [{ "kind": "text", "value": "An herbalist identifies, grades, and prepares plants without claiming to diagnose the patient." }] }],
+            "effects": [], "prompt": null }
+        ] },
+        { "id": "notebook", "label": "Physician notebook", "initially_known": true,
         "responses": [{ "id": "explain-notebook", "priority": 0,
           "turns": [
             { "speaker": "patient", "fragments": [{ "kind": "period_claim", "value": "Surely one careful examination tells you the disease and its remedy." }] },
@@ -127,7 +161,20 @@
     },
     { "id": "religion-service", "roles": { "player": { "kind": "player" }, "cleric": { "kind": "npc" } },
       "on_start": [{ "id": "cleric-greeting", "priority": 0, "turns": [{ "speaker": "cleric", "fragments": [{ "kind": "text", "value": "Welcome. You may ask me about our " }, { "kind": "topic", "topic": "faith", "label": "faith" }, { "kind": "text", "value": "." }] }], "effects": [], "prompt": null }],
-      "topics": [{ "id": "faith", "label": "Faith", "initially_known": true,
+      "topics": [{ "id": "profession", "label": "Profession", "initially_known": true,
+        "responses": [
+          { "id": "cleric-profession-referral", "priority": 10,
+            "conditions": { "op": "fact", "key": { "kind": "local_organization_representative", "role": "cleric" }, "equals": true },
+            "turns": [{ "speaker": "cleric", "fragments": [
+              { "kind": "text", "value": "The clergy teach doctrine, prayer, and the care of a congregation. Talk to " },
+              { "kind": "runtime", "slot": "organization_representative_name" },
+              { "kind": "text", "value": " if you're interested in becoming an apprentice." }
+            ] }], "effects": [], "prompt": null },
+          { "id": "cleric-profession-fallback", "priority": 0,
+            "turns": [{ "speaker": "cleric", "fragments": [{ "kind": "text", "value": "The clergy teach doctrine, prayer, and the care of a congregation." }] }],
+            "effects": [], "prompt": null }
+        ] },
+        { "id": "faith", "label": "Faith", "initially_known": true,
         "responses": [{ "id": "explain-faith", "priority": 0,
           "turns": [{ "speaker": "cleric", "fragments": [{ "kind": "text", "value": "Our congregation welcomes travelers who wish to learn its doctrine. Do you wish to profess our local faith?" }] }],
           "effects": [], "prompt": { "id": "profess-faith", "respondent": "player", "mode": "yes_no", "choices": [

--- a/crates/adventuresim-core/src/organization.rs
+++ b/crates/adventuresim-core/src/organization.rs
@@ -154,7 +154,8 @@ pub fn initial_social_role(
 #[serde(deny_unknown_fields)]
 pub struct OrganizationChapter {
     pub settlement_id: String,
-    /// Stable, settlement-scoped navigation and NPC-presence identifier.
+    /// Stable settlement-scoped chapter identity and standalone navigation ID.
+    /// A service-linked chapter may derive a different physical NPC location.
     pub location_id: String,
     pub building_name: String,
     pub building_kind: ChapterBuildingKind,
@@ -442,15 +443,81 @@ pub fn organization_chapter_at(
     })
 }
 
+/// Ordinary settlement venue that can physically host representatives for a
+/// service-linked organization. The authored chapter location remains the
+/// chapter's stable institutional identity.
+pub fn service_npc_location_id(service_id: &str) -> Option<&'static str> {
+    match service_id {
+        "merchants" => Some("market"),
+        "weapons" => Some("forge"),
+        "armor" => Some("armoury"),
+        "clothing" => Some("tailor"),
+        "herbalist" => Some("herbalist"),
+        "inn" => Some("inn"),
+        "religion" => Some("church"),
+        _ => None,
+    }
+}
+
+pub fn service_npc_location_available(
+    profile: &adventuresim_world_schema::SettlementEconomyProfile,
+    service_id: &str,
+) -> bool {
+    use crate::settlement_economy::{
+        SettlementActionService, Storefront, action_service_available, storefront_available,
+    };
+    match service_id {
+        "merchants" => storefront_available(profile, Storefront::General),
+        "weapons" => storefront_available(profile, Storefront::Weapons),
+        "armor" => storefront_available(profile, Storefront::Armor),
+        "clothing" => storefront_available(profile, Storefront::Clothing),
+        "herbalist" => storefront_available(profile, Storefront::Herbalist),
+        "inn" => action_service_available(profile, SettlementActionService::Inn),
+        "religion" => action_service_available(profile, SettlementActionService::Temple),
+        _ => false,
+    }
+}
+
+pub fn chapter_effective_location_id<'a>(
+    organization: &'a OrganizationDefinition,
+    chapter: &'a OrganizationChapter,
+    profile: &adventuresim_world_schema::SettlementEconomyProfile,
+) -> &'a str {
+    if let Some(service_id) = organization.service_id.as_deref()
+        && service_npc_location_available(profile, service_id)
+        && let Some(location_id) = service_npc_location_id(service_id)
+    {
+        return location_id;
+    }
+    &chapter.location_id
+}
+
+pub fn chapter_has_standalone_building(
+    organization: &OrganizationDefinition,
+    chapter: &OrganizationChapter,
+    profile: &adventuresim_world_schema::SettlementEconomyProfile,
+) -> bool {
+    chapter_effective_location_id(organization, chapter, profile) == chapter.location_id.as_str()
+}
+
+/// Stable representative identity is deliberately independent of provider
+/// ordinals and physical venue so co-location cannot collide with service NPCs.
+pub fn organization_representative_id(settlement_id: &str, organization_id: &str) -> String {
+    format!("npc:organization-representative:{settlement_id}:{organization_id}")
+}
+
 pub fn exact_representative_fields_match(
     npc_id: &str,
     expected_id: &str,
     home_settlement_id: &str,
     settlement_id: &str,
+    organization_id: &str,
+    expected_organization_id: &str,
     conversation_id: &str,
 ) -> bool {
     npc_id == expected_id
         && home_settlement_id == settlement_id
+        && organization_id == expected_organization_id
         && conversation_id == "organization-representative"
 }
 
@@ -894,27 +961,110 @@ mod tests {
             "npc:goslar:ranger-lodge:0",
             "goslar",
             "goslar",
+            "ranger_lodge",
+            "ranger_lodge",
             "organization-representative",
         );
         assert!(exact_representative_fields_match(
-            valid.0, valid.1, valid.2, valid.3, valid.4
+            valid.0, valid.1, valid.2, valid.3, valid.4, valid.5, valid.6
         ));
         assert!(!exact_representative_fields_match(
             "npc:goslar:ranger-lodge:1",
             valid.1,
             valid.2,
             valid.3,
-            valid.4
+            valid.4,
+            valid.5,
+            valid.6,
         ));
         assert!(!exact_representative_fields_match(
-            valid.0, valid.1, "other", valid.3, valid.4
+            valid.0, valid.1, "other", valid.3, valid.4, valid.5, valid.6
+        ));
+        assert!(!exact_representative_fields_match(
+            valid.0, valid.1, valid.2, valid.3, "other", valid.5, valid.6
         ));
         assert!(!exact_representative_fields_match(
             valid.0,
             valid.1,
             valid.2,
             valid.3,
-            "innkeeper"
+            valid.4,
+            valid.5,
+            "innkeeper",
         ));
+    }
+
+    #[test]
+    fn service_chapters_have_stable_physical_location_mappings() {
+        assert_eq!(service_npc_location_id("merchants"), Some("market"));
+        assert_eq!(service_npc_location_id("weapons"), Some("forge"));
+        assert_eq!(service_npc_location_id("armor"), Some("armoury"));
+        assert_eq!(service_npc_location_id("clothing"), Some("tailor"));
+        assert_eq!(service_npc_location_id("herbalist"), Some("herbalist"));
+        assert_eq!(service_npc_location_id("inn"), Some("inn"));
+        assert_eq!(service_npc_location_id("religion"), Some("church"));
+        assert_eq!(service_npc_location_id("physician"), None);
+        assert_eq!(service_npc_location_id("surgeon"), None);
+    }
+
+    #[test]
+    fn chapter_location_is_colocated_only_when_the_mapped_service_is_available() {
+        use adventuresim_world_schema::{SettlementEconomyProfile, SettlementService};
+
+        let merchant = organization("merchant_guild").unwrap();
+        let merchant_chapter = merchant.chapter("viabundus-0").unwrap();
+        let mut profile = SettlementEconomyProfile::stage_placeholder();
+        profile.services = vec![SettlementService::Market];
+        assert_eq!(
+            chapter_effective_location_id(merchant, merchant_chapter, &profile),
+            "market"
+        );
+        assert!(!chapter_has_standalone_building(
+            merchant,
+            merchant_chapter,
+            &profile
+        ));
+
+        profile.services.clear();
+        assert_eq!(
+            chapter_effective_location_id(merchant, merchant_chapter, &profile),
+            merchant_chapter.location_id
+        );
+        assert!(chapter_has_standalone_building(
+            merchant,
+            merchant_chapter,
+            &profile
+        ));
+
+        let physicians = organization("physicians_college").unwrap();
+        let physician_chapter = physicians.chapter("viabundus-0").unwrap();
+        profile.services = vec![SettlementService::Market, SettlementService::Temple];
+        assert_eq!(
+            chapter_effective_location_id(physicians, physician_chapter, &profile),
+            physician_chapter.location_id
+        );
+
+        for id in ["hunt_pale_lantern", "order_saint_george", "lodge_hart_king"] {
+            let definition = organization(id).unwrap();
+            let chapter = &definition.chapters[0];
+            assert!(definition.service_id.is_none());
+            assert!(chapter_has_standalone_building(
+                definition, chapter, &profile
+            ));
+        }
+    }
+
+    #[test]
+    fn representative_ids_are_location_independent_and_organization_unique() {
+        let merchant = organization_representative_id("viabundus-0", "merchant_guild");
+        assert_eq!(
+            merchant,
+            organization_representative_id("viabundus-0", "merchant_guild")
+        );
+        assert_ne!(
+            merchant,
+            organization_representative_id("viabundus-0", "weaponsmith_guild")
+        );
+        assert!(!merchant.ends_with(":0"));
     }
 }

--- a/crates/adventuresim-core/src/settlement_economy.rs
+++ b/crates/adventuresim-core/src/settlement_economy.rs
@@ -159,10 +159,12 @@ pub fn player_visible_npc_tabs(
         let chapter = organization
             .chapter(settlement_id)
             .expect("chapter iterator guarantees a local chapter");
-        tabs.push(SettlementNpcTab {
-            location_id: chapter.location_id.as_str(),
-            label: chapter.building_name.as_str(),
-        });
+        if crate::organization::chapter_has_standalone_building(organization, chapter, profile) {
+            tabs.push(SettlementNpcTab {
+                location_id: chapter.location_id.as_str(),
+                label: chapter.building_name.as_str(),
+            });
+        }
     }
     tabs
 }
@@ -431,6 +433,20 @@ mod tests {
         assert!(npc_location_is_navigable(&p, true, "viabundus-0", "keep"));
         assert!(npc_location_is_navigable(
             &p,
+            false,
+            "viabundus-0",
+            "organization-merchant-guild"
+        ));
+        assert!(npc_location_is_navigable(&p, false, "viabundus-0", "inn"));
+        let market = profile(vec![Service::Market], vec![Stock::GeneralGoods]);
+        assert!(npc_location_is_navigable(
+            &market,
+            false,
+            "viabundus-0",
+            "market"
+        ));
+        assert!(!npc_location_is_navigable(
+            &market,
             false,
             "viabundus-0",
             "organization-merchant-guild"

--- a/crates/adventuresim-dialogue/build.rs
+++ b/crates/adventuresim-dialogue/build.rs
@@ -43,6 +43,7 @@ fn validate_fragment(fragment: &BuildFragment, relative: &str) {
                     | "organization_admission_terms"
                     | "organization_dues_terms"
                     | "organization_rank_standing"
+                    | "organization_representative_name"
             ),
             "unknown runtime slot {slot} in {relative}"
         );

--- a/crates/adventuresim-dialogue/src/authoring_schema.rs
+++ b/crates/adventuresim-dialogue/src/authoring_schema.rs
@@ -210,6 +210,9 @@ pub enum FactKey {
     ParticipantReferralContact {
         role: String,
     },
+    LocalOrganizationRepresentative {
+        role: String,
+    },
     OrganizationMembership {
         player: String,
         representative: String,
@@ -282,6 +285,7 @@ impl FactKey {
             | Self::ParticipantPresent { role }
             | Self::ParticipantRumorCase { role }
             | Self::ParticipantReferralContact { role }
+            | Self::LocalOrganizationRepresentative { role }
             | Self::PriorQuestioning { role }
             | Self::PartyLeader { role }
             | Self::Service { role } => [Some(role.as_str()), None],

--- a/crates/adventuresim-dialogue/src/lib.rs
+++ b/crates/adventuresim-dialogue/src/lib.rs
@@ -135,6 +135,7 @@ pub enum RuntimeSlot {
     OrganizationAdmissionTerms,
     OrganizationDuesTerms,
     OrganizationRankStanding,
+    OrganizationRepresentativeName,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -1039,6 +1040,56 @@ mod tests {
         let eligible = eligible_topics(c, &known, &FactContext::default());
         assert!(eligible.iter().any(|t| t.id == "profession"));
     }
+
+    #[test]
+    fn service_profession_refers_to_named_representative_without_direct_offer() {
+        let conversation = find_conversation("service-professions").unwrap();
+        let profession = conversation
+            .topics
+            .iter()
+            .find(|topic| topic.id == "profession")
+            .unwrap();
+        let apprenticeship = conversation
+            .topics
+            .iter()
+            .find(|topic| topic.id == "apprenticeship")
+            .unwrap();
+        let mut facts = FactContext::default();
+        facts.facts.insert(
+            FactKey::Service {
+                role: "professional".into(),
+            },
+            FactValue::Text("merchants".into()),
+        );
+        assert_eq!(
+            select_response(profession, &facts).unwrap().id,
+            "merchant-profession"
+        );
+        assert!(facts.matches(&apprenticeship.conditions));
+
+        facts.facts.insert(
+            FactKey::LocalOrganizationRepresentative {
+                role: "professional".into(),
+            },
+            FactValue::Bool(true),
+        );
+        let referral = select_response(profession, &facts).unwrap();
+        assert_eq!(referral.id, "merchant-profession-referral");
+        assert!(referral.effects.is_empty());
+        assert!(!facts.matches(&apprenticeship.conditions));
+        let mut bindings = RuntimeBindings::default();
+        bindings.bind(
+            RuntimeSlot::OrganizationRepresentativeName,
+            "<script>Greta & Co.</script>",
+        );
+        let resolved = bindings.resolve(&referral.turns[0].fragments).unwrap();
+        assert!(resolved.iter().any(|fragment| {
+            matches!(fragment, ResolvedFragment::Text { value } if value == "<script>Greta & Co.</script>")
+        }));
+        assert!(referral.turns[0].fragments.iter().all(|fragment| {
+            !matches!(fragment, Fragment::Topic { topic, .. } if topic == "apprenticeship")
+        }));
+    }
     #[test]
     fn generated_case_resolution_actions_are_compiled_for_services_and_residents() {
         for conversation_id in ["service-professions", "local-resident"] {
@@ -1286,6 +1337,7 @@ mod tests {
             "organization_admission_terms",
             "organization_dues_terms",
             "organization_rank_standing",
+            "organization_representative_name",
         ] {
             assert!(build.contains(&format!("| \"{slot}\"")));
         }

--- a/crates/adventuresim-stdb-module/src/local_problem.rs
+++ b/crates/adventuresim-stdb-module/src/local_problem.rs
@@ -1114,6 +1114,7 @@ fn source_may_disclose_public_threat(
     minute: u64,
 ) -> Option<&'static str> {
     let organization_id = crate::strategic::exact_organization_representative(
+        ctx,
         source_npc,
         listener_settlement_id,
         location_id,

--- a/crates/adventuresim-stdb-module/src/settlement_population.rs
+++ b/crates/adventuresim-stdb-module/src/settlement_population.rs
@@ -271,6 +271,28 @@ fn insert_npc(
     is_default: bool,
 ) -> Result<(), String> {
     let id = format!("npc:{settlement_id}:{location}:{ordinal}");
+    insert_npc_with_id(
+        ctx,
+        id,
+        settlement_id,
+        location,
+        service,
+        provider_profession,
+        supplied_role,
+        is_default,
+    )
+}
+
+fn insert_npc_with_id(
+    ctx: &ReducerContext,
+    id: String,
+    settlement_id: &str,
+    location: &str,
+    service: &str,
+    provider_profession: &str,
+    supplied_role: &str,
+    is_default: bool,
+) -> Result<(), String> {
     if let Some(existing) = ctx.db.settlement_npc().id().find(&id) {
         let settlement = ctx
             .db
@@ -525,22 +547,36 @@ pub fn ensure_settlement_population(
         let chapter = organization
             .chapter(settlement_id)
             .expect("chapter iterator guarantees a local chapter");
-        insert_npc(
-            ctx,
+        let settlement = ctx
+            .db
+            .settlement()
+            .id()
+            .find(&settlement_id.to_owned())
+            .ok_or("Organization chapter references an unknown settlement")?;
+        let physical_location = adventuresim_core::organization::chapter_effective_location_id(
+            organization,
+            chapter,
+            &settlement.economy,
+        );
+        let representative_id = adventuresim_core::organization::organization_representative_id(
             settlement_id,
-            &chapter.location_id,
+            &organization.id,
+        );
+        insert_npc_with_id(
+            ctx,
+            representative_id.clone(),
+            settlement_id,
+            physical_location,
             "organization",
             &chapter.representative_profession,
             &chapter.representative_title,
-            0,
-            true,
+            physical_location == chapter.location_id.as_str(),
         )?;
-        let npc_id = format!("npc:{settlement_id}:{}:0", chapter.location_id);
         let mut representative = ctx
             .db
             .settlement_npc()
             .id()
-            .find(&npc_id)
+            .find(&representative_id)
             .ok_or("Organization representative was not seeded")?;
         representative.service_id.clear();
         representative.organization_id = organization.id.clone();
@@ -749,10 +785,11 @@ mod tests {
             .and_then(|tail| tail.split("pub fn npc_is_present").next())
             .expect("population seeding body");
         assert!(ensure.contains("organizations_for_chapter(settlement_id)"));
-        assert!(ensure.contains("chapter.location_id"));
+        assert!(ensure.contains("chapter_effective_location_id"));
         assert!(ensure.contains("representative.organization_id = organization.id.clone()"));
         assert!(ensure.contains("\"organization-representative\""));
-        assert!(ensure.contains("ordinal"));
+        assert!(ensure.contains("organization_representative_id"));
         assert!(source.contains("id = format!(\"npc:{settlement_id}:{location}:{ordinal}\")"));
+        assert!(ensure.contains("physical_location == chapter.location_id.as_str()"));
     }
 }

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_effects.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_effects.rs
@@ -51,19 +51,19 @@ fn apply_dialogue_effect(
             crate::organization::join_organization(ctx, character_id, organization_id)
         }
         adventuresim_dialogue::Effect::JoinOrganization => {
-            let organization_id = dialogue_organization_id(session, &live_npc)?;
+            let organization_id = dialogue_organization_id(ctx, session, &live_npc)?;
             crate::organization::join_organization(ctx, character_id, organization_id)
         }
         adventuresim_dialogue::Effect::PayOrganizationDues => {
-            let organization_id = dialogue_organization_id(session, &live_npc)?;
+            let organization_id = dialogue_organization_id(ctx, session, &live_npc)?;
             crate::organization::pay_organization_dues(ctx, character_id, organization_id)
         }
         adventuresim_dialogue::Effect::RequestOrganizationPromotion => {
-            let organization_id = dialogue_organization_id(session, &live_npc)?;
+            let organization_id = dialogue_organization_id(ctx, session, &live_npc)?;
             crate::organization::promote_organization_membership(ctx, character_id, organization_id)
         }
         adventuresim_dialogue::Effect::PresentOrganization => {
-            let organization_id = dialogue_organization_id(session, &live_npc)?;
+            let organization_id = dialogue_organization_id(ctx, session, &live_npc)?;
             crate::organization::present_organization(ctx, character_id, organization_id)
         }
         adventuresim_dialogue::Effect::ReceiveReferredTestimony => {
@@ -172,18 +172,33 @@ fn apply_dialogue_effect(
 /// Resolve organization business only from the trusted persistent NPC and its
 /// exact authored chapter. Dialogue content and clients never supply this ID.
 pub(crate) fn exact_organization_representative(
+    ctx: &ReducerContext,
     npc: &crate::settlement_population::SettlementNpc,
     settlement_id: &str,
     location_id: &str,
 ) -> Option<String> {
     let organization = adventuresim_core::organization::organization(&npc.organization_id)?;
-    let chapter = organization.chapter_at_location(settlement_id, location_id)?;
-    let expected_id = format!("npc:{settlement_id}:{}:0", chapter.location_id);
+    let chapter = organization.chapter(settlement_id)?;
+    let settlement = ctx.db.settlement().id().find(&settlement_id.to_owned())?;
+    if adventuresim_core::organization::chapter_effective_location_id(
+        organization,
+        chapter,
+        &settlement.economy,
+    ) != location_id
+    {
+        return None;
+    }
+    let expected_id = adventuresim_core::organization::organization_representative_id(
+        settlement_id,
+        &organization.id,
+    );
     if !adventuresim_core::organization::exact_representative_fields_match(
         &npc.id,
         &expected_id,
         &npc.home_settlement_id,
         settlement_id,
+        &npc.organization_id,
+        &organization.id,
         &npc.conversation_id,
     ) {
         return None;
@@ -192,10 +207,11 @@ pub(crate) fn exact_organization_representative(
 }
 
 fn dialogue_organization_id(
+    ctx: &ReducerContext,
     session: &DialogueSession,
     npc: &crate::settlement_population::SettlementNpc,
 ) -> Result<String, String> {
-    exact_organization_representative(npc, &session.settlement_id, &session.location_id)
+    exact_organization_representative(ctx, npc, &session.settlement_id, &session.location_id)
         .ok_or_else(|| "Dialogue NPC is not the representative of this chapter".into())
 }
 

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_provenance.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_provenance.rs
@@ -307,6 +307,46 @@ fn validate_dialogue_cardinality(
     Ok(())
 }
 
+fn local_service_organization_representative(
+    ctx: &ReducerContext,
+    settlement_id: &str,
+    location_id: &str,
+    service_id: &str,
+) -> Option<crate::settlement_population::SettlementNpc> {
+    adventuresim_core::organization::organizations_for_chapter(settlement_id)
+        .filter(|organization| organization.service_id.as_deref() == Some(service_id))
+        .find_map(|organization| {
+            let chapter = organization.chapter(settlement_id)?;
+            let settlement = ctx.db.settlement().id().find(&settlement_id.to_owned())?;
+            (adventuresim_core::organization::chapter_effective_location_id(
+                organization,
+                chapter,
+                &settlement.economy,
+            ) == location_id)
+                .then(|| {
+                    adventuresim_core::organization::organization_representative_id(
+                        settlement_id,
+                        &organization.id,
+                    )
+                })
+                .and_then(|id| ctx.db.settlement_npc().id().find(&id))
+                .filter(|npc| {
+                    exact_organization_representative(ctx, npc, settlement_id, location_id)
+                        .as_deref()
+                        == Some(organization.id.as_str())
+                        && ctx
+                            .db
+                            .settlement_npc_presence()
+                            .npc_id()
+                            .find(&npc.id)
+                            .is_some_and(|presence| {
+                                presence.settlement_id == settlement_id
+                                    && presence.location_id == location_id
+                            })
+                })
+        })
+}
+
 fn dialogue_fact_context(
     ctx: &ReducerContext,
     session: &DialogueSession,
@@ -357,6 +397,20 @@ fn dialogue_fact_context(
                             role: participant.role.clone(),
                         },
                         FactValue::Text(npc.service_id.clone()),
+                    );
+                    result.facts.insert(
+                        FactKey::LocalOrganizationRepresentative {
+                            role: participant.role.clone(),
+                        },
+                        FactValue::Bool(
+                            local_service_organization_representative(
+                                ctx,
+                                &session.settlement_id,
+                                &session.location_id,
+                                &npc.service_id,
+                            )
+                            .is_some(),
+                        ),
                     );
                 }
                 result.facts.insert(
@@ -537,7 +591,7 @@ fn dialogue_fact_context(
             let Some(npc) = ctx.db.settlement_npc().id().find(&representative.actor_id) else {
                 continue;
             };
-            let Ok(organization_id) = dialogue_organization_id(session, &npc) else {
+            let Ok(organization_id) = dialogue_organization_id(ctx, session, &npc) else {
                 continue;
             };
             let definition = adventuresim_core::organization::organization(&organization_id)
@@ -863,7 +917,7 @@ fn bind_organization_business_terms(
     bindings: &mut adventuresim_dialogue::RuntimeBindings,
 ) -> Result<(), String> {
     use adventuresim_dialogue::RuntimeSlot as S;
-    let organization_id = dialogue_organization_id(session, npc)?;
+    let organization_id = dialogue_organization_id(ctx, session, npc)?;
     let definition = adventuresim_core::organization::organization(&organization_id)
         .ok_or("Organization representative has an unknown organization")?;
     bindings.bind(S::OrganizationName, definition.name.clone());
@@ -981,6 +1035,19 @@ fn dialogue_runtime_bindings(
     );
     bindings.bind(S::Settlement, session.settlement_id.clone());
     bindings.bind(S::Location, session.location_id.clone());
+    if !npc.service_id.is_empty()
+        && let Some(representative) = local_service_organization_representative(
+            ctx,
+            &session.settlement_id,
+            &session.location_id,
+            &npc.service_id,
+        )
+    {
+        bindings.bind(
+            S::OrganizationRepresentativeName,
+            representative.name,
+        );
+    }
     if !npc.organization_id.is_empty() {
         bind_organization_business_terms(ctx, session, character_id, &npc, &mut bindings)?;
     }

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_schema.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_schema.rs
@@ -534,6 +534,19 @@ fn require_live_dialogue_presence(
         {
             return Err("Dialogue NPC is not present at the session location and time".into());
         }
+        if (npc.organization_id.is_empty()
+            && npc.conversation_id == "organization-representative")
+            || (!npc.organization_id.is_empty()
+                && exact_organization_representative(
+                    ctx,
+                    &npc,
+                    &session.settlement_id,
+                    &session.location_id,
+                )
+                .is_none())
+        {
+            return Err("Dialogue NPC has no exact authority at the session location".into());
+        }
         primary.get_or_insert(npc);
     }
     Ok(primary.expect("nonempty NPC participants"))

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_sessions.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_sessions.rs
@@ -34,6 +34,19 @@ pub fn start_dialogue(
     if npc.home_settlement_id != settlement_id {
         return Err("Dialogue actor is not at this settlement".into());
     }
+    if (npc.organization_id.is_empty()
+        && npc.conversation_id == "organization-representative")
+        || (!npc.organization_id.is_empty()
+            && exact_organization_representative(
+                ctx,
+                &npc,
+                &settlement_id,
+                &location_id,
+            )
+            .is_none())
+    {
+        return Err("Dialogue actor has no exact authority at this location".into());
+    }
     let presence = ctx
         .db
         .settlement_npc_presence()

--- a/crates/adventuresim-stdb-module/src/strategic/mission_bootstrap.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/mission_bootstrap.rs
@@ -1744,12 +1744,13 @@ mod developer_quest_source_tests {
     fn organization_effects_resolve_only_from_the_bound_live_representative() {
         let source = STRATEGIC_SOURCE;
         let resolver = source
-            .split("fn dialogue_organization_id")
+            .split("fn exact_organization_representative")
             .nth(1)
             .and_then(|tail| tail.split("fn dialogue_service_id").next())
             .expect("organization dialogue authority");
         assert!(resolver.contains("npc.organization_id"));
-        assert!(resolver.contains("chapter_at_location"));
+        assert!(resolver.contains("chapter_effective_location_id"));
+        assert!(resolver.contains("organization_representative_id"));
         assert!(resolver.contains("session.settlement_id"));
         assert!(resolver.contains("session.location_id"));
         assert!(resolver.contains("\"organization-representative\""));
@@ -1762,7 +1763,7 @@ mod developer_quest_source_tests {
                     .next()
             })
             .expect("organization dialogue effects");
-        assert!(effects.contains("dialogue_organization_id(session, &live_npc)"));
+        assert!(effects.contains("dialogue_organization_id(ctx, session, &live_npc)"));
         assert!(!effects.contains("organization_id: String"));
     }
 

--- a/crates/strategic-web/src/routes/dialogue.rs
+++ b/crates/strategic-web/src/routes/dialogue.rs
@@ -247,20 +247,65 @@ fn npc_matches_location_binding(
     npc: &SettlementNpcRow,
     settlement_id: &str,
     location_id: &str,
+    profile: &adventuresim_world_schema::SettlementEconomyProfile,
 ) -> bool {
-    match adventuresim_core::organization::organization_chapter_at(settlement_id, location_id) {
-        Some((organization, _)) => {
-            npc.organization_id == organization.id
-                && npc.conversation_id == "organization-representative"
-        }
-        None => npc.organization_id.is_empty(),
+    if npc.organization_id.is_empty() {
+        return npc.conversation_id != "organization-representative";
     }
+    let Some(organization) = adventuresim_core::organization::organization(&npc.organization_id)
+    else {
+        return false;
+    };
+    let Some(chapter) = organization.chapter(settlement_id) else {
+        return false;
+    };
+    let expected_id = adventuresim_core::organization::organization_representative_id(
+        settlement_id,
+        &organization.id,
+    );
+    adventuresim_core::organization::chapter_effective_location_id(organization, chapter, profile)
+        == location_id
+        && adventuresim_core::organization::exact_representative_fields_match(
+            &npc.id,
+            &expected_id,
+            &npc.home_settlement_id,
+            settlement_id,
+            &npc.organization_id,
+            &organization.id,
+            &npc.conversation_id,
+        )
 }
 
 #[cfg(test)]
 mod npc_navigation_tests {
-    use super::{npc_location_is_navigable, npc_presence_contains};
+    use super::{
+        SettlementNpcRow, npc_location_is_navigable, npc_matches_location_binding,
+        npc_presence_contains,
+    };
     use crate::spacetimedb::SettlementCategory;
+
+    fn npc(id: &str, organization_id: &str, conversation_id: &str) -> SettlementNpcRow {
+        SettlementNpcRow {
+            id: id.into(),
+            home_settlement_id: "viabundus-0".into(),
+            name: "Greta Test".into(),
+            age_band: "adult".into(),
+            presentation: "woman".into(),
+            height: "average".into(),
+            build: "sturdy".into(),
+            hair: "brown hair".into(),
+            facial_hair: "none visible".into(),
+            complexion: "fair".into(),
+            visible_features: "work-worn hands".into(),
+            clothing: "working clothes".into(),
+            profession: "merchant".into(),
+            household: "market household".into(),
+            local_role: "market steward".into(),
+            service_id: "merchants".into(),
+            organization_id: organization_id.into(),
+            conversation_id: conversation_id.into(),
+        }
+    }
 
     #[test]
     fn browser_npc_description_uses_presentation_not_private_sex() {
@@ -332,6 +377,70 @@ mod npc_navigation_tests {
             &SettlementCategory::City,
             "viabundus-0",
             "organization-not-authored"
+        ));
+    }
+
+    #[test]
+    fn service_location_accepts_default_visitor_and_only_exact_local_representatives() {
+        let mut profile = adventuresim_world_schema::SettlementEconomyProfile::stage_placeholder();
+        profile.services = vec![adventuresim_world_schema::SettlementService::Market];
+        let representative_id = adventuresim_core::organization::organization_representative_id(
+            "viabundus-0",
+            "merchant_guild",
+        );
+        let provider = npc("npc:viabundus-0:market:0", "", "service-professions");
+        let visitor = npc("npc:viabundus-0:market:1", "", "local-resident");
+        let representative = npc(
+            &representative_id,
+            "merchant_guild",
+            "organization-representative",
+        );
+        assert!(npc_matches_location_binding(
+            &provider,
+            "viabundus-0",
+            "market",
+            &profile
+        ));
+        assert!(npc_matches_location_binding(
+            &visitor,
+            "viabundus-0",
+            "market",
+            &profile
+        ));
+        assert!(npc_matches_location_binding(
+            &representative,
+            "viabundus-0",
+            "market",
+            &profile
+        ));
+
+        for spoofed in [
+            npc(
+                "npc:viabundus-0:market:0",
+                "merchant_guild",
+                "organization-representative",
+            ),
+            npc(
+                &representative_id,
+                "weaponsmith_guild",
+                "organization-representative",
+            ),
+            npc(&representative_id, "", "organization-representative"),
+        ] {
+            assert!(!npc_matches_location_binding(
+                &spoofed,
+                "viabundus-0",
+                "market",
+                &profile
+            ));
+        }
+        let mut wrong_settlement = representative;
+        wrong_settlement.home_settlement_id = "viabundus-2337".into();
+        assert!(!npc_matches_location_binding(
+            &wrong_settlement,
+            "viabundus-0",
+            "market",
+            &profile
         ));
     }
 
@@ -442,7 +551,7 @@ async fn location_npcs(
     let mut views = presences.into_iter().filter(|presence| presence.settlement_id == settlement_id && presence.location_id == location_id && npc_presence_contains(presence.start_minute, presence.end_minute, minute)).filter_map(|presence| {
         let npc = npcs.iter().find(|npc| {
             npc.id == presence.npc_id
-                && npc_matches_location_binding(npc, &settlement_id, &location_id)
+                && npc_matches_location_binding(npc, &settlement_id, &location_id, &settlement.economy)
         })?;
         let facial = if npc.facial_hair == "none visible" { String::new() } else { format!(", with {}", npc.facial_hair) };
         Some(NpcView { id: npc.id.clone(), name: npc.name.clone(), initials: npc.name.split_whitespace().filter_map(|part| part.chars().next()).take(2).collect(), description: format!("{} is a {} {} person with {} presentation, a {} build, {}{}, and a {} complexion. Visible details include {}. They wear {}. Occupation: {}. Household: {}. Local role: {}.", npc.name, npc.height, npc.age_band.to_lowercase(), npc.presentation.to_lowercase(), npc.build, npc.hair, facial, npc.complexion, npc.visible_features, npc.clothing, npc.profession, npc.household, npc.local_role), is_default: presence.is_default })
@@ -496,7 +605,12 @@ async fn social_npc_in_scope(
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
         .filter(|npc| {
             npc.home_settlement_id == settlement_id
-                && npc_matches_location_binding(npc, settlement_id, location_id)
+                && npc_matches_location_binding(
+                    npc,
+                    settlement_id,
+                    location_id,
+                    &settlement.economy,
+                )
         })
         .ok_or(StatusCode::NOT_FOUND)
 }
@@ -839,9 +953,6 @@ async fn start(
         .await
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
         .ok_or(StatusCode::BAD_REQUEST)?;
-    if !npc_matches_location_binding(&npc, &npc.home_settlement_id, &request.location_id) {
-        return Err(StatusCode::NOT_FOUND);
-    }
     let settlement = state
         .db
         .query_one::<Settlement>(&format!(
@@ -851,6 +962,14 @@ async fn start(
         .await
         .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?
         .ok_or(StatusCode::BAD_REQUEST)?;
+    if !npc_matches_location_binding(
+        &npc,
+        &npc.home_settlement_id,
+        &request.location_id,
+        &settlement.economy,
+    ) {
+        return Err(StatusCode::NOT_FOUND);
+    }
     if !npc_location_is_navigable(
         &settlement.economy,
         &settlement.category,

--- a/crates/strategic-web/src/routes/settlements/medical.rs
+++ b/crates/strategic-web/src/routes/settlements/medical.rs
@@ -461,6 +461,15 @@ pub(super) async fn settlement_npc_place(
     let Some(settlement) = settlement else {
         return Html("<h1>Settlement not found</h1>".into());
     };
+    if let Some((organization, chapter)) = organization_chapter
+        && !adventuresim_core::organization::chapter_has_standalone_building(
+            organization,
+            chapter,
+            &settlement.economy,
+        )
+    {
+        return Html("<h1>Settlement place not found</h1>".into());
+    }
     let active = get_active_character(&state, session.character_id_u64()).await;
     let Some((character, _)) = active.as_ref() else {
         return Html("<h1>Choose a character first</h1>".into());

--- a/crates/strategic-web/src/routes/settlements/rest.rs
+++ b/crates/strategic-web/src/routes/settlements/rest.rs
@@ -687,7 +687,7 @@ mod service_availability_tests {
     }
 
     #[test]
-    fn service_apprenticeship_is_a_narrow_trainer_mediated_join_exception() {
+    fn service_apprenticeship_fallback_defers_to_colocated_representatives() {
         let source = SETTLEMENTS_SOURCE;
         let handler = source
             .split("async fn begin_service_apprenticeship")
@@ -699,6 +699,8 @@ mod service_availability_tests {
             .expect("service apprenticeship handler");
         assert!(handler.contains("organizations_for_chapter(&id)"));
         assert!(handler.contains("organization.service_id"));
+        assert!(handler.contains("chapter_has_standalone_building"));
+        assert!(handler.contains("Speak to the local organization representative"));
         assert!(handler.contains("\"join_organization\""));
         for forbidden in [
             "pay_organization_dues",

--- a/crates/strategic-web/src/routes/settlements/rest.rs
+++ b/crates/strategic-web/src/routes/settlements/rest.rs
@@ -699,7 +699,9 @@ mod service_availability_tests {
             .expect("service apprenticeship handler");
         assert!(handler.contains("organizations_for_chapter(&id)"));
         assert!(handler.contains("organization.service_id"));
-        assert!(handler.contains("chapter_has_standalone_building"));
+        assert!(handler.contains("exact_apprenticeship_representative_present"));
+        assert!(handler.contains("settlement_npc_presence"));
+        assert!(handler.contains("chapter_effective_location_id"));
         assert!(handler.contains("Speak to the local organization representative"));
         assert!(handler.contains("\"join_organization\""));
         for forbidden in [

--- a/crates/strategic-web/src/routes/settlements/service_quests.rs
+++ b/crates/strategic-web/src/routes/settlements/service_quests.rs
@@ -37,6 +37,46 @@ pub(super) struct ApprenticeshipResult {
     message: &'static str,
 }
 
+#[derive(Deserialize)]
+struct ApprenticeshipRepresentativeRow {
+    id: String,
+    home_settlement_id: String,
+    organization_id: String,
+    conversation_id: String,
+}
+
+#[derive(Deserialize)]
+struct ApprenticeshipRepresentativePresenceRow {
+    npc_id: String,
+    settlement_id: String,
+    location_id: String,
+}
+
+fn exact_apprenticeship_representative_present(
+    representative: Option<&ApprenticeshipRepresentativeRow>,
+    presences: &[ApprenticeshipRepresentativePresenceRow],
+    expected_id: &str,
+    settlement_id: &str,
+    organization_id: &str,
+    effective_location_id: &str,
+) -> bool {
+    representative.is_some_and(|representative| {
+        adventuresim_core::organization::exact_representative_fields_match(
+            &representative.id,
+            expected_id,
+            &representative.home_settlement_id,
+            settlement_id,
+            &representative.organization_id,
+            organization_id,
+            &representative.conversation_id,
+        ) && presences.iter().any(|presence| {
+            presence.npc_id == representative.id
+                && presence.settlement_id == settlement_id
+                && presence.location_id == effective_location_id
+        })
+    })
+}
+
 pub(super) async fn begin_service_apprenticeship(
     State(state): State<AppState>,
     Path((id, service_id)): Path<(String, String)>,
@@ -69,13 +109,61 @@ pub(super) async fn begin_service_apprenticeship(
             message: "The local training authority is unavailable.",
         });
     };
-    if organization.chapter(&id).is_some_and(|chapter| {
-        !adventuresim_core::organization::chapter_has_standalone_building(
+    let chapter = organization
+        .chapter(&id)
+        .expect("chapter iterator guarantees a local chapter");
+    let effective_location_id =
+        adventuresim_core::organization::chapter_effective_location_id(
             organization,
             chapter,
             &settlement.economy,
-        )
-    }) {
+        );
+    let representative_id = adventuresim_core::organization::organization_representative_id(
+        &id,
+        &organization.id,
+    );
+    let representative = match state
+        .db
+        .query_one::<ApprenticeshipRepresentativeRow>(&format!(
+            "SELECT * FROM backend_settlement_npcs WHERE id = {}",
+            sql_string_literal(&representative_id)
+        ))
+        .await
+    {
+        Ok(representative) => representative,
+        Err(error) => {
+            tracing::warn!(%error, %representative_id, "failed to verify apprenticeship representative");
+            return Json(ApprenticeshipResult {
+                enrolled: false,
+                message: "The local training authority is unavailable.",
+            });
+        }
+    };
+    let presences = match state
+        .db
+        .query::<ApprenticeshipRepresentativePresenceRow>(&format!(
+            "SELECT * FROM settlement_npc_presence WHERE npc_id = {}",
+            sql_string_literal(&representative_id)
+        ))
+        .await
+    {
+        Ok(presences) => presences,
+        Err(error) => {
+            tracing::warn!(%error, %representative_id, "failed to verify apprenticeship representative presence");
+            return Json(ApprenticeshipResult {
+                enrolled: false,
+                message: "The local training authority is unavailable.",
+            });
+        }
+    };
+    if exact_apprenticeship_representative_present(
+        representative.as_ref(),
+        &presences,
+        &representative_id,
+        &id,
+        &organization.id,
+        effective_location_id,
+    ) {
         return Json(ApprenticeshipResult {
             enrolled: false,
             message: "Speak to the local organization representative about apprenticeship.",
@@ -113,6 +201,83 @@ pub(super) async fn begin_service_apprenticeship(
                 message: "I cannot take you on just now.",
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod apprenticeship_representative_tests {
+    use super::*;
+
+    fn representative(
+        id: &str,
+        settlement_id: &str,
+        organization_id: &str,
+    ) -> ApprenticeshipRepresentativeRow {
+        ApprenticeshipRepresentativeRow {
+            id: id.into(),
+            home_settlement_id: settlement_id.into(),
+            organization_id: organization_id.into(),
+            conversation_id: "organization-representative".into(),
+        }
+    }
+
+    fn presence(
+        id: &str,
+        settlement_id: &str,
+        location_id: &str,
+    ) -> ApprenticeshipRepresentativePresenceRow {
+        ApprenticeshipRepresentativePresenceRow {
+            npc_id: id.into(),
+            settlement_id: settlement_id.into(),
+            location_id: location_id.into(),
+        }
+    }
+
+    #[test]
+    fn standalone_exact_representative_blocks_direct_apprenticeship() {
+        let id = adventuresim_core::organization::organization_representative_id(
+            "viabundus-0",
+            "physicians_college",
+        );
+        let representative = representative(&id, "viabundus-0", "physicians_college");
+        let presences = [presence(
+            &id,
+            "viabundus-0",
+            "organization-physicians-college",
+        )];
+        assert!(exact_apprenticeship_representative_present(
+            Some(&representative),
+            &presences,
+            &id,
+            "viabundus-0",
+            "physicians_college",
+            "organization-physicians-college",
+        ));
+    }
+
+    #[test]
+    fn missing_or_wrong_presence_keeps_the_direct_fallback_available() {
+        let id = adventuresim_core::organization::organization_representative_id(
+            "viabundus-0",
+            "merchant_guild",
+        );
+        let representative = representative(&id, "viabundus-0", "merchant_guild");
+        assert!(!exact_apprenticeship_representative_present(
+            Some(&representative),
+            &[],
+            &id,
+            "viabundus-0",
+            "merchant_guild",
+            "market",
+        ));
+        assert!(!exact_apprenticeship_representative_present(
+            Some(&representative),
+            &[presence(&id, "viabundus-0", "forge")],
+            &id,
+            "viabundus-0",
+            "merchant_guild",
+            "market",
+        ));
     }
 }
 

--- a/crates/strategic-web/src/routes/settlements/service_quests.rs
+++ b/crates/strategic-web/src/routes/settlements/service_quests.rs
@@ -54,6 +54,33 @@ pub(super) async fn begin_service_apprenticeship(
             message: "No local organization offers that professional activity.",
         });
     };
+    let settlement = state
+        .db
+        .query_one::<Settlement>(&format!(
+            "SELECT * FROM settlement WHERE id = {}",
+            sql_string_literal(&id)
+        ))
+        .await
+        .ok()
+        .flatten();
+    let Some(settlement) = settlement else {
+        return Json(ApprenticeshipResult {
+            enrolled: false,
+            message: "The local training authority is unavailable.",
+        });
+    };
+    if organization.chapter(&id).is_some_and(|chapter| {
+        !adventuresim_core::organization::chapter_has_standalone_building(
+            organization,
+            chapter,
+            &settlement.economy,
+        )
+    }) {
+        return Json(ApprenticeshipResult {
+            enrolled: false,
+            message: "Speak to the local organization representative about apprenticeship.",
+        });
+    }
     let Some((character, _)) = get_active_character(&state, session.character_id_u64()).await
     else {
         return Json(ApprenticeshipResult {

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -336,6 +336,8 @@ fn settlement_top_bar(
                 }
                 @for organization in adventuresim_core::organization::organizations_for_chapter(settlement_id) {
                     @let chapter = organization.chapter(settlement_id).expect("local chapter");
+                    @let standalone = economy.is_none_or(|profile| adventuresim_core::organization::chapter_has_standalone_building(organization, chapter, profile));
+                    @if standalone {
                     @let kind = format!("{:?}", chapter.building_kind).to_ascii_lowercase();
                     @let tint = building_tint(settlement_id, &chapter.location_id, material);
                     a href=(format!("/settlements/{}/places/{}", settlement_id, chapter.location_id))
@@ -351,6 +353,7 @@ fn settlement_top_bar(
                         span class="service-tab-building" aria-hidden="true" {}
                         span class="service-tab-icon service-tab-icon-organization" aria-hidden="true" {}
                         span class="service-tab-label" aria-hidden="true" { (&chapter.building_name) }
+                    }
                     }
                 }
             }

--- a/crates/strategic-web/src/templates/settlement/chrome.rs
+++ b/crates/strategic-web/src/templates/settlement/chrome.rs
@@ -180,10 +180,12 @@ pub fn settlement_npc_location_page(
                     }
                     @for organization in adventuresim_core::organization::organizations_for_chapter(&settlement.id) {
                         @let chapter = organization.chapter(&settlement.id).expect("local chapter");
+                        @if adventuresim_core::organization::chapter_has_standalone_building(organization, chapter, &settlement.economy) {
                         a href=(format!("/settlements/{}/places/{}", settlement.id, chapter.location_id))
                             class=(if location_id == chapter.location_id { "active" } else { "" })
                             aria-current=(if location_id == chapter.location_id { "page" } else { "false" }) {
                             (&chapter.building_name)
+                        }
                         }
                     }
                 }
@@ -760,6 +762,23 @@ mod tests {
         assert!(residence_places.contains(&format!(">{}</a>", public_square.label)));
         assert!(residence_places.contains("aria-current=\"false\""));
         assert!(residence_places.contains("class=\"active\" aria-current=\"page\">Residences</a>"));
+
+        let mut colocated = settlement;
+        colocated.id = "viabundus-0".into();
+        colocated.economy.services = vec![adventuresim_world_schema::SettlementService::Market];
+        let mut colocated_character = character;
+        colocated_character.current_settlement_id = Some(colocated.id.clone());
+        let colocated_places = settlement_npc_location_page(
+            &colocated,
+            &colocated_character,
+            &[],
+            "residences",
+            Some("Visitor"),
+        )
+        .into_string();
+        assert!(!colocated_places.contains("organization-merchant-guild"));
+        assert!(colocated_places.contains("organization-physicians-college"));
+        assert!(colocated_places.contains("organization-surgeons-guild"));
 
         let components = include_str!("../../../static/css/components.css");
         assert!(components.contains(".settlement-places-nav {\n  display: grid;\n  gap: 0.3rem;"));

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -406,13 +406,9 @@ pub(super) fn player_chat_area(subject: &Character, active_character: &Character
 }
 
 pub(super) fn npc_location_id(service_id: &str) -> &str {
-    match service_id {
-        "merchants" => "market",
-        "weapons" => "forge",
-        "armor" => "armoury",
-        "clothing" => "tailor",
-        "religion" => "church",
-        other => other,
+    match adventuresim_core::organization::service_npc_location_id(service_id) {
+        Some(location_id) => location_id,
+        None => service_id,
     }
 }
 

--- a/wiki/reference/organizations.md
+++ b/wiki/reference/organizations.md
@@ -31,10 +31,12 @@ rights or impose movement, faction, or eligibility restrictions.
 
 Chapters are explicit authored records, not settlement-ID flags. Every record
 names its settlement, a bounded stable `organization-*` location ID, building
-name and kind, and the title and profession of its representative. Each
-chapter therefore becomes a distinct navigable building even when several
-organizations share a settlement or an organization is also linked to an
-ordinary settlement service.
+name and kind, and the title and profession of its representative. That
+authored location remains the chapter's institutional identity. When a chapter
+is linked to an ordinary service that is present in the settlement, its
+representative is physically co-located with the service operator and visitors
+instead of adding another building. Chapters with no mapped available service,
+including physicians and surgeons, remain distinct navigable buildings.
 
 An organization may also declare explicit `starting_role` metadata: one of the
 ten authored start profession families plus distinct adult and old rank IDs.
@@ -78,7 +80,7 @@ existed in every listed settlement.
 The character sheet exposes the presented organization as a compact profession
 picker; it is only a self-presentation control. Joining, dues, reactivation,
 and promotion are conducted by speaking to the representative in the
-organization's chapter building. Its large label combines the member's rank with the service profession
+organization's local chapter venue. Its large label combines the member's rank with the service profession
 where one exists (for example, `Apprentice Weaponsmith`), while the smaller
 label names the organization. Crests are stable heraldic marks derived from the
 organization ID and service using the locally vendored Game Icons charges, so
@@ -90,13 +92,18 @@ presentation-only persistence fields.
 SpacetimeDB owns membership, rank, dues, presentation, payment, promotion, and
 equipment-law enforcement. Startup seeds exactly one deterministic persistent
 representative per authored chapter. The NPC carries an explicit organization
-binding, has an all-day authoritative presence at the exact chapter location,
+binding and has an all-day authoritative presence at either the mapped ordinary
+service building or, when no such service is available, the chapter building,
 and uses the compiled `organization-representative` conversation. Dialogue
 effects carry no organization ID: authority resolves it from that live NPC and
-revalidates the actor, session settlement, and exact chapter location before
+revalidates the actor, session settlement, authored local chapter, derived
+physical location, and organization-bound representative ID before
 reusing membership reducers. Joining is idempotent; the joining fee is charged once.
 Crossing a paid-through boundary suspends membership and clears its
-presentation. Paying at a chapter reactivates it without retroactive arrears.
+presentation. Service operators refer prospective apprentices to the named
+representative when one is present; the representative remains the authority
+for joining and membership. Paying at a chapter reactivates it without
+retroactive arrears.
 
 Forester (ranger), witch-hunter, and knightly organizations explicitly author
 `public_threat_referrals`; the capability is never inferred from names, skills,

--- a/wiki/strategic/settlement.md
+++ b/wiki/strategic/settlement.md
@@ -98,7 +98,7 @@ the live sky tint and brightness. Until imported terrain selects the actual
 biome, a deterministic hash of the camp party or quest-location ID keeps the
 assigned scenery stable between visits without adding persisted state.
 
-Each settlement offers a number of services as tabs of a unified trade page. Each service corresponds to a profession, represented by a single NPC. A greeting links the NPC's profession; asking about it explains the work and offers a second linked topic through which the active character may become an apprentice. The left side lists what the NPC offers, including training or other services where appropriate, and the right side lists what the party offers.
+Each settlement offers a number of services as tabs of a unified trade page. Each service corresponds to a profession and has a default operator NPC. A greeting links the NPC's profession; when a matching local organization representative shares the building, asking about the work names that representative and directs prospective apprentices to them. Without a matching representative, the operator preserves the lightweight direct apprenticeship fallback. The left side lists what the NPC offers, including training or other services where appropriate, and the right side lists what the party offers.
 
 The general merchant teaches Command; cooks at inns teach Cooking; weaponsmiths and armourers teach Smithing; and tailors teach Tailoring. Medical crafts use three distinct organizations: the informal, fee-free Fellowship of Herbalists teaches Herbalism, the College of Physicians teaches Physiology for patient assessment, fallible differentials, and non-operative treatment, and the Surgeons' Guild teaches Surgery for operations. Their ranks and practice rewards are independent. The church teaches its own religious tradition through prayer and practice activities. Inns also sell cooking implements and food ingredients. Most apprentices pay for instruction; fellowship learners do not. At rank 2 in an associated profession skill they may practice independently for a small wage, and at rank 4 they may reach a senior rank whose practice earns a good income. Religious progression uses novice, cleric, and teacher as neutral interface terms, and visible religious practice earns local Fame rather than money.
 
@@ -235,10 +235,11 @@ trade, herbalist care, and repairs. The overview exposes prosperity,
 specializations, and every religion represented by the canonical legal status,
 not merely the faith selected for the single church/priest presentation.
 
-Authored organization chapters add distinct Place Facades alongside ordinary
-settlement services. Each opens a real organization building with one
-deterministic persistent representative. Visitors may enter and speak to the
-representative; nonmembers may ask to join, while members conduct dues,
-reactivation, promotion, and presentation business through the compiled
-dialogue. A service-linked guild keeps its ordinary merchant or craft service
-and dialogue in addition to its separate chapter building.
+Authored organization chapters retain stable settlement and `organization-*`
+location identity metadata. Chapters linked to an available market, forge,
+armoury, tailor, herbalist, inn, or church service place their deterministic
+persistent representative inside that ordinary service building, alongside its
+default operator and visitor, and do not add another Place Facade. If the
+mapped service is unavailable the chapter safely retains its standalone
+building. Physician and surgeon chapters, and organizations without a service,
+remain standalone. Organization-aware dialogue stays with the representative.


### PR DESCRIPTION
## Summary

- Co-locate service-linked organization representatives with their ordinary market, forge, armoury, tailor, herbalist, inn, or church venue when that service is available.
- Suppress redundant guildhall Place Facades while preserving authored `organization-*` chapter identity.
- Keep physician, surgeon, unavailable-service, and non-service organization chapters as standalone buildings.
- Have service operators refer prospective apprentices to the authoritative representative by name; organization joining and membership business remain with that representative.

## Implementation notes

- Representative IDs are stable, organization-bound, and independent of physical location/provider ordinals.
- Browser and reducer authority validate the exact NPC, organization, settlement, chapter, derived location, conversation, and presence.
- Default operators and visitors coexist with representatives; the operator remains the default portrait.
- Direct service apprenticeship is only a fallback when the exact representative and authoritative presence are absent. Query failures fail closed.
- No database migration or generated client schema change is required under the pre-launch policy.

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p adventuresim-dialogue` — 21 passed
- `cargo check -p adventuresim-stdb-module --lib`
- `cargo test -p strategic-web npc_navigation_tests` — 7 passed
- `cargo test -p strategic-web apprenticeship_representative_tests` — 2 passed
- `cargo test -p strategic-web service_apprenticeship_fallback_defers_to_colocated_representatives` — passed
- Strategic-web Places navigation test — passed
- Dialogue-client, local-chat, and strategic-navigation Node suites — 29 passed
- `cargo run -p adventuresim-dialogue --bin dialogue-check -- check`
- `just verify-db-client`
- `python scripts/update_project_map.py --check`

The existing `adventuresim-stdb-module` lib-test harness remains blocked by unrelated baseline `include_str!` path and `STRATEGIC_SOURCE` errors; the production library and full workspace compile successfully.

## Demo

Start a disposable strategic stack with:

```powershell
just web-isolated-strategic guild-representatives-demo 24650
```

The locally verified UI was available at `http://127.0.0.1:24651/`, returned HTTP 200, and had no browser console errors.

## Risk / rollback

The change is limited to chapter placement/presentation, NPC population, dialogue binding, and related authority checks. Roll back by reverting the two commits and recreating the disposable development database.