### PR TITLE
Let party Physiology reduce preventable disease exposure

### DIFF
--- a/crates/adventuresim-core/src/disease.rs
+++ b/crates/adventuresim-core/src/disease.rs
@@ -294,6 +294,25 @@ pub fn elapsed_presence_window(
     (start <= end).then_some((start, end))
 }
 
+/// End of a recorded presence span for an interval plan. Explicitly
+/// co-advancing participants may project to their shared horizon. A solo
+/// participant may consume already-recorded overlap only through the peer's
+/// current clock.
+pub fn projected_presence_end(
+    ended_at: Option<u64>,
+    low_horizon: Option<u64>,
+    high_horizon: Option<u64>,
+    low_clock: u64,
+    high_clock: u64,
+) -> Option<u64> {
+    ended_at.or_else(|| match (low_horizon, high_horizon) {
+        (Some(low), Some(high)) => Some(low.min(high)),
+        (Some(low), None) => Some(low.min(high_clock)),
+        (None, Some(high)) => Some(high.min(low_clock)),
+        (None, None) => None,
+    })
+}
+
 /// Disease-agnostic infectiousness for close company. Contact risk begins
 /// during incubation, peaks through the acute phases, and declines during
 /// recovery. It does not depend on whether symptoms are publicly visible.
@@ -320,6 +339,191 @@ pub fn close_contact_infectiousness(episode: InfectionEpisode, at: u64) -> f32 {
         return ((resolved - age) / definition.recovery_minutes.max(1) as f32).clamp(0.0, 1.0);
     }
     0.0
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ContactWindow {
+    pub low_id: u64,
+    pub high_id: u64,
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct AcquisitionTimeline {
+    pub proposals: std::collections::BTreeMap<u64, Vec<InfectionEpisode>>,
+    pub work_units: u64,
+}
+
+/// Resolve already-assembled route candidates and contact transmission in one
+/// absolute-minute timeline. Acquisitions at a minute are simultaneous and
+/// become eligible contact sources only on the following minute.
+pub fn resolve_acquisition_timeline(
+    target_ids: &std::collections::BTreeSet<u64>,
+    initial: &std::collections::BTreeMap<u64, Vec<InfectionEpisode>>,
+    scheduled: impl IntoIterator<Item = InfectionEpisode>,
+    windows: &[ContactWindow],
+    immunity: &std::collections::BTreeMap<u64, f32>,
+    from: u64,
+    to: u64,
+    initial_work: u64,
+    max_work: u64,
+    physiology_check_at: impl Fn(u64, u64) -> f32,
+) -> Result<AcquisitionTimeline, &'static str> {
+    if to <= from || initial_work > max_work {
+        return (initial_work <= max_work)
+            .then_some(AcquisitionTimeline {
+                work_units: initial_work,
+                ..Default::default()
+            })
+            .ok_or("Disease interval exceeds bounded exposure work");
+    }
+    let mut scheduled_by_minute = std::collections::BTreeMap::<u64, Vec<InfectionEpisode>>::new();
+    let mut work_units = initial_work;
+    for episode in scheduled {
+        if target_ids.contains(&episode.character_id)
+            && episode.contracted_at > from
+            && episode.contracted_at <= to
+        {
+            work_units = work_units.saturating_add(1);
+            if work_units > max_work {
+                return Err("Disease interval exceeds bounded exposure work");
+            }
+            scheduled_by_minute
+                .entry(episode.contracted_at)
+                .or_default()
+                .push(episode);
+        }
+    }
+    let mut state = initial.clone();
+    let mut result = AcquisitionTimeline {
+        work_units,
+        ..Default::default()
+    };
+    let first_scheduled = scheduled_by_minute.keys().next().copied();
+    let first_contact = windows
+        .iter()
+        .filter_map(|window| {
+            let start = window.start.max(from.saturating_add(1));
+            (start <= window.end && start <= to).then_some(start)
+        })
+        .min();
+    let Some(mut minute) = first_scheduled.into_iter().chain(first_contact).min() else {
+        return Ok(result);
+    };
+    while minute <= to {
+        let mut candidates = scheduled_by_minute.remove(&minute).unwrap_or_default();
+        for window in windows {
+            result.work_units = result.work_units.saturating_add(1);
+            if result.work_units > max_work {
+                return Err("Disease interval exceeds bounded exposure work");
+            }
+            if minute < window.start || minute > window.end {
+                continue;
+            }
+            for (source_id, target_id) in [
+                (window.low_id, window.high_id),
+                (window.high_id, window.low_id),
+            ] {
+                if !target_ids.contains(&target_id) {
+                    continue;
+                }
+                let target_immunity = immunity.get(&target_id).copied().unwrap_or(3.0);
+                let target_episodes = state.get(&target_id).map_or(&[][..], Vec::as_slice);
+                for source_episode in state.get(&source_id).into_iter().flatten() {
+                    result.work_units = result.work_units.saturating_add(1);
+                    if result.work_units > max_work {
+                        return Err("Disease interval exceeds bounded exposure work");
+                    }
+                    if source_episode.contracted_at >= minute
+                        || !definition(source_episode.disease_id)
+                            .supports(TransmissionVector::CloseContact)
+                        || has_unresolved_disease(
+                            target_episodes,
+                            source_episode.disease_id,
+                            minute,
+                            target_immunity,
+                        )
+                    {
+                        continue;
+                    }
+                    let exposure = residual_exposure(
+                        close_contact_infectiousness(*source_episode, minute) / 1_440.0,
+                        TransmissionVector::CloseContact,
+                        physiology_check_at(target_id, minute),
+                    );
+                    let prior = acquired_immunity(
+                        target_episodes,
+                        source_episode.disease_id,
+                        minute,
+                        target_immunity,
+                    );
+                    let seed =
+                        contact_exposure_seed(target_id, source_id, source_episode.id, minute);
+                    if acquisition_succeeds(
+                        seed,
+                        definition(source_episode.disease_id),
+                        target_immunity,
+                        prior,
+                        exposure,
+                    ) {
+                        candidates.push(InfectionEpisode {
+                            id: seed,
+                            character_id: target_id,
+                            disease_id: source_episode.disease_id,
+                            contracted_at: minute,
+                            ruleset_version: source_episode.ruleset_version,
+                            phenotype_key_version: source_episode.phenotype_key_version,
+                        });
+                    }
+                }
+            }
+        }
+        candidates.sort_by_key(|episode| {
+            (
+                episode.character_id,
+                episode.disease_id as u8,
+                episode.contracted_at,
+                episode.id,
+            )
+        });
+        for candidate in candidates {
+            let current = state.entry(candidate.character_id).or_default();
+            let target_immunity = immunity
+                .get(&candidate.character_id)
+                .copied()
+                .unwrap_or(3.0);
+            if has_unresolved_disease(current, candidate.disease_id, minute, target_immunity) {
+                continue;
+            }
+            current.push(candidate);
+            current.sort_by_key(|episode| (episode.contracted_at, episode.id));
+            result
+                .proposals
+                .entry(candidate.character_id)
+                .or_default()
+                .push(candidate);
+        }
+        let next_scheduled = scheduled_by_minute
+            .range(minute.saturating_add(1)..)
+            .next()
+            .map(|(next, _)| *next);
+        let next_contact = windows
+            .iter()
+            .filter_map(|window| {
+                let next = minute.saturating_add(1).max(window.start);
+                (next <= window.end && next <= to).then_some(next)
+            })
+            .min();
+        let Some(next) = next_scheduled.into_iter().chain(next_contact).min() else {
+            break;
+        };
+        if next <= minute {
+            break;
+        }
+        minute = next;
+    }
+    Ok(result)
 }
 
 const DAY: u64 = 1_440;
@@ -635,6 +839,24 @@ pub fn outbreak_exposure_seed(character_id: u64, outbreak_id: &str) -> u64 {
         .copied()
         .chain(character_id.to_le_bytes())
         .chain(outbreak_id.bytes()))
+}
+
+/// Contact candidates vary at minute granularity. FNV supplies stable domain
+/// identity and this finalizer avalanches adjacent minute suffixes so the high
+/// 53 bits consumed by acquisition rolls are not correlated.
+pub fn contact_exposure_seed(
+    target_id: u64,
+    source_id: u64,
+    source_episode_id: u64,
+    minute: u64,
+) -> u64 {
+    let mut value = outbreak_exposure_seed(
+        target_id,
+        &format!("party:{source_id}:{source_episode_id}:{minute}"),
+    );
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
 }
 
 /// True while an episode of the same disease remains unresolved at the
@@ -1724,5 +1946,265 @@ mod tests {
             close_contact_infectiousness(e(21, DiseaseId::Dysentery), 100),
             0.0
         );
+    }
+
+    fn timeline_episode(id: u64, character_id: u64, contracted_at: u64) -> InfectionEpisode {
+        InfectionEpisode {
+            id,
+            character_id,
+            disease_id: DiseaseId::Influenza,
+            contracted_at,
+            ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
+            phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+        }
+    }
+
+    #[test]
+    fn chronological_contact_chain_is_order_independent_and_chunk_invariant() {
+        let targets = [1, 2, 3].into_iter().collect();
+        let initial = [(1, vec![timeline_episode(11, 1, 0)])]
+            .into_iter()
+            .collect();
+        let immunity = [(1, 0.0), (2, 0.0), (3, 0.0)].into_iter().collect();
+        let windows = [
+            ContactWindow {
+                low_id: 1,
+                high_id: 2,
+                start: 1,
+                end: 30_000,
+            },
+            ContactWindow {
+                low_id: 2,
+                high_id: 3,
+                start: 1,
+                end: 30_000,
+            },
+        ];
+        let whole = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            [],
+            &windows,
+            &immunity,
+            0,
+            30_000,
+            0,
+            2_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        let b_at = whole.proposals[&2][0].contracted_at;
+        let c_at = whole.proposals[&3][0].contracted_at;
+        assert!(
+            c_at > b_at,
+            "new sources become eligible on the next minute"
+        );
+
+        let reversed = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            [],
+            &[windows[1], windows[0]],
+            &immunity,
+            0,
+            30_000,
+            0,
+            2_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        assert_eq!(whole.proposals, reversed.proposals);
+
+        let first = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            [],
+            &windows,
+            &immunity,
+            0,
+            b_at,
+            0,
+            2_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        let mut split_initial = initial.clone();
+        for (id, episodes) in &first.proposals {
+            split_initial.entry(*id).or_default().extend(episodes);
+        }
+        let second = resolve_acquisition_timeline(
+            &targets,
+            &split_initial,
+            [],
+            &windows,
+            &immunity,
+            b_at,
+            30_000,
+            first.work_units,
+            2_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        let mut split = first.proposals;
+        for (id, episodes) in second.proposals {
+            split.entry(id).or_default().extend(episodes);
+        }
+        assert_eq!(whole.proposals, split);
+    }
+
+    #[test]
+    fn blood_scheduled_acquisition_becomes_contact_source_next_minute() {
+        let targets = [2, 3].into_iter().collect();
+        let immunity = [(2, 0.0), (3, 0.0)].into_iter().collect();
+        let blood = timeline_episode(22, 2, 100);
+        let result = resolve_acquisition_timeline(
+            &targets,
+            &Default::default(),
+            [blood],
+            &[ContactWindow {
+                low_id: 2,
+                high_id: 3,
+                start: 1,
+                end: 30_000,
+            }],
+            &immunity,
+            0,
+            30_000,
+            0,
+            1_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        assert_eq!(result.proposals[&2], vec![blood]);
+        assert!(result.proposals[&3][0].contracted_at > blood.contracted_at);
+    }
+
+    #[test]
+    fn synchronized_prevention_and_clipped_timeline_are_executable() {
+        let targets = [1, 2].into_iter().collect();
+        let initial = [(1, vec![timeline_episode(31, 1, 0)])]
+            .into_iter()
+            .collect();
+        let immunity = [(1, 0.0), (2, 0.0)].into_iter().collect();
+        let window = [ContactWindow {
+            low_id: 1,
+            high_id: 2,
+            start: 1,
+            end: 30_000,
+        }];
+        let unprotected = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            [],
+            &window,
+            &immunity,
+            0,
+            30_000,
+            0,
+            1_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        let protected = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            [],
+            &window,
+            &immunity,
+            0,
+            30_000,
+            0,
+            1_000_000,
+            |_, _| 5.0,
+        )
+        .unwrap();
+        assert!(
+            protected
+                .proposals
+                .get(&2)
+                .and_then(|episodes| episodes.first())
+                .map(|episode| episode.contracted_at)
+                .unwrap_or(u64::MAX)
+                > unprotected.proposals[&2][0].contracted_at
+        );
+
+        let scheduled_after_death_clip = timeline_episode(32, 2, 501);
+        let clipped = resolve_acquisition_timeline(
+            &targets,
+            &Default::default(),
+            [scheduled_after_death_clip],
+            &[],
+            &immunity,
+            0,
+            500,
+            0,
+            1_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        assert!(clipped.proposals.is_empty());
+        assert_eq!(
+            resolve_acquisition_timeline(
+                &targets,
+                &initial,
+                [],
+                &window,
+                &immunity,
+                0,
+                30_000,
+                0,
+                1,
+                |_, _| 0.0,
+            ),
+            Err("Disease interval exceeds bounded exposure work")
+        );
+    }
+
+    #[test]
+    fn solo_catchup_uses_only_already_elapsed_peer_overlap() {
+        assert_eq!(
+            projected_presence_end(None, Some(300), None, 100, 250),
+            Some(250)
+        );
+        assert_eq!(
+            projected_presence_end(None, Some(200), None, 100, 250),
+            Some(200)
+        );
+        assert_eq!(
+            projected_presence_end(None, Some(300), Some(280), 100, 250),
+            Some(280)
+        );
+        assert_eq!(
+            projected_presence_end(Some(175), Some(300), None, 100, 250),
+            Some(175)
+        );
+
+        let target_horizon = 20_000;
+        let peer_clock = 10_000;
+        let overlap_end =
+            projected_presence_end(None, Some(target_horizon), None, 100, peer_clock).unwrap();
+        let targets = [2].into_iter().collect();
+        let initial = [(1, vec![timeline_episode(41, 1, 0)])]
+            .into_iter()
+            .collect();
+        let result = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            [],
+            &[ContactWindow {
+                low_id: 1,
+                high_id: 2,
+                start: 101,
+                end: overlap_end,
+            }],
+            &[(2, 0.0)].into_iter().collect(),
+            100,
+            target_horizon,
+            0,
+            1_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        assert!(result.proposals[&2][0].contracted_at <= peer_clock);
     }
 }

--- a/crates/adventuresim-core/src/disease.rs
+++ b/crates/adventuresim-core/src/disease.rs
@@ -355,6 +355,32 @@ pub struct AcquisitionTimeline {
     pub work_units: u64,
 }
 
+pub fn insert_unique_bounded<K: Ord, V>(
+    values: &mut std::collections::BTreeMap<K, V>,
+    key: K,
+    value: V,
+    limit: usize,
+) -> Result<bool, &'static str> {
+    use std::collections::btree_map::Entry;
+    if values.len() >= limit && !values.contains_key(&key) {
+        return Err("Disease interval has too many raw presence spans");
+    }
+    Ok(match values.entry(key) {
+        Entry::Vacant(entry) => {
+            entry.insert(value);
+            true
+        }
+        Entry::Occupied(_) => false,
+    })
+}
+
+pub fn add_bounded_work(work: &mut u64, amount: u64, max: u64) -> Result<(), &'static str> {
+    *work = work.saturating_add(amount);
+    (*work <= max)
+        .then_some(())
+        .ok_or("Disease interval exceeds bounded exposure work")
+}
+
 /// Resolve already-assembled route candidates and contact transmission in one
 /// absolute-minute timeline. Acquisitions at a minute are simultaneous and
 /// become eligible contact sources only on the following minute.
@@ -983,6 +1009,51 @@ pub fn first_eligible_protected_presence_exposure_minute(
         )
     })
 }
+
+#[allow(clippy::too_many_arguments)]
+pub fn eligible_protected_presence_exposure_attempt_minutes(
+    episodes: &[InfectionEpisode],
+    disease_id: DiseaseId,
+    character_id: u64,
+    exposure_id: &str,
+    from: u64,
+    to: u64,
+    intensity: f32,
+    base_acquisition: f32,
+    immunity: f32,
+    vector: TransmissionVector,
+    max_attempts: usize,
+    physiology_check_at: impl Fn(u64) -> f32,
+) -> Result<Vec<u64>, &'static str> {
+    if to <= from || intensity <= 0.0 {
+        return Ok(Vec::new());
+    }
+    let mut attempts = Vec::new();
+    for minute in (from + 1)..=to {
+        if has_unresolved_disease(episodes, disease_id, minute, immunity) {
+            continue;
+        }
+        let prior_immunity = acquired_immunity(episodes, disease_id, minute, immunity);
+        let key = format!("{exposure_id}:{minute}");
+        if acquisition_succeeds(
+            outbreak_exposure_seed(character_id, &key),
+            &DiseaseDefinition {
+                base_acquisition: base_acquisition / 1_440.0,
+                ..*definition(disease_id)
+            },
+            immunity,
+            prior_immunity,
+            residual_exposure(intensity, vector, physiology_check_at(minute)),
+        ) {
+            if attempts.len() >= max_attempts {
+                return Err("Disease interval exceeds bounded acquisition candidates");
+            }
+            attempts.push(minute);
+        }
+    }
+    Ok(attempts)
+}
+
 pub fn severity(e: InfectionEpisode, immunity: f32) -> f32 {
     let unit = (severity_seed(e) >> 11) as f64 / (1u64 << 53) as f64;
     let innate = (immunity / 5.0).clamp(0.0, 1.0);
@@ -2206,5 +2277,117 @@ mod tests {
         )
         .unwrap();
         assert!(result.proposals[&2][0].contracted_at <= peer_clock);
+    }
+
+    #[test]
+    fn long_environmental_source_reattempts_after_resolution_whole_or_split() {
+        let initial_episode = timeline_episode(51, 7, 0);
+        let initial = [(7, vec![initial_episode])].into_iter().collect();
+        let immunity = [(7, 0.0)].into_iter().collect();
+        let targets = [7].into_iter().collect();
+        let resolution = (1..60 * DAY)
+            .find(|minute| evaluate(initial_episode, *minute, 0.0).stage == DiseaseStage::Resolved)
+            .unwrap();
+        let split_at = resolution.saturating_sub(1);
+        let to = resolution + 30 * DAY;
+        let scheduled = |from, to| {
+            eligible_protected_presence_exposure_attempt_minutes(
+                &[initial_episode],
+                DiseaseId::Influenza,
+                7,
+                "long-running-outbreak",
+                from,
+                to,
+                1_000.0,
+                definition(DiseaseId::Influenza).base_acquisition,
+                0.0,
+                TransmissionVector::CloseContact,
+                100_000,
+                |_| 0.0,
+            )
+            .unwrap()
+            .into_iter()
+            .map(|at| InfectionEpisode {
+                id: outbreak_exposure_seed(7, &format!("long-running-outbreak:{at}")),
+                character_id: 7,
+                disease_id: DiseaseId::Influenza,
+                contracted_at: at,
+                ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
+                phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+            })
+            .collect::<Vec<_>>()
+        };
+        let whole = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            scheduled(0, to),
+            &[],
+            &immunity,
+            0,
+            to,
+            0,
+            1_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        assert!(whole.proposals[&7][0].contracted_at >= resolution);
+
+        let first = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            scheduled(0, split_at),
+            &[],
+            &immunity,
+            0,
+            split_at,
+            0,
+            1_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        let mut split_initial = initial;
+        for (id, episodes) in &first.proposals {
+            split_initial.entry(*id).or_default().extend(episodes);
+        }
+        let second = resolve_acquisition_timeline(
+            &targets,
+            &split_initial,
+            scheduled(split_at, to),
+            &[],
+            &immunity,
+            split_at,
+            to,
+            first.work_units,
+            1_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        let mut split = first.proposals;
+        for (id, episodes) in second.proposals {
+            split.entry(id).or_default().extend(episodes);
+        }
+        assert_eq!(whole.proposals, split);
+    }
+
+    #[test]
+    fn raw_presence_span_and_checkpoint_work_caps_fail_closed() {
+        let mut spans = std::collections::BTreeMap::new();
+        assert_eq!(insert_unique_bounded(&mut spans, 1, "a", 2), Ok(true));
+        assert_eq!(
+            insert_unique_bounded(&mut spans, 1, "duplicate", 2),
+            Ok(false)
+        );
+        assert_eq!(insert_unique_bounded(&mut spans, 2, "b", 2), Ok(true));
+        assert_eq!(
+            insert_unique_bounded(&mut spans, 3, "excess", 2),
+            Err("Disease interval has too many raw presence spans")
+        );
+
+        let mut work = 0;
+        assert_eq!(add_bounded_work(&mut work, 4, 5), Ok(()));
+        assert_eq!(
+            add_bounded_work(&mut work, 2, 5),
+            Err("Disease interval exceeds bounded exposure work")
+        );
     }
 }

--- a/crates/adventuresim-core/src/disease.rs
+++ b/crates/adventuresim-core/src/disease.rs
@@ -206,9 +206,60 @@ pub fn maximum_preventable_fraction(vector: TransmissionVector) -> f32 {
     }
 }
 
-pub fn residual_exposure(exposure: f32, vector: TransmissionVector, physiology_check: f32) -> f32 {
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ExposureComponents {
+    pub unavoidable: f32,
+    pub preventable: f32,
+}
+
+/// Split a route's total dose into unavoidable/environmental exposure and the
+/// party-behavior share that Physiology can mitigate. `affordance` represents
+/// how much of the route's ordinary preventive behavior is physically
+/// possible with the current space, sanitation, and supplies.
+pub fn exposure_components(
+    exposure: f32,
+    vector: TransmissionVector,
+    affordance: f32,
+) -> ExposureComponents {
+    let exposure = exposure.max(0.0);
+    let preventable = exposure * maximum_preventable_fraction(vector) * affordance.clamp(0.0, 1.0);
+    ExposureComponents {
+        unavoidable: exposure - preventable,
+        preventable,
+    }
+}
+
+pub fn residual_exposure_with_affordance(
+    exposure: f32,
+    vector: TransmissionVector,
+    physiology_check: f32,
+    affordance: f32,
+) -> f32 {
+    let components = exposure_components(exposure, vector, affordance);
     let competence = (physiology_check.clamp(0.0, 5.0) / 5.0).powf(1.25);
-    exposure.max(0.0) * (1.0 - maximum_preventable_fraction(vector) * competence)
+    components.unavoidable + components.preventable * (1.0 - competence)
+}
+
+pub const BLOOD_BASIC_HANDLING_AFFORDANCE: f32 = 0.25;
+pub const BLOOD_CLEAN_HANDLING_BONUS: f32 = 0.45;
+pub const BLOOD_CLOSED_WOUND_BONUS: f32 = 0.30;
+
+/// Circumstance cap for blood/caregiving prevention. Basic avoidance remains
+/// possible without supplies, but clean handling and a protected wound must
+/// come from real sanitation and wound-care state.
+pub fn blood_caregiving_affordance(clean_handling: bool, cut_route: f32) -> f32 {
+    (BLOOD_BASIC_HANDLING_AFFORDANCE
+        + if clean_handling {
+            BLOOD_CLEAN_HANDLING_BONUS
+        } else {
+            0.0
+        }
+        + BLOOD_CLOSED_WOUND_BONUS * (1.0 - cut_route.clamp(0.0, 1.0)))
+    .clamp(0.0, 1.0)
+}
+
+pub fn residual_exposure(exposure: f32, vector: TransmissionVector, physiology_check: f32) -> f32 {
+    residual_exposure_with_affordance(exposure, vector, physiology_check, 1.0)
 }
 
 /// Aggregate distinct practitioners whose pinned capability covers `minute`.
@@ -1467,6 +1518,95 @@ mod tests {
             residual_exposure(exposure, TransmissionVector::Wound, 5.0),
             exposure
         );
+    }
+
+    #[test]
+    fn prevention_separates_unavoidable_dose_and_caps_missing_affordances() {
+        let fully_possible = exposure_components(1.0, TransmissionVector::FoodWater, 1.0);
+        let impossible = exposure_components(1.0, TransmissionVector::FoodWater, 0.0);
+        assert!(fully_possible.preventable > fully_possible.unavoidable);
+        assert_eq!(impossible.preventable, 0.0);
+        assert_eq!(impossible.unavoidable, 1.0);
+
+        let missing_supplies_open_wound = blood_caregiving_affordance(false, 1.0);
+        let clean_handling_protected_wound = blood_caregiving_affordance(true, 0.18);
+        assert_eq!(missing_supplies_open_wound, BLOOD_BASIC_HANDLING_AFFORDANCE);
+        assert!(clean_handling_protected_wound > missing_supplies_open_wound);
+        assert!(
+            residual_exposure_with_affordance(
+                1.0,
+                TransmissionVector::Blood,
+                5.0,
+                missing_supplies_open_wound,
+            ) > residual_exposure_with_affordance(
+                1.0,
+                TransmissionVector::Blood,
+                5.0,
+                clean_handling_protected_wound,
+            )
+        );
+        assert_eq!(
+            residual_exposure_with_affordance(
+                0.0,
+                TransmissionVector::Blood,
+                5.0,
+                clean_handling_protected_wound,
+            ),
+            0.0,
+            "successful physical cleaning removes the dose before Physiology"
+        );
+    }
+
+    #[test]
+    fn strategic_prevention_fixture_reduces_contraction_and_secondary_attack_by_level() {
+        let simulated_rate = |vector, physiology_check| {
+            let definition = match vector {
+                TransmissionVector::FoodWater => definition(DiseaseId::Dysentery),
+                TransmissionVector::CloseContact => definition(DiseaseId::Influenza),
+                _ => unreachable!("fixture covers authored high-preventability routes"),
+            };
+            let exposure = residual_exposure(0.20, vector, physiology_check);
+            (0..20_000_u64)
+                .map(|character_id| outbreak_exposure_seed(character_id, "prevention-fixture"))
+                .filter(|seed| acquisition_succeeds(*seed, definition, 2.5, 0.0, exposure))
+                .count()
+        };
+        for vector in [
+            TransmissionVector::FoodWater,
+            TransmissionVector::CloseContact,
+        ] {
+            let rates = [0.0, 1.0, 3.0, 5.0].map(|level| simulated_rate(vector, level));
+            assert!(rates.windows(2).all(|pair| pair[1] < pair[0]), "{rates:?}");
+            assert!(rates[3] * 2 < rates[0], "{rates:?}");
+            assert!(rates[3] > 0, "mastery must retain residual risk");
+        }
+    }
+
+    #[test]
+    fn shared_sleep_is_close_contact_presence_and_is_chunk_invariant() {
+        let overnight_start = 18 * 60;
+        let overnight_end = overnight_start + 12 * 60;
+        let physician_span = [(9, overnight_start + 1, overnight_end, 5.0)];
+        let evaluate = |from, to| {
+            first_eligible_protected_presence_exposure_minute(
+                &[],
+                DiseaseId::Influenza,
+                7,
+                "shared-sleep:source-8",
+                from,
+                to,
+                10_000.0,
+                definition(DiseaseId::Influenza).base_acquisition,
+                2.5,
+                TransmissionVector::CloseContact,
+                |minute| historical_physiology_check_at(physician_span, minute),
+            )
+        };
+        let whole = evaluate(overnight_start, overnight_end);
+        let chunked = (overnight_start..overnight_end)
+            .step_by(60)
+            .find_map(|from| evaluate(from, (from + 60).min(overnight_end)));
+        assert_eq!(whole, chunked);
     }
 
     #[test]

--- a/crates/adventuresim-core/src/disease.rs
+++ b/crates/adventuresim-core/src/disease.rs
@@ -172,6 +172,9 @@ pub struct DiseaseDefinition {
     pub symptoms: &'static [Symptom],
     pub acquired_immunity: f32,
     pub transmission_vectors: &'static [TransmissionVector],
+    /// Route represented by abstract settlement/outbreak intensity. Direct
+    /// exposures such as food, wounds, and blood always supply their route.
+    pub primary_community_vector: TransmissionVector,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -187,6 +190,85 @@ impl DiseaseDefinition {
     pub fn supports(&self, vector: TransmissionVector) -> bool {
         self.transmission_vectors.contains(&vector)
     }
+}
+
+/// Maximum fraction of route exposure that perfect Physiology practice can
+/// prevent. Every route retains residual risk. Wounds remain Surgery's domain;
+/// blood protection is deliberately modest because cleaning and wound closure
+/// are the stronger modeled controls.
+pub fn maximum_preventable_fraction(vector: TransmissionVector) -> f32 {
+    match vector {
+        TransmissionVector::CloseContact => 0.90,
+        TransmissionVector::FoodWater => 0.94,
+        TransmissionVector::Vermin => 0.65,
+        TransmissionVector::Wound => 0.0,
+        TransmissionVector::Blood => 0.30,
+    }
+}
+
+pub fn residual_exposure(exposure: f32, vector: TransmissionVector, physiology_check: f32) -> f32 {
+    let competence = (physiology_check.clamp(0.0, 5.0) / 5.0).powf(1.25);
+    exposure.max(0.0) * (1.0 - maximum_preventable_fraction(vector) * competence)
+}
+
+/// Aggregate distinct practitioners whose pinned capability covers `minute`.
+/// Duplicate spans for one practitioner use the strongest matching pinned
+/// value, which makes adjacent join/rejoin and band-boundary records harmless.
+pub fn historical_physiology_check_at(
+    spans: impl IntoIterator<Item = (u64, u64, u64, f32)>,
+    minute: u64,
+) -> f32 {
+    let mut contributors = std::collections::BTreeMap::<u64, f32>::new();
+    for (contributor_id, start, end, check) in spans {
+        if minute < start || minute > end {
+            continue;
+        }
+        contributors
+            .entry(contributor_id)
+            .and_modify(|value| *value = (*value).max(check))
+            .or_insert(check);
+    }
+    crate::capability::aggregate_bounded_party_check(contributors.into_values())
+}
+
+pub fn elapsed_presence_window(
+    span_start: u64,
+    span_end: Option<u64>,
+    joint_now: u64,
+    from: u64,
+    to: u64,
+) -> Option<(u64, u64)> {
+    let start = span_start.max(from.saturating_add(1));
+    let end = span_end.unwrap_or(joint_now).min(joint_now).min(to);
+    (start <= end).then_some((start, end))
+}
+
+/// Disease-agnostic infectiousness for close company. Contact risk begins
+/// during incubation, peaks through the acute phases, and declines during
+/// recovery. It does not depend on whether symptoms are publicly visible.
+pub fn close_contact_infectiousness(episode: InfectionEpisode, at: u64) -> f32 {
+    if at < episode.contracted_at {
+        return 0.0;
+    }
+    let definition = definition(episode.disease_id);
+    if !definition.supports(TransmissionVector::CloseContact) {
+        return 0.0;
+    }
+    let age = at.saturating_sub(episode.contracted_at) as f32;
+    let incubation = definition.incubation_minutes.max(1) as f32;
+    if age < incubation {
+        return 0.15 + 0.45 * age / incubation;
+    }
+    let acute_end =
+        (definition.incubation_minutes + definition.rise_minutes + definition.peak_minutes) as f32;
+    if age < acute_end {
+        return 1.0;
+    }
+    let resolved = acute_end + definition.recovery_minutes.max(1) as f32;
+    if age < resolved {
+        return ((resolved - age) / definition.recovery_minutes.max(1) as f32).clamp(0.0, 1.0);
+    }
+    0.0
 }
 
 const DAY: u64 = 1_440;
@@ -245,6 +327,7 @@ pub const STARTER_DISEASES: [DiseaseDefinition; 8] = [
         COUGH,
         0.30,
         &[TransmissionVector::CloseContact],
+        TransmissionVector::CloseContact,
     ),
     d(
         DiseaseId::Dysentery,
@@ -264,6 +347,7 @@ pub const STARTER_DISEASES: [DiseaseDefinition; 8] = [
         FLUX,
         0.15,
         &[TransmissionVector::FoodWater],
+        TransmissionVector::FoodWater,
     ),
     d(
         DiseaseId::Typhus,
@@ -283,6 +367,7 @@ pub const STARTER_DISEASES: [DiseaseDefinition; 8] = [
         SPOTTED,
         0.55,
         &[TransmissionVector::CloseContact, TransmissionVector::Vermin],
+        TransmissionVector::Vermin,
     ),
     d(
         DiseaseId::Tetanus,
@@ -306,6 +391,7 @@ pub const STARTER_DISEASES: [DiseaseDefinition; 8] = [
         LOCKJAW,
         0.05,
         &[TransmissionVector::Wound],
+        TransmissionVector::Wound,
     ),
     d(
         DiseaseId::Erysipelas,
@@ -324,6 +410,7 @@ pub const STARTER_DISEASES: [DiseaseDefinition; 8] = [
         RASH,
         0.15,
         &[TransmissionVector::Wound],
+        TransmissionVector::Wound,
     ),
     d(
         DiseaseId::Smallpox,
@@ -347,6 +434,7 @@ pub const STARTER_DISEASES: [DiseaseDefinition; 8] = [
         POX,
         0.90,
         &[TransmissionVector::CloseContact],
+        TransmissionVector::CloseContact,
     ),
     d(
         DiseaseId::Plague,
@@ -374,6 +462,7 @@ pub const STARTER_DISEASES: [DiseaseDefinition; 8] = [
             TransmissionVector::Vermin,
             TransmissionVector::Blood,
         ],
+        TransmissionVector::Vermin,
     ),
     d(
         DiseaseId::Consumption,
@@ -396,6 +485,7 @@ pub const STARTER_DISEASES: [DiseaseDefinition; 8] = [
         CONSUMPTION,
         0.20,
         &[TransmissionVector::CloseContact],
+        TransmissionVector::CloseContact,
     ),
 ];
 const Z: AttributeImpairment = AttributeImpairment {
@@ -426,6 +516,7 @@ const fn d(
     symptoms: &'static [Symptom],
     acquired_immunity: f32,
     transmission_vectors: &'static [TransmissionVector],
+    primary_community_vector: TransmissionVector,
 ) -> DiseaseDefinition {
     DiseaseDefinition {
         id,
@@ -441,6 +532,7 @@ const fn d(
         symptoms,
         acquired_immunity,
         transmission_vectors,
+        primary_community_vector,
     }
 }
 
@@ -579,6 +671,42 @@ pub fn first_eligible_presence_exposure_minute(
             immunity,
             prior_immunity,
             intensity,
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn first_eligible_protected_presence_exposure_minute(
+    episodes: &[InfectionEpisode],
+    disease_id: DiseaseId,
+    character_id: u64,
+    exposure_id: &str,
+    from: u64,
+    to: u64,
+    intensity: f32,
+    base_acquisition: f32,
+    immunity: f32,
+    vector: TransmissionVector,
+    physiology_check_at: impl Fn(u64) -> f32,
+) -> Option<u64> {
+    if to <= from || intensity <= 0.0 {
+        return None;
+    }
+    ((from + 1)..=to).find(|minute| {
+        if has_unresolved_disease(episodes, disease_id, *minute, immunity) {
+            return false;
+        }
+        let prior_immunity = acquired_immunity(episodes, disease_id, *minute, immunity);
+        let key = format!("{exposure_id}:{minute}");
+        acquisition_succeeds(
+            outbreak_exposure_seed(character_id, &key),
+            &DiseaseDefinition {
+                base_acquisition: base_acquisition / 1_440.0,
+                ..*definition(disease_id)
+            },
+            immunity,
+            prior_immunity,
+            residual_exposure(intensity, vector, physiology_check_at(*minute)),
         )
     })
 }
@@ -1306,5 +1434,155 @@ mod tests {
         });
         assert!(whole.is_some());
         assert_eq!(whole, chunked);
+    }
+
+    #[test]
+    fn physiology_prevention_is_route_ordered_bounded_and_monotonic() {
+        let exposure = 1.0;
+        for vector in [
+            TransmissionVector::FoodWater,
+            TransmissionVector::CloseContact,
+            TransmissionVector::Vermin,
+            TransmissionVector::Blood,
+        ] {
+            assert_eq!(residual_exposure(exposure, vector, 0.0), exposure);
+            assert!(residual_exposure(exposure, vector, 5.0) > 0.0);
+            assert!(
+                residual_exposure(exposure, vector, 5.0) < residual_exposure(exposure, vector, 2.5)
+            );
+        }
+        assert!(
+            residual_exposure(exposure, TransmissionVector::FoodWater, 5.0)
+                < residual_exposure(exposure, TransmissionVector::CloseContact, 5.0)
+        );
+        assert!(
+            residual_exposure(exposure, TransmissionVector::CloseContact, 5.0)
+                < residual_exposure(exposure, TransmissionVector::Vermin, 5.0)
+        );
+        assert!(
+            residual_exposure(exposure, TransmissionVector::Vermin, 5.0)
+                < residual_exposure(exposure, TransmissionVector::Blood, 5.0)
+        );
+        assert_eq!(
+            residual_exposure(exposure, TransmissionVector::Wound, 5.0),
+            exposure
+        );
+    }
+
+    #[test]
+    fn every_community_route_is_authored_and_supported() {
+        for definition in STARTER_DISEASES {
+            assert!(definition.supports(definition.primary_community_vector));
+        }
+        assert_eq!(
+            definition(DiseaseId::Dysentery).primary_community_vector,
+            TransmissionVector::FoodWater
+        );
+        assert_eq!(
+            definition(DiseaseId::Plague).primary_community_vector,
+            TransmissionVector::Vermin
+        );
+    }
+
+    #[test]
+    fn maximum_physician_protection_retains_acquisition_risk() {
+        let definition = definition(DiseaseId::Influenza);
+        let residual = residual_exposure(1.0, TransmissionVector::CloseContact, 5.0);
+        assert!(residual > 0.0);
+        assert!(
+            (0..10_000).any(|seed| { acquisition_succeeds(seed, definition, 0.0, 0.0, residual) })
+        );
+    }
+
+    #[test]
+    fn historical_party_support_respects_join_leave_and_band_boundaries() {
+        let spans = [
+            (7, 100, 199, 1.0),
+            (8, 100, 199, 4.0),
+            (7, 200, 300, 3.0),
+            (8, 200, 300, 4.0),
+            (9, 225, 250, 2.0),
+        ];
+        assert_eq!(historical_physiology_check_at(spans, 99), 0.0);
+        let before_training = historical_physiology_check_at(spans, 150);
+        let after_training = historical_physiology_check_at(spans, 210);
+        let with_supporter = historical_physiology_check_at(spans, 240);
+        assert!(after_training > before_training);
+        assert!(with_supporter > after_training);
+        assert_eq!(historical_physiology_check_at(spans, 301), 0.0);
+    }
+
+    #[test]
+    fn duplicate_coverage_does_not_count_one_supporter_twice() {
+        let duplicate = historical_physiology_check_at([(7, 0, 100, 4.0), (7, 50, 150, 4.0)], 75);
+        assert!((duplicate - 4.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn changing_historical_protection_is_chunk_invariant() {
+        let spans = [(7, 101, 500, 1.0), (7, 501, 1_000, 5.0)];
+        let evaluate = |from, to| {
+            first_eligible_protected_presence_exposure_minute(
+                &[],
+                DiseaseId::Influenza,
+                77,
+                "protected",
+                from,
+                to,
+                10_000.0,
+                definition(DiseaseId::Influenza).base_acquisition,
+                0.0,
+                TransmissionVector::CloseContact,
+                |minute| historical_physiology_check_at(spans, minute),
+            )
+        };
+        let whole = evaluate(100, 1_000);
+        let chunked = (100..1_000)
+            .step_by(100)
+            .find_map(|from| evaluate(from, (from + 100).min(1_000)));
+        assert!(whole.is_some());
+        assert_eq!(whole, chunked);
+    }
+
+    #[test]
+    fn presence_window_never_advances_beyond_the_lagging_source_clock() {
+        assert_eq!(
+            elapsed_presence_window(100, None, 250, 150, 500),
+            Some((151, 250))
+        );
+        assert_eq!(elapsed_presence_window(100, None, 150, 150, 500), None);
+        assert_eq!(
+            elapsed_presence_window(100, Some(220), 300, 150, 500),
+            Some((151, 220))
+        );
+    }
+
+    #[test]
+    fn close_contact_infectiousness_precedes_symptoms_and_resolves() {
+        let episode = e(20, DiseaseId::Influenza);
+        let definition = definition(episode.disease_id);
+        assert!(close_contact_infectiousness(episode, episode.contracted_at) > 0.0);
+        assert_eq!(
+            close_contact_infectiousness(
+                episode,
+                episode.contracted_at + definition.incubation_minutes + definition.rise_minutes
+            ),
+            1.0
+        );
+        assert_eq!(
+            close_contact_infectiousness(
+                episode,
+                episode.contracted_at
+                    + definition.incubation_minutes
+                    + definition.rise_minutes
+                    + definition.peak_minutes
+                    + definition.recovery_minutes
+            ),
+            0.0
+        );
+        assert_eq!(
+            close_contact_infectiousness(e(21, DiseaseId::Dysentery), 100),
+            0.0
+        );
     }
 }

--- a/crates/adventuresim-core/src/disease.rs
+++ b/crates/adventuresim-core/src/disease.rs
@@ -365,6 +365,18 @@ pub struct AcquisitionAttempt {
     pub exposure: Option<f32>,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct EnvironmentalExposureSource {
+    pub character_id: u64,
+    pub disease_id: DiseaseId,
+    pub exposure_id: String,
+    pub start: u64,
+    pub end: u64,
+    pub intensity: f32,
+    pub base_acquisition: f32,
+    pub vector: TransmissionVector,
+}
+
 impl AcquisitionAttempt {
     pub fn guaranteed(episode: InfectionEpisode) -> Self {
         Self {
@@ -416,6 +428,7 @@ pub fn resolve_acquisition_timeline(
     target_ids: &std::collections::BTreeSet<u64>,
     initial: &std::collections::BTreeMap<u64, Vec<InfectionEpisode>>,
     scheduled: impl IntoIterator<Item = AcquisitionAttempt>,
+    environmental: &[EnvironmentalExposureSource],
     windows: &[ContactWindow],
     immunity: &std::collections::BTreeMap<u64, f32>,
     from: u64,
@@ -456,6 +469,14 @@ pub fn resolve_acquisition_timeline(
         ..Default::default()
     };
     let first_scheduled = scheduled_by_minute.keys().next().copied();
+    let first_environmental = environmental
+        .iter()
+        .filter_map(|source| {
+            let start = source.start.max(from.saturating_add(1));
+            (target_ids.contains(&source.character_id) && start <= source.end && start <= to)
+                .then_some(start)
+        })
+        .min();
     let first_contact = windows
         .iter()
         .filter_map(|window| {
@@ -463,7 +484,12 @@ pub fn resolve_acquisition_timeline(
             (start <= window.end && start <= to).then_some(start)
         })
         .min();
-    let Some(mut minute) = first_scheduled.into_iter().chain(first_contact).min() else {
+    let Some(mut minute) = first_scheduled
+        .into_iter()
+        .chain(first_environmental)
+        .chain(first_contact)
+        .min()
+    else {
         return Ok(result);
     };
     while minute <= to {
@@ -509,6 +535,49 @@ pub fn resolve_acquisition_timeline(
                 .then_some(candidate)
             })
             .collect::<Vec<_>>();
+        for source in environmental {
+            if !target_ids.contains(&source.character_id)
+                || minute < source.start
+                || minute > source.end
+                || minute > to
+            {
+                continue;
+            }
+            result.work_units = result.work_units.saturating_add(1);
+            if result.work_units > max_work {
+                return Err("Disease interval exceeds bounded exposure work");
+            }
+            let target_immunity = immunity.get(&source.character_id).copied().unwrap_or(3.0);
+            let target_episodes = state
+                .get(&source.character_id)
+                .map_or(&[][..], Vec::as_slice);
+            if has_unresolved_disease(target_episodes, source.disease_id, minute, target_immunity) {
+                continue;
+            }
+            let id = outbreak_exposure_seed(
+                source.character_id,
+                &format!("{}:{minute}", source.exposure_id),
+            );
+            let prior =
+                acquired_immunity(target_episodes, source.disease_id, minute, target_immunity);
+            let mut source_definition = *definition(source.disease_id);
+            source_definition.base_acquisition = source.base_acquisition / 1_440.0;
+            let exposure = residual_exposure(
+                source.intensity,
+                source.vector,
+                physiology_check_at(source.character_id, minute),
+            );
+            if acquisition_succeeds(id, &source_definition, target_immunity, prior, exposure) {
+                candidates.push(InfectionEpisode {
+                    id,
+                    character_id: source.character_id,
+                    disease_id: source.disease_id,
+                    contracted_at: minute,
+                    ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
+                    phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+                });
+            }
+        }
         for window in windows {
             result.work_units = result.work_units.saturating_add(1);
             if result.work_units > max_work {
@@ -604,6 +673,43 @@ pub fn resolve_acquisition_timeline(
             .range(minute.saturating_add(1)..)
             .next()
             .map(|(next, _)| *next);
+        let next_environmental = environmental
+            .iter()
+            .filter_map(|source| {
+                if !target_ids.contains(&source.character_id) {
+                    return None;
+                }
+                let mut next = minute.saturating_add(1).max(source.start);
+                if next > source.end || next > to {
+                    return None;
+                }
+                let target_immunity = immunity.get(&source.character_id).copied().unwrap_or(3.0);
+                if let Some(resolution) = state
+                    .get(&source.character_id)
+                    .into_iter()
+                    .flatten()
+                    .filter(|episode| {
+                        episode.disease_id == source.disease_id
+                            && episode.contracted_at <= next
+                            && evaluate(**episode, next, target_immunity).stage
+                                != DiseaseStage::Resolved
+                    })
+                    .map(|episode| {
+                        let definition = definition(episode.disease_id);
+                        episode.contracted_at.saturating_add(
+                            definition.incubation_minutes
+                                + definition.rise_minutes
+                                + definition.peak_minutes
+                                + definition.recovery_minutes,
+                        )
+                    })
+                    .max()
+                {
+                    next = next.max(resolution);
+                }
+                (next <= source.end && next <= to).then_some(next)
+            })
+            .min();
         let next_contact = windows
             .iter()
             .filter_map(|window| {
@@ -611,7 +717,12 @@ pub fn resolve_acquisition_timeline(
                 (next <= window.end && next <= to).then_some(next)
             })
             .min();
-        let Some(next) = next_scheduled.into_iter().chain(next_contact).min() else {
+        let Some(next) = next_scheduled
+            .into_iter()
+            .chain(next_environmental)
+            .chain(next_contact)
+            .min()
+        else {
             break;
         };
         if next <= minute {
@@ -1081,7 +1192,7 @@ pub fn first_eligible_protected_presence_exposure_minute(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn protected_presence_exposure_attempts(
+pub fn protected_presence_exposure_source(
     disease_id: DiseaseId,
     character_id: u64,
     exposure_id: &str,
@@ -1090,33 +1201,20 @@ pub fn protected_presence_exposure_attempts(
     intensity: f32,
     base_acquisition: f32,
     vector: TransmissionVector,
-    max_attempts: usize,
-    physiology_check_at: impl Fn(u64) -> f32,
-) -> Result<Vec<AcquisitionAttempt>, &'static str> {
+) -> Option<EnvironmentalExposureSource> {
     if to <= from || intensity <= 0.0 {
-        return Ok(Vec::new());
+        return None;
     }
-    let attempt_count = to.saturating_sub(from);
-    if attempt_count > max_attempts as u64 {
-        return Err("Disease interval exceeds bounded acquisition candidates");
-    }
-    Ok(((from + 1)..=to)
-        .map(|minute| {
-            let id = outbreak_exposure_seed(character_id, &format!("{exposure_id}:{minute}"));
-            AcquisitionAttempt::exposure(
-                InfectionEpisode {
-                    id,
-                    character_id,
-                    disease_id,
-                    contracted_at: minute,
-                    ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
-                    phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
-                },
-                base_acquisition / 1_440.0,
-                residual_exposure(intensity, vector, physiology_check_at(minute)),
-            )
-        })
-        .collect())
+    Some(EnvironmentalExposureSource {
+        character_id,
+        disease_id,
+        exposure_id: exposure_id.to_string(),
+        start: from.saturating_add(1),
+        end: to,
+        intensity,
+        base_acquisition,
+        vector,
+    })
 }
 
 pub fn severity(e: InfectionEpisode, immunity: f32) -> f32 {
@@ -2120,6 +2218,7 @@ mod tests {
             &targets,
             &initial,
             [],
+            &[],
             &windows,
             &immunity,
             0,
@@ -2140,6 +2239,7 @@ mod tests {
             &targets,
             &initial,
             [],
+            &[],
             &[windows[1], windows[0]],
             &immunity,
             0,
@@ -2155,6 +2255,7 @@ mod tests {
             &targets,
             &initial,
             [],
+            &[],
             &windows,
             &immunity,
             0,
@@ -2172,6 +2273,7 @@ mod tests {
             &targets,
             &split_initial,
             [],
+            &[],
             &windows,
             &immunity,
             b_at,
@@ -2197,6 +2299,7 @@ mod tests {
             &targets,
             &Default::default(),
             [AcquisitionAttempt::guaranteed(blood)],
+            &[],
             &[ContactWindow {
                 low_id: 2,
                 high_id: 3,
@@ -2232,6 +2335,7 @@ mod tests {
             &targets,
             &initial,
             [],
+            &[],
             &window,
             &immunity,
             0,
@@ -2245,6 +2349,7 @@ mod tests {
             &targets,
             &initial,
             [],
+            &[],
             &window,
             &immunity,
             0,
@@ -2270,6 +2375,7 @@ mod tests {
             &Default::default(),
             [AcquisitionAttempt::guaranteed(scheduled_after_death_clip)],
             &[],
+            &[],
             &immunity,
             0,
             500,
@@ -2284,6 +2390,7 @@ mod tests {
                 &targets,
                 &initial,
                 [],
+                &[],
                 &window,
                 &immunity,
                 0,
@@ -2327,6 +2434,7 @@ mod tests {
             &targets,
             &initial,
             [],
+            &[],
             &[ContactWindow {
                 low_id: 1,
                 high_id: 2,
@@ -2408,6 +2516,7 @@ mod tests {
             &initial,
             scheduled(0, to),
             &[],
+            &[],
             &immunity,
             0,
             to,
@@ -2435,6 +2544,7 @@ mod tests {
             &initial,
             scheduled(0, split_at),
             &[],
+            &[],
             &immunity,
             0,
             split_at,
@@ -2452,11 +2562,90 @@ mod tests {
             &split_initial,
             scheduled(split_at, to),
             &[],
+            &[],
             &immunity,
             split_at,
             to,
             first.work_units,
             1_000_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        let mut split = first.proposals;
+        for (id, episodes) in second.proposals {
+            split.entry(id).or_default().extend(episodes);
+        }
+        assert_eq!(whole.proposals, split);
+    }
+
+    #[test]
+    fn one_year_environmental_source_stays_compact_and_chunk_invariant() {
+        let targets = [7].into_iter().collect();
+        let immunity = [(7, 0.0)].into_iter().collect();
+        let initial = std::collections::BTreeMap::new();
+        let through = 365 * DAY;
+        let source = protected_presence_exposure_source(
+            DiseaseId::Influenza,
+            7,
+            "year-long-outbreak",
+            0,
+            through,
+            1_000_000.0,
+            definition(DiseaseId::Influenza).base_acquisition,
+            TransmissionVector::CloseContact,
+        )
+        .unwrap();
+        assert!(std::mem::size_of_val(&source) < 128);
+        let whole = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            [],
+            std::slice::from_ref(&source),
+            &[],
+            &immunity,
+            0,
+            through,
+            0,
+            10_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        assert!(whole.proposals[&7].len() > 20);
+        assert!(
+            whole.work_units < 1_000,
+            "resolved intervals should be skipped instead of evaluated minute by minute"
+        );
+
+        let split_at = through / 2;
+        let first = resolve_acquisition_timeline(
+            &targets,
+            &initial,
+            [],
+            std::slice::from_ref(&source),
+            &[],
+            &immunity,
+            0,
+            split_at,
+            0,
+            10_000,
+            |_, _| 0.0,
+        )
+        .unwrap();
+        let mut split_initial = initial;
+        for (id, episodes) in &first.proposals {
+            split_initial.entry(*id).or_default().extend(episodes);
+        }
+        let second = resolve_acquisition_timeline(
+            &targets,
+            &split_initial,
+            [],
+            std::slice::from_ref(&source),
+            &[],
+            &immunity,
+            split_at,
+            through,
+            first.work_units,
+            10_000,
             |_, _| 0.0,
         )
         .unwrap();

--- a/crates/adventuresim-core/src/disease.rs
+++ b/crates/adventuresim-core/src/disease.rs
@@ -355,6 +355,34 @@ pub struct AcquisitionTimeline {
     pub work_units: u64,
 }
 
+/// A route-specific exposure that must be evaluated against the target's
+/// episode history at its absolute minute. `exposure == None` is reserved for
+/// acquisitions that were authoritatively decided outside this timeline.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct AcquisitionAttempt {
+    pub episode: InfectionEpisode,
+    pub base_acquisition: f32,
+    pub exposure: Option<f32>,
+}
+
+impl AcquisitionAttempt {
+    pub fn guaranteed(episode: InfectionEpisode) -> Self {
+        Self {
+            episode,
+            base_acquisition: 0.0,
+            exposure: None,
+        }
+    }
+
+    pub fn exposure(episode: InfectionEpisode, base_acquisition: f32, exposure: f32) -> Self {
+        Self {
+            episode,
+            base_acquisition,
+            exposure: Some(exposure),
+        }
+    }
+}
+
 pub fn insert_unique_bounded<K: Ord, V>(
     values: &mut std::collections::BTreeMap<K, V>,
     key: K,
@@ -381,13 +409,13 @@ pub fn add_bounded_work(work: &mut u64, amount: u64, max: u64) -> Result<(), &'s
         .ok_or("Disease interval exceeds bounded exposure work")
 }
 
-/// Resolve already-assembled route candidates and contact transmission in one
-/// absolute-minute timeline. Acquisitions at a minute are simultaneous and
-/// become eligible contact sources only on the following minute.
+/// Resolve route exposure attempts and contact transmission in one absolute-
+/// minute timeline. Acquisitions at a minute are simultaneous and become
+/// eligible contact sources only on the following minute.
 pub fn resolve_acquisition_timeline(
     target_ids: &std::collections::BTreeSet<u64>,
     initial: &std::collections::BTreeMap<u64, Vec<InfectionEpisode>>,
-    scheduled: impl IntoIterator<Item = InfectionEpisode>,
+    scheduled: impl IntoIterator<Item = AcquisitionAttempt>,
     windows: &[ContactWindow],
     immunity: &std::collections::BTreeMap<u64, f32>,
     from: u64,
@@ -404,9 +432,10 @@ pub fn resolve_acquisition_timeline(
             })
             .ok_or("Disease interval exceeds bounded exposure work");
     }
-    let mut scheduled_by_minute = std::collections::BTreeMap::<u64, Vec<InfectionEpisode>>::new();
+    let mut scheduled_by_minute = std::collections::BTreeMap::<u64, Vec<AcquisitionAttempt>>::new();
     let mut work_units = initial_work;
-    for episode in scheduled {
+    for attempt in scheduled {
+        let episode = attempt.episode;
         if target_ids.contains(&episode.character_id)
             && episode.contracted_at > from
             && episode.contracted_at <= to
@@ -418,7 +447,7 @@ pub fn resolve_acquisition_timeline(
             scheduled_by_minute
                 .entry(episode.contracted_at)
                 .or_default()
-                .push(episode);
+                .push(attempt);
         }
     }
     let mut state = initial.clone();
@@ -438,7 +467,48 @@ pub fn resolve_acquisition_timeline(
         return Ok(result);
     };
     while minute <= to {
-        let mut candidates = scheduled_by_minute.remove(&minute).unwrap_or_default();
+        let mut candidates = scheduled_by_minute
+            .remove(&minute)
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|attempt| {
+                let candidate = attempt.episode;
+                let target_immunity = immunity
+                    .get(&candidate.character_id)
+                    .copied()
+                    .unwrap_or(3.0);
+                let target_episodes = state
+                    .get(&candidate.character_id)
+                    .map_or(&[][..], Vec::as_slice);
+                if has_unresolved_disease(
+                    target_episodes,
+                    candidate.disease_id,
+                    minute,
+                    target_immunity,
+                ) {
+                    return None;
+                }
+                let Some(exposure) = attempt.exposure else {
+                    return Some(candidate);
+                };
+                let prior = acquired_immunity(
+                    target_episodes,
+                    candidate.disease_id,
+                    minute,
+                    target_immunity,
+                );
+                let mut attempt_definition = *definition(candidate.disease_id);
+                attempt_definition.base_acquisition = attempt.base_acquisition;
+                acquisition_succeeds(
+                    candidate.id,
+                    &attempt_definition,
+                    target_immunity,
+                    prior,
+                    exposure,
+                )
+                .then_some(candidate)
+            })
+            .collect::<Vec<_>>();
         for window in windows {
             result.work_units = result.work_units.saturating_add(1);
             if result.work_units > max_work {
@@ -1011,8 +1081,7 @@ pub fn first_eligible_protected_presence_exposure_minute(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn eligible_protected_presence_exposure_attempt_minutes(
-    episodes: &[InfectionEpisode],
+pub fn protected_presence_exposure_attempts(
     disease_id: DiseaseId,
     character_id: u64,
     exposure_id: &str,
@@ -1020,38 +1089,34 @@ pub fn eligible_protected_presence_exposure_attempt_minutes(
     to: u64,
     intensity: f32,
     base_acquisition: f32,
-    immunity: f32,
     vector: TransmissionVector,
     max_attempts: usize,
     physiology_check_at: impl Fn(u64) -> f32,
-) -> Result<Vec<u64>, &'static str> {
+) -> Result<Vec<AcquisitionAttempt>, &'static str> {
     if to <= from || intensity <= 0.0 {
         return Ok(Vec::new());
     }
-    let mut attempts = Vec::new();
-    for minute in (from + 1)..=to {
-        if has_unresolved_disease(episodes, disease_id, minute, immunity) {
-            continue;
-        }
-        let prior_immunity = acquired_immunity(episodes, disease_id, minute, immunity);
-        let key = format!("{exposure_id}:{minute}");
-        if acquisition_succeeds(
-            outbreak_exposure_seed(character_id, &key),
-            &DiseaseDefinition {
-                base_acquisition: base_acquisition / 1_440.0,
-                ..*definition(disease_id)
-            },
-            immunity,
-            prior_immunity,
-            residual_exposure(intensity, vector, physiology_check_at(minute)),
-        ) {
-            if attempts.len() >= max_attempts {
-                return Err("Disease interval exceeds bounded acquisition candidates");
-            }
-            attempts.push(minute);
-        }
+    let attempt_count = to.saturating_sub(from);
+    if attempt_count > max_attempts as u64 {
+        return Err("Disease interval exceeds bounded acquisition candidates");
     }
-    Ok(attempts)
+    Ok(((from + 1)..=to)
+        .map(|minute| {
+            let id = outbreak_exposure_seed(character_id, &format!("{exposure_id}:{minute}"));
+            AcquisitionAttempt::exposure(
+                InfectionEpisode {
+                    id,
+                    character_id,
+                    disease_id,
+                    contracted_at: minute,
+                    ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
+                    phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+                },
+                base_acquisition / 1_440.0,
+                residual_exposure(intensity, vector, physiology_check_at(minute)),
+            )
+        })
+        .collect())
 }
 
 pub fn severity(e: InfectionEpisode, immunity: f32) -> f32 {
@@ -2131,7 +2196,7 @@ mod tests {
         let result = resolve_acquisition_timeline(
             &targets,
             &Default::default(),
-            [blood],
+            [AcquisitionAttempt::guaranteed(blood)],
             &[ContactWindow {
                 low_id: 2,
                 high_id: 3,
@@ -2203,7 +2268,7 @@ mod tests {
         let clipped = resolve_acquisition_timeline(
             &targets,
             &Default::default(),
-            [scheduled_after_death_clip],
+            [AcquisitionAttempt::guaranteed(scheduled_after_death_clip)],
             &[],
             &immunity,
             0,
@@ -2280,40 +2345,61 @@ mod tests {
     }
 
     #[test]
-    fn long_environmental_source_reattempts_after_resolution_whole_or_split() {
-        let initial_episode = timeline_episode(51, 7, 0);
-        let initial = [(7, vec![initial_episode])].into_iter().collect();
+    fn environmental_immunity_evolves_across_multiple_cycles_whole_or_split() {
+        let initial = std::collections::BTreeMap::new();
         let immunity = [(7, 0.0)].into_iter().collect();
         let targets = [7].into_iter().collect();
-        let resolution = (1..60 * DAY)
-            .find(|minute| evaluate(initial_episode, *minute, 0.0).stage == DiseaseStage::Resolved)
-            .unwrap();
-        let split_at = resolution.saturating_sub(1);
-        let to = resolution + 30 * DAY;
-        let scheduled = |from, to| {
-            eligible_protected_presence_exposure_attempt_minutes(
-                &[initial_episode],
-                DiseaseId::Influenza,
-                7,
-                "long-running-outbreak",
-                from,
-                to,
-                1_000.0,
-                definition(DiseaseId::Influenza).base_acquisition,
-                0.0,
-                TransmissionVector::CloseContact,
-                100_000,
-                |_| 0.0,
-            )
-            .unwrap()
+        let duration = {
+            let episode = timeline_episode(1, 7, 1);
+            (2..60 * DAY)
+                .find(|minute| evaluate(episode, *minute, 0.0).stage == DiseaseStage::Resolved)
+                .unwrap()
+                - episode.contracted_at
+        };
+        let first_at = 1;
+        let split_at = first_at + duration;
+        let threshold_at = split_at + 1;
+        let second_at = threshold_at + 1;
+        let third_at = second_at + duration + 1;
+        let to = third_at;
+        let definition = definition(DiseaseId::Influenza);
+        let threshold_seed = ((0.55_f64 * (1_u64 << 53) as f64) as u64) << 11;
+        assert!(acquisition_succeeds(
+            threshold_seed,
+            definition,
+            0.0,
+            0.0,
+            1.0
+        ));
+        assert!(!acquisition_succeeds(
+            threshold_seed,
+            definition,
+            0.0,
+            definition.acquired_immunity,
+            1.0
+        ));
+        let episode = |id, at| InfectionEpisode {
+            id,
+            character_id: 7,
+            disease_id: DiseaseId::Influenza,
+            contracted_at: at,
+            ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
+            phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+        };
+        let scheduled = |from, through| {
+            [
+                AcquisitionAttempt::exposure(episode(61, first_at), 0.65, 1_000.0),
+                AcquisitionAttempt::exposure(
+                    episode(threshold_seed, threshold_at),
+                    definition.base_acquisition,
+                    1.0,
+                ),
+                AcquisitionAttempt::exposure(episode(62, second_at), 0.65, 1_000.0),
+                AcquisitionAttempt::exposure(episode(63, third_at), 0.65, 1_000.0),
+            ]
             .into_iter()
-            .map(|at| InfectionEpisode {
-                id: outbreak_exposure_seed(7, &format!("long-running-outbreak:{at}")),
-                character_id: 7,
-                disease_id: DiseaseId::Influenza,
-                contracted_at: at,
-                ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
-                phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+            .filter(|attempt| {
+                attempt.episode.contracted_at > from && attempt.episode.contracted_at <= through
             })
             .collect::<Vec<_>>()
         };
@@ -2330,7 +2416,19 @@ mod tests {
             |_, _| 0.0,
         )
         .unwrap();
-        assert!(whole.proposals[&7][0].contracted_at >= resolution);
+        assert_eq!(
+            whole.proposals[&7]
+                .iter()
+                .map(|episode| episode.contracted_at)
+                .collect::<Vec<_>>(),
+            vec![first_at, second_at, third_at]
+        );
+        assert!(
+            !whole.proposals[&7]
+                .iter()
+                .any(|episode| episode.id == threshold_seed),
+            "the threshold-sensitive roll must be rejected by immunity acquired during this run"
+        );
 
         let first = resolve_acquisition_timeline(
             &targets,

--- a/crates/adventuresim-stdb-module/src/disease.rs
+++ b/crates/adventuresim-stdb-module/src/disease.rs
@@ -11,7 +11,9 @@ use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, reducer, ta
 use crate::capability::{character_capability, character_capability__view};
 use crate::character::{character as _, character__view, character_attributes__view};
 use crate::local_problem::local_problem_authority;
-use crate::social::{physiology_presence_span, physiology_presence_span__view};
+use crate::social::{
+    PhysiologyPresenceSpan, physiology_presence_span, physiology_presence_span__view,
+};
 use crate::time::character_time__view;
 use crate::{
     character_attributes, character_skills, character_time,
@@ -799,11 +801,54 @@ pub fn character_episodes(
 /// spans pin capability bands when they open and split whenever a band changes,
 /// so later training cannot rewrite earlier prevention. Open spans are clamped
 /// to both characters' clocks.
+fn bounded_physiology_spans(
+    ctx: &ReducerContext,
+    ids: &[u64],
+) -> Result<Vec<PhysiologyPresenceSpan>, String> {
+    let mut spans_by_id = BTreeMap::new();
+    let mut raw_rows = 0usize;
+    for id in ids {
+        for span in ctx
+            .db
+            .physiology_presence_span()
+            .presence_low_id()
+            .filter(*id)
+            .chain(
+                ctx.db
+                    .physiology_presence_span()
+                    .presence_high_id()
+                    .filter(*id),
+            )
+        {
+            raw_rows = raw_rows.saturating_add(1);
+            if raw_rows > MAX_PARTY_INTERVAL_SPANS.saturating_mul(2) {
+                return Err("Disease interval has too many raw presence spans".into());
+            }
+            disease::insert_unique_bounded(
+                &mut spans_by_id,
+                span.id,
+                span,
+                MAX_PARTY_INTERVAL_SPANS,
+            )
+            .map_err(str::to_string)?;
+        }
+    }
+    Ok(spans_by_id.into_values().collect())
+}
+
 pub(crate) fn party_physiology_check_at(
     ctx: &ReducerContext,
     character_id: u64,
     minute: u64,
 ) -> f32 {
+    try_party_physiology_check_at(ctx, character_id, minute).unwrap_or(0.0)
+}
+
+fn try_party_physiology_check_at(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minute: u64,
+) -> Result<f32, String> {
     let clock = |id| {
         ctx.db
             .character_time()
@@ -812,12 +857,7 @@ pub(crate) fn party_physiology_check_at(
             .map_or(0, |row| row.minutes)
     };
     let mut coverage = Vec::new();
-    for span in ctx
-        .db
-        .physiology_presence_span()
-        .iter()
-        .filter(|span| span.low_id == character_id || span.high_id == character_id)
-    {
+    for span in bounded_physiology_spans(ctx, &[character_id])? {
         let joint_now = clock(span.low_id).min(clock(span.high_id));
         let end = span.ended_at.unwrap_or(joint_now).min(joint_now);
         coverage.push((
@@ -833,7 +873,7 @@ pub(crate) fn party_physiology_check_at(
             f32::from(span.high_observer_band),
         ));
     }
-    disease::historical_physiology_check_at(coverage, minute)
+    Ok(disease::historical_physiology_check_at(coverage, minute))
 }
 
 #[cfg(test)]
@@ -861,7 +901,7 @@ pub(crate) fn protected_point_exposure(
     vector: TransmissionVector,
     exposure: f32,
 ) -> Result<f32, String> {
-    let historical = party_physiology_check_at(ctx, character_id, minute);
+    let historical = try_party_physiology_check_at(ctx, character_id, minute)?;
     let check = if historical > 0.0 {
         historical
     } else {
@@ -871,8 +911,8 @@ pub(crate) fn protected_point_exposure(
 }
 
 const MAX_PARTY_INTERVAL_SPANS: usize = 4_096;
-const MAX_PARTY_INTERVAL_WORK: u64 = 50_000_000;
-const MAX_PARTY_INTERVAL_CANDIDATES: usize = 1_000_000;
+const MAX_PARTY_INTERVAL_WORK: u64 = 2_000_000;
+const MAX_PARTY_INTERVAL_CANDIDATES: usize = 100_000;
 
 fn blood_interval_work_budget(minutes: u64) -> u64 {
     let routes = disease::STARTER_DISEASES
@@ -970,29 +1010,10 @@ pub fn plan_party_disease_interval(
     let mut coverage = BTreeMap::<u64, Vec<CachedCoverage>>::new();
     let mut pairs = Vec::new();
     let id_set = ids.iter().copied().collect::<BTreeSet<_>>();
-    let mut spans_by_id = BTreeMap::new();
-    for id in &ids {
-        for span in ctx
-            .db
-            .physiology_presence_span()
-            .presence_low_id()
-            .filter(*id)
-            .chain(
-                ctx.db
-                    .physiology_presence_span()
-                    .presence_high_id()
-                    .filter(*id),
-            )
-        {
-            disease::insert_unique_bounded(
-                &mut spans_by_id,
-                span.id,
-                span,
-                MAX_PARTY_INTERVAL_SPANS,
-            )
-            .map_err(str::to_string)?;
-        }
-    }
+    let spans_by_id = bounded_physiology_spans(ctx, &ids)?
+        .into_iter()
+        .map(|span| (span.id, span))
+        .collect::<BTreeMap<_, _>>();
     let peer_ids = spans_by_id
         .values()
         .flat_map(|span| [span.low_id, span.high_id])
@@ -1096,10 +1117,7 @@ pub fn plan_party_disease_interval(
             (character_id, segments)
         })
         .collect();
-    let base_work = requested
-        .saturating_mul(ids.len() as u64)
-        .saturating_mul(2)
-        .saturating_mul(blood_interval_work_budget(1));
+    let base_work = ids.len() as u64;
     if base_work > MAX_PARTY_INTERVAL_WORK {
         return Err("Party disease interval exceeds bounded exposure work".into());
     }
@@ -1131,6 +1149,7 @@ pub fn plan_party_disease_interval(
         })
         .collect::<BTreeMap<_, _>>();
     let mut scheduled = Vec::new();
+    let mut environmental = Vec::new();
     for id in &ids {
         let start = starts[id];
         let end = horizons[id];
@@ -1184,14 +1203,8 @@ pub fn plan_party_disease_interval(
                 let disease_id = parse_id(&disease_key)?;
                 let from = start.max(source_start);
                 let to = end.min(source_end);
-                plan.work_units = plan.work_units.saturating_add(to.saturating_sub(from));
-                if plan.work_units > MAX_PARTY_INTERVAL_WORK {
-                    return Err("Party disease interval exceeds bounded exposure work".into());
-                }
                 let definition = disease::definition(disease_id);
-                let remaining_candidates =
-                    MAX_PARTY_INTERVAL_CANDIDATES.saturating_sub(scheduled.len());
-                let attempts = disease::protected_presence_exposure_attempts(
+                if let Some(source) = disease::protected_presence_exposure_source(
                     disease_id,
                     *id,
                     &source_id,
@@ -1200,11 +1213,16 @@ pub fn plan_party_disease_interval(
                     intensity,
                     definition.base_acquisition,
                     definition.primary_community_vector,
-                    remaining_candidates,
-                    |minute| plan.check_at(*id, minute),
-                )
-                .map_err(str::to_string)?;
-                scheduled.extend(attempts);
+                ) {
+                    if environmental.len()
+                        >= MAX_PARTY_INTERVAL_CANDIDATES.saturating_sub(scheduled.len())
+                    {
+                        return Err(
+                            "Disease interval exceeds bounded acquisition candidates".into()
+                        );
+                    }
+                    environmental.push(source);
+                }
             }
         }
         let blood_attempts = crate::filth::blood_exposure_attempts_through(
@@ -1217,7 +1235,11 @@ pub fn plan_party_disease_interval(
             Some(&plan),
             blood_interval_work_budget(end.saturating_sub(start)),
         )?;
-        if blood_attempts.len() > MAX_PARTY_INTERVAL_CANDIDATES.saturating_sub(scheduled.len()) {
+        if blood_attempts.len()
+            > MAX_PARTY_INTERVAL_CANDIDATES
+                .saturating_sub(scheduled.len())
+                .saturating_sub(environmental.len())
+        {
             return Err("Disease interval exceeds bounded acquisition candidates".into());
         }
         scheduled.extend(blood_attempts);
@@ -1258,6 +1280,7 @@ pub fn plan_party_disease_interval(
         &id_set,
         &initial,
         scheduled,
+        &environmental,
         &windows,
         &immunities,
         from,
@@ -2697,17 +2720,27 @@ mod herbalist_purchase_source_tests {
     #[test]
     fn interval_plan_prefetches_private_presence_through_both_indexes() {
         let source = include_str!("disease.rs");
-        let plan = source
-            .split("pub fn plan_party_disease_interval")
+        let helper = source
+            .split("fn bounded_physiology_spans")
             .nth(1)
             .unwrap()
-            .split("fn party_contact_episodes_through")
+            .split("pub(crate) fn party_physiology_check_at")
             .next()
             .unwrap();
-        assert!(plan.contains("presence_low_id()"));
-        assert!(plan.contains("presence_high_id()"));
-        assert!(plan.contains("spans_by_id.entry(span.id).or_insert(span)"));
-        assert!(!plan.contains("physiology_presence_span()\n        .iter()"));
+        assert!(helper.contains("presence_low_id()"));
+        assert!(helper.contains("presence_high_id()"));
+        assert!(helper.contains("insert_unique_bounded"));
+        assert!(helper.contains("raw_rows > MAX_PARTY_INTERVAL_SPANS.saturating_mul(2)"));
+        assert!(!helper.contains("physiology_presence_span().iter()"));
+
+        let point = source
+            .split("fn try_party_physiology_check_at")
+            .nth(1)
+            .unwrap()
+            .split("#[cfg(test)]")
+            .next()
+            .unwrap();
+        assert!(point.contains("bounded_physiology_spans(ctx, &[character_id])?"));
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/disease.rs
+++ b/crates/adventuresim-stdb-module/src/disease.rs
@@ -1,9 +1,9 @@
 //! Durable strategic disease facts and authoritative treatment.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use adventuresim_core::disease::{
-    self, DiseaseEventKind, DiseaseId, InfectionEpisode, TerminalFailure,
+    self, DiseaseEventKind, DiseaseId, InfectionEpisode, TerminalFailure, TransmissionVector,
 };
 use adventuresim_core::physiology::{self, BodyRegion, InterventionRoute};
 use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, reducer, table, view};
@@ -795,6 +795,228 @@ pub fn character_episodes(
         .collect()
 }
 
+/// Historical, private party protection at one personal-clock minute. Presence
+/// spans pin capability bands when they open and split whenever a band changes,
+/// so later training cannot rewrite earlier prevention. Open spans are clamped
+/// to both characters' clocks.
+pub(crate) fn party_physiology_check_at(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minute: u64,
+) -> f32 {
+    let clock = |id| {
+        ctx.db
+            .character_time()
+            .character_id()
+            .find(id)
+            .map_or(0, |row| row.minutes)
+    };
+    let mut coverage = Vec::new();
+    for span in ctx
+        .db
+        .physiology_presence_span()
+        .iter()
+        .filter(|span| span.low_id == character_id || span.high_id == character_id)
+    {
+        let joint_now = clock(span.low_id).min(clock(span.high_id));
+        let end = span.ended_at.unwrap_or(joint_now).min(joint_now);
+        coverage.push((
+            span.low_id,
+            span.started_at,
+            end,
+            f32::from(span.low_observer_band),
+        ));
+        coverage.push((
+            span.high_id,
+            span.started_at,
+            end,
+            f32::from(span.high_observer_band),
+        ));
+    }
+    disease::historical_physiology_check_at(coverage, minute)
+}
+
+pub(crate) fn protected_exposure_at(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minute: u64,
+    vector: TransmissionVector,
+    exposure: f32,
+) -> f32 {
+    disease::residual_exposure(
+        exposure,
+        vector,
+        party_physiology_check_at(ctx, character_id, minute),
+    )
+}
+
+/// Point actions have no interval-splitting ambiguity, so a solo character may
+/// use their current capability. Party members still use pinned presence
+/// history whenever it covers the action minute.
+pub(crate) fn protected_point_exposure(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minute: u64,
+    vector: TransmissionVector,
+    exposure: f32,
+) -> Result<f32, String> {
+    let historical = party_physiology_check_at(ctx, character_id, minute);
+    let check = if historical > 0.0 {
+        historical
+    } else {
+        crate::capability::evaluate_character(ctx, character_id)?.physiology
+    };
+    Ok(disease::residual_exposure(exposure, vector, check))
+}
+
+fn party_contact_episodes_through(
+    ctx: &ReducerContext,
+    character_id: u64,
+    from: u64,
+    to: u64,
+) -> Result<Vec<InfectionEpisode>, String> {
+    if to <= from {
+        return Ok(Vec::new());
+    }
+    let clock = |id| {
+        ctx.db
+            .character_time()
+            .character_id()
+            .find(id)
+            .map_or(0, |row| row.minutes)
+    };
+    let mut source_windows = BTreeMap::<u64, Vec<(u64, u64)>>::new();
+    for span in ctx
+        .db
+        .physiology_presence_span()
+        .iter()
+        .filter(|span| span.low_id == character_id || span.high_id == character_id)
+    {
+        let source_id = if span.low_id == character_id {
+            span.high_id
+        } else {
+            span.low_id
+        };
+        let joint_now = clock(span.low_id).min(clock(span.high_id));
+        if let Some((start, end)) =
+            disease::elapsed_presence_window(span.started_at, span.ended_at, joint_now, from, to)
+        {
+            source_windows
+                .entry(source_id)
+                .or_default()
+                .push((start, end));
+        }
+    }
+    let immunity = ctx
+        .db
+        .character_attributes()
+        .character_id()
+        .find(character_id)
+        .map_or(3.0, |row| row.immunity);
+    let target_episodes = character_episodes(ctx, character_id)?;
+    let mut proposals = Vec::new();
+    let mut evaluated = BTreeSet::new();
+    for (source_id, windows) in source_windows {
+        let Some(_source) = ctx.db.character().id().find(source_id) else {
+            continue;
+        };
+        let source_immunity = ctx
+            .db
+            .character_attributes()
+            .character_id()
+            .find(source_id)
+            .map_or(3.0, |row| row.immunity);
+        for source_row in ctx.db.infection_episode().character_id().filter(source_id) {
+            let source_episode = episode(&source_row)?;
+            let definition = disease::definition(source_episode.disease_id);
+            if !definition.supports(TransmissionVector::CloseContact) {
+                continue;
+            }
+            for (start, end) in &windows {
+                for minute in *start..=*end {
+                    if !evaluated.insert((source_episode.id, minute))
+                        || disease::has_unresolved_disease(
+                            &target_episodes,
+                            source_episode.disease_id,
+                            minute,
+                            immunity,
+                        )
+                    {
+                        continue;
+                    }
+                    let infectiousness =
+                        disease::close_contact_infectiousness(source_episode, minute);
+                    if infectiousness <= 0.0
+                        || matches!(
+                            disease::evaluate(source_episode, minute, source_immunity).stage,
+                            disease::DiseaseStage::Resolved
+                        )
+                    {
+                        continue;
+                    }
+                    let exposure = protected_exposure_at(
+                        ctx,
+                        character_id,
+                        minute,
+                        TransmissionVector::CloseContact,
+                        infectiousness / 1_440.0,
+                    );
+                    let prior = disease::acquired_immunity(
+                        &target_episodes,
+                        source_episode.disease_id,
+                        minute,
+                        immunity,
+                    );
+                    let seed = disease::outbreak_exposure_seed(
+                        character_id,
+                        &format!("party:{}:{}:{minute}", source_id, source_episode.id),
+                    );
+                    if disease::acquisition_succeeds(seed, definition, immunity, prior, exposure) {
+                        proposals.push(InfectionEpisode {
+                            id: seed,
+                            character_id,
+                            disease_id: source_episode.disease_id,
+                            contracted_at: minute,
+                            ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
+                            phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+                        });
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(merge_acquisition_proposals(Vec::new(), proposals))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn first_protected_presence_exposure_minute(
+    ctx: &ReducerContext,
+    episodes: &[InfectionEpisode],
+    disease_id: DiseaseId,
+    character_id: u64,
+    exposure_id: &str,
+    from: u64,
+    to: u64,
+    intensity: f32,
+    immunity: f32,
+) -> Option<u64> {
+    let definition = disease::definition(disease_id);
+    disease::first_eligible_protected_presence_exposure_minute(
+        episodes,
+        disease_id,
+        character_id,
+        exposure_id,
+        from,
+        to,
+        intensity,
+        definition.base_acquisition,
+        immunity,
+        definition.primary_community_vector,
+        |minute| party_physiology_check_at(ctx, character_id, minute),
+    )
+}
+
 pub fn effective_attributes(
     ctx: &ReducerContext,
     character_id: u64,
@@ -863,7 +1085,8 @@ fn outbreak_episodes_through(
         if overlap_to <= overlap_from {
             continue;
         }
-        let Some(at) = disease::first_eligible_presence_exposure_minute(
+        let Some(at) = first_protected_presence_exposure_minute(
+            ctx,
             &episodes,
             disease_id,
             character_id,
@@ -871,7 +1094,6 @@ fn outbreak_episodes_through(
             overlap_from,
             overlap_to,
             outbreak.intensity,
-            disease::definition(disease_id).base_acquisition,
             immunity,
         ) else {
             continue;
@@ -914,7 +1136,8 @@ fn outbreak_episodes_through(
         let intensity = f32::from(problem.disease_intensity)
             * f32::from(10_000_u16.saturating_sub(problem.mitigation_bps))
             / 10_000_000.0;
-        let Some(at) = disease::first_eligible_presence_exposure_minute(
+        let Some(at) = first_protected_presence_exposure_minute(
+            ctx,
             &episodes,
             disease_id,
             character_id,
@@ -922,7 +1145,6 @@ fn outbreak_episodes_through(
             overlap_from,
             overlap_to,
             intensity,
-            disease::definition(disease_id).base_acquisition,
             immunity,
         ) else {
             continue;
@@ -944,7 +1166,7 @@ fn outbreak_episodes_through(
     Ok(episodes.split_off(existing_len))
 }
 
-fn persist_outbreak_episodes(
+fn persist_acquisition_episodes(
     ctx: &ReducerContext,
     character_id: u64,
     episodes: impl IntoIterator<Item = InfectionEpisode>,
@@ -1165,7 +1387,10 @@ pub fn clip_elapsed_for_disease(
     let mut episodes = character_episodes(ctx, character_id)?;
     let interval_end = now.saturating_add(requested);
     let proposed = merge_acquisition_proposals(
-        outbreak_episodes_through(ctx, character_id, now, interval_end)?,
+        merge_acquisition_proposals(
+            outbreak_episodes_through(ctx, character_id, now, interval_end)?,
+            party_contact_episodes_through(ctx, character_id, now, interval_end)?,
+        ),
         crate::filth::blood_episodes_through(
             ctx,
             character_id,
@@ -1195,7 +1420,7 @@ pub fn clip_elapsed_for_disease(
     // The terminal minute is inclusive: infections and notices occurring at
     // that boundary are committed; later effects from the requested interval
     // are never persisted.
-    persist_outbreak_episodes(
+    persist_acquisition_episodes(
         ctx,
         character_id,
         proposed
@@ -1274,7 +1499,10 @@ pub fn preview_elapsed_for_disease(
         .map_or(3.0, |a| a.immunity);
     let mut episodes = character_episodes(ctx, character_id)?;
     episodes.extend(merge_acquisition_proposals(
-        outbreak_episodes_through(ctx, character_id, now, now.saturating_add(requested))?,
+        merge_acquisition_proposals(
+            outbreak_episodes_through(ctx, character_id, now, now.saturating_add(requested))?,
+            party_contact_episodes_through(ctx, character_id, now, now.saturating_add(requested))?,
+        ),
         crate::filth::blood_episodes_through(
             ctx,
             character_id,
@@ -1995,5 +2223,43 @@ mod herbalist_purchase_source_tests {
         let body = purchase.split("#[cfg(test)]").next().unwrap();
         assert!(body.contains("add_inventory_item_checked(ctx, patient_id, item_id, *quantity)"));
         assert!(!body.contains("for _ in 0..*quantity"));
+    }
+
+    #[test]
+    fn interval_authority_assembles_community_contact_and_blood_exposure() {
+        let source = include_str!("disease.rs");
+        let clip = source
+            .split("pub fn clip_elapsed_for_disease")
+            .nth(1)
+            .unwrap()
+            .split("pub fn preview_elapsed_for_disease")
+            .next()
+            .unwrap();
+        for assembler in [
+            "outbreak_episodes_through",
+            "party_contact_episodes_through",
+            "blood_episodes_through",
+        ] {
+            assert!(clip.contains(assembler));
+        }
+        assert!(clip.contains("infection_occurs_through"));
+    }
+
+    #[test]
+    fn contact_transmission_uses_private_presence_and_stable_source_minute_seed() {
+        let source = include_str!("disease.rs");
+        let contact = source
+            .split("fn party_contact_episodes_through")
+            .nth(1)
+            .unwrap()
+            .split("fn first_protected_presence_exposure_minute")
+            .next()
+            .unwrap();
+        assert!(contact.contains("physiology_presence_span"));
+        assert!(contact.contains("joint_now"));
+        assert!(contact.contains("party:{}:{}:{minute}"));
+        assert!(contact.contains("protected_exposure_at"));
+        assert!(contact.contains("merge_acquisition_proposals(Vec::new(), proposals)"));
+        assert!(!contact.contains("character_illness_status"));
     }
 }

--- a/crates/adventuresim-stdb-module/src/disease.rs
+++ b/crates/adventuresim-stdb-module/src/disease.rs
@@ -869,6 +869,409 @@ pub(crate) fn protected_point_exposure(
     Ok(disease::residual_exposure(exposure, vector, check))
 }
 
+const MAX_PARTY_INTERVAL_SPANS: usize = 4_096;
+const MAX_PARTY_INTERVAL_WORK: u64 = 50_000_000;
+
+#[derive(Clone, Debug)]
+struct CachedCoverage {
+    contributor_id: u64,
+    start: u64,
+    end: u64,
+    check: f32,
+}
+
+#[derive(Clone, Debug)]
+struct CachedCheckSegment {
+    start: u64,
+    end: u64,
+    check: f32,
+}
+
+#[derive(Clone, Debug)]
+struct CachedPairPresence {
+    low_id: u64,
+    high_id: u64,
+    start: u64,
+    end: u64,
+}
+
+/// Reducer-local immutable acquisition snapshot for members explicitly known
+/// to co-advance. Preview and commit consume the same proposals, so database
+/// mutation and member iteration order cannot alter the interval.
+#[derive(Clone, Debug, Default)]
+pub struct PartyDiseaseIntervalPlan {
+    proposals: BTreeMap<u64, Vec<InfectionEpisode>>,
+    coverage: BTreeMap<u64, Vec<CachedCheckSegment>>,
+    work_units: u64,
+}
+
+impl PartyDiseaseIntervalPlan {
+    pub(crate) fn check_at(&self, character_id: u64, minute: u64) -> f32 {
+        let Some(segments) = self.coverage.get(&character_id) else {
+            return 0.0;
+        };
+        let index = segments.partition_point(|segment| segment.end < minute);
+        segments
+            .get(index)
+            .filter(|segment| segment.start <= minute)
+            .map_or(0.0, |segment| segment.check)
+    }
+
+    fn proposals_for(&self, character_id: u64, from: u64, to: u64) -> Vec<InfectionEpisode> {
+        self.proposals
+            .get(&character_id)
+            .into_iter()
+            .flatten()
+            .copied()
+            .filter(|episode| episode.contracted_at > from && episode.contracted_at <= to)
+            .collect()
+    }
+
+    pub fn work_units(&self) -> u64 {
+        self.work_units
+    }
+}
+
+pub fn plan_party_disease_interval(
+    ctx: &ReducerContext,
+    member_ids: &[u64],
+    requested: u64,
+) -> Result<PartyDiseaseIntervalPlan, String> {
+    let mut ids = member_ids.to_vec();
+    ids.sort_unstable();
+    ids.dedup();
+    let starts = ids
+        .iter()
+        .map(|id| {
+            ctx.db
+                .character_time()
+                .character_id()
+                .find(*id)
+                .map(|row| (*id, row.minutes))
+                .ok_or_else(|| "Party member has no strategic clock".to_string())
+        })
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let horizons = starts
+        .iter()
+        .map(|(id, start)| (*id, start.saturating_add(requested)))
+        .collect::<BTreeMap<_, _>>();
+    let mut coverage = BTreeMap::<u64, Vec<CachedCoverage>>::new();
+    let mut pairs = Vec::new();
+    let id_set = ids.iter().copied().collect::<BTreeSet<_>>();
+    for span in ctx
+        .db
+        .physiology_presence_span()
+        .iter()
+        .filter(|span| id_set.contains(&span.low_id) || id_set.contains(&span.high_id))
+    {
+        let current_joint = starts
+            .get(&span.low_id)
+            .copied()
+            .unwrap_or_else(|| {
+                ctx.db
+                    .character_time()
+                    .character_id()
+                    .find(span.low_id)
+                    .map_or(0, |row| row.minutes)
+            })
+            .min(starts.get(&span.high_id).copied().unwrap_or_else(|| {
+                ctx.db
+                    .character_time()
+                    .character_id()
+                    .find(span.high_id)
+                    .map_or(0, |row| row.minutes)
+            }));
+        let projected_joint = match (
+            horizons.get(&span.low_id).copied(),
+            horizons.get(&span.high_id).copied(),
+        ) {
+            (Some(low), Some(high)) if span.ended_at.is_none() => low.min(high),
+            _ => current_joint,
+        };
+        let end = span
+            .ended_at
+            .unwrap_or(projected_joint)
+            .min(projected_joint);
+        if end < span.started_at {
+            continue;
+        }
+        if id_set.contains(&span.low_id) {
+            coverage.entry(span.low_id).or_default().extend([
+                CachedCoverage {
+                    contributor_id: span.low_id,
+                    start: span.started_at,
+                    end,
+                    check: f32::from(span.low_observer_band),
+                },
+                CachedCoverage {
+                    contributor_id: span.high_id,
+                    start: span.started_at,
+                    end,
+                    check: f32::from(span.high_observer_band),
+                },
+            ]);
+        }
+        if id_set.contains(&span.high_id) {
+            coverage.entry(span.high_id).or_default().extend([
+                CachedCoverage {
+                    contributor_id: span.low_id,
+                    start: span.started_at,
+                    end,
+                    check: f32::from(span.low_observer_band),
+                },
+                CachedCoverage {
+                    contributor_id: span.high_id,
+                    start: span.started_at,
+                    end,
+                    check: f32::from(span.high_observer_band),
+                },
+            ]);
+        }
+        if id_set.contains(&span.low_id) && id_set.contains(&span.high_id) {
+            pairs.push(CachedPairPresence {
+                low_id: span.low_id,
+                high_id: span.high_id,
+                start: span.started_at,
+                end,
+            });
+        }
+    }
+    let span_count = coverage.values().map(Vec::len).sum::<usize>() + pairs.len();
+    if span_count > MAX_PARTY_INTERVAL_SPANS {
+        return Err("Party disease interval has too many relevant presence spans".into());
+    }
+    let coverage = coverage
+        .into_iter()
+        .map(|(character_id, spans)| {
+            let mut boundaries = spans
+                .iter()
+                .flat_map(|span| [span.start, span.end.saturating_add(1)])
+                .collect::<Vec<_>>();
+            boundaries.sort_unstable();
+            boundaries.dedup();
+            let segments = boundaries
+                .windows(2)
+                .filter_map(|window| {
+                    let start = window[0];
+                    let end = window[1].saturating_sub(1);
+                    let check = disease::historical_physiology_check_at(
+                        spans
+                            .iter()
+                            .map(|span| (span.contributor_id, span.start, span.end, span.check)),
+                        start,
+                    );
+                    (check > 0.0).then_some(CachedCheckSegment { start, end, check })
+                })
+                .collect::<Vec<_>>();
+            (character_id, segments)
+        })
+        .collect();
+    let base_work = requested.saturating_mul(ids.len() as u64);
+    if base_work > MAX_PARTY_INTERVAL_WORK {
+        return Err("Party disease interval exceeds bounded exposure work".into());
+    }
+    let mut plan = PartyDiseaseIntervalPlan {
+        coverage,
+        work_units: base_work,
+        ..Default::default()
+    };
+    let mut source_episodes = BTreeMap::<u64, Vec<InfectionEpisode>>::new();
+    for id in &ids {
+        let start = starts[id];
+        let end = horizons[id];
+        let mut episodes = character_episodes(ctx, *id)?;
+        let immunity = ctx
+            .db
+            .character_attributes()
+            .character_id()
+            .find(*id)
+            .map_or(3.0, |row| row.immunity);
+        let Some(character) = ctx.db.character().id().find(*id) else {
+            continue;
+        };
+        if let Some(settlement_id) = character.current_settlement_id {
+            let mut outbreaks = ctx
+                .db
+                .settlement_outbreak()
+                .settlement_id()
+                .filter(&settlement_id)
+                .map(|row| {
+                    (
+                        row.id,
+                        row.disease_id,
+                        row.start_minute,
+                        row.end_minute,
+                        row.intensity,
+                    )
+                })
+                .collect::<Vec<_>>();
+            outbreaks
+                .sort_by(|left, right| (left.2, left.0.as_str()).cmp(&(right.2, right.0.as_str())));
+            let scope_key = format!("settlement:{settlement_id}");
+            let mut problems = ctx
+                .db
+                .local_problem_authority()
+                .scope_key()
+                .filter(&scope_key)
+                .filter(|row| {
+                    !row.disease_id.is_empty()
+                        && row.disease_intensity > 0
+                        && row.mitigation_bps < 10_000
+                })
+                .collect::<Vec<_>>();
+            problems.sort_by(|left, right| left.id.cmp(&right.id));
+            problems.truncate(adventuresim_core::local_problem::MAX_ACTIVE_PER_SCOPE);
+            let sources = outbreaks.into_iter().chain(problems.into_iter().map(|row| {
+                (
+                    row.id,
+                    row.disease_id,
+                    row.starts_at,
+                    row.ends_at.min(row.resolved_at.unwrap_or(u64::MAX)),
+                    f32::from(row.disease_intensity)
+                        * f32::from(10_000_u16.saturating_sub(row.mitigation_bps))
+                        / 10_000_000.0,
+                )
+            }));
+            for (source_id, disease_key, source_start, source_end, intensity) in sources {
+                let disease_id = parse_id(&disease_key)?;
+                let from = start.max(source_start);
+                let to = end.min(source_end);
+                plan.work_units = plan.work_units.saturating_add(to.saturating_sub(from));
+                if plan.work_units > MAX_PARTY_INTERVAL_WORK {
+                    return Err("Party disease interval exceeds bounded exposure work".into());
+                }
+                let definition = disease::definition(disease_id);
+                if let Some(at) = disease::first_eligible_protected_presence_exposure_minute(
+                    &episodes,
+                    disease_id,
+                    *id,
+                    &source_id,
+                    from,
+                    to,
+                    intensity,
+                    definition.base_acquisition,
+                    immunity,
+                    definition.primary_community_vector,
+                    |minute| plan.check_at(*id, minute),
+                ) {
+                    episodes.push(InfectionEpisode {
+                        id: disease::outbreak_exposure_seed(*id, &format!("{source_id}:{at}")),
+                        character_id: *id,
+                        disease_id,
+                        contracted_at: at,
+                        ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
+                        phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+                    });
+                }
+            }
+        }
+        source_episodes.insert(*id, episodes);
+    }
+    let initial = ids
+        .iter()
+        .map(|id| character_episodes(ctx, *id).map(|episodes| (*id, episodes)))
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let mut contact_proposals = Vec::new();
+    for target_id in &ids {
+        let immunity = ctx
+            .db
+            .character_attributes()
+            .character_id()
+            .find(*target_id)
+            .map_or(3.0, |row| row.immunity);
+        for source_id in ids.iter().filter(|source_id| *source_id != target_id) {
+            let windows = pairs
+                .iter()
+                .filter(|pair| {
+                    (pair.low_id == *target_id && pair.high_id == *source_id)
+                        || (pair.high_id == *target_id && pair.low_id == *source_id)
+                })
+                .map(|pair| {
+                    (
+                        pair.start.max(starts[target_id].saturating_add(1)),
+                        pair.end.min(horizons[target_id]),
+                    )
+                })
+                .filter(|(start, end)| start <= end)
+                .collect::<Vec<_>>();
+            for source_episode in &source_episodes[source_id] {
+                let definition = disease::definition(source_episode.disease_id);
+                if !definition.supports(TransmissionVector::CloseContact) {
+                    continue;
+                }
+                'window: for (start, end) in &windows {
+                    plan.work_units = plan
+                        .work_units
+                        .saturating_add(end.saturating_sub(*start).saturating_add(1));
+                    if plan.work_units > MAX_PARTY_INTERVAL_WORK {
+                        return Err("Party disease interval exceeds bounded exposure work".into());
+                    }
+                    for minute in *start..=*end {
+                        if disease::has_unresolved_disease(
+                            &initial[target_id],
+                            source_episode.disease_id,
+                            minute,
+                            immunity,
+                        ) {
+                            continue;
+                        }
+                        let infectiousness =
+                            disease::close_contact_infectiousness(*source_episode, minute);
+                        let exposure = disease::residual_exposure(
+                            infectiousness / 1_440.0,
+                            TransmissionVector::CloseContact,
+                            plan.check_at(*target_id, minute),
+                        );
+                        let prior = disease::acquired_immunity(
+                            &initial[target_id],
+                            source_episode.disease_id,
+                            minute,
+                            immunity,
+                        );
+                        let seed = disease::outbreak_exposure_seed(
+                            *target_id,
+                            &format!("party:{source_id}:{}:{minute}", source_episode.id),
+                        );
+                        if disease::acquisition_succeeds(
+                            seed, definition, immunity, prior, exposure,
+                        ) {
+                            contact_proposals.push(InfectionEpisode {
+                                id: seed,
+                                character_id: *target_id,
+                                disease_id: source_episode.disease_id,
+                                contracted_at: minute,
+                                ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
+                                phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
+                            });
+                            break 'window;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    for id in ids {
+        let environmental = source_episodes
+            .remove(&id)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|episode| {
+                !initial[&id]
+                    .iter()
+                    .any(|existing| existing.id == episode.id)
+            });
+        let contacts = contact_proposals
+            .iter()
+            .copied()
+            .filter(|episode| episode.character_id == id);
+        plan.proposals.insert(
+            id,
+            merge_acquisition_proposals(Vec::new(), environmental.chain(contacts)),
+        );
+    }
+    Ok(plan)
+}
+
 fn party_contact_episodes_through(
     ctx: &ReducerContext,
     character_id: u64,
@@ -1363,11 +1766,12 @@ fn first_private_terminal(
 
 /// Returns the safe prefix of an interval and a terminal mechanism, if any.
 /// All boundary events at the earliest minute are considered together.
-pub fn clip_elapsed_for_disease(
+fn clip_elapsed_for_disease_planned(
     ctx: &ReducerContext,
     character_id: u64,
     requested: u64,
     allow_healing: bool,
+    plan: Option<&PartyDiseaseIntervalPlan>,
 ) -> Result<(u64, Option<TerminalFailure>), String> {
     if requested == 0 {
         return Ok((0, None));
@@ -1386,11 +1790,16 @@ pub fn clip_elapsed_for_disease(
         .map_or(3.0, |a| a.immunity);
     let mut episodes = character_episodes(ctx, character_id)?;
     let interval_end = now.saturating_add(requested);
-    let proposed = merge_acquisition_proposals(
+    let community_and_contact = if let Some(plan) = plan {
+        plan.proposals_for(character_id, now, interval_end)
+    } else {
         merge_acquisition_proposals(
             outbreak_episodes_through(ctx, character_id, now, interval_end)?,
             party_contact_episodes_through(ctx, character_id, now, interval_end)?,
-        ),
+        )
+    };
+    let proposed = merge_acquisition_proposals(
+        community_and_contact,
         crate::filth::blood_episodes_through(
             ctx,
             character_id,
@@ -1398,6 +1807,7 @@ pub fn clip_elapsed_for_disease(
             interval_end,
             false,
             allow_healing,
+            plan,
         )?,
     );
     episodes.extend(proposed.iter().copied());
@@ -1429,8 +1839,15 @@ pub fn clip_elapsed_for_disease(
     )?;
     // Re-evaluate only the committed prefix and advance the private cursor.
     // Absolute-minute seeds guarantee the same proposal as preview/full evaluation.
-    let _ =
-        crate::filth::blood_episodes_through(ctx, character_id, now, through, true, allow_healing)?;
+    let _ = crate::filth::blood_episodes_through(
+        ctx,
+        character_id,
+        now,
+        through,
+        true,
+        allow_healing,
+        plan,
+    )?;
     for event in events.iter().filter(|event| event.minute <= through) {
         match event.kind {
             DiseaseEventKind::SymptomOnset => notice(
@@ -1477,13 +1894,33 @@ pub fn clip_elapsed_for_disease(
     ))
 }
 
-/// Side-effect-free party preflight. Acquisition and notice delivery happen
-/// only in the subsequent committed interval.
-pub fn preview_elapsed_for_disease(
+pub fn clip_elapsed_for_disease(
     ctx: &ReducerContext,
     character_id: u64,
     requested: u64,
     allow_healing: bool,
+) -> Result<(u64, Option<TerminalFailure>), String> {
+    clip_elapsed_for_disease_planned(ctx, character_id, requested, allow_healing, None)
+}
+
+pub fn clip_elapsed_for_disease_in_plan(
+    ctx: &ReducerContext,
+    character_id: u64,
+    requested: u64,
+    allow_healing: bool,
+    plan: &PartyDiseaseIntervalPlan,
+) -> Result<(u64, Option<TerminalFailure>), String> {
+    clip_elapsed_for_disease_planned(ctx, character_id, requested, allow_healing, Some(plan))
+}
+
+/// Side-effect-free party preflight. Acquisition and notice delivery happen
+/// only in the subsequent committed interval.
+fn preview_elapsed_for_disease_planned(
+    ctx: &ReducerContext,
+    character_id: u64,
+    requested: u64,
+    allow_healing: bool,
+    plan: Option<&PartyDiseaseIntervalPlan>,
 ) -> Result<u64, String> {
     let now = ctx
         .db
@@ -1498,11 +1935,16 @@ pub fn preview_elapsed_for_disease(
         .find(character_id)
         .map_or(3.0, |a| a.immunity);
     let mut episodes = character_episodes(ctx, character_id)?;
-    episodes.extend(merge_acquisition_proposals(
+    let community_and_contact = if let Some(plan) = plan {
+        plan.proposals_for(character_id, now, now.saturating_add(requested))
+    } else {
         merge_acquisition_proposals(
             outbreak_episodes_through(ctx, character_id, now, now.saturating_add(requested))?,
             party_contact_episodes_through(ctx, character_id, now, now.saturating_add(requested))?,
-        ),
+        )
+    };
+    episodes.extend(merge_acquisition_proposals(
+        community_and_contact,
         crate::filth::blood_episodes_through(
             ctx,
             character_id,
@@ -1510,6 +1952,7 @@ pub fn preview_elapsed_for_disease(
             now.saturating_add(requested),
             false,
             allow_healing,
+            plan,
         )?,
     ));
     Ok(first_private_terminal(
@@ -1521,6 +1964,25 @@ pub fn preview_elapsed_for_disease(
         immunity,
     )?
     .map_or(requested, |(minute, _)| minute.saturating_sub(now)))
+}
+
+pub fn preview_elapsed_for_disease(
+    ctx: &ReducerContext,
+    character_id: u64,
+    requested: u64,
+    allow_healing: bool,
+) -> Result<u64, String> {
+    preview_elapsed_for_disease_planned(ctx, character_id, requested, allow_healing, None)
+}
+
+pub fn preview_elapsed_for_disease_in_plan(
+    ctx: &ReducerContext,
+    character_id: u64,
+    requested: u64,
+    allow_healing: bool,
+    plan: &PartyDiseaseIntervalPlan,
+) -> Result<u64, String> {
+    preview_elapsed_for_disease_planned(ctx, character_id, requested, allow_healing, Some(plan))
 }
 
 pub fn finish_disease_interval(
@@ -2229,10 +2691,10 @@ mod herbalist_purchase_source_tests {
     fn interval_authority_assembles_community_contact_and_blood_exposure() {
         let source = include_str!("disease.rs");
         let clip = source
-            .split("pub fn clip_elapsed_for_disease")
+            .split("fn clip_elapsed_for_disease_planned")
             .nth(1)
             .unwrap()
-            .split("pub fn preview_elapsed_for_disease")
+            .split("pub fn clip_elapsed_for_disease")
             .next()
             .unwrap();
         for assembler in [
@@ -2261,5 +2723,41 @@ mod herbalist_purchase_source_tests {
         assert!(contact.contains("protected_exposure_at"));
         assert!(contact.contains("merge_acquisition_proposals(Vec::new(), proposals)"));
         assert!(!contact.contains("character_illness_status"));
+    }
+
+    #[test]
+    fn shared_interval_plan_is_bounded_order_stable_and_used_by_all_party_time_paths() {
+        let disease = include_str!("disease.rs");
+        let plan = disease
+            .split("pub fn plan_party_disease_interval")
+            .nth(1)
+            .unwrap()
+            .split("fn party_contact_episodes_through")
+            .next()
+            .unwrap();
+        assert!(plan.contains("ids.sort_unstable()"));
+        assert!(plan.contains("ids.dedup()"));
+        assert!(plan.contains("MAX_PARTY_INTERVAL_SPANS"));
+        assert!(plan.contains("MAX_PARTY_INTERVAL_WORK"));
+        assert!(plan.contains("horizons"));
+        assert!(plan.contains("source_episodes"));
+
+        let time = include_str!("time.rs");
+        let rest = time.split("pub fn rest_at_camp").nth(1).unwrap();
+        assert!(rest.contains("plan_party_disease_interval"));
+        assert!(rest.contains("preview_elapsed_for_disease_in_plan"));
+        assert!(rest.contains("clip_elapsed_for_disease_in_plan"));
+
+        let journey = include_str!("strategic/journey_camp.rs");
+        let movement = journey.split("fn advance_party_movement").nth(1).unwrap();
+        assert!(movement.contains("plan_party_disease_interval"));
+        assert!(movement.contains("preview_travel_time_in_plan"));
+        assert!(movement.contains("advance_travel_time_in_plan"));
+
+        let surgery = include_str!("surgery.rs");
+        let treatment = surgery.split("fn align_and_advance").nth(1).unwrap();
+        assert!(treatment.contains("plan_party_disease_interval"));
+        assert!(treatment.contains("preview_elapsed_for_disease_in_plan"));
+        assert!(treatment.contains("advance_character_wait_time_in_plan"));
     }
 }

--- a/crates/adventuresim-stdb-module/src/disease.rs
+++ b/crates/adventuresim-stdb-module/src/disease.rs
@@ -836,6 +836,7 @@ pub(crate) fn party_physiology_check_at(
     disease::historical_physiology_check_at(coverage, minute)
 }
 
+#[cfg(test)]
 pub(crate) fn protected_exposure_at(
     ctx: &ReducerContext,
     character_id: u64,
@@ -936,6 +937,7 @@ pub fn plan_party_disease_interval(
     ctx: &ReducerContext,
     member_ids: &[u64],
     requested: u64,
+    allow_healing: bool,
 ) -> Result<PartyDiseaseIntervalPlan, String> {
     let mut ids = member_ids.to_vec();
     ids.sort_unstable();
@@ -958,40 +960,52 @@ pub fn plan_party_disease_interval(
     let mut coverage = BTreeMap::<u64, Vec<CachedCoverage>>::new();
     let mut pairs = Vec::new();
     let id_set = ids.iter().copied().collect::<BTreeSet<_>>();
-    for span in ctx
-        .db
-        .physiology_presence_span()
-        .iter()
-        .filter(|span| id_set.contains(&span.low_id) || id_set.contains(&span.high_id))
-    {
-        let current_joint = starts
-            .get(&span.low_id)
-            .copied()
-            .unwrap_or_else(|| {
+    let mut spans_by_id = BTreeMap::new();
+    for id in &ids {
+        for span in ctx
+            .db
+            .physiology_presence_span()
+            .presence_low_id()
+            .filter(*id)
+            .chain(
                 ctx.db
-                    .character_time()
-                    .character_id()
-                    .find(span.low_id)
-                    .map_or(0, |row| row.minutes)
-            })
-            .min(starts.get(&span.high_id).copied().unwrap_or_else(|| {
-                ctx.db
-                    .character_time()
-                    .character_id()
-                    .find(span.high_id)
-                    .map_or(0, |row| row.minutes)
-            }));
-        let projected_joint = match (
+                    .physiology_presence_span()
+                    .presence_high_id()
+                    .filter(*id),
+            )
+        {
+            spans_by_id.entry(span.id).or_insert(span);
+        }
+    }
+    let peer_ids = spans_by_id
+        .values()
+        .flat_map(|span| [span.low_id, span.high_id])
+        .collect::<BTreeSet<_>>();
+    let clocks = peer_ids
+        .into_iter()
+        .map(|id| {
+            (
+                id,
+                starts.get(&id).copied().unwrap_or_else(|| {
+                    ctx.db
+                        .character_time()
+                        .character_id()
+                        .find(id)
+                        .map_or(0, |row| row.minutes)
+                }),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for span in spans_by_id.into_values() {
+        let Some(end) = disease::projected_presence_end(
+            span.ended_at,
             horizons.get(&span.low_id).copied(),
             horizons.get(&span.high_id).copied(),
-        ) {
-            (Some(low), Some(high)) if span.ended_at.is_none() => low.min(high),
-            _ => current_joint,
+            clocks[&span.low_id],
+            clocks[&span.high_id],
+        ) else {
+            continue;
         };
-        let end = span
-            .ended_at
-            .unwrap_or(projected_joint)
-            .min(projected_joint);
         if end < span.started_at {
             continue;
         }
@@ -1027,7 +1041,7 @@ pub fn plan_party_disease_interval(
                 },
             ]);
         }
-        if id_set.contains(&span.low_id) && id_set.contains(&span.high_id) {
+        if id_set.contains(&span.low_id) || id_set.contains(&span.high_id) {
             pairs.push(CachedPairPresence {
                 low_id: span.low_id,
                 high_id: span.high_id,
@@ -1066,7 +1080,14 @@ pub fn plan_party_disease_interval(
             (character_id, segments)
         })
         .collect();
-    let base_work = requested.saturating_mul(ids.len() as u64);
+    let blood_routes = disease::STARTER_DISEASES
+        .iter()
+        .filter(|definition| definition.supports(TransmissionVector::Blood))
+        .count()
+        .max(1) as u64;
+    let base_work = requested
+        .saturating_mul(ids.len() as u64)
+        .saturating_mul(blood_routes);
     if base_work > MAX_PARTY_INTERVAL_WORK {
         return Err("Party disease interval exceeds bounded exposure work".into());
     }
@@ -1075,17 +1096,34 @@ pub fn plan_party_disease_interval(
         work_units: base_work,
         ..Default::default()
     };
-    let mut source_episodes = BTreeMap::<u64, Vec<InfectionEpisode>>::new();
+    let source_ids = pairs
+        .iter()
+        .flat_map(|pair| [pair.low_id, pair.high_id])
+        .chain(ids.iter().copied())
+        .collect::<BTreeSet<_>>();
+    let initial = source_ids
+        .iter()
+        .map(|id| character_episodes(ctx, *id).map(|episodes| (*id, episodes)))
+        .collect::<Result<BTreeMap<_, _>, _>>()?;
+    let immunities = ids
+        .iter()
+        .map(|id| {
+            (
+                *id,
+                ctx.db
+                    .character_attributes()
+                    .character_id()
+                    .find(*id)
+                    .map_or(3.0, |row| row.immunity),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut scheduled = Vec::new();
     for id in &ids {
         let start = starts[id];
         let end = horizons[id];
-        let mut episodes = character_episodes(ctx, *id)?;
-        let immunity = ctx
-            .db
-            .character_attributes()
-            .character_id()
-            .find(*id)
-            .map_or(3.0, |row| row.immunity);
+        let episodes = &initial[id];
+        let immunity = immunities[id];
         let Some(character) = ctx.db.character().id().find(*id) else {
             continue;
         };
@@ -1154,7 +1192,7 @@ pub fn plan_party_disease_interval(
                     definition.primary_community_vector,
                     |minute| plan.check_at(*id, minute),
                 ) {
-                    episodes.push(InfectionEpisode {
+                    scheduled.push(InfectionEpisode {
                         id: disease::outbreak_exposure_seed(*id, &format!("{source_id}:{at}")),
                         character_id: *id,
                         disease_id,
@@ -1165,113 +1203,67 @@ pub fn plan_party_disease_interval(
                 }
             }
         }
-        source_episodes.insert(*id, episodes);
+        scheduled.extend(crate::filth::blood_episodes_through(
+            ctx,
+            *id,
+            start,
+            end,
+            false,
+            allow_healing,
+            Some(&plan),
+        )?);
     }
-    let initial = ids
-        .iter()
-        .map(|id| character_episodes(ctx, *id).map(|episodes| (*id, episodes)))
-        .collect::<Result<BTreeMap<_, _>, _>>()?;
-    let mut contact_proposals = Vec::new();
-    for target_id in &ids {
-        let immunity = ctx
-            .db
-            .character_attributes()
-            .character_id()
-            .find(*target_id)
-            .map_or(3.0, |row| row.immunity);
-        for source_id in ids.iter().filter(|source_id| *source_id != target_id) {
-            let windows = pairs
-                .iter()
-                .filter(|pair| {
-                    (pair.low_id == *target_id && pair.high_id == *source_id)
-                        || (pair.high_id == *target_id && pair.low_id == *source_id)
-                })
-                .map(|pair| {
-                    (
-                        pair.start.max(starts[target_id].saturating_add(1)),
-                        pair.end.min(horizons[target_id]),
-                    )
-                })
-                .filter(|(start, end)| start <= end)
+    let windows = pairs
+        .into_iter()
+        .filter_map(|pair| {
+            let participant_starts = [pair.low_id, pair.high_id]
+                .into_iter()
+                .filter_map(|id| starts.get(&id).copied())
                 .collect::<Vec<_>>();
-            for source_episode in &source_episodes[source_id] {
-                let definition = disease::definition(source_episode.disease_id);
-                if !definition.supports(TransmissionVector::CloseContact) {
-                    continue;
-                }
-                'window: for (start, end) in &windows {
-                    plan.work_units = plan
-                        .work_units
-                        .saturating_add(end.saturating_sub(*start).saturating_add(1));
-                    if plan.work_units > MAX_PARTY_INTERVAL_WORK {
-                        return Err("Party disease interval exceeds bounded exposure work".into());
-                    }
-                    for minute in *start..=*end {
-                        if disease::has_unresolved_disease(
-                            &initial[target_id],
-                            source_episode.disease_id,
-                            minute,
-                            immunity,
-                        ) {
-                            continue;
-                        }
-                        let infectiousness =
-                            disease::close_contact_infectiousness(*source_episode, minute);
-                        let exposure = disease::residual_exposure(
-                            infectiousness / 1_440.0,
-                            TransmissionVector::CloseContact,
-                            plan.check_at(*target_id, minute),
-                        );
-                        let prior = disease::acquired_immunity(
-                            &initial[target_id],
-                            source_episode.disease_id,
-                            minute,
-                            immunity,
-                        );
-                        let seed = disease::outbreak_exposure_seed(
-                            *target_id,
-                            &format!("party:{source_id}:{}:{minute}", source_episode.id),
-                        );
-                        if disease::acquisition_succeeds(
-                            seed, definition, immunity, prior, exposure,
-                        ) {
-                            contact_proposals.push(InfectionEpisode {
-                                id: seed,
-                                character_id: *target_id,
-                                disease_id: source_episode.disease_id,
-                                contracted_at: minute,
-                                ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
-                                phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
-                            });
-                            break 'window;
-                        }
-                    }
-                }
-            }
-        }
-    }
-    for id in ids {
-        let environmental = source_episodes
-            .remove(&id)
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|episode| {
-                !initial[&id]
-                    .iter()
-                    .any(|existing| existing.id == episode.id)
-            });
-        let contacts = contact_proposals
-            .iter()
-            .copied()
-            .filter(|episode| episode.character_id == id);
-        plan.proposals.insert(
-            id,
-            merge_acquisition_proposals(Vec::new(), environmental.chain(contacts)),
-        );
-    }
+            let participant_horizons = [pair.low_id, pair.high_id]
+                .into_iter()
+                .filter_map(|id| horizons.get(&id).copied())
+                .collect::<Vec<_>>();
+            let start = participant_starts
+                .into_iter()
+                .max()
+                .unwrap_or(pair.start)
+                .saturating_add(1)
+                .max(pair.start);
+            let end = participant_horizons
+                .into_iter()
+                .min()
+                .unwrap_or(pair.end)
+                .min(pair.end);
+            (start <= end).then_some(disease::ContactWindow {
+                low_id: pair.low_id,
+                high_id: pair.high_id,
+                start,
+                end,
+            })
+        })
+        .collect::<Vec<_>>();
+    let from = starts.values().copied().min().unwrap_or(0);
+    let to = horizons.values().copied().max().unwrap_or(from);
+    let resolved = disease::resolve_acquisition_timeline(
+        &id_set,
+        &initial,
+        scheduled,
+        &windows,
+        &immunities,
+        from,
+        to,
+        plan.work_units,
+        MAX_PARTY_INTERVAL_WORK,
+        |character_id, minute| plan.check_at(character_id, minute),
+    )
+    .map_err(str::to_string)?;
+    plan.proposals = resolved.proposals;
+    plan.work_units = resolved.work_units;
     Ok(plan)
 }
 
+#[cfg(test)]
 fn party_contact_episodes_through(
     ctx: &ReducerContext,
     character_id: u64,
@@ -1370,9 +1362,11 @@ fn party_contact_episodes_through(
                         minute,
                         immunity,
                     );
-                    let seed = disease::outbreak_exposure_seed(
+                    let seed = disease::contact_exposure_seed(
                         character_id,
-                        &format!("party:{}:{}:{minute}", source_id, source_episode.id),
+                        source_id,
+                        source_episode.id,
+                        minute,
                     );
                     if disease::acquisition_succeeds(seed, definition, immunity, prior, exposure) {
                         proposals.push(InfectionEpisode {
@@ -1393,6 +1387,7 @@ fn party_contact_episodes_through(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 fn first_protected_presence_exposure_minute(
     ctx: &ReducerContext,
     episodes: &[InfectionEpisode],
@@ -1452,6 +1447,7 @@ pub fn effective_attributes(
     Ok(attributes)
 }
 
+#[cfg(test)]
 fn outbreak_episodes_through(
     ctx: &ReducerContext,
     character_id: u64,
@@ -1605,6 +1601,7 @@ fn persist_acquisition_episodes(
     Ok(())
 }
 
+#[cfg(test)]
 fn merge_acquisition_proposals(
     mut proposals: Vec<InfectionEpisode>,
     additional: impl IntoIterator<Item = InfectionEpisode>,
@@ -1776,6 +1773,13 @@ fn clip_elapsed_for_disease_planned(
     if requested == 0 {
         return Ok((0, None));
     }
+    let owned_plan;
+    let plan = if let Some(plan) = plan {
+        plan
+    } else {
+        owned_plan = plan_party_disease_interval(ctx, &[character_id], requested, allow_healing)?;
+        &owned_plan
+    };
     let now = ctx
         .db
         .character_time()
@@ -1790,26 +1794,7 @@ fn clip_elapsed_for_disease_planned(
         .map_or(3.0, |a| a.immunity);
     let mut episodes = character_episodes(ctx, character_id)?;
     let interval_end = now.saturating_add(requested);
-    let community_and_contact = if let Some(plan) = plan {
-        plan.proposals_for(character_id, now, interval_end)
-    } else {
-        merge_acquisition_proposals(
-            outbreak_episodes_through(ctx, character_id, now, interval_end)?,
-            party_contact_episodes_through(ctx, character_id, now, interval_end)?,
-        )
-    };
-    let proposed = merge_acquisition_proposals(
-        community_and_contact,
-        crate::filth::blood_episodes_through(
-            ctx,
-            character_id,
-            now,
-            interval_end,
-            false,
-            allow_healing,
-            plan,
-        )?,
-    );
+    let proposed = plan.proposals_for(character_id, now, interval_end);
     episodes.extend(proposed.iter().copied());
     let mut events = episodes
         .iter()
@@ -1846,7 +1831,7 @@ fn clip_elapsed_for_disease_planned(
         through,
         true,
         allow_healing,
-        plan,
+        Some(plan),
     )?;
     for event in events.iter().filter(|event| event.minute <= through) {
         match event.kind {
@@ -1922,6 +1907,13 @@ fn preview_elapsed_for_disease_planned(
     allow_healing: bool,
     plan: Option<&PartyDiseaseIntervalPlan>,
 ) -> Result<u64, String> {
+    let owned_plan;
+    let plan = if let Some(plan) = plan {
+        plan
+    } else {
+        owned_plan = plan_party_disease_interval(ctx, &[character_id], requested, allow_healing)?;
+        &owned_plan
+    };
     let now = ctx
         .db
         .character_time()
@@ -1935,26 +1927,7 @@ fn preview_elapsed_for_disease_planned(
         .find(character_id)
         .map_or(3.0, |a| a.immunity);
     let mut episodes = character_episodes(ctx, character_id)?;
-    let community_and_contact = if let Some(plan) = plan {
-        plan.proposals_for(character_id, now, now.saturating_add(requested))
-    } else {
-        merge_acquisition_proposals(
-            outbreak_episodes_through(ctx, character_id, now, now.saturating_add(requested))?,
-            party_contact_episodes_through(ctx, character_id, now, now.saturating_add(requested))?,
-        )
-    };
-    episodes.extend(merge_acquisition_proposals(
-        community_and_contact,
-        crate::filth::blood_episodes_through(
-            ctx,
-            character_id,
-            now,
-            now.saturating_add(requested),
-            false,
-            allow_healing,
-            plan,
-        )?,
-    ));
+    episodes.extend(plan.proposals_for(character_id, now, now.saturating_add(requested)));
     Ok(first_private_terminal(
         ctx,
         character_id,
@@ -2690,6 +2663,17 @@ mod herbalist_purchase_source_tests {
     #[test]
     fn interval_authority_assembles_community_contact_and_blood_exposure() {
         let source = include_str!("disease.rs");
+        let plan = source
+            .split("pub fn plan_party_disease_interval")
+            .nth(1)
+            .unwrap()
+            .split("fn party_contact_episodes_through")
+            .next()
+            .unwrap();
+        assert!(plan.contains("settlement_outbreak"));
+        assert!(plan.contains("local_problem_authority"));
+        assert!(plan.contains("blood_episodes_through"));
+        assert!(plan.contains("resolve_acquisition_timeline"));
         let clip = source
             .split("fn clip_elapsed_for_disease_planned")
             .nth(1)
@@ -2697,32 +2681,23 @@ mod herbalist_purchase_source_tests {
             .split("pub fn clip_elapsed_for_disease")
             .next()
             .unwrap();
-        for assembler in [
-            "outbreak_episodes_through",
-            "party_contact_episodes_through",
-            "blood_episodes_through",
-        ] {
-            assert!(clip.contains(assembler));
-        }
         assert!(clip.contains("infection_occurs_through"));
     }
 
     #[test]
-    fn contact_transmission_uses_private_presence_and_stable_source_minute_seed() {
+    fn interval_plan_prefetches_private_presence_through_both_indexes() {
         let source = include_str!("disease.rs");
-        let contact = source
-            .split("fn party_contact_episodes_through")
+        let plan = source
+            .split("pub fn plan_party_disease_interval")
             .nth(1)
             .unwrap()
-            .split("fn first_protected_presence_exposure_minute")
+            .split("fn party_contact_episodes_through")
             .next()
             .unwrap();
-        assert!(contact.contains("physiology_presence_span"));
-        assert!(contact.contains("joint_now"));
-        assert!(contact.contains("party:{}:{}:{minute}"));
-        assert!(contact.contains("protected_exposure_at"));
-        assert!(contact.contains("merge_acquisition_proposals(Vec::new(), proposals)"));
-        assert!(!contact.contains("character_illness_status"));
+        assert!(plan.contains("presence_low_id()"));
+        assert!(plan.contains("presence_high_id()"));
+        assert!(plan.contains("spans_by_id.entry(span.id).or_insert(span)"));
+        assert!(!plan.contains("physiology_presence_span()\n        .iter()"));
     }
 
     #[test]
@@ -2740,7 +2715,7 @@ mod herbalist_purchase_source_tests {
         assert!(plan.contains("MAX_PARTY_INTERVAL_SPANS"));
         assert!(plan.contains("MAX_PARTY_INTERVAL_WORK"));
         assert!(plan.contains("horizons"));
-        assert!(plan.contains("source_episodes"));
+        assert!(plan.contains("resolve_acquisition_timeline"));
 
         let time = include_str!("time.rs");
         let rest = time.split("pub fn rest_at_camp").nth(1).unwrap();

--- a/crates/adventuresim-stdb-module/src/disease.rs
+++ b/crates/adventuresim-stdb-module/src/disease.rs
@@ -1134,8 +1134,6 @@ pub fn plan_party_disease_interval(
     for id in &ids {
         let start = starts[id];
         let end = horizons[id];
-        let episodes = &initial[id];
-        let immunity = immunities[id];
         let Some(character) = ctx.db.character().id().find(*id) else {
             continue;
         };
@@ -1193,8 +1191,7 @@ pub fn plan_party_disease_interval(
                 let definition = disease::definition(disease_id);
                 let remaining_candidates =
                     MAX_PARTY_INTERVAL_CANDIDATES.saturating_sub(scheduled.len());
-                let attempts = disease::eligible_protected_presence_exposure_attempt_minutes(
-                    &episodes,
+                let attempts = disease::protected_presence_exposure_attempts(
                     disease_id,
                     *id,
                     &source_id,
@@ -1202,25 +1199,15 @@ pub fn plan_party_disease_interval(
                     to,
                     intensity,
                     definition.base_acquisition,
-                    immunity,
                     definition.primary_community_vector,
                     remaining_candidates,
                     |minute| plan.check_at(*id, minute),
                 )
                 .map_err(str::to_string)?;
-                for at in attempts {
-                    scheduled.push(InfectionEpisode {
-                        id: disease::outbreak_exposure_seed(*id, &format!("{source_id}:{at}")),
-                        character_id: *id,
-                        disease_id,
-                        contracted_at: at,
-                        ruleset_version: physiology::PHYSIOLOGY_RULESET_VERSION,
-                        phenotype_key_version: physiology::PHENOTYPE_KEY_VERSION,
-                    });
-                }
+                scheduled.extend(attempts);
             }
         }
-        scheduled.extend(crate::filth::blood_episodes_through(
+        let blood_attempts = crate::filth::blood_exposure_attempts_through(
             ctx,
             *id,
             start,
@@ -1229,7 +1216,11 @@ pub fn plan_party_disease_interval(
             allow_healing,
             Some(&plan),
             blood_interval_work_budget(end.saturating_sub(start)),
-        )?);
+        )?;
+        if blood_attempts.len() > MAX_PARTY_INTERVAL_CANDIDATES.saturating_sub(scheduled.len()) {
+            return Err("Disease interval exceeds bounded acquisition candidates".into());
+        }
+        scheduled.extend(blood_attempts);
     }
     let windows = pairs
         .into_iter()
@@ -1842,7 +1833,7 @@ fn clip_elapsed_for_disease_planned(
     )?;
     // Re-evaluate only the committed prefix and advance the private cursor.
     // Absolute-minute seeds guarantee the same proposal as preview/full evaluation.
-    let _ = crate::filth::blood_episodes_through(
+    let _ = crate::filth::blood_exposure_attempts_through(
         ctx,
         character_id,
         now,
@@ -2691,7 +2682,7 @@ mod herbalist_purchase_source_tests {
             .unwrap();
         assert!(plan.contains("settlement_outbreak"));
         assert!(plan.contains("local_problem_authority"));
-        assert!(plan.contains("blood_episodes_through"));
+        assert!(plan.contains("blood_exposure_attempts_through"));
         assert!(plan.contains("resolve_acquisition_timeline"));
         let clip = source
             .split("fn clip_elapsed_for_disease_planned")

--- a/crates/adventuresim-stdb-module/src/disease.rs
+++ b/crates/adventuresim-stdb-module/src/disease.rs
@@ -872,6 +872,16 @@ pub(crate) fn protected_point_exposure(
 
 const MAX_PARTY_INTERVAL_SPANS: usize = 4_096;
 const MAX_PARTY_INTERVAL_WORK: u64 = 50_000_000;
+const MAX_PARTY_INTERVAL_CANDIDATES: usize = 1_000_000;
+
+fn blood_interval_work_budget(minutes: u64) -> u64 {
+    let routes = disease::STARTER_DISEASES
+        .iter()
+        .filter(|definition| definition.supports(TransmissionVector::Blood))
+        .count()
+        .max(1) as u64;
+    minutes.saturating_mul(routes)
+}
 
 #[derive(Clone, Debug)]
 struct CachedCoverage {
@@ -974,7 +984,13 @@ pub fn plan_party_disease_interval(
                     .filter(*id),
             )
         {
-            spans_by_id.entry(span.id).or_insert(span);
+            disease::insert_unique_bounded(
+                &mut spans_by_id,
+                span.id,
+                span,
+                MAX_PARTY_INTERVAL_SPANS,
+            )
+            .map_err(str::to_string)?;
         }
     }
     let peer_ids = spans_by_id
@@ -1080,14 +1096,10 @@ pub fn plan_party_disease_interval(
             (character_id, segments)
         })
         .collect();
-    let blood_routes = disease::STARTER_DISEASES
-        .iter()
-        .filter(|definition| definition.supports(TransmissionVector::Blood))
-        .count()
-        .max(1) as u64;
     let base_work = requested
         .saturating_mul(ids.len() as u64)
-        .saturating_mul(blood_routes);
+        .saturating_mul(2)
+        .saturating_mul(blood_interval_work_budget(1));
     if base_work > MAX_PARTY_INTERVAL_WORK {
         return Err("Party disease interval exceeds bounded exposure work".into());
     }
@@ -1179,7 +1191,9 @@ pub fn plan_party_disease_interval(
                     return Err("Party disease interval exceeds bounded exposure work".into());
                 }
                 let definition = disease::definition(disease_id);
-                if let Some(at) = disease::first_eligible_protected_presence_exposure_minute(
+                let remaining_candidates =
+                    MAX_PARTY_INTERVAL_CANDIDATES.saturating_sub(scheduled.len());
+                let attempts = disease::eligible_protected_presence_exposure_attempt_minutes(
                     &episodes,
                     disease_id,
                     *id,
@@ -1190,8 +1204,11 @@ pub fn plan_party_disease_interval(
                     definition.base_acquisition,
                     immunity,
                     definition.primary_community_vector,
+                    remaining_candidates,
                     |minute| plan.check_at(*id, minute),
-                ) {
+                )
+                .map_err(str::to_string)?;
+                for at in attempts {
                     scheduled.push(InfectionEpisode {
                         id: disease::outbreak_exposure_seed(*id, &format!("{source_id}:{at}")),
                         character_id: *id,
@@ -1211,6 +1228,7 @@ pub fn plan_party_disease_interval(
             false,
             allow_healing,
             Some(&plan),
+            blood_interval_work_budget(end.saturating_sub(start)),
         )?);
     }
     let windows = pairs
@@ -1832,6 +1850,7 @@ fn clip_elapsed_for_disease_planned(
         true,
         allow_healing,
         Some(plan),
+        blood_interval_work_budget(through.saturating_sub(now)),
     )?;
     for event in events.iter().filter(|event| event.minute <= through) {
         match event.kind {

--- a/crates/adventuresim-stdb-module/src/filth.rs
+++ b/crates/adventuresim-stdb-module/src/filth.rs
@@ -150,6 +150,7 @@ pub fn blood_episodes_through(
     to: u64,
     persist_checkpoint: bool,
     allow_healing: bool,
+    plan: Option<&crate::disease::PartyDiseaseIntervalPlan>,
 ) -> Result<Vec<adventuresim_core::disease::InfectionEpisode>, String> {
     if to <= from {
         return Ok(Vec::new());
@@ -212,12 +213,20 @@ pub fn blood_episodes_through(
                 continue;
             }
             let route = filth::timed_cut_exposure(&routes, minute.saturating_sub(from));
-            let exposure = crate::disease::protected_exposure_at(
-                ctx,
-                character_id,
-                minute,
-                adventuresim_core::disease::TransmissionVector::Blood,
+            let check = plan.map_or_else(
+                || crate::disease::party_physiology_check_at(ctx, character_id, minute),
+                |plan| plan.check_at(character_id, minute),
+            );
+            // Any infectious deposit still present here survived or preceded
+            // explicit washing, so clean handling is not available for this
+            // dose. Bandaging/stitching still raises the physical affordance
+            // through the predicted cut-route state.
+            let affordance = adventuresim_core::disease::blood_caregiving_affordance(false, route);
+            let exposure = adventuresim_core::disease::residual_exposure_with_affordance(
                 filth::blood_exposure(&relevant, disease_id, minute, route) / 1_440.0,
+                adventuresim_core::disease::TransmissionVector::Blood,
+                check,
+                affordance,
             );
             if exposure <= 0.0 {
                 continue;
@@ -884,10 +893,11 @@ mod source_tests {
             .nth(1)
             .and_then(|tail| tail.split("/// Reusable strategic boundary").next())
             .expect("blood exposure source");
-        let prevention = exposure.find("protected_exposure_at").unwrap();
+        let prevention = exposure.find("residual_exposure").unwrap();
         let physical = exposure.find("filth::blood_exposure").unwrap();
         assert!(prevention < physical);
         assert!(exposure.contains("TransmissionVector::Blood"));
         assert!(exposure.contains("timed_cut_exposure"));
+        assert!(exposure.contains("blood_caregiving_affordance(false, route)"));
     }
 }

--- a/crates/adventuresim-stdb-module/src/filth.rs
+++ b/crates/adventuresim-stdb-module/src/filth.rs
@@ -212,7 +212,13 @@ pub fn blood_episodes_through(
                 continue;
             }
             let route = filth::timed_cut_exposure(&routes, minute.saturating_sub(from));
-            let exposure = filth::blood_exposure(&relevant, disease_id, minute, route) / 1_440.0;
+            let exposure = crate::disease::protected_exposure_at(
+                ctx,
+                character_id,
+                minute,
+                adventuresim_core::disease::TransmissionVector::Blood,
+                filth::blood_exposure(&relevant, disease_id, minute, route) / 1_440.0,
+            );
             if exposure <= 0.0 {
                 continue;
             }
@@ -866,4 +872,22 @@ pub(crate) fn seed_demo(
         crate::add_inventory_item(ctx, character_id, SOAP_ITEM_ID, 3 - existing);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod source_tests {
+    #[test]
+    fn blood_route_receives_partial_physician_protection_after_physical_controls() {
+        let source = include_str!("filth.rs");
+        let exposure = source
+            .split("pub fn blood_episodes_through")
+            .nth(1)
+            .and_then(|tail| tail.split("/// Reusable strategic boundary").next())
+            .expect("blood exposure source");
+        let prevention = exposure.find("protected_exposure_at").unwrap();
+        let physical = exposure.find("filth::blood_exposure").unwrap();
+        assert!(prevention < physical);
+        assert!(exposure.contains("TransmissionVector::Blood"));
+        assert!(exposure.contains("timed_cut_exposure"));
+    }
 }

--- a/crates/adventuresim-stdb-module/src/filth.rs
+++ b/crates/adventuresim-stdb-module/src/filth.rs
@@ -143,7 +143,7 @@ fn predicted_wound_routes(
         .collect())
 }
 
-pub fn blood_episodes_through(
+pub fn blood_exposure_attempts_through(
     ctx: &ReducerContext,
     character_id: u64,
     from: u64,
@@ -152,7 +152,7 @@ pub fn blood_episodes_through(
     allow_healing: bool,
     plan: Option<&crate::disease::PartyDiseaseIntervalPlan>,
     max_work: u64,
-) -> Result<Vec<adventuresim_core::disease::InfectionEpisode>, String> {
+) -> Result<Vec<adventuresim_core::disease::AcquisitionAttempt>, String> {
     if to <= from {
         return Ok(Vec::new());
     }
@@ -168,15 +168,8 @@ pub fn blood_episodes_through(
     if !has_active_compatible_foreign_blood {
         return Ok(Vec::new());
     }
-    let immunity = ctx
-        .db
-        .character_attributes()
-        .character_id()
-        .find(character_id)
-        .map_or(3.0, |attributes| attributes.immunity);
     let routes = predicted_wound_routes(ctx, character_id, allow_healing)?;
-    let mut episodes = crate::disease::character_episodes(ctx, character_id)?;
-    let original_len = episodes.len();
+    let mut attempts = Vec::new();
     let mut work = 0;
     for disease_id in adventuresim_core::disease::STARTER_DISEASES
         .iter()
@@ -211,11 +204,6 @@ pub fn blood_episodes_through(
         {
             adventuresim_core::disease::add_bounded_work(&mut work, 1, max_work)
                 .map_err(str::to_string)?;
-            if adventuresim_core::disease::has_unresolved_disease(
-                &episodes, disease_id, minute, immunity,
-            ) {
-                continue;
-            }
             let route = filth::timed_cut_exposure(&routes, minute.saturating_sub(from));
             let check = plan.map_or_else(
                 || crate::disease::party_physiology_check_at(ctx, character_id, minute),
@@ -235,30 +223,22 @@ pub fn blood_episodes_through(
             if exposure <= 0.0 {
                 continue;
             }
-            let prior = adventuresim_core::disease::acquired_immunity(
-                &episodes, disease_id, minute, immunity,
-            );
             let seed = adventuresim_core::disease::outbreak_exposure_seed(
                 character_id,
                 &format!("blood:{}:{minute}", crate::disease::disease_key(disease_id)),
             );
-            if adventuresim_core::disease::acquisition_succeeds(
-                seed,
-                adventuresim_core::disease::definition(disease_id),
-                immunity,
-                prior,
-                exposure,
-            ) {
-                episodes.push(adventuresim_core::disease::InfectionEpisode {
+            attempts.push(adventuresim_core::disease::AcquisitionAttempt::exposure(
+                adventuresim_core::disease::InfectionEpisode {
                     id: seed,
                     character_id,
                     disease_id,
                     contracted_at: minute,
                     ruleset_version: adventuresim_core::physiology::PHYSIOLOGY_RULESET_VERSION,
                     phenotype_key_version: adventuresim_core::physiology::PHENOTYPE_KEY_VERSION,
-                });
-                break;
-            }
+                },
+                adventuresim_core::disease::definition(disease_id).base_acquisition,
+                exposure,
+            ));
         }
         if persist_checkpoint {
             let row = BloodExposureCheckpoint {
@@ -274,7 +254,7 @@ pub fn blood_episodes_through(
             }
         }
     }
-    Ok(episodes.split_off(original_len))
+    Ok(attempts)
 }
 
 pub fn next_travel_dirt_boundary(ctx: &ReducerContext, character_id: u64) -> u64 {
@@ -893,7 +873,7 @@ mod source_tests {
     fn blood_route_receives_partial_physician_protection_after_physical_controls() {
         let source = include_str!("filth.rs");
         let exposure = source
-            .split("pub fn blood_episodes_through")
+            .split("pub fn blood_exposure_attempts_through")
             .nth(1)
             .and_then(|tail| tail.split("/// Reusable strategic boundary").next())
             .expect("blood exposure source");

--- a/crates/adventuresim-stdb-module/src/filth.rs
+++ b/crates/adventuresim-stdb-module/src/filth.rs
@@ -151,6 +151,7 @@ pub fn blood_episodes_through(
     persist_checkpoint: bool,
     allow_healing: bool,
     plan: Option<&crate::disease::PartyDiseaseIntervalPlan>,
+    max_work: u64,
 ) -> Result<Vec<adventuresim_core::disease::InfectionEpisode>, String> {
     if to <= from {
         return Ok(Vec::new());
@@ -176,6 +177,7 @@ pub fn blood_episodes_through(
     let routes = predicted_wound_routes(ctx, character_id, allow_healing)?;
     let mut episodes = crate::disease::character_episodes(ctx, character_id)?;
     let original_len = episodes.len();
+    let mut work = 0;
     for disease_id in adventuresim_core::disease::STARTER_DISEASES
         .iter()
         .filter(|definition| {
@@ -207,6 +209,8 @@ pub fn blood_episodes_through(
             .into_iter()
             .flat_map(|(window_start, window_end)| window_start..=window_end)
         {
+            adventuresim_core::disease::add_bounded_work(&mut work, 1, max_work)
+                .map_err(str::to_string)?;
             if adventuresim_core::disease::has_unresolved_disease(
                 &episodes, disease_id, minute, immunity,
             ) {

--- a/crates/adventuresim-stdb-module/src/food.rs
+++ b/crates/adventuresim-stdb-module/src/food.rs
@@ -591,12 +591,19 @@ fn expose_to_dysentery(
     let prior = disease::acquired_immunity(&episodes, DiseaseId::Dysentery, minute, immunity);
     let seed =
         disease::outbreak_exposure_seed(character_id, &format!("food:{lot_id}:{}", minute / 1));
+    let protected_dose = crate::disease::protected_point_exposure(
+        ctx,
+        character_id,
+        minute,
+        adventuresim_core::disease::TransmissionVector::FoodWater,
+        dose,
+    )?;
     if disease::acquisition_succeeds(
         seed,
         disease::definition(DiseaseId::Dysentery),
         immunity,
         prior,
-        dose,
+        protected_dose,
     ) {
         ctx.db.infection_episode().insert(InfectionEpisodeRow {
             id: 0,
@@ -1159,5 +1166,18 @@ mod tests {
             .and_then(|tail| tail.split("pub fn create_party_food_lot").next())
             .expect("personal lot constructor");
         assert!(constructor.contains("quality: definition.default_quality.clamp(1, 5)"));
+    }
+
+    #[test]
+    fn hidden_food_contamination_uses_explicit_food_water_prevention() {
+        let source = include_str!("food.rs");
+        let exposure = source
+            .split("fn expose_to_dysentery")
+            .nth(1)
+            .and_then(|tail| tail.split("fn consume_food_amount").next())
+            .expect("foodborne exposure source");
+        assert!(exposure.contains("protected_point_exposure"));
+        assert!(exposure.contains("TransmissionVector::FoodWater"));
+        assert!(exposure.contains("protected_dose"));
     }
 }

--- a/crates/adventuresim-stdb-module/src/strategic/autoresolve.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/autoresolve.rs
@@ -56,8 +56,7 @@ use crate::{
         tactical_server_authority, tactical_server_claim, tactical_server_request_authority,
     },
     time::{
-        advance_travel_time, character_time, character_training_schedule, preview_travel_time,
-        settle_travel_boundary,
+        advance_travel_time, character_time, character_training_schedule, settle_travel_boundary,
     },
 };
 use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet};

--- a/crates/adventuresim-stdb-module/src/strategic/journey_camp.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/journey_camp.rs
@@ -538,7 +538,7 @@ fn advance_party_movement(
     requested_minutes: u64,
 ) -> Result<(u64, bool), String> {
     let disease_plan =
-        crate::disease::plan_party_disease_interval(ctx, traveler_ids, requested_minutes)?;
+        crate::disease::plan_party_disease_interval(ctx, traveler_ids, requested_minutes, false)?;
     let mut safe_prefixes = Vec::with_capacity(traveler_ids.len());
     for member_id in traveler_ids {
         safe_prefixes.push(crate::time::preview_travel_time_in_plan(

--- a/crates/adventuresim-stdb-module/src/strategic/journey_camp.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/journey_camp.rs
@@ -537,9 +537,16 @@ fn advance_party_movement(
     traveler_ids: &[u64],
     requested_minutes: u64,
 ) -> Result<(u64, bool), String> {
+    let disease_plan =
+        crate::disease::plan_party_disease_interval(ctx, traveler_ids, requested_minutes)?;
     let mut safe_prefixes = Vec::with_capacity(traveler_ids.len());
     for member_id in traveler_ids {
-        safe_prefixes.push(preview_travel_time(ctx, *member_id, requested_minutes)?);
+        safe_prefixes.push(crate::time::preview_travel_time_in_plan(
+            ctx,
+            *member_id,
+            requested_minutes,
+            &disease_plan,
+        )?);
     }
     let actual_minutes = common_movement_prefix(requested_minutes, safe_prefixes.iter().copied());
     if actual_minutes == 0 {
@@ -553,7 +560,12 @@ fn advance_party_movement(
     }
     let mut all_survived = true;
     for member_id in traveler_ids.iter().copied() {
-        all_survived &= advance_travel_time(ctx, member_id, actual_minutes)?;
+        all_survived &= crate::time::advance_travel_time_in_plan(
+            ctx,
+            member_id,
+            actual_minutes,
+            &disease_plan,
+        )?;
     }
     // Training is committed only after every participant's authoritative
     // clock has committed the same safe movement prefix.

--- a/crates/adventuresim-stdb-module/src/surgery.rs
+++ b/crates/adventuresim-stdb-module/src/surgery.rs
@@ -836,14 +836,26 @@ fn align_and_advance(
     } else {
         vec![actor_id, patient_id]
     };
+    let disease_plan = crate::disease::plan_party_disease_interval(ctx, &participants, duration)?;
     let safe_duration = participants.iter().try_fold(duration, |limit, id| {
-        let disease = crate::disease::preview_elapsed_for_disease(ctx, *id, limit, true)?;
+        let disease = crate::disease::preview_elapsed_for_disease_in_plan(
+            ctx,
+            *id,
+            limit,
+            true,
+            &disease_plan,
+        )?;
         let injury = preview_elapsed_for_injuries(ctx, *id, limit, true)?;
         Ok::<u64, String>(limit.min(disease).min(injury))
     })?;
     let mut completed = safe_duration == duration;
     for id in participants {
-        completed &= crate::time::advance_character_wait_time(ctx, id, safe_duration)?;
+        completed &= crate::time::advance_character_wait_time_in_plan(
+            ctx,
+            id,
+            safe_duration,
+            &disease_plan,
+        )?;
     }
     Ok(completed)
 }

--- a/crates/adventuresim-stdb-module/src/surgery.rs
+++ b/crates/adventuresim-stdb-module/src/surgery.rs
@@ -836,7 +836,8 @@ fn align_and_advance(
     } else {
         vec![actor_id, patient_id]
     };
-    let disease_plan = crate::disease::plan_party_disease_interval(ctx, &participants, duration)?;
+    let disease_plan =
+        crate::disease::plan_party_disease_interval(ctx, &participants, duration, true)?;
     let safe_duration = participants.iter().try_fold(duration, |limit, id| {
         let disease = crate::disease::preview_elapsed_for_disease_in_plan(
             ctx,

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -2096,7 +2096,7 @@ pub fn rest_at_camp(
     // and injury interval clipping, and dead members were excluded above.
     crate::filth::wash_party_before_explicit_rest(ctx, &members)?;
     let disease_plan =
-        crate::disease::plan_party_disease_interval(ctx, &members, requested_minutes)?;
+        crate::disease::plan_party_disease_interval(ctx, &members, requested_minutes, true)?;
     let elapsed = members
         .iter()
         .try_fold(requested_minutes, |limit, member_id| {

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -222,6 +222,48 @@ pub fn advance_character_time(
     Ok(true)
 }
 
+fn advance_character_time_in_plan(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minutes: u64,
+    plan: &crate::disease::PartyDiseaseIntervalPlan,
+) -> Result<bool, String> {
+    crate::character::require_living_character(ctx, character_id)?;
+    ensure_character_time(ctx, character_id)?;
+    let mut character_time = ctx
+        .db
+        .character_time()
+        .character_id()
+        .find(character_id)
+        .ok_or_else(|| "Character time record not found".to_string())?;
+    let starting_minute = character_time.minutes;
+    let injury_limit =
+        crate::surgery::preview_elapsed_for_injuries(ctx, character_id, minutes, false)?;
+    let (elapsed, terminal) = crate::disease::clip_elapsed_for_disease_in_plan(
+        ctx,
+        character_id,
+        injury_limit,
+        false,
+        plan,
+    )?;
+    let settled = crate::surgery::settle_injuries(ctx, character_id, elapsed, false)?;
+    let elapsed = settled.elapsed;
+    character_time.minutes = character_time.minutes.saturating_add(elapsed);
+    ctx.db
+        .character_time()
+        .character_id()
+        .update(character_time);
+    crate::organization::settle_membership_dues(ctx, character_id)?;
+    crate::social::settle_shared_party_time(ctx, character_id);
+    crate::disease::finish_disease_interval(ctx, character_id, terminal)?;
+    if terminal.is_some() || !settled.alive {
+        return Ok(false);
+    }
+    crate::condition::apply_travel_condition(ctx, character_id, starting_minute, elapsed, 0)?;
+    crate::capability::refresh_character_capability(ctx, character_id)?;
+    Ok(true)
+}
+
 /// Actual strategic movement, split at exact dirt boundaries so filth and its
 /// wound-risk multiplier are independent of caller chunking.
 pub fn preview_travel_time(
@@ -231,6 +273,16 @@ pub fn preview_travel_time(
 ) -> Result<u64, String> {
     let injury = crate::surgery::preview_elapsed_for_injuries(ctx, character_id, requested, false)?;
     crate::disease::preview_elapsed_for_disease(ctx, character_id, injury, false)
+}
+
+pub fn preview_travel_time_in_plan(
+    ctx: &ReducerContext,
+    character_id: u64,
+    requested: u64,
+    plan: &crate::disease::PartyDiseaseIntervalPlan,
+) -> Result<u64, String> {
+    let injury = crate::surgery::preview_elapsed_for_injuries(ctx, character_id, requested, false)?;
+    crate::disease::preview_elapsed_for_disease_in_plan(ctx, character_id, injury, false, plan)
 }
 
 /// Commit a terminal injury or disease event that falls exactly on the
@@ -263,6 +315,37 @@ pub fn advance_travel_time(
             .find(character_id)
             .map_or(0, |row| row.minutes);
         let alive = advance_character_time(ctx, character_id, chunk)?;
+        let after = ctx
+            .db
+            .character_time()
+            .character_id()
+            .find(character_id)
+            .map_or(before, |row| row.minutes);
+        let elapsed = after.saturating_sub(before);
+        crate::filth::record_travel_elapsed(ctx, character_id, elapsed, after)?;
+        if !alive || elapsed < chunk {
+            return Ok(false);
+        }
+        minutes -= elapsed;
+    }
+    Ok(true)
+}
+
+pub fn advance_travel_time_in_plan(
+    ctx: &ReducerContext,
+    character_id: u64,
+    mut minutes: u64,
+    plan: &crate::disease::PartyDiseaseIntervalPlan,
+) -> Result<bool, String> {
+    while minutes > 0 {
+        let chunk = minutes.min(crate::filth::next_travel_dirt_boundary(ctx, character_id));
+        let before = ctx
+            .db
+            .character_time()
+            .character_id()
+            .find(character_id)
+            .map_or(0, |row| row.minutes);
+        let alive = advance_character_time_in_plan(ctx, character_id, chunk, plan)?;
         let after = ctx
             .db
             .character_time()
@@ -378,6 +461,54 @@ pub fn advance_character_wait_time(
         crate::surgery::preview_elapsed_for_injuries(ctx, character_id, minutes, true)?;
     let (elapsed, terminal) =
         crate::disease::clip_elapsed_for_disease(ctx, character_id, injury_limit, true)?;
+    let settled = crate::surgery::settle_injuries(ctx, character_id, elapsed, true)?;
+    time.minutes = time.minutes.saturating_add(settled.elapsed);
+    ctx.db.character_time().character_id().update(time);
+    crate::organization::settle_membership_dues(ctx, character_id)?;
+    crate::social::settle_shared_party_time(ctx, character_id);
+    crate::disease::finish_disease_interval(ctx, character_id, terminal)?;
+    if terminal.is_some() || !settled.alive {
+        return Ok(false);
+    }
+    let at_settlement = ctx
+        .db
+        .character()
+        .id()
+        .find(character_id)
+        .is_some_and(|row| row.current_settlement_id.is_some());
+    if at_settlement {
+        crate::condition::apply_rest_condition(ctx, character_id, settled.elapsed)?;
+    } else {
+        crate::condition::apply_elapsed_needs(ctx, character_id, settled.elapsed)?;
+        crate::condition::apply_camp_rest_recovery_condition(ctx, character_id, settled.elapsed)?;
+    }
+    crate::capability::refresh_character_capability(ctx, character_id)?;
+    Ok(true)
+}
+
+pub fn advance_character_wait_time_in_plan(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minutes: u64,
+    plan: &crate::disease::PartyDiseaseIntervalPlan,
+) -> Result<bool, String> {
+    crate::character::require_living_character(ctx, character_id)?;
+    ensure_character_time(ctx, character_id)?;
+    let mut time = ctx
+        .db
+        .character_time()
+        .character_id()
+        .find(character_id)
+        .ok_or("Character time record not found")?;
+    let injury_limit =
+        crate::surgery::preview_elapsed_for_injuries(ctx, character_id, minutes, true)?;
+    let (elapsed, terminal) = crate::disease::clip_elapsed_for_disease_in_plan(
+        ctx,
+        character_id,
+        injury_limit,
+        true,
+        plan,
+    )?;
     let settled = crate::surgery::settle_injuries(ctx, character_id, elapsed, true)?;
     time.minutes = time.minutes.saturating_add(settled.elapsed);
     ctx.db.character_time().character_id().update(time);
@@ -1964,11 +2095,18 @@ pub fn rest_at_camp(
     // This reducer is an explicit player-chosen rest. Washing precedes disease
     // and injury interval clipping, and dead members were excluded above.
     crate::filth::wash_party_before_explicit_rest(ctx, &members)?;
+    let disease_plan =
+        crate::disease::plan_party_disease_interval(ctx, &members, requested_minutes)?;
     let elapsed = members
         .iter()
         .try_fold(requested_minutes, |limit, member_id| {
-            let disease =
-                crate::disease::preview_elapsed_for_disease(ctx, *member_id, limit, true)?;
+            let disease = crate::disease::preview_elapsed_for_disease_in_plan(
+                ctx,
+                *member_id,
+                limit,
+                true,
+                &disease_plan,
+            )?;
             let injury =
                 crate::surgery::preview_elapsed_for_injuries(ctx, *member_id, limit, true)?;
             Ok::<u64, String>(limit.min(disease).min(injury))
@@ -2014,9 +2152,15 @@ pub fn rest_at_camp(
             .map_or(0.0, |stats| stats.calories_used.max(0.0));
         let physiology_check = party_physiology_check(ctx, member_id)?;
         let convalescing = convalescence_minutes(ctx, member_id, physiology_check).min(elapsed);
-        let (_, terminal) =
-            crate::disease::clip_elapsed_for_disease(ctx, member_id, elapsed, true)?;
-        let settled = crate::surgery::settle_injuries(ctx, member_id, elapsed, true)?;
+        let (disease_elapsed, terminal) = crate::disease::clip_elapsed_for_disease_in_plan(
+            ctx,
+            member_id,
+            elapsed,
+            true,
+            &disease_plan,
+        )?;
+        let settled =
+            crate::surgery::settle_injuries(ctx, member_id, elapsed.min(disease_elapsed), true)?;
         let member_elapsed = settled.elapsed;
         time.minutes = time.minutes.saturating_add(member_elapsed);
         let interval_end_minute = time.minutes;

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -56,7 +56,10 @@ Multi-character strategic time actions snapshot disease exposure before the
 first participant clock mutates. The reducer-local plan projects only the
 explicit co-advancing set, prefetches bounded pair-presence coverage, and gives
 preview and commit the same deterministic acquisition proposals. Solo
-catch-up reads recorded history instead of projecting absent companions.
+catch-up reads indexed recorded history and caps open-span overlap at the
+peer's already-elapsed clock. Route candidates are resolved simultaneously
+within each absolute minute and become contact sources on the following
+minute.
 
 The largest strategic implementations are organized behind their established
 Rust module paths. `strategic` and `investigation` retain ordered same-scope

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -52,6 +52,12 @@ current party, character, location, time, custody, and source identity before
 changing state. Shared-core functions perform deterministic calculations, but
 do not grant authority by themselves.
 
+Multi-character strategic time actions snapshot disease exposure before the
+first participant clock mutates. The reducer-local plan projects only the
+explicit co-advancing set, prefetches bounded pair-presence coverage, and gives
+preview and commit the same deterministic acquisition proposals. Solo
+catch-up reads recorded history instead of projecting absent companions.
+
 The largest strategic implementations are organized behind their established
 Rust module paths. `strategic` and `investigation` retain ordered same-scope
 source fragments because SpacetimeDB table, reducer, view, and generated

--- a/wiki/reference/physiology.md
+++ b/wiki/reference/physiology.md
@@ -77,6 +77,21 @@ that route. Every route retains residual risk, and available washing supplies,
 wound closure, and other physical affordances continue to determine their own
 stronger effects.
 
+Each route splits its dose into an unavoidable/environmental component and a
+preventable party-behavior component. Physiology reduces only the latter.
+Route preventability and the current physical-affordance multiplier are named
+inputs to that split. Infected blood illustrates the distinction: automatic
+washing with actual soap removes blood before exposure, while bandaging or
+stitching lowers the real cut route; if infectious blood remains, missing clean
+handling and an open wound cap how much additional Physiology judgment can do.
+
+Shared travel, camp rest, and treatment snapshot the explicitly co-advancing
+participants and their capability-pinned Physiology coverage before changing
+any clock. Every participant is previewed and committed against that immutable
+plan, so character ID and reducer iteration order cannot change prevention or
+transmission. Solo catch-up uses recorded co-presence only and never projects
+an absent physician into the interval.
+
 The authoritative database initializes private key material from runtime
 randomness and persists one private key for the lifetime of the database.
 Changing its version requires recreating the disposable pre-launch database;

--- a/wiki/reference/physiology.md
+++ b/wiki/reference/physiology.md
@@ -1,11 +1,12 @@
 # Physiology system
 
-Physiology is the skill for observing health, administering prepared
-interventions, and improving wound recovery. It produces a fallible differential
-of possible diseases, but never reveals the authoritative disease identity or
-recommends a treatment. [Herbalism](herbalism.md) now owns bounded biological
-preparation while Alchemy #215 remains independent. Preparations act through
-versioned generic meter profiles and never disease-keyed effects.
+Physiology is the skill for preventing avoidable disease exposure, observing
+health, administering prepared interventions, and improving wound recovery. It
+produces a fallible differential of possible diseases, but never reveals the
+authoritative disease identity or recommends a treatment.
+[Herbalism](herbalism.md) now owns bounded biological preparation while
+Alchemy #215 remains independent. Preparations act through versioned generic
+meter profiles and never disease-keyed effects.
 
 ## Professional boundary
 
@@ -65,6 +66,17 @@ together. The earliest integer-minute terminal crossing wins, with a stable
 meter-order tie-break, so splitting an interval into smaller calls cannot change
 the result.
 
+Disease exposure is assembled by an explicit transmission route before the
+private acquisition roll. Abstract settlement outbreaks use each disease's
+authored primary community route; contaminated food and water, wounds, infected
+blood, and within-party close contact retain their direct routes. Party
+Physiology sharply reduces avoidable food/water and close-contact exposure,
+reduces vermin exposure by a lower ceiling, and only modestly reduces blood
+exposure. Wound risk is unchanged because Surgery and physical wound care own
+that route. Every route retains residual risk, and available washing supplies,
+wound closure, and other physical affordances continue to determine their own
+stronger effects.
+
 The authoritative database initializes private key material from runtime
 randomness and persists one private key for the lifetime of the database.
 Changing its version requires recreating the disposable pre-launch database;
@@ -87,6 +99,20 @@ observer's Physiology capability band at that boundary, preventing later
 training from sharpening historical observations. Every notebook records at
 most one examination per day. Higher bands produce more finely quantized
 readings and a better-calibrated differential, but do not add examinations.
+
+The same private spans bound passive prevention. Each span pins both members'
+Physiology bands and is clamped to their lesser personal clock, so joining,
+leaving, training across a band boundary, lazy catch-up, and split time advances
+cannot rewrite who supplied knowledge during an elapsed minute. A character
+without any pair-presence history receives no interval-wide solo fallback,
+because applying a current skill retroactively would make catch-up chunking
+change outcomes. Point-in-time actions such as consuming a food lot may use the
+actor's current capability safely.
+
+Close-contact transmission reads source infections and pair presence only
+inside private authority. Browsers learn neither who exposed whom nor whether a
+Physiology reduction changed a particular roll; ordinary symptom notices remain
+the first public illness signal.
 
 The trusted strategic gateway derives a bounded, pre-quantized chart on demand
 from causal infection, administration, presence, capability, ruleset, and key

--- a/wiki/reference/physiology.md
+++ b/wiki/reference/physiology.md
@@ -93,6 +93,8 @@ transmission. Community, blood, and contact acquisitions resolve together in
 absolute-minute order. Acquisitions within one minute are simultaneous and a
 new infection can transmit onward starting on the following minute, making
 secondary spread agree between one long interval and equivalent chunks.
+Environmental sources retain stable later attempts, allowing exposure to
+resume if an earlier episode resolves while the outbreak continues.
 
 Solo catch-up uses recorded co-presence only. An open span may cover the
 catching-up character through the lesser of their requested horizon and an

--- a/wiki/reference/physiology.md
+++ b/wiki/reference/physiology.md
@@ -89,8 +89,15 @@ Shared travel, camp rest, and treatment snapshot the explicitly co-advancing
 participants and their capability-pinned Physiology coverage before changing
 any clock. Every participant is previewed and committed against that immutable
 plan, so character ID and reducer iteration order cannot change prevention or
-transmission. Solo catch-up uses recorded co-presence only and never projects
-an absent physician into the interval.
+transmission. Community, blood, and contact acquisitions resolve together in
+absolute-minute order. Acquisitions within one minute are simultaneous and a
+new infection can transmit onward starting on the following minute, making
+secondary spread agree between one long interval and equivalent chunks.
+
+Solo catch-up uses recorded co-presence only. An open span may cover the
+catching-up character through the lesser of their requested horizon and an
+already-ahead peer's current clock, but never borrows time the peer has not
+elapsed.
 
 The authoritative database initializes private key material from runtime
 randomness and persists one private key for the lifetime of the database.

--- a/wiki/shared/health.md
+++ b/wiki/shared/health.md
@@ -67,6 +67,12 @@ transmission independent of character ID or reducer iteration order. Solo
 catch-up uses recorded co-presence only; it cannot borrow future protection
 from a physician who is not advancing with the patient.
 
+Community, blood, and close-contact acquisitions share one absolute-minute
+timeline. Characters infected in the same minute do not infect one another
+instantaneously; each becomes a possible contact source on the following
+minute. Long shared rests and equivalent shorter chunks therefore preserve the
+same secondary-spread chain.
+
 Prepared interventions act on the patient's condition rather than naming a
 disease they magically cure. Treatment may improve or worsen the evidence
 available to an observer, but never reveals hidden truth directly.

--- a/wiki/shared/health.md
+++ b/wiki/shared/health.md
@@ -44,6 +44,16 @@ water, vermin, wounds, or infected blood. Filth raises some risks. Blood on a
 character remains visibly dirty until washed, while its infectiousness fades
 over strategic time.
 
+Physiology knowledge in a co-located party passively reduces preventable
+exposure: physicians can warn against suspect food or water, separate close
+company, and reduce vermin contact. The reduction is dramatic for food, water,
+and close contact, bounded for vermin, and modest for infected blood. It never
+removes all risk. Wound acquisition remains Surgery's responsibility, and
+Physiology does not invent missing space, clean water, soap, bandages, or
+disinfectant. Those physical controls retain their stronger modeled effects.
+Infections capable of close-contact spread can pass between party members,
+including before symptoms make the source publicly identifiable.
+
 Prepared interventions act on the patient's condition rather than naming a
 disease they magically cure. Treatment may improve or worsen the evidence
 available to an observer, but never reveals hidden truth directly.

--- a/wiki/shared/health.md
+++ b/wiki/shared/health.md
@@ -54,6 +54,19 @@ disinfectant. Those physical controls retain their stronger modeled effects.
 Infections capable of close-contact spread can pass between party members,
 including before symptoms make the source publicly identifiable.
 
+The exposure calculation keeps the preventable behavior dose separate from
+unavoidable environmental dose. Existing physical state also caps the
+preventable share where relevant: soap-backed washing removes blood first,
+while an unprotected wound and unavailable clean handling sharply limit what
+knowledge alone can prevent.
+
+Shared sleep is the overnight form of close-contact co-presence. Sleep, travel,
+and treatment evaluate all co-advancing party members
+from one pre-action snapshot. This makes prevention and close-contact
+transmission independent of character ID or reducer iteration order. Solo
+catch-up uses recorded co-presence only; it cannot borrow future protection
+from a physician who is not advancing with the patient.
+
 Prepared interventions act on the patient's condition rather than naming a
 disease they magically cure. Treatment may improve or worsen the evidence
 available to an observer, but never reveals hidden truth directly.

--- a/wiki/strategic/time.md
+++ b/wiki/strategic/time.md
@@ -21,10 +21,18 @@ identical interval does not reroll exposure.
 
 Lazy catch-up and other solo elapsed-time actions do not project an absent
 companion forward and do not retroactively substitute the character's current
-Physiology rank. They use only recorded pair-presence history. Point actions
-can use the current rank without changing elapsed-time semantics. Planning
-prefetches and caps relevant presence spans and exposure work, so long rests
-remain bounded instead of rescanning all historical spans for every minute.
+Physiology rank. They use only recorded pair-presence history, including open
+span overlap through an already-ahead peer's current clock but never beyond
+it. Point actions can use the current rank without changing elapsed-time
+semantics. Planning fetches relevant spans through the low/high participant
+indexes, deduplicates them, compiles piecewise coverage, and caps both spans
+and exposure work.
+
+All assembled community, infected-blood, and contact candidates enter one
+absolute-minute timeline. Candidates in the same minute resolve
+simultaneously; a newly infected character becomes a contact source on the
+next minute. This preserves multi-person transmission chains across whole and
+chunked travel, sleep, treatment, rest, and catch-up intervals.
 
 The server stores official time as an absolute number of game minutes rather than a wrapping calendar value. A newly initialized world begins on August 20 at 00:00. A 365-day year is 525,600 minutes, and one game minute takes exactly 84/73 real seconds, making one game year one real week. Calendar displays wrap this absolute number into a day-of-year and time-of-day, but comparisons never wrap.
 

--- a/wiki/strategic/time.md
+++ b/wiki/strategic/time.md
@@ -33,6 +33,14 @@ absolute-minute timeline. Candidates in the same minute resolve
 simultaneously; a newly infected character becomes a contact source on the
 next minute. This preserves multi-person transmission chains across whole and
 chunked travel, sleep, treatment, rest, and catch-up intervals.
+Long-running outbreaks and local problems keep stable future attempts in that
+timeline, so exposure resumes after an earlier episode resolves instead of
+depending on where the player split the action.
+
+The interval work reservation includes both the side-effect-free infected-blood
+planning pass and the bounded checkpoint pass over the actually committed
+prefix. Raw indexed presence rows are rejected as soon as their deduplicated
+count exceeds the cap, before coverage materialization.
 
 The server stores official time as an absolute number of game minutes rather than a wrapping calendar value. A newly initialized world begins on August 20 at 00:00. A 365-day year is 525,600 minutes, and one game minute takes exactly 84/73 real seconds, making one game year one real week. Calendar displays wrap this absolute number into a day-of-year and time-of-day, but comparisons never wrap.
 

--- a/wiki/strategic/time.md
+++ b/wiki/strategic/time.md
@@ -8,6 +8,16 @@ by the interval. If terminal physiological failure occurs, the clock and all
 work stop at that exact minute. This prevents a long skip from jumping over a
 fatal peak into apparent recovery.
 
+The same centralized interval evaluation assembles settlement exposure,
+within-party close-contact transmission, and infected-blood exposure before
+acquisition. Preventive Physiology uses private, capability-pinned pair-presence
+spans at each absolute minute and clamps open spans to both characters' clocks.
+It therefore cannot grant protection or transmission for time a companion has
+not yet elapsed, and splitting an otherwise identical interval does not reroll
+exposure. A solo character has no retroactive interval fallback to their current
+Physiology rank; point actions can use the current rank without changing elapsed
+time semantics.
+
 The server stores official time as an absolute number of game minutes rather than a wrapping calendar value. A newly initialized world begins on August 20 at 00:00. A 365-day year is 525,600 minutes, and one game minute takes exactly 84/73 real seconds, making one game year one real week. Calendar displays wrap this absolute number into a day-of-year and time-of-day, but comparisons never wrap.
 
 The server stores an epoch rather than updating the clock table continuously. When a browser opens a page, it requests one snapshot of the character and official clocks and renders that snapshot without a wall-clock timer. The character snapshot also determines the interpolated location sky, the edge-to-edge sun or moon position, and building illumination until an explicit action returns a newer time. Authoritative reducers derive the current official minute from the epoch when gameplay needs it.

--- a/wiki/strategic/time.md
+++ b/wiki/strategic/time.md
@@ -10,13 +10,21 @@ fatal peak into apparent recovery.
 
 The same centralized interval evaluation assembles settlement exposure,
 within-party close-contact transmission, and infected-blood exposure before
-acquisition. Preventive Physiology uses private, capability-pinned pair-presence
-spans at each absolute minute and clamps open spans to both characters' clocks.
-It therefore cannot grant protection or transmission for time a companion has
-not yet elapsed, and splitting an otherwise identical interval does not reroll
-exposure. A solo character has no retroactive interval fallback to their current
-Physiology rank; point actions can use the current rank without changing elapsed
-time semantics.
+acquisition. Party travel, camp rest, and treatment first construct one
+immutable interval plan for the characters explicitly advancing together.
+That plan projects only those characters' open pair-presence spans through
+their shared horizon, then supplies the same acquisition proposals to every
+preview and commit. Participant iteration order therefore cannot change who
+was protected or infected. Existing closed spans and companions who are not
+co-advancing remain clamped to their recorded clocks. Splitting an otherwise
+identical interval does not reroll exposure.
+
+Lazy catch-up and other solo elapsed-time actions do not project an absent
+companion forward and do not retroactively substitute the character's current
+Physiology rank. They use only recorded pair-presence history. Point actions
+can use the current rank without changing elapsed-time semantics. Planning
+prefetches and caps relevant presence spans and exposure work, so long rests
+remain bounded instead of rescanning all historical spans for every minute.
 
 The server stores official time as an absolute number of game minutes rather than a wrapping calendar value. A newly initialized world begins on August 20 at 00:00. A 365-day year is 525,600 minutes, and one game minute takes exactly 84/73 real seconds, making one game year one real week. Calendar displays wrap this absolute number into a day-of-year and time-of-day, but comparisons never wrap.
 


### PR DESCRIPTION
## Summary

- make party Physiology reduce preventable food/water, close-contact, blood/caregiving, and partially preventable environmental disease exposure
- preserve route-specific residual risk so prevention changes behavior and exposure rather than pathogen biology or immunity
- add real within-party close-contact transmission, including shared sleeping and pre-symptomatic spread
- use immutable party interval plans across travel, camp, rest, treatment, and catch-up paths
- document the prevention model, privacy boundary, physical affordances, and strategic-time invariants

## Implementation

Route definitions separate preventable party-behavior exposure from unavoidable exposure. High Physiology is dramatic for food/water and close contact, bounded for vermin/environmental exposure, modest for blood handling, and ineffective for wound exposure owned by Surgery.

Eligible living, co-located supporters contribute through bounded party aggregation over their actual historical coverage. Point exposures and interval plans use indexed, deduplicated, capped presence reads.

Environmental, blood, and contact acquisition resolve on one deterministic absolute-minute timeline. Same-minute acquisitions are simultaneous and can become contact sources only on the following minute. The resolver evaluates unresolved disease and acquired immunity against its evolving state, preserving whole-versus-chunked results through multiple infection and reinfection cycles.

Long intervals keep environmental sources compact and skip unresolved disease periods to their exact resolution boundary. Reducer work and candidate counts fail closed under explicit transaction budgets.

## Review remediation

Independent correctness and security reviews drove several fixes:

- prospective coverage now uses explicit co-advancing horizons instead of current clocks
- preview and commit share one immutable, order-independent proposal plan
- multi-hop contact and blood-to-contact propagation are chronological and chunk invariant
- solo catch-up is capped by time already elapsed by the non-advancing companion
- environmental reinfection uses current acquired immunity rather than a stale pre-action snapshot
- global presence-history scans were replaced with indexed, early-capped reads
- one-year intervals no longer materialize one candidate per minute
- blood checkpoint recomputation is included in the bounded work budget

Final targeted reviewers reported no medium-or-higher findings.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `python scripts/update_project_map.py --check`
- `cargo test -p adventuresim-core disease` — 38 passed
- `cargo check -p adventuresim-stdb-module`
- `cargo check --workspace`

The native `adventuresim-stdb-module --lib` test target remains blocked by pre-existing unrelated broken `include_str!` paths and missing `STRATEGIC_SOURCE` imports. The production module compiles, while the extracted authoritative planner behavior is covered by executable core tests.

## Compatibility and rollback

No database schema, generated client binding, migration, or tactical persistence change is included. Reverting this PR restores the previous exposure behavior without a data migration.

Closes #294.
