### PR TITLE
Add dodge/parry defense with primitive bot AI

### DIFF
--- a/crates/adventuresim-core/src/combat.rs
+++ b/crates/adventuresim-core/src/combat.rs
@@ -69,7 +69,7 @@ impl Mul<f32> for AttackResult {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 pub enum DefenderResponse {
     #[default]
     None,

--- a/crates/adventuresim-stdb-client/src/mod.rs
+++ b/crates/adventuresim-stdb-client/src/mod.rs
@@ -1809,6 +1809,7 @@ pub enum Reducer {
         mission_id: String,
         scene_key: String,
         required_enemy_kills: u32,
+        tactical_claim: String,
     },
     SendLocalChatMessage {
         sender_id: u64,
@@ -2954,12 +2955,14 @@ Reducer::BeginWorldDataImport{
                 mission_id,
                 scene_key,
                 required_enemy_kills,
+                tactical_claim,
 }             => __sats::bsatn::to_vec(&seed_standalone_tactical_mission_reducer::SeedStandaloneTacticalMissionArgs {
                 bootstrap_token: bootstrap_token.clone(),
                 character_id: character_id.clone(),
                 mission_id: mission_id.clone(),
                 scene_key: scene_key.clone(),
                 required_enemy_kills: required_enemy_kills.clone(),
+                tactical_claim: tactical_claim.clone(),
 }),
             Reducer::SendLocalChatMessage{
                 sender_id,

--- a/crates/adventuresim-stdb-client/src/seed_standalone_tactical_mission_reducer.rs
+++ b/crates/adventuresim-stdb-client/src/seed_standalone_tactical_mission_reducer.rs
@@ -12,6 +12,7 @@ pub(super) struct SeedStandaloneTacticalMissionArgs {
     pub mission_id: String,
     pub scene_key: String,
     pub required_enemy_kills: u32,
+    pub tactical_claim: String,
 }
 
 impl From<SeedStandaloneTacticalMissionArgs> for super::Reducer {
@@ -22,6 +23,7 @@ impl From<SeedStandaloneTacticalMissionArgs> for super::Reducer {
             mission_id: args.mission_id,
             scene_key: args.scene_key,
             required_enemy_kills: args.required_enemy_kills,
+            tactical_claim: args.tactical_claim,
         }
     }
 }
@@ -48,6 +50,7 @@ pub trait seed_standalone_tactical_mission {
         mission_id: String,
         scene_key: String,
         required_enemy_kills: u32,
+        tactical_claim: String,
     ) -> __sdk::Result<()> {
         self.seed_standalone_tactical_mission_then(
             bootstrap_token,
@@ -55,6 +58,7 @@ pub trait seed_standalone_tactical_mission {
             mission_id,
             scene_key,
             required_enemy_kills,
+            tactical_claim,
             |_, _| {},
         )
     }
@@ -72,6 +76,7 @@ pub trait seed_standalone_tactical_mission {
         mission_id: String,
         scene_key: String,
         required_enemy_kills: u32,
+        tactical_claim: String,
 
         callback: impl FnOnce(
             &super::ReducerEventContext,
@@ -89,6 +94,7 @@ impl seed_standalone_tactical_mission for super::RemoteReducers {
         mission_id: String,
         scene_key: String,
         required_enemy_kills: u32,
+        tactical_claim: String,
 
         callback: impl FnOnce(
             &super::ReducerEventContext,
@@ -103,6 +109,7 @@ impl seed_standalone_tactical_mission for super::RemoteReducers {
                 mission_id,
                 scene_key,
                 required_enemy_kills,
+                tactical_claim,
             },
             callback,
         )

--- a/crates/adventuresim-stdb-module/src/strategic/mission_bootstrap.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/mission_bootstrap.rs
@@ -321,12 +321,16 @@ pub fn bootstrap_development_world(
 }
 
 /// Seed a standalone tactical mission: a solo party occupying a typed case
-/// site with a bound hostile group, mission, and tactical-server request.
+/// site with a bound hostile group, mission, tactical-server request, and
+/// its authorized claim.
 ///
 /// Lets an isolated, strategic-layer-free SpacetimeDB instance host a
 /// standalone tactical server/client test without hand-authoring party and
-/// quest state. Gated by the same development capability as
-/// [`bootstrap_development_world`].
+/// quest state, or running the trusted dispatcher to authorize a claim.
+/// `tactical_claim` is the plaintext one-use secret the caller will later
+/// launch the tactical server with (as `ADVENTURESIM_TACTICAL_CLAIM`); only
+/// its hash is stored, mirroring [`crate::tactical::authorize_tactical_server_claim`].
+/// Gated by the same development capability as [`bootstrap_development_world`].
 #[reducer]
 pub fn seed_standalone_tactical_mission(
     ctx: &ReducerContext,
@@ -335,6 +339,7 @@ pub fn seed_standalone_tactical_mission(
     mission_id: String,
     scene_key: String,
     required_enemy_kills: u32,
+    tactical_claim: String,
 ) -> Result<(), String> {
     if !adventuresim_core::simulation_security::simulation_bootstrap_authorized(
         COMPILED_DEV_BOOTSTRAP_TOKEN,
@@ -563,7 +568,7 @@ pub fn seed_standalone_tactical_mission(
     ctx.db
         .tactical_server_request_authority()
         .insert(crate::tactical::TacticalServerRequest {
-            mission_id,
+            mission_id: mission_id.clone(),
             gateway_bucket: 0,
             scene_key,
             party_id,
@@ -572,6 +577,12 @@ pub fn seed_standalone_tactical_mission(
             enemy_difficulty: mission.enemy_difficulty,
             enemy_combat_scale_bps: mission.enemy_combat_scale_bps,
             normalized_combat_power: mission.normalized_combat_power,
+        });
+    ctx.db
+        .tactical_server_claim()
+        .insert(crate::tactical::TacticalServerClaim {
+            mission_id,
+            claim_hash: Sha256::digest(tactical_claim.as_bytes()).to_vec(),
         });
     Ok(())
 }

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -1,6 +1,6 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
-    bevy_replicon::prelude::ClientTriggerExt, prelude::AttackRequest,
+    bevy_replicon::prelude::ClientTriggerExt, message::DefendRequest, prelude::AttackRequest,
 };
 use bevy::prelude::*;
 
@@ -54,6 +54,8 @@ impl Plugin for PlayerPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(on_new_player_added_hook)
             .add_observer(on_attack_fired_hook)
+            .add_observer(on_dodge_fired)
+            .add_observer(on_parry_fired)
             .add_systems(
                 Update,
                 (
@@ -142,6 +144,14 @@ fn on_new_player_added_hook(
                 (
                     Action::<Attack>::new(),
                     bindings![MouseButton::Left],
+                ),
+                (
+                    Action::<Dodge>::new(),
+                    bindings![KeyCode::KeyF],
+                ),
+                (
+                    Action::<Parry>::new(),
+                    bindings![KeyCode::KeyG],
                 ),
             ]),
         ));
@@ -298,4 +308,12 @@ fn update_character_look_rotation(
     for (mut transform, look) in &mut q_characters {
         transform.rotation = Quat::from_rotation_y(look.yaw + std::f32::consts::PI);
     }
+}
+
+fn on_dodge_fired(_event: On<Fire<Dodge>>, mut cmd: Commands) {
+    cmd.client_trigger(DefendRequest::Dodge);
+}
+
+fn on_parry_fired(_event: On<Fire<Parry>>, mut cmd: Commands) {
+    cmd.client_trigger(DefendRequest::Parry);
 }

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -1,6 +1,8 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
-    bevy_replicon::prelude::ClientTriggerExt, message::DefendRequest, prelude::AttackRequest,
+    bevy_replicon::prelude::ClientTriggerExt,
+    message::{AttackStartedRequest, DefendRequest},
+    prelude::AttackRequest,
 };
 use bevy::prelude::*;
 
@@ -297,6 +299,7 @@ fn on_attack_fired_hook(
 
     cmd.entity(event.context)
         .insert(AttackState::new(PRE_HIT_DELAY, reach));
+    cmd.client_trigger(AttackStartedRequest);
 }
 
 fn update_character_look_rotation(

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -559,9 +559,14 @@ fn on_successful_attack_display(
             children.spawn(TextSpan::new(": "));
             match event.result {
                 AttackResult::ToAttacker { balance_damage, .. } => {
+                    let reason = match event.defender_response {
+                        DefenderResponse::None => "Missed",
+                        DefenderResponse::Dodge { .. } => "Dodged",
+                        DefenderResponse::Parry { .. } => "Parried",
+                    };
                     children.spawn((ClassList::new("error"), TextSpan::new("fail")));
                     children.spawn(TextSpan::new(format!(
-                        "\n\nGot {balance_damage:.1} balance damage\n\n[part: {}]",
+                        "\n\n{reason}! Got {balance_damage:.1} balance damage\n\n[part: {}]",
                         event.body_part
                     )));
                 }

--- a/crates/adventuresim-tactical-core/src/combat.rs
+++ b/crates/adventuresim-tactical-core/src/combat.rs
@@ -3,3 +3,11 @@ use bevy_enhanced_input::prelude::InputAction;
 #[derive(Debug, InputAction, Default)]
 #[action_output(f32)]
 pub struct Attack;
+
+#[derive(Debug, InputAction, Default)]
+#[action_output(f32)]
+pub struct Dodge;
+
+#[derive(Debug, InputAction, Default)]
+#[action_output(f32)]
+pub struct Parry;

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -16,7 +16,7 @@ pub use avian3d;
 
 pub mod prelude {
     pub use crate::AdventureSimulatorCorePlugins;
-    pub use crate::combat::Attack;
+    pub use crate::combat::{Attack, Dodge, Parry};
     pub use crate::inventory::{
         ArmorItem, ArmorSide, ArmorSlot, EquipSlot, InventoryItems, ItemOf, ItemProperties,
         ItemQuantity, ShieldItem, WeaponItem,

--- a/crates/adventuresim-tactical-netcode/src/lib.rs
+++ b/crates/adventuresim-tactical-netcode/src/lib.rs
@@ -17,7 +17,9 @@ pub mod prelude {
     pub use crate::AdventureSimulatorNetPlugins;
     #[cfg(feature = "client")]
     pub use crate::client::AdventureSimulatorClient;
-    pub use crate::message::{AttackRequest, DefendRequest, JoinRequest, PlayerInputRequest};
+    pub use crate::message::{
+        AttackRequest, AttackStartedRequest, DefendRequest, JoinRequest, PlayerInputRequest,
+    };
     #[cfg(feature = "server")]
     pub use crate::server::AdventureSimulatorServer;
 }

--- a/crates/adventuresim-tactical-netcode/src/lib.rs
+++ b/crates/adventuresim-tactical-netcode/src/lib.rs
@@ -17,7 +17,7 @@ pub mod prelude {
     pub use crate::AdventureSimulatorNetPlugins;
     #[cfg(feature = "client")]
     pub use crate::client::AdventureSimulatorClient;
-    pub use crate::message::{AttackRequest, JoinRequest, PlayerInputRequest};
+    pub use crate::message::{AttackRequest, DefendRequest, JoinRequest, PlayerInputRequest};
     #[cfg(feature = "server")]
     pub use crate::server::AdventureSimulatorServer;
 }

--- a/crates/adventuresim-tactical-netcode/src/message.rs
+++ b/crates/adventuresim-tactical-netcode/src/message.rs
@@ -2,6 +2,16 @@ use adventuresim_tactical_core::prelude::*;
 use bevy::{ecs::entity::MapEntities, prelude::*};
 use serde::{Deserialize, Serialize};
 
+/// Sent by the client whenever the player presses dodge or parry.
+///
+/// This is a simplified version of [`DefenderResponse`] that omits
+/// `input_reflex` — the server computes reflex from timestamp delta.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Event, Serialize, Deserialize)]
+pub enum DefendRequest {
+    Dodge,
+    Parry,
+}
+
 #[derive(Debug, Clone, Copy, Event, Serialize, Deserialize)]
 pub struct JoinRequest {
     pub player_id: u64,

--- a/crates/adventuresim-tactical-netcode/src/message.rs
+++ b/crates/adventuresim-tactical-netcode/src/message.rs
@@ -12,6 +12,12 @@ pub enum DefendRequest {
     Parry,
 }
 
+/// Sent by the client the moment it starts a melee attack windup, before the
+/// hit itself is resolved. Carries no data of its own — the attacker is the
+/// message sender.
+#[derive(Debug, Clone, Copy, Event, Serialize, Deserialize)]
+pub struct AttackStartedRequest;
+
 #[derive(Debug, Clone, Copy, Event, Serialize, Deserialize)]
 pub struct JoinRequest {
     pub player_id: u64,
@@ -41,6 +47,7 @@ pub struct SuccessfulAttackResponse {
     pub body_part: BodyPart,
     pub result: AttackResult,
     pub flanking: f32,
+    pub defender_response: DefenderResponse,
 }
 
 impl SuccessfulAttackResponse {

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -5,7 +5,8 @@ use bevy_replicon::prelude::*;
 
 use crate::FIXED_TIMESTEP_HZ;
 use crate::message::{
-    AttackRequest, DefendRequest, JoinRequest, PlayerInputRequest, SuccessfulAttackResponse,
+    AttackRequest, AttackStartedRequest, DefendRequest, JoinRequest, PlayerInputRequest,
+    SuccessfulAttackResponse,
 };
 
 #[derive(Default)]
@@ -39,6 +40,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .add_client_event::<JoinRequest>(Channel::Ordered)
             .add_client_event::<PlayerInputRequest>(Channel::Unreliable)
             .add_client_event::<DefendRequest>(Channel::Unreliable)
+            .add_client_event::<AttackStartedRequest>(Channel::Unreliable)
             .add_mapped_client_event::<AttackRequest>(Channel::Ordered)
             .add_mapped_server_event::<SuccessfulAttackResponse>(Channel::Ordered);
 

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -4,7 +4,9 @@ use bevy::state::app::StatesPlugin;
 use bevy_replicon::prelude::*;
 
 use crate::FIXED_TIMESTEP_HZ;
-use crate::message::{AttackRequest, JoinRequest, PlayerInputRequest, SuccessfulAttackResponse};
+use crate::message::{
+    AttackRequest, DefendRequest, JoinRequest, PlayerInputRequest, SuccessfulAttackResponse,
+};
 
 #[derive(Default)]
 pub struct AdventureSimulatorReplicationPlugin;
@@ -36,6 +38,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .replicate::<SceneTerrain>()
             .add_client_event::<JoinRequest>(Channel::Ordered)
             .add_client_event::<PlayerInputRequest>(Channel::Unreliable)
+            .add_client_event::<DefendRequest>(Channel::Unreliable)
             .add_mapped_client_event::<AttackRequest>(Channel::Ordered)
             .add_mapped_server_event::<SuccessfulAttackResponse>(Channel::Ordered);
 

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -1,0 +1,155 @@
+use adventuresim_tactical_core::prelude::*;
+use adventuresim_tactical_netcode::{
+    bevy_replicon::prelude::FromClient,
+    message::{AttackStartedRequest, DefendRequest},
+};
+use bevy::prelude::*;
+
+use crate::{MissionState, combat::PendingDefenderResponse};
+
+/// Chance that a bot notices an incoming attack in time to parry it.
+const PARRY_CHANCE: f64 = 0.2;
+/// Chance that a bot notices an incoming attack in time to dodge it.
+const DODGE_CHANCE: f64 = 0.2;
+/// Flanking values at or below this are considered "facing each other" (see
+/// [`flanking_from_dir`]), which is the only case a bot can react at all.
+const FRONTAL_FLANKING_MAX: f32 = 0.01;
+/// Range (in seconds) a bot's reaction to a noticed attack is delayed by,
+/// simulating varying skill/reflexes between bots. A bot that rolls a long
+/// delay may end up committing its reaction only after the attack has
+/// already been resolved, i.e. reacting too late to matter.
+const REACTION_DELAY_SECS: std::ops::Range<f32> = 0.05..0.6;
+
+/// Marks a server-controlled bot filling in for a temporary (non-connected)
+/// mission character.
+#[derive(Component)]
+pub struct MissionEnemy;
+
+#[derive(Component)]
+pub struct CountedEnemyDeath;
+
+/// Emitted only by the server's authoritative combat/death pipeline. Combat
+/// damage is not implemented yet, so no client-controlled path can emit it and
+/// incomplete missions fail closed at timeout.
+#[derive(Event)]
+pub struct AuthoritativeEnemyDeath(pub Entity);
+
+/// A bot's yet-to-commit reaction to a noticed attack. Ticks down for
+/// [`REACTION_DELAY_SECS`] before becoming a [`PendingDefenderResponse`],
+/// simulating the bot's reflexes.
+#[derive(Component)]
+struct PendingBotReaction {
+    timer: Timer,
+    choice: DefendRequest,
+}
+
+pub struct BotPlugin;
+
+impl Plugin for BotPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_authoritative_enemy_death)
+            .add_observer(on_attack_started)
+            .add_systems(Update, tick_bot_reactions);
+    }
+}
+
+fn on_authoritative_enemy_death(
+    death: On<AuthoritativeEnemyDeath>,
+    enemies: Query<(), (With<MissionEnemy>, Without<CountedEnemyDeath>)>,
+    mut commands: Commands,
+    mut state: ResMut<MissionState>,
+) {
+    let entity = death.0;
+    if enemies.get(entity).is_err() {
+        return;
+    }
+    commands.entity(entity).insert(CountedEnemyDeath);
+    state.enemies_killed = state.enemies_killed.saturating_add(1);
+}
+
+pub fn mission_objective_satisfied(required: u32, killed: u32) -> bool {
+    killed >= required
+}
+
+/// Predicts, for every bot facing the attacker head-on, whether it notices
+/// this attack starting and, primitively, decides to dodge or parry it.
+///
+/// A bot has no real reflexes: it only ever gets a chance to react when it is
+/// facing its attacker (`flanking <= FRONTAL_FLANKING_MAX`), and even then it
+/// correctly reads the attack only some of the time. A decision to react is
+/// committed only after a random delay (see [`REACTION_DELAY_SECS`]).
+fn on_attack_started(
+    event: On<FromClient<AttackStartedRequest>>,
+    mut cmd: Commands,
+    q_character: Query<&CharacterLook>,
+    q_bots: Query<(Entity, &CharacterLook), With<MissionEnemy>>,
+) {
+    let Some(attacker) = event.client_id.entity() else {
+        return;
+    };
+    let Ok(attacker_look) = q_character.get(attacker) else {
+        return;
+    };
+    let (a2, a1) = attacker_look.yaw.sin_cos();
+
+    for (bot, bot_look) in &q_bots {
+        let (d2, d1) = bot_look.yaw.sin_cos();
+        if flanking_from_dir((a1, a2), (d1, d2)) > FRONTAL_FLANKING_MAX {
+            continue;
+        }
+
+        let Some(choice) = roll_defend_choice() else {
+            continue;
+        };
+
+        cmd.entity(bot).insert(PendingBotReaction {
+            timer: Timer::from_seconds(rand::random_range(REACTION_DELAY_SECS), TimerMode::Once),
+            choice,
+        });
+    }
+}
+
+fn roll_defend_choice() -> Option<DefendRequest> {
+    let roll: f64 = rand::random();
+    if roll < PARRY_CHANCE {
+        Some(DefendRequest::Parry)
+    } else if roll < PARRY_CHANCE + DODGE_CHANCE {
+        Some(DefendRequest::Dodge)
+    } else {
+        None
+    }
+}
+
+fn tick_bot_reactions(
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    mut q_reacting: Query<(Entity, &mut PendingBotReaction)>,
+) {
+    for (bot, mut reaction) in &mut q_reacting {
+        reaction.timer.tick(time.delta());
+        if !reaction.timer.is_finished() {
+            continue;
+        }
+
+        cmd.entity(bot)
+            .remove::<PendingBotReaction>()
+            .insert(PendingDefenderResponse {
+                choice: reaction.choice,
+                set_at: time.elapsed_secs(),
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mission_objective_satisfied;
+
+    #[test]
+    fn mission_success_requires_the_full_authoritative_objective() {
+        assert!(mission_objective_satisfied(0, 0));
+        assert!(!mission_objective_satisfied(3, 0));
+        assert!(!mission_objective_satisfied(3, 2));
+        assert!(mission_objective_satisfied(3, 3));
+        assert!(mission_objective_satisfied(3, 4));
+    }
+}

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -13,10 +13,13 @@ const MAX_REFLEX_WINDOW: f32 = 0.5;
 
 /// Stores the defender's most recent dodge/parry choice along with the
 /// server timestamp when it was received. Consumed on each attack resolution.
+///
+/// Set either by [`on_defender_response`] for a real player's key press, or by
+/// [`crate::bot`]'s AI standing in for a bot's reaction.
 #[derive(Component)]
-struct PendingDefenderResponse {
-    choice: DefendRequest,
-    set_at: f32,
+pub struct PendingDefenderResponse {
+    pub choice: DefendRequest,
+    pub set_at: f32,
 }
 
 pub struct CombatPlugin;
@@ -172,6 +175,7 @@ fn on_attack_action_triggered(
             body_part: event.body_part,
             result,
             flanking,
+            defender_response,
         },
     });
 }

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -1,16 +1,77 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::{FromClient, SendMode, ServerTriggerExt, ToClients},
-    message::SuccessfulAttackResponse,
+    message::{DefendRequest, SuccessfulAttackResponse},
     prelude::AttackRequest,
 };
 use bevy::prelude::*;
+
+/// Maximum window (in seconds) after pressing dodge/parry that the response
+/// is still considered valid. A fresh press gives `input_reflex = 1.0`;
+/// a press older than this window is treated as no response.
+const MAX_REFLEX_WINDOW: f32 = 0.5;
+
+/// Stores the defender's most recent dodge/parry choice along with the
+/// server timestamp when it was received. Consumed on each attack resolution.
+#[derive(Component)]
+struct PendingDefenderResponse {
+    choice: DefendRequest,
+    set_at: f32,
+}
 
 pub struct CombatPlugin;
 
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(on_attack_action_triggered);
+        app.add_observer(on_attack_action_triggered)
+            .add_observer(on_defender_response);
+    }
+}
+
+fn on_defender_response(
+    event: On<FromClient<DefendRequest>>,
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+) {
+    let Some(entity) = event.client_id.entity() else {
+        warn!(
+            "Got defender response from an unknown client: {:?}",
+            event.client_id
+        );
+        return;
+    };
+
+    cmd.entity(entity).insert(PendingDefenderResponse {
+        choice: **event,
+        set_at: time.elapsed_secs(),
+    });
+}
+
+fn resolve_defender_response(
+    pending: Option<&PendingDefenderResponse>,
+    time: &Time<()>,
+    defender_view: &TacticalPlayerView,
+) -> DefenderResponse {
+    let Some(pending) = pending else {
+        return DefenderResponse::None;
+    };
+
+    let elapsed = time.elapsed_secs() - pending.set_at;
+    if elapsed > MAX_REFLEX_WINDOW {
+        return DefenderResponse::None;
+    }
+
+    let input_reflex = (1.0 - elapsed / MAX_REFLEX_WINDOW).clamp(0.0, 1.0);
+
+    match pending.choice {
+        DefendRequest::Dodge => DefenderResponse::Dodge { input_reflex },
+        DefendRequest::Parry => {
+            if defender_view.shield_block_bonus() > 0.0 {
+                DefenderResponse::Parry { input_reflex }
+            } else {
+                DefenderResponse::None
+            }
+        }
     }
 }
 
@@ -20,6 +81,8 @@ fn on_attack_action_triggered(
     viewer: TacticalPlayerViewer,
     q_character: Query<&CharacterLook>,
     q_bestiary_categories: Query<&BestiaryCategories>,
+    q_pending: Query<&PendingDefenderResponse>,
+    time: Res<Time<()>>,
 ) {
     let Some(entity) = event.client_id.entity() else {
         warn!(
@@ -57,7 +120,12 @@ fn on_attack_action_triggered(
         return;
     };
 
-    let defender_response = DefenderResponse::Dodge { input_reflex: 1.0 };
+    let pending = q_pending.get(event.target).ok();
+    let defender_response = resolve_defender_response(pending, &time, &defender_view);
+
+    // Consume the pending response so it is not reused.
+    cmd.entity(event.target).remove::<PendingDefenderResponse>();
+
     let fallback_categories = BestiaryCategories::default();
     let defender_categories = q_bestiary_categories
         .get(event.target)

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -1,5 +1,6 @@
 //! Tactical Server - Replicon + Aeronet websocket game server
 
+mod bot;
 mod combat;
 mod stdb;
 mod terrain;
@@ -19,7 +20,7 @@ use bevy::prelude::*;
 use bevy::time::Stopwatch;
 use clap::{ArgAction, Parser};
 
-use crate::{stdb::SpacetimeDb, terrain::TerrainGenerator};
+use crate::{bot::MissionEnemy, stdb::SpacetimeDb, terrain::TerrainGenerator};
 use input::AccumulatedInput;
 
 /// Default [`Args::timeout`] time.
@@ -102,7 +103,11 @@ fn main() {
                 }),
             AdventureSimulatorNetPlugins,
         ))
-        .add_plugins((stdb::SpacetimeDbPlugin, combat::CombatPlugin))
+        .add_plugins((
+            stdb::SpacetimeDbPlugin,
+            combat::CombatPlugin,
+            bot::BotPlugin,
+        ))
         .insert_resource(MissionState {
             timeout: (!args.no_timeout)
                 .then_some(args.timeout)
@@ -124,7 +129,6 @@ fn main() {
         .add_observer(on_join_request)
         .add_observer(on_player_input)
         .add_observer(on_client_disconnected)
-        .add_observer(on_authoritative_enemy_death)
         .run();
 }
 
@@ -134,41 +138,11 @@ struct LoadingPlayer {
 }
 
 #[derive(Resource)]
-struct MissionState {
+pub struct MissionState {
     timeout: Option<Timer>,
-    enemies_killed: u32,
+    pub enemies_killed: u32,
     required_enemy_kills: u32,
     committed: bool,
-}
-
-#[derive(Component)]
-struct MissionEnemy;
-
-#[derive(Component)]
-struct CountedEnemyDeath;
-
-/// Emitted only by the server's authoritative combat/death pipeline. Combat
-/// damage is not implemented yet, so no client-controlled path can emit it and
-/// incomplete missions fail closed at timeout.
-#[derive(Event)]
-struct AuthoritativeEnemyDeath(Entity);
-
-fn mission_objective_satisfied(required: u32, killed: u32) -> bool {
-    killed >= required
-}
-
-fn on_authoritative_enemy_death(
-    death: On<AuthoritativeEnemyDeath>,
-    enemies: Query<(), (With<MissionEnemy>, Without<CountedEnemyDeath>)>,
-    mut commands: Commands,
-    mut state: ResMut<MissionState>,
-) {
-    let entity = death.0;
-    if enemies.get(entity).is_err() {
-        return;
-    }
-    commands.entity(entity).insert(CountedEnemyDeath);
-    state.enemies_killed = state.enemies_killed.saturating_add(1);
 }
 
 fn setup_server(mut commands: Commands, args: Res<Args>) {
@@ -497,7 +471,8 @@ fn check_mission_timeout(
     info!("Mission timeout, committing results...");
     state.committed = true;
 
-    let success = mission_objective_satisfied(state.required_enemy_kills, state.enemies_killed);
+    let success =
+        bot::mission_objective_satisfied(state.required_enemy_kills, state.enemies_killed);
     let xp_gained = (state.enemies_killed * 25) as i32;
 
     let resolution = if success {
@@ -625,20 +600,6 @@ fn on_join_request(
     );
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::mission_objective_satisfied;
-
-    #[test]
-    fn mission_success_requires_the_full_authoritative_objective() {
-        assert!(mission_objective_satisfied(0, 0));
-        assert!(!mission_objective_satisfied(3, 0));
-        assert!(!mission_objective_satisfied(3, 2));
-        assert!(mission_objective_satisfied(3, 3));
-        assert!(mission_objective_satisfied(3, 4));
-    }
 }
 
 fn on_player_input(

--- a/justfile
+++ b/justfile
@@ -286,7 +286,7 @@ client id=env_var_or_default("TACTICAL_CHARACTER_ID", "0") port=env_var_or_defau
 # No strategic layer, no WASM build - just the DB plus a mission. Writes
 # .env.tactical so a bare `just tactical` / `just client` (no arguments) in
 # other terminals targets it automatically.
-tactical-isolated profile="tactical-dev" base_port="23200" mission_id="test-mission" scene_key="hills" character_id="0" bots="3": preflight verify-db-client build-tactical
+tactical-isolated profile="tactical-dev" base_port="23200" mission_id="mission:test-mission" scene_key="hills" character_id="0" bots="3": preflight verify-db-client build-tactical
     @{{ python_bin }} scripts/dev_stack.py run-profile --mode tactical {{ quote(profile) }} {{ quote(base_port) }} --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --character-id {{ quote(character_id) }} --enemy-count {{ quote(bots) }}
 
 # Generate self-signed WebTransport certificates

--- a/scripts/dev_stack.py
+++ b/scripts/dev_stack.py
@@ -700,7 +700,7 @@ def run_profile(
     base_port: int,
     mode: ProfileMode = ProfileMode.STRATEGIC,
     verify_http: bool = False,
-    mission_id: str = "test-mission",
+    mission_id: str = "mission:test-mission",
     scene_key: str = "hills",
     character_id: int = 0,
     enemy_count: int = 3,
@@ -890,7 +890,7 @@ def create_parser() -> argparse.ArgumentParser:
     sub.add_parser("verify-bindings")
     runner = sub.add_parser("run-profile")
     runner.add_argument("--mode", choices=[m.value for m in ProfileMode], default=ProfileMode.STRATEGIC.value)
-    runner.add_argument("--mission-id", default="test-mission")
+    runner.add_argument("--mission-id", default="mission:test-mission")
     runner.add_argument("--scene-key", default="hills")
     runner.add_argument("--character-id", type=int, default=0)
     runner.add_argument("--enemy-count", type=int, default=3)

--- a/scripts/dev_stack.py
+++ b/scripts/dev_stack.py
@@ -388,6 +388,7 @@ def write_tactical_env_file(
     scene_key: str,
     character_id: int,
     enemy_count: int,
+    tactical_claim: str,
 ) -> None:
     TACTICAL_ENV_FILE.write_text(
         "\n".join([
@@ -398,6 +399,9 @@ def write_tactical_env_file(
             f"TACTICAL_SCENE_KEY={scene_key}",
             f"TACTICAL_CHARACTER_ID={character_id}",
             f"TACTICAL_BOTS={enemy_count}",
+            # Matches the tactical server's own `--tactical-claim` env fallback,
+            # so a bare `just tactical` picks it up with no extra flag.
+            f"ADVENTURESIM_TACTICAL_CLAIM={tactical_claim}",
             "",
         ])
     )
@@ -767,10 +771,12 @@ def run_profile(
                 return code
 
             if mode is ProfileMode.TACTICAL:
+                tactical_claim = secrets.token_hex(32)
                 result = run_checked([
                     "spacetime", "call", "--server", server, database,
                     "seed_standalone_tactical_mission", bootstrap_token,
                     str(character_id), mission_id, scene_key, str(enemy_count),
+                    tactical_claim,
                 ])
                 write_console(result.stdout)
                 if result.returncode:
@@ -780,6 +786,7 @@ def run_profile(
                     url=server, database=database, port=int(values["tactical_port"]),
                     mission_id=mission_id, scene_key=scene_key,
                     character_id=character_id, enemy_count=enemy_count,
+                    tactical_claim=tactical_claim,
                 )
                 wrote_tactical_env = True
                 print("")

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -234,7 +234,7 @@ class WorkflowTests(unittest.TestCase):
             "run-profile", "--mode", "tactical", "demo", "23100",
         ])
         self.assertEqual(args.mode, "tactical")
-        self.assertEqual(args.mission_id, "test-mission")
+        self.assertEqual(args.mission_id, "mission:test-mission")
         self.assertEqual(args.scene_key, "hills")
         self.assertEqual(args.character_id, 0)
         self.assertEqual(args.enemy_count, 3)

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -322,6 +322,7 @@ class WorkflowTests(unittest.TestCase):
                 scene_key="hills",
                 character_id=0,
                 enemy_count=3,
+                tactical_claim="deadbeef",
             )
             content = dev_stack.TACTICAL_ENV_FILE.read_text()
             self.assertIn("TACTICAL_SPACETIMEDB_URL=http://127.0.0.1:23310", content)
@@ -331,6 +332,7 @@ class WorkflowTests(unittest.TestCase):
             self.assertIn("TACTICAL_SCENE_KEY=hills", content)
             self.assertIn("TACTICAL_CHARACTER_ID=0", content)
             self.assertIn("TACTICAL_BOTS=3", content)
+            self.assertIn("ADVENTURESIM_TACTICAL_CLAIM=deadbeef", content)
             dev_stack.remove_tactical_env_file()
             self.assertFalse(dev_stack.TACTICAL_ENV_FILE.exists())
             dev_stack.remove_tactical_env_file()


### PR DESCRIPTION
## Summary
- Add client-driven dodge/parry: pressing dodge/parry sends a `DefendRequest`; the server tracks it in a reflex window (`PendingDefenderResponse`) and applies it to the next incoming attack resolution.
- Add primitive bot AI (`bot.rs`): bots react to an `AttackStartedRequest` telegraph sent when a player begins their attack windup, deciding to parry (20%), dodge (20%), or do nothing (60%) only when facing the attacker head-on, after a randomized reaction delay to simulate varying skill.
- Surface the failure reason (Missed/Dodged/Parried) in the tactical client's attack-result UI.
- Fix `just tactical-isolated`: the standalone mission seed reducer now requires a canonical `mission:`-prefixed ID and authorizes a `TacticalServerClaim` for itself (previously only the trusted dispatcher could), so `just tactical`/`just client` work against an isolated stack without hand-authorizing a claim.

Part of #29.