### PR TITLE
Remount rest controls after Datastar updates

### DIFF
--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -206,7 +206,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/building-state.js?v=non-service-building-tabs-2" defer {}
                     script src="/static/travel-planner.js?v=travel-rails-1" defer {}
                     script src="/static/strategic-map.js?v=population-culling-3" defer {}
-                    script src="/static/rest-duration.js?v=wake-time-3" defer {}
+                    script src="/static/rest-duration.js?v=wake-time-4" defer {}
                     script src="/static/training-schedule.js?v=apprentice-system-1" defer {}
                     script src="/static/immediate-activity.js?v=manual-activities-1" defer {}
                 }

--- a/crates/strategic-web/static/rest-duration.js
+++ b/crates/strategic-web/static/rest-duration.js
@@ -51,13 +51,10 @@
   };
   if (typeof document === "undefined") return;
 
-  const mounted = new WeakSet();
   const dirty = new WeakSet();
   const states = new WeakMap();
 
   const mount = (control) => {
-    if (mounted.has(control)) return;
-    mounted.add(control);
     const form = control.closest("form");
     const duration = control.querySelector("[data-rest-duration-input]");
     const exact = control.querySelector("[data-rest-exact-minutes]");
@@ -66,6 +63,22 @@
     const panel = control.querySelector("[data-wake-time-panel]");
     const submit = form.querySelector("[data-rest-submit]");
     const radios = [...control.querySelectorAll("input[type=radio][name=unit]")];
+    const buttons = [...control.querySelectorAll("[data-rest-step]")];
+    const signature = [
+      duration, exact, slider, output, panel, submit, ...radios, ...buttons,
+      control.dataset.restMinimumMinutes ?? "",
+      control.dataset.restDefaultMinutes ?? "",
+      control.dataset.restScheduledWakeMinute ?? "",
+    ];
+    const previous = states.get(control);
+    if (previous?.signature.length === signature.length
+      && previous.signature.every((value, index) => value === signature[index])) return;
+    previous?.listeners.abort();
+    dirty.delete(control);
+    const listeners = new AbortController();
+    const listen = (target, type, listener) => target.addEventListener(type, listener, {
+      signal: listeners.signal,
+    });
     const minimumMinutes = Math.max(1, Math.round(Number(control.dataset.restMinimumMinutes) || DAY_MINUTES));
     const defaultMinutes = Math.max(0, Math.round(Number(control.dataset.restDefaultMinutes) || 0));
     const scheduledWakeMinute = control.dataset.restScheduledWakeMinute === undefined
@@ -123,7 +136,7 @@
     setTarget(scheduledWakeMinute ?? (characterMinutes !== null && defaultMinutes > 0
       ? targetForDuration(characterMinutes, defaultMinutes)
       : 480));
-    slider.addEventListener("input", () => {
+    listen(slider, "input", () => {
       dirty.add(control);
       const clock = formatClock(slider.value);
       output.value = clock;
@@ -131,8 +144,8 @@
       slider.setAttribute("aria-valuetext", clock);
       if (characterMinutes !== null) setHoursMinutes(minutesUntilWakeWithMinimum(characterMinutes, slider.value, minimumMinutes));
     });
-    slider.addEventListener("pointerdown", () => { slider.step = "60"; });
-    slider.addEventListener("keydown", (event) => {
+    listen(slider, "pointerdown", () => { slider.step = "60"; });
+    listen(slider, "keydown", (event) => {
       const direction = ["ArrowRight", "ArrowUp"].includes(event.key) ? 1
         : ["ArrowLeft", "ArrowDown"].includes(event.key) ? -1 : 0;
       if (!direction) return;
@@ -145,7 +158,7 @@
       slider.value = Math.min(1_380, Math.max(0, next));
       slider.dispatchEvent(new Event("input", { bubbles: true }));
     });
-    duration.addEventListener("input", () => {
+    listen(duration, "input", () => {
       dirty.add(control);
       if (selectedUnit() === "days") {
         const value = Number(duration.value);
@@ -165,7 +178,7 @@
       submit.disabled = false;
       setTarget(targetForDuration(characterMinutes, durationMinutes));
     });
-    duration.addEventListener("change", () => {
+    listen(duration, "change", () => {
       if (selectedUnit() === "hours") {
         const durationMinutes = parseDuration(duration.value);
         duration.value = formatDuration(durationMinutes === null ? minimumMinutes : Math.max(minimumMinutes, durationMinutes));
@@ -173,11 +186,11 @@
       if (selectedUnit() === "days" && Number(duration.value) < 1) duration.value = "1";
       duration.dispatchEvent(new Event("input", { bubbles: true }));
     });
-    radios.forEach((radio) => radio.addEventListener("change", () => {
+    radios.forEach((radio) => listen(radio, "change", () => {
       dirty.add(control);
       applyUnit();
     }));
-    control.querySelectorAll("[data-rest-step]").forEach((button) => button.addEventListener("click", () => {
+    buttons.forEach((button) => listen(button, "click", () => {
       dirty.add(control);
       if (selectedUnit() === "hours") {
         const current = parseDuration(duration.value) ?? minimumMinutes;
@@ -189,6 +202,8 @@
       duration.dispatchEvent(new Event("change", { bubbles: true }));
     }));
     states.set(control, {
+      signature,
+      listeners,
       syncTime(minutes) {
         characterMinutes = Number(minutes);
         if (selectedUnit() === "hours") {
@@ -214,6 +229,14 @@
   };
 
   const mountAll = (root = document) => root.querySelectorAll?.("[data-wake-time]").forEach(mount);
+  const mountAdded = (root) => {
+    if (root.matches?.("[data-wake-time]")) mount(root);
+    const owner = root.closest?.("[data-wake-time]");
+    if (owner) mount(owner);
+    const form = root.matches?.("form") ? root : root.closest?.("form");
+    if (form) mountAll(form);
+    mountAll(root);
+  };
   const isDirty = (root = document) => [...root.querySelectorAll?.("[data-wake-time]") || []]
     .some((control) => dirty.has(control));
   const syncTime = (root, minutes) => {
@@ -249,6 +272,21 @@
   window.strategicRestDuration = { isDirty, mountAll };
   mountAll();
   mountRestSummary();
+  if (typeof MutationObserver !== "undefined") {
+    new MutationObserver((records) => records.forEach((record) => {
+      if (record.type === "attributes") mountAdded(record.target);
+      else record.addedNodes.forEach(mountAdded);
+    })).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: [
+        "data-rest-minimum-minutes",
+        "data-rest-default-minutes",
+        "data-rest-scheduled-wake-minute",
+      ],
+      childList: true,
+      subtree: true,
+    });
+  }
   document.addEventListener("strategic-page-mounted", () => {
     mountAll();
     mountRestSummary();

--- a/crates/strategic-web/tests/rest-duration.test.cjs
+++ b/crates/strategic-web/tests/rest-duration.test.cjs
@@ -76,54 +76,99 @@ test("wake slider uses the travel rail's solid time-period colors", () => {
   }
 });
 
-test("controls remount after replacement and keep independent days state", () => {
+test("controls remount when raw DOM patches repeatedly replace only their descendants", () => {
   const fs = require("node:fs");
   const vm = require("node:vm");
   const source = fs.readFileSync("crates/strategic-web/static/rest-duration.js", "utf8");
   const documentListeners = {};
+  let mutationCallback;
   let liveControls = [];
 
   const eventTarget = (properties = {}) => {
     const listeners = {};
     return {
       ...properties,
-      addEventListener(type, listener) { (listeners[type] ||= []).push(listener); },
-      dispatchEvent(event) { (listeners[event.type] || []).forEach((listener) => listener(event)); },
+      addEventListener(type, listener, options = {}) {
+        (listeners[type] ||= []).push({ listener, signal: options.signal });
+      },
+      dispatchEvent(event) {
+        (listeners[event.type] || []).forEach(({ listener, signal }) => {
+          if (!signal?.aborted) listener(event);
+        });
+      },
       setAttribute(name, value) { this[name] = String(value); },
     };
   };
   const makeControl = (unit, value, dataset = {}) => {
-    const submit = { disabled: false };
-    const form = { querySelector: () => submit };
-    const labels = [{ classList: { toggle() {} } }, { classList: { toggle() {} } }];
-    const radios = ["hours", "days"].map((radioUnit, index) => eventTarget({
-      checked: radioUnit === unit,
-      value: radioUnit,
-      closest: () => labels[index],
-    }));
-    const duration = eventTarget({ value: String(value), min: "", max: "", step: "" });
-    const exact = { value: "", disabled: false };
-    const slider = eventTarget({ value: "480", step: "60", disabled: false });
-    const output = { value: "", textContent: "" };
-    const panel = { setAttribute(name, panelValue) { this[name] = String(panelValue); } };
-    const buttons = [eventTarget({ dataset: { restStep: "-1" } }), eventTarget({ dataset: { restStep: "1" } })];
-    const bySelector = new Map([
-      ["[data-rest-duration-input]", duration], ["[data-rest-exact-minutes]", exact],
-      ["[data-wake-time-slider]", slider], ["[data-wake-time-output]", output],
-      ["[data-wake-time-panel]", panel], ["[data-rest-unit-label]", { textContent: "" }],
-    ]);
-    const control = {
-      dataset,
-      closest: () => form,
-      querySelector: (selector) => bySelector.get(selector),
-      querySelectorAll: (selector) => selector.includes("radio") ? radios : buttons,
+    let submit;
+    let control;
+    const form = {
+      querySelector: () => submit,
+      querySelectorAll: (selector) => selector === "[data-wake-time]" ? [control] : [],
     };
-    return { buttons, control, duration, exact, radios, slider, submit };
+    let bySelector;
+    let radios;
+    let buttons;
+    control = {
+      dataset,
+      closest: (selector) => selector === "form" ? form : null,
+      matches: (selector) => selector === "[data-wake-time]",
+      querySelector: (selector) => bySelector.get(selector),
+      querySelectorAll: (selector) => {
+        if (selector.includes("radio")) return radios;
+        if (selector === "[data-rest-step]") return buttons;
+        return [];
+      },
+    };
+    const fixture = { control };
+    fixture.replaceSubmit = () => {
+      submit = { disabled: false, closest: (selector) => selector === "form" ? form : null };
+      fixture.submit = submit;
+    };
+    fixture.replaceChildren = (nextUnit, nextValue) => {
+      const labels = [{ classList: { toggle() {} } }, { classList: { toggle() {} } }];
+      const owner = (selector) => selector === "[data-wake-time]" ? control : null;
+      radios = ["hours", "days"].map((radioUnit, index) => eventTarget({
+        checked: radioUnit === nextUnit,
+        value: radioUnit,
+        closest: (selector) => selector === "label" ? labels[index] : owner(selector),
+      }));
+      const duration = eventTarget({
+        value: String(nextValue), min: "", max: "", step: "", closest: owner,
+      });
+      const exact = { value: "", disabled: false };
+      const slider = eventTarget({
+        value: "480", step: "60", disabled: false, closest: owner,
+      });
+      const output = { value: "", textContent: "" };
+      const panel = { setAttribute(name, panelValue) { this[name] = String(panelValue); } };
+      buttons = ["-1", "1"].map((restStep) => eventTarget({
+        dataset: { restStep }, closest: owner,
+      }));
+      bySelector = new Map([
+        ["[data-rest-duration-input]", duration], ["[data-rest-exact-minutes]", exact],
+        ["[data-wake-time-slider]", slider], ["[data-wake-time-output]", output],
+        ["[data-wake-time-panel]", panel], ["[data-rest-unit-label]", { textContent: "" }],
+      ]);
+      Object.assign(fixture, { buttons, duration, exact, radios, slider });
+    };
+    fixture.replaceSubmit();
+    fixture.replaceChildren(unit, value);
+    return fixture;
   };
   const document = {
+    documentElement: {},
     querySelectorAll: () => liveControls.map(({ control }) => control),
     addEventListener(type, listener) { (documentListeners[type] ||= []).push(listener); },
   };
+  class MutationObserver {
+    constructor(callback) { mutationCallback = callback; }
+    observe() {}
+  }
+  class AbortController {
+    constructor() { this.signal = { aborted: false }; }
+    abort() { this.signal.aborted = true; }
+  }
   const window = { strategicCharacterMinutes: 480 };
   class Event {
     constructor(type, options = {}) { this.type = type; Object.assign(this, options); }
@@ -131,7 +176,9 @@ test("controls remount after replacement and keep independent days state", () =>
   }
   const first = makeControl("hours", "24:00");
   liveControls = [first];
-  vm.runInNewContext(source, { document, window, Event, Number, Math, String, WeakMap, WeakSet });
+  vm.runInNewContext(source, {
+    AbortController, document, window, Event, MutationObserver, Number, Math, String, WeakMap, WeakSet,
+  });
 
   first.radios[0].checked = false;
   first.radios[1].checked = true;
@@ -140,29 +187,63 @@ test("controls remount after replacement and keep independent days state", () =>
   assert.equal(first.exact.disabled, true);
   assert.equal(window.strategicRestDuration.isDirty(document), true);
 
-  const replacement = makeControl("hours", "24:00");
-  liveControls = [replacement];
-  documentListeners["strategic-live-regions-refreshed"][0](new Event("strategic-live-regions-refreshed"));
-  assert.equal(replacement.duration.value, "24:00");
-  assert.equal(replacement.submit.disabled, false);
-  assert.equal(replacement.control.dataset.wakeTimeMounted, undefined);
+  const exerciseReplacement = () => {
+    first.replaceChildren("hours", "24:00");
+    const record = [{ addedNodes: [first.duration] }];
+    mutationCallback(record);
+    mutationCallback(record);
+    assert.equal(first.duration.value, "24:00");
+    assert.equal(first.submit.disabled, false);
 
-  replacement.duration.value = "25:30";
-  replacement.duration.dispatchEvent(new Event("input"));
-  assert.equal(replacement.exact.value, "1530");
-  assert.equal(replacement.slider.value, 570);
-  assert.equal(replacement.slider.step, "1");
+    first.duration.value = "25:30";
+    first.duration.dispatchEvent(new Event("input"));
+    assert.equal(first.exact.value, "1530");
+    assert.equal(first.slider.value, 570);
 
-  replacement.slider.dispatchEvent(new Event("keydown", { key: "ArrowRight" }));
-  assert.equal(replacement.slider.value, 600);
-  assert.equal(replacement.duration.value, "26:00");
+    first.buttons[1].dispatchEvent(new Event("click"));
+    assert.equal(first.duration.value, "26:30", "one click has one handler");
+    first.buttons[0].dispatchEvent(new Event("click"));
+    assert.equal(first.duration.value, "25:30");
 
-  replacement.slider.dispatchEvent(new Event("pointerdown"));
-  assert.equal(replacement.slider.step, "60");
+    first.radios[0].checked = false;
+    first.radios[1].checked = true;
+    first.radios[1].dispatchEvent(new Event("change"));
+    first.duration.value = "5";
+    first.duration.dispatchEvent(new Event("input"));
+    first.buttons[1].dispatchEvent(new Event("click"));
+    assert.equal(first.duration.value, "6", "days increment once");
+    first.buttons[0].dispatchEvent(new Event("click"));
+    assert.equal(first.duration.value, "5");
 
-  replacement.buttons[1].dispatchEvent(new Event("click"));
-  assert.equal(replacement.duration.value, "27:00");
-  assert.equal(replacement.exact.value, "1620");
+    first.radios[0].checked = true;
+    first.radios[1].checked = false;
+    first.radios[0].dispatchEvent(new Event("change"));
+    assert.equal(first.duration.value, "25:30");
+    first.slider.dispatchEvent(new Event("keydown", { key: "ArrowRight" }));
+    assert.equal(first.slider.value, 600);
+    assert.equal(first.duration.value, "26:00");
+  };
+
+  exerciseReplacement();
+  exerciseReplacement();
+
+  first.replaceSubmit();
+  mutationCallback([{ type: "childList", addedNodes: [first.submit] }]);
+  first.duration.value = "invalid";
+  first.duration.dispatchEvent(new Event("input"));
+  assert.equal(first.submit.disabled, true, "replacement submit receives invalid state");
+  first.duration.value = "26:00";
+  first.duration.dispatchEvent(new Event("input"));
+  assert.equal(first.submit.disabled, false, "replacement submit receives valid state");
+
+  first.control.dataset.restMinimumMinutes = "2880";
+  mutationCallback([{ type: "attributes", target: first.control }]);
+  first.duration.value = "25:00";
+  first.duration.dispatchEvent(new Event("input"));
+  assert.equal(first.submit.disabled, true, "updated minimum applies after attribute-only morph");
+  first.duration.value = "48:00";
+  first.duration.dispatchEvent(new Event("input"));
+  assert.equal(first.submit.disabled, false);
 
   const scheduled = makeControl("hours", "16:00", {
     restDefaultMinutes: "960",


### PR DESCRIPTION
## What changed

- Remount wake-time controls after full or partial Datastar DOM replacement.
- Tear down stale listeners with `AbortController` and keep repeated mounts idempotent.
- Detect replaced submit siblings and attribute-only rest-configuration morphs.
- Bump the rest-duration asset cache key.

## Why

Datastar could preserve the rest-control parent while replacing its descendants or adjacent submit button. Existing closures then referenced detached elements, leaving Hours/Days, the slider, or step buttons unresponsive.

Part of #337.

## Validation

- `node --test crates/strategic-web/tests/rest-duration.test.cjs` (8 passed)
- `cargo check -p strategic-web --all-targets`
- `cargo fmt --all -- --check`
- `python scripts/update_project_map.py --check`
- `git diff --check`

The regression covers repeated descendant replacement, duplicate mutation delivery, submit-sibling replacement, and attribute-only configuration updates.
