### PR TITLE
Synchronize strategic clock accessibility text

### DIFF
--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -283,7 +283,8 @@ fn settlement_top_bar(
                 a href=(format!("/locations/settlement/{}", settlement_id)) class="settlement-name" {
                     (settlement_name)
                 }
-                span class="settlement-time" data-player-time title="Loading official time…" {
+                span class="settlement-time" data-player-time title="Loading official time…"
+                    aria-label="1st of First Seed · 08:00" {
                     "1st of First Seed · 08:00"
                 }
                 }
@@ -419,7 +420,7 @@ fn settlement_top_bar(
                 }
             }
         }
-        script src="/static/strategic-time.js?v=continuous-environment-1" {}
+        script src="/static/strategic-time.js?v=accessible-clock-1" {}
     }
 }
 
@@ -480,7 +481,8 @@ fn quest_location_top_bar(
                     } @else {
                         a href=(format!("/locations/case-site/{}", location_id)) class="settlement-name" { (location_name) }
                     }
-                    span class="settlement-time" data-player-time { "1st of First Seed · 08:00" }
+                    span class="settlement-time" data-player-time
+                        aria-label="1st of First Seed · 08:00" { "1st of First Seed · 08:00" }
                 }
                 (journal_button())
             }
@@ -530,7 +532,7 @@ fn quest_location_top_bar(
                 }
             }
         }
-        script src="/static/strategic-time.js?v=continuous-environment-1" {}
+        script src="/static/strategic-time.js?v=accessible-clock-1" {}
     }
 }
 

--- a/crates/strategic-web/static/strategic-time.js
+++ b/crates/strategic-web/static/strategic-time.js
@@ -81,9 +81,12 @@
     .then((response) => response.json())
     .then(({ character_minutes: characterMinutes, official_minutes: officialMinutes }) => {
       window.strategicCharacterMinutes = characterMinutes;
+      const characterTime = format(characterMinutes);
+      const officialTime = format(officialMinutes);
       document.querySelectorAll("[data-player-time]").forEach((element) => {
-        element.textContent = format(characterMinutes);
-        element.title = `Official time: ${format(officialMinutes)}`;
+        element.textContent = characterTime;
+        element.setAttribute("aria-label", characterTime);
+        element.title = `Official time: ${officialTime}`;
       });
       applyLighting(characterMinutes);
       document.dispatchEvent(new CustomEvent("strategic-time-ready", {

--- a/crates/strategic-web/tests/live-refresh.test.cjs
+++ b/crates/strategic-web/tests/live-refresh.test.cjs
@@ -6,6 +6,58 @@ const vm = require("node:vm");
 
 const root = path.join(__dirname, "..");
 
+test("all strategic clock script references use the accessible clock cache key", () => {
+  const layout = fs.readFileSync(path.join(root, "src", "templates", "layout.rs"), "utf8");
+  const references = [...layout.matchAll(/\/static\/strategic-time\.js\?v=([^\"]+)/g)]
+    .map((match) => match[1]);
+  assert.deepEqual(references, ["accessible-clock-1", "accessible-clock-1"]);
+});
+
+test("strategic clock refresh keeps visible and accessible character time synchronized", async () => {
+  const source = fs.readFileSync(path.join(root, "static", "strategic-time.js"), "utf8");
+  const attributes = new Map();
+  const listeners = new Map();
+  const responses = [
+    { character_minutes: 1505, official_minutes: 2945 },
+    { character_minutes: 2946, official_minutes: 4386 },
+  ];
+  const clock = {
+    textContent: "1st of First Seed · 08:00",
+    title: "Loading official time…",
+    setAttribute(name, value) { attributes.set(name, value); },
+  };
+  const document = {
+    documentElement: { style: { setProperty() {} } },
+    querySelectorAll: () => [clock],
+    dispatchEvent() {},
+    addEventListener(type, listener) { listeners.set(type, listener); },
+  };
+  const window = {
+    queueStrategicInitialLoad: (load) => Promise.resolve().then(load),
+    strategicBackgroundFetch: async () => ({
+      json: async () => responses.shift(),
+    }),
+    reportStrategicError(error) { throw error; },
+  };
+  class CustomEvent {
+    constructor(type, init) { this.type = type; this.detail = init.detail; }
+  }
+
+  vm.runInNewContext(source, { window, document, CustomEvent, Promise });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(clock.textContent, "Day 2 · 01:05");
+  assert.equal(attributes.get("aria-label"), clock.textContent);
+  assert.equal(clock.title, "Official time: Day 3 · 01:05");
+
+  listeners.get("strategic-page-mounted")();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(clock.textContent, "Day 3 · 01:06");
+  assert.equal(attributes.get("aria-label"), clock.textContent);
+  assert.equal(clock.title, "Official time: Day 4 · 01:06");
+});
+
 test("SSE subscribes before reading its initial revision", () => {
   const source = fs.readFileSync(path.join(root, "src", "live.rs"), "utf8");
   const subscribe = source.indexOf("let receiver = state.live.subscribe()");


### PR DESCRIPTION
## What changed

- Keep the strategic clock's visible text and accessible name synchronized to character time.
- Retain official server time as supplemental tooltip text.
- Apply the behavior on initial load and subsequent strategic-page mounts.
- Bump both strategic-time asset cache keys together.

## Why

The page displayed character time visually while assistive technology could expose stale or official time, producing conflicting clock values.

Part of #337.

## Validation

- `node --test crates/strategic-web/tests/live-refresh.test.cjs` (5 passed)
- `cargo check -p strategic-web --all-targets`
- `cargo fmt --all -- --check`
- `python scripts/update_project_map.py --check`
- `git diff --check`

The regression covers initial and repeated lifecycle refreshes and locks both layout references to the same cache key.
