### PR TITLE
Treat settlement rest as indoor shelter

### DIFF
--- a/crates/adventuresim-core/src/survival.rs
+++ b/crates/adventuresim-core/src/survival.rs
@@ -46,17 +46,21 @@ pub enum FieldShelter {
     #[default]
     Bivouac,
     Tent,
+    /// A settlement building whose interior protects occupants from ambient
+    /// thermal loading as well as precipitation and wind.
+    Indoor,
 }
 
 impl FieldShelter {
     pub const fn blocks_rain(self) -> bool {
-        matches!(self, Self::Tent)
+        matches!(self, Self::Tent | Self::Indoor)
     }
 
     pub const fn wind_multiplier_bps(self) -> u16 {
         match self {
             Self::Bivouac => 10_000,
             Self::Tent => 2_500,
+            Self::Indoor => 0,
         }
     }
 }
@@ -168,6 +172,13 @@ fn next_thermal_strain(
     clothing: ClothingExposure,
     shelter: FieldShelter,
 ) -> i32 {
+    // Settlement downtime happens inside a building rather than in a tent
+    // pitched outdoors. Ignore the exterior temperature while indoors and
+    // let any existing strain recover at the same bounded neutral rate used
+    // for comfortable weather.
+    if shelter == FieldShelter::Indoor {
+        return strain - strain.signum();
+    }
     const COMFORT_DECI_C: i32 = 180;
     let wind =
         i32::from(weather.wind_speed_bps) * i32::from(shelter.wind_multiplier_bps()) / 10_000;
@@ -306,6 +317,35 @@ mod tests {
             .thermal_strain,
             0
         );
+    }
+
+    #[test]
+    fn indoor_rest_does_not_create_extreme_thermal_exposure() {
+        for weather in [weather(-800, 10_000, true), weather(500, 0, false)] {
+            let outcome = advance_exposure(
+                SurvivalState::default(),
+                [weather; 1_440],
+                ClothingExposure::default(),
+                FieldShelter::Indoor,
+            );
+            assert_eq!(outcome.state.thermal_strain, 0);
+            assert_eq!(thermal_incapacitation(outcome.state.thermal_strain), 0.0);
+            assert!(outcome.frostbite_event_offsets.is_empty());
+        }
+
+        let recovering = advance_exposure(
+            SurvivalState {
+                wetness_bps: MAX_WETNESS_BPS,
+                thermal_strain: COLD_STAGGER_STRAIN,
+                frostbite_progress_minutes: 10,
+            },
+            [weather(-800, 10_000, true); 60],
+            ClothingExposure::default(),
+            FieldShelter::Indoor,
+        );
+        assert!(recovering.state.wetness_bps < MAX_WETNESS_BPS);
+        assert!(recovering.state.thermal_strain > COLD_STAGGER_STRAIN);
+        assert_eq!(recovering.state.frostbite_progress_minutes, 0);
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -2406,7 +2406,7 @@ fn rest_for_minutes(
         starting_minute,
         elapsed,
         false,
-        adventuresim_core::survival::FieldShelter::Tent,
+        adventuresim_core::survival::FieldShelter::Indoor,
     )?;
     if provision == SettlementRestProvision::Inn {
         let elapsed_cost = inn_stay_cost(elapsed)?;
@@ -3408,6 +3408,18 @@ mod tests {
         let validation = rest.find("\"field_shelter\"").unwrap();
         assert!(validation < rest.find("wash_party_before_explicit_rest").unwrap());
         assert!(rest.contains("FieldShelter::Tent"));
+    }
+
+    #[test]
+    fn settlement_rest_uses_indoor_exposure() {
+        let source = include_str!("time.rs");
+        let rest = source
+            .split("fn rest_for_minutes")
+            .nth(1)
+            .and_then(|tail| tail.split("fn inn_stay_cost").next())
+            .expect("settlement rest implementation");
+        assert!(rest.contains("FieldShelter::Indoor"));
+        assert!(!rest.contains("FieldShelter::Tent"));
     }
 
     #[test]

--- a/wiki/strategic/time.md
+++ b/wiki/strategic/time.md
@@ -199,7 +199,10 @@ its actually elapsed prefix is committed. This includes terminal-clipped
 travel, settlement activity/rest, field waiting/rest, and official-time
 synchronization. The pure minute calculation gives the same result when an
 interval is partitioned. Settlement shelter blocks rain and wind; explicit
-field rest instead uses the chosen bivouac or party-owned tent.
+field rest instead uses the chosen bivouac or party-owned tent. Rest at an
+inn, temple, or residence occurs indoors: exterior temperature cannot create
+new thermal strain there, and existing wetness and strain recover toward
+neutral.
 
 The calendar treats Day 7 and every seventh day thereafter as Sunday. A religious character who is in a settlement on Sunday receives an explicit call to keep a full day of worship and rest. Traveling during any part of Sunday counts as refusing that call. The server applies the same continuous Fervor- and party-Command-based morale penalty once for that Sunday, including when a journey begins Saturday night and ends Monday morning. A pending Sunday demand is automatically resolved as refused when the party departs; already resolved Sundays cannot be penalized twice.
 


### PR DESCRIPTION
## What changed

- Add a core-only indoor shelter mode for exposure simulation.
- Use indoor protection for inn, temple, and residence rest.
- Prevent exterior rain, wind, heat, and cold from creating exposure while resting indoors.
- Let existing thermal strain and wetness recover through the established bounded state transitions.
- Document the settlement-rest behavior.

## Why

Settlement rest was modeled as an outdoor tent, so long rests in extreme ambient weather could create thermal incapacitation even inside an inn, temple, or residence.

Part of #337.

## Validation

- `cargo test -p adventuresim-core indoor_rest_does_not_create_extreme_thermal_exposure -- --nocapture`
- `cargo check -p adventuresim-stdb-module --all-targets`
- `cargo fmt --all -- --check`
- `python scripts/update_project_map.py --check`
- `git diff --check`

The focused core regression covers a full day of extreme cold/rain/wind, extreme heat, and recovery from existing cold exposure. The SpacetimeDB module's native unit-test binary cannot link outside its host runtime; its all-target compile check passes, and a source-wiring assertion covers the reducer seam.
