### PR TITLE
Add proud traveler errands encounter

### DIFF
--- a/content/encounters/proud-traveler-errands.yaml
+++ b/content/encounters/proud-traveler-errands.yaml
@@ -1,0 +1,116 @@
+{
+  "encounters": [
+    {
+      "id": "proud_traveler_errands_v1",
+      "version": 1,
+      "weight": 70,
+      "triggers": { "travel": true, "rest": false },
+      "provenance": {
+        "works": ["Parzival", "Lanzelet", "Le Morte d'Arthur"],
+        "motifs": ["proud_traveler", "roadside_service", "mired_household", "entrusted_purse"],
+        "adaptation_note": "An original synthesis of proud travelers, testing errands, and compromised household journeys common in chivalric romance; it does not reproduce a particular episode."
+      },
+      "cast": [
+        { "id": "proud_traveler", "name": "Proud traveler", "nature": "mortal" }
+      ],
+      "opening": [
+        {
+          "speaker": "proud_traveler",
+          "text": "Good travelers, behold what service fortune sendeth you. My baggage cart standeth mired beyond this causeway, and my mail-clad riders have spent their strength in drawing it. Render me worthy aid, and I shall remember the hand that gave it.",
+          "reviewed_shakespearean": true
+        }
+      ],
+      "choices": [
+        {
+          "id": "render_service",
+          "label": "Render the requested service without bargaining",
+          "response": [{ "speaker": "proud_traveler", "text": "Thy courtesy hath done what pride alone could not. Take eight groschen, and mark how every mailed rider foundered where the soft ground held his feet.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest an hour freeing the baggage cart, acceptest modest payment, and observest that mail-clad riders move slowly through soft ground.",
+          "deed": "render_service_to_proud_traveler",
+          "outcome_tags": ["courtesy", "service", "physical_observation"],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 8 },
+            { "kind": "information", "information_id": "mired_mail_riders_move_slowly" }
+          ],
+          "personality": [{ "axis": "sociability", "delta": 80, "virtue": "courtesy" }],
+          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "bargain_as_equals",
+          "label": "Bargain as an equal before lending aid",
+          "response": [{ "speaker": "proud_traveler", "text": "Thou speakest as one who knoweth the worth of labor. Sixteen groschen shall answer it; then help us where these heavy riders sink within the mire.", "reviewed_shakespearean": true }],
+          "result": "Thou bargainest for just payment, spendest half an hour directing the release, and observest the mail-clad riders' poor speed in soft ground.",
+          "deed": "bargain_as_equal_for_causeway_service",
+          "outcome_tags": ["justice", "bargain", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1000 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 16 },
+            { "kind": "information", "information_id": "mired_mail_riders_move_slowly" }
+          ],
+          "personality": [{ "axis": "conscience", "delta": 90, "virtue": "justice" }],
+          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "transition": { "kind": "travel_delay", "minutes": 30 }
+        },
+        {
+          "id": "order_household",
+          "label": "Order his household into an efficient hauling line",
+          "response": [{ "speaker": "proud_traveler", "text": "Thy command hath lent one purpose unto many weary hands. The cart is free, and thou hast seen how ill these armoured riders master yielding earth.", "reviewed_shakespearean": true }],
+          "result": "Thou orderest the household into a hauling line, freest the cart in twenty minutes, and observest how soft ground checks the mail-clad riders.",
+          "deed": "order_proud_travelers_household_at_causeway",
+          "outcome_tags": ["prudence", "command", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1000 }],
+          "effects": [{ "kind": "information", "information_id": "mired_mail_riders_move_slowly" }],
+          "personality": [{ "axis": "drive", "delta": 90, "virtue": "prudence" }],
+          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "transition": { "kind": "travel_delay", "minutes": 20 }
+        },
+        {
+          "id": "rebuke_pride",
+          "label": "Rebuke his pride and remind him of Christian duty",
+          "response": [{ "speaker": "proud_traveler", "text": "Thy rebuke striketh home. A Christian master oweth duty unto the exhausted servant, not scorn. I shall take my share of the rope; accept two flasks of table wine, and heed how slowly mail fareth in this mire.", "reviewed_shakespearean": true }],
+          "result": "Thou recallest the traveler to his duty toward exhausted servants, helpest for forty minutes, receivest two flasks of wine, and observest the mail-clad riders' weakness in soft ground.",
+          "deed": "rebuke_proud_traveler_by_christian_duty",
+          "outcome_tags": ["faith", "duty", "physical_observation"],
+          "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
+          "checks": [{ "kind": "religion", "religion": "roman_catholic", "difficulty_milli": 1000 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "table_wine", "quantity": 2 },
+            { "kind": "information", "information_id": "mired_mail_riders_move_slowly" }
+          ],
+          "personality": [{ "axis": "conviction", "delta": 100, "virtue": "faith" }],
+          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "transition": { "kind": "travel_delay", "minutes": 40 }
+        },
+        {
+          "id": "keep_entrusted_purse",
+          "label": "Offer to carry his entrusted purse, then keep it",
+          "response": [{ "speaker": "proud_traveler", "text": "Thy hands are free whilst mine must take the rope. Keep this purse and road note safe until the cart standeth firm; I doubt not thy honest charge.", "reviewed_shakespearean": true }],
+          "result": "Thou readest upon the entrusted road note that mail-clad riders move slowly through soft ground, then concealest the note and stealest the forty-eight groschen purse whilst the household laboureth.",
+          "deed": "steal_proud_travelers_entrusted_purse",
+          "outcome_tags": ["deception", "theft", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1100 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
+            { "kind": "information", "information_id": "mired_mail_riders_move_slowly" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": -220, "virtue": "honesty" }],
+          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "transition": { "kind": "travel_delay", "minutes": 20 }
+        },
+        {
+          "id": "ignore",
+          "label": "Continue along the open edge of the causeway",
+          "response": [],
+          "result": "Thou passest along the open edge of the causeway and leavest the proud traveler to his mired cart.",
+          "deed": "ignore_proud_traveler_at_causeway",
+          "outcome_tags": []
+        }
+      ],
+      "quest_reward_eligibility": ["physical_tactical_information"]
+    }
+  ]
+}

--- a/content/encounters/proud-traveler-errands.yaml
+++ b/content/encounters/proud-traveler-errands.yaml
@@ -16,7 +16,7 @@
       "opening": [
         {
           "speaker": "proud_traveler",
-          "text": "Good travelers, behold what service fortune sendeth you. My baggage cart standeth mired beyond this causeway, and my mail-clad riders have spent their strength in drawing it. Render me worthy aid, and I shall remember the hand that gave it.",
+          "text": "Good travelers, behold what service fortune sendeth you. My baggage cart standeth mired beyond this causeway, and my riders and servants have spent their strength in fruitless pulling. Render me worthy aid, and I shall remember the hand that gave it.",
           "reviewed_shakespearean": true
         }
       ],
@@ -24,81 +24,81 @@
         {
           "id": "render_service",
           "label": "Render the requested service without bargaining",
-          "response": [{ "speaker": "proud_traveler", "text": "Thy courtesy hath done what pride alone could not. Take eight groschen, and mark how every mailed rider foundered where the soft ground held his feet.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest an hour freeing the baggage cart, acceptest modest payment, and observest that mail-clad riders move slowly through soft ground.",
+          "response": [{ "speaker": "proud_traveler", "text": "Thy courtesy hath done what pride alone could not. Take eight groschen, and mark what our close labor hath shown: where mire rose to mid-shin, mail-burdened riders and horses could scarce advance, whilst lightly burdened haulers yet moved freely.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest an hour hauling beside the household, acceptest modest payment, and observest that mid-shin mud stops effective movement by mail-burdened riders and horses whilst lightly burdened haulers remain mobile.",
           "deed": "render_service_to_proud_traveler",
           "outcome_tags": ["courtesy", "service", "physical_observation"],
           "effects": [
             { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 8 },
-            { "kind": "information", "information_id": "mired_mail_riders_move_slowly" }
+            { "kind": "information", "information_id": "mid_shin_mud_checks_mail_burdened_movement" }
           ],
           "personality": [{ "axis": "sociability", "delta": 80, "virtue": "courtesy" }],
-          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "quest_reward_tags": ["heavy_attackers_slow_in_mid_shin_mud"],
           "transition": { "kind": "travel_delay", "minutes": 60 }
         },
         {
           "id": "bargain_as_equals",
           "label": "Bargain as an equal before lending aid",
-          "response": [{ "speaker": "proud_traveler", "text": "Thou speakest as one who knoweth the worth of labor. Sixteen groschen shall answer it; then help us where these heavy riders sink within the mire.", "reviewed_shakespearean": true }],
-          "result": "Thou bargainest for just payment, spendest half an hour directing the release, and observest the mail-clad riders' poor speed in soft ground.",
+          "response": [{ "speaker": "proud_traveler", "text": "Thou speakest as one who knoweth the worth of labor. Sixteen groschen shall answer it. Our work hath proved besides that mid-shin mire stealeth movement from mail-burdened riders and horses, though lightly burdened haulers pass yet.", "reviewed_shakespearean": true }],
+          "result": "Thou bargainest for just payment, spendest half an hour hauling at close quarters, and observest mail-burdened riders and horses lose effective movement in mid-shin mud whilst lightly burdened haulers remain mobile.",
           "deed": "bargain_as_equal_for_causeway_service",
           "outcome_tags": ["justice", "bargain", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
           "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1000 }],
           "effects": [
             { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 16 },
-            { "kind": "information", "information_id": "mired_mail_riders_move_slowly" }
+            { "kind": "information", "information_id": "mid_shin_mud_checks_mail_burdened_movement" }
           ],
           "personality": [{ "axis": "conscience", "delta": 90, "virtue": "justice" }],
-          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "quest_reward_tags": ["heavy_attackers_slow_in_mid_shin_mud"],
           "transition": { "kind": "travel_delay", "minutes": 30 }
         },
         {
           "id": "order_household",
           "label": "Order his household into an efficient hauling line",
-          "response": [{ "speaker": "proud_traveler", "text": "Thy command hath lent one purpose unto many weary hands. The cart is free, and thou hast seen how ill these armoured riders master yielding earth.", "reviewed_shakespearean": true }],
-          "result": "Thou orderest the household into a hauling line, freest the cart in twenty minutes, and observest how soft ground checks the mail-clad riders.",
+          "response": [{ "speaker": "proud_traveler", "text": "Thy command hath lent one purpose unto many weary hands. The cart is free, and thou hast seen the measure plainly: mid-shin mire arresteth mail-burdened riders and horses, whilst lightly burdened haulers keep their movement.", "reviewed_shakespearean": true }],
+          "result": "Thou orderest and joinest the household hauling line for twenty minutes, observing that mid-shin mud checks mail-burdened riders and horses but leaves lightly burdened haulers mobile.",
           "deed": "order_proud_travelers_household_at_causeway",
           "outcome_tags": ["prudence", "command", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
           "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1000 }],
-          "effects": [{ "kind": "information", "information_id": "mired_mail_riders_move_slowly" }],
+          "effects": [{ "kind": "information", "information_id": "mid_shin_mud_checks_mail_burdened_movement" }],
           "personality": [{ "axis": "drive", "delta": 90, "virtue": "prudence" }],
-          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "quest_reward_tags": ["heavy_attackers_slow_in_mid_shin_mud"],
           "transition": { "kind": "travel_delay", "minutes": 20 }
         },
         {
           "id": "rebuke_pride",
           "label": "Rebuke his pride and remind him of Christian duty",
-          "response": [{ "speaker": "proud_traveler", "text": "Thy rebuke striketh home. A Christian master oweth duty unto the exhausted servant, not scorn. I shall take my share of the rope; accept two flasks of table wine, and heed how slowly mail fareth in this mire.", "reviewed_shakespearean": true }],
-          "result": "Thou recallest the traveler to his duty toward exhausted servants, helpest for forty minutes, receivest two flasks of wine, and observest the mail-clad riders' weakness in soft ground.",
+          "response": [{ "speaker": "proud_traveler", "text": "Thy rebuke striketh home. A Christian master oweth duty unto the exhausted servant, not scorn. I shall take my share of the rope. Accept two flasks of table wine, and remember what our common labor showed: mid-shin mire stayed the mail-burdened riders and horses, not the lightly burdened haulers.", "reviewed_shakespearean": true }],
+          "result": "Thou recallest the traveler to his duty toward exhausted servants and haulest beside them for forty minutes, receiving two flasks of wine and observing how mid-shin mud stops mail-burdened movement but not lightly burdened haulers.",
           "deed": "rebuke_proud_traveler_by_christian_duty",
           "outcome_tags": ["faith", "duty", "physical_observation"],
           "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
           "checks": [{ "kind": "religion", "religion": "roman_catholic", "difficulty_milli": 1000 }],
           "effects": [
             { "kind": "grant_item", "item_id": "table_wine", "quantity": 2 },
-            { "kind": "information", "information_id": "mired_mail_riders_move_slowly" }
+            { "kind": "information", "information_id": "mid_shin_mud_checks_mail_burdened_movement" }
           ],
           "personality": [{ "axis": "conviction", "delta": 100, "virtue": "faith" }],
-          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "quest_reward_tags": ["heavy_attackers_slow_in_mid_shin_mud"],
           "transition": { "kind": "travel_delay", "minutes": 40 }
         },
         {
           "id": "keep_entrusted_purse",
-          "label": "Offer to carry his entrusted purse, then keep it",
-          "response": [{ "speaker": "proud_traveler", "text": "Thy hands are free whilst mine must take the rope. Keep this purse and road note safe until the cart standeth firm; I doubt not thy honest charge.", "reviewed_shakespearean": true }],
-          "result": "Thou readest upon the entrusted road note that mail-clad riders move slowly through soft ground, then concealest the note and stealest the forty-eight groschen purse whilst the household laboureth.",
+          "label": "Claim noble-household experience and keep the haulers' wage purse",
+          "response": [{ "speaker": "proud_traveler", "text": "Thou hast served a noble household and knowest how laborers must be ordered and paid. Take this purse of forty-eight groschen, stage the haulers, and give each man his wage when the cart standeth free; I trust the charge unto thee.", "reviewed_shakespearean": true }],
+          "result": "Thou falsely claimest household experience, spendest twenty minutes staging haulers and opening payment, and thereby observest that mid-shin mud stops mail-burdened riders and horses whilst lightly burdened haulers remain mobile; then thou abscondest with their forty-eight-groschen wage purse.",
           "deed": "steal_proud_travelers_entrusted_purse",
           "outcome_tags": ["deception", "theft", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
           "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1100 }],
           "effects": [
             { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
-            { "kind": "information", "information_id": "mired_mail_riders_move_slowly" }
+            { "kind": "information", "information_id": "mid_shin_mud_checks_mail_burdened_movement" }
           ],
           "personality": [{ "axis": "transparency", "delta": -220, "virtue": "honesty" }],
-          "quest_reward_tags": ["heavy_attackers_slow_in_soft_ground"],
+          "quest_reward_tags": ["heavy_attackers_slow_in_mid_shin_mud"],
           "transition": { "kind": "travel_delay", "minutes": 20 }
         },
         {

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -950,6 +950,10 @@ mod tests {
                 )
                 .all(|line| line.reviewed_shakespearean && !line.reviewed_iambic_pentameter)
         );
+        let opening = definition.opening[0].text.to_ascii_lowercase();
+        for withheld_fact in ["mail", "mid-shin", "lightly burdened", "movement"] {
+            assert!(!opening.contains(withheld_fact));
+        }
         let choice = |id| {
             definition
                 .choices
@@ -1154,9 +1158,9 @@ mod tests {
                 matches!(
                     effect,
                     Effect::Information { information_id }
-                        if information_id == "mired_mail_riders_move_slowly"
+                        if information_id == "mid_shin_mud_checks_mail_burdened_movement"
                 )
-            }) && choice.quest_reward_tags == ["heavy_attackers_slow_in_soft_ground"]
+            }) && choice.quest_reward_tags == ["heavy_attackers_slow_in_mid_shin_mud"]
                 && choice
                     .outcome_tags
                     .iter()
@@ -1233,6 +1237,12 @@ mod tests {
             assert_eq!(exemplified_virtue(&choice(route).personality), Some(virtue));
         }
         let theft = choice("keep_entrusted_purse");
+        assert!(theft.response[0].text.contains("served a noble household"));
+        assert!(theft.response[0].text.contains("forty-eight groschen"));
+        assert!(!theft.response[0].text.contains("road note"));
+        assert!(theft.result.contains("twenty minutes staging haulers"));
+        assert!(theft.result.contains("mid-shin mud"));
+        assert!(theft.result.contains("abscondest"));
         assert!(matches!(
             theft.effects[0],
             Effect::Currency { amount: 48, .. }

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1100,6 +1100,162 @@ mod tests {
     }
 
     #[test]
+    fn proud_traveler_routes_are_mortal_distinct_grounded_and_balanced() {
+        let definition = encounter("proud_traveler_errands_v1").unwrap();
+        assert!(definition.triggers.travel && !definition.triggers.rest);
+        assert_eq!(definition.weight, 70);
+        assert!(
+            definition
+                .cast
+                .iter()
+                .all(|speaker| speaker.nature == SpeakerNature::Mortal)
+        );
+        assert!(
+            definition
+                .opening
+                .iter()
+                .chain(
+                    definition
+                        .choices
+                        .iter()
+                        .flat_map(|choice| &choice.response)
+                )
+                .all(|line| line.reviewed_shakespearean && !line.reviewed_iambic_pentameter)
+        );
+        let choice = |id| {
+            definition
+                .choices
+                .iter()
+                .find(|choice| choice.id == id)
+                .unwrap()
+        };
+        let non_ignore = definition
+            .choices
+            .iter()
+            .filter(|choice| choice.id != "ignore")
+            .collect::<Vec<_>>();
+        assert_eq!(non_ignore.len(), 5);
+        let route_signatures = non_ignore
+            .iter()
+            .map(|choice| {
+                serde_json::to_string(&(
+                    &choice.requirements,
+                    &choice.checks,
+                    &choice.effects,
+                    &choice.personality,
+                    &choice.transition,
+                ))
+                .unwrap()
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(route_signatures.len(), 5);
+        assert!(non_ignore.iter().all(|choice| {
+            choice.effects.iter().any(|effect| {
+                matches!(
+                    effect,
+                    Effect::Information { information_id }
+                        if information_id == "mired_mail_riders_move_slowly"
+                )
+            }) && choice.quest_reward_tags == ["heavy_attackers_slow_in_soft_ground"]
+                && choice
+                    .outcome_tags
+                    .iter()
+                    .any(|tag| tag == "physical_observation")
+        }));
+        let delays = non_ignore
+            .iter()
+            .map(|choice| match choice.transition.as_ref() {
+                Some(EncounterTransition::TravelDelay { minutes }) => *minutes,
+                _ => panic!("non-ignore route lacks a travel delay"),
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(delays, BTreeSet::from([20, 30, 40, 60]));
+        for (route, expected_minutes) in [
+            ("render_service", 60),
+            ("bargain_as_equals", 30),
+            ("order_household", 20),
+            ("rebuke_pride", 40),
+            ("keep_entrusted_purse", 20),
+        ] {
+            assert!(matches!(
+                choice(route).transition.as_ref(),
+                Some(EncounterTransition::TravelDelay { minutes })
+                    if *minutes == expected_minutes
+            ));
+        }
+        assert!(matches!(
+            choice("bargain_as_equals").checks[0],
+            Check::Skill {
+                skill: SkillId::Charm,
+                difficulty_milli: 1000
+            }
+        ));
+        assert!(matches!(
+            choice("order_household").checks[0],
+            Check::Skill {
+                skill: SkillId::Command,
+                difficulty_milli: 1000
+            }
+        ));
+        assert!(matches!(
+            choice("rebuke_pride").requirements[0],
+            Requirement::Religion {
+                religion: ReligionId::RomanCatholic
+            }
+        ));
+        assert!(
+            choice("rebuke_pride").response[0]
+                .text
+                .contains("duty unto the exhausted servant")
+        );
+        assert!(choice("rebuke_pride").effects.iter().any(|effect| matches!(
+            effect,
+            Effect::GrantItem { item_id, quantity: 2 } if item_id == "table_wine"
+        )));
+        assert!(
+            choice("render_service")
+                .effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::Currency { amount: 8, .. }))
+        );
+        assert!(
+            choice("bargain_as_equals")
+                .effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::Currency { amount: 16, .. }))
+        );
+        for (route, virtue) in [
+            ("render_service", VirtueId::Courtesy),
+            ("bargain_as_equals", VirtueId::Justice),
+            ("order_household", VirtueId::Prudence),
+            ("rebuke_pride", VirtueId::Faith),
+        ] {
+            assert_eq!(exemplified_virtue(&choice(route).personality), Some(virtue));
+        }
+        let theft = choice("keep_entrusted_purse");
+        assert!(matches!(
+            theft.effects[0],
+            Effect::Currency { amount: 48, .. }
+        ));
+        assert!(theft.personality[0].delta < 0);
+        assert_eq!(exemplified_virtue(&theft.personality), None);
+        let largest_honest_coin = non_ignore
+            .iter()
+            .filter(|choice| choice.id != "keep_entrusted_purse")
+            .flat_map(|choice| &choice.effects)
+            .filter_map(|effect| match effect {
+                Effect::Currency { amount, .. } if *amount > 0 => Some(*amount),
+                _ => None,
+            })
+            .max()
+            .unwrap();
+        assert!(48 > largest_honest_coin);
+        assert!(choice("ignore").transition.is_none());
+        assert!(choice("ignore").effects.is_empty());
+        assert!(choice("ignore").personality.is_empty());
+    }
+
+    #[test]
     fn combat_transition_rejects_unsafe_counts() {
         let mut definition = encounter("unlawful_bridge_custom_v1").unwrap().clone();
         let choice = definition

--- a/crates/adventuresim-stdb-module/src/strategic/challenges.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/challenges.rs
@@ -1313,13 +1313,10 @@ pub fn resolve_errantry_road_challenge(
         && overlay.origin == NarrativeEncounterOrigin::Errantry && overlay.reward_eligible
         && !selected.quest_reward_tags.is_empty()
     {
-        let has_material_token = selected.effects.iter().any(|effect| matches!(effect,
-            adventuresim_core::road_encounter_catalog::Effect::GrantItem { .. }));
-        overlay.reward_addendum = Some(if has_material_token {
-            "Thy deed hath also yielded practical knowledge for the danger ahead; consult the material token before battle."
-        } else {
-            "Thy deed hath also yielded practical knowledge for the danger ahead; remember this observation when preparing for battle."
-        }.into());
+        overlay.reward_addendum = Some(
+            "Thy deed hath also yielded practical knowledge for the danger ahead; consult what thou hast learned or recovered before battle."
+                .into(),
+        );
         ctx.db.narrative_encounter_private_authority().occurrence_id().update(overlay);
     }
     challenge.open = false;
@@ -2179,6 +2176,9 @@ mod challenge_source_boundary_tests {
         assert!(source.contains("finale_defenses_json"));
         assert!(reducer.contains("overlay.origin == NarrativeEncounterOrigin::Errantry"));
         assert!(reducer.contains("apply_narrative_effect"));
+        assert!(reducer.contains("consult what thou hast learned or recovered before battle"));
+        assert!(!reducer.contains("has_material_token"));
+        assert!(!reducer.contains("consult the material token"));
         assert!(reducer.find("apply_narrative_effect").unwrap() < reducer.find("reward_addendum").unwrap());
         assert!(reducer.find("road_challenge_resolution_receipt()").unwrap()
             < reducer.find("apply_narrative_effect").unwrap());

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1652)
+## Files (1653)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -35,6 +35,7 @@ development, or other wiki document before changing a subsystem.
 - `content/dialogue/examples.yaml` — Repository support file.
 - `content/dialogue/organizations.yaml` — Repository support file.
 - `content/dialogue/services.yaml` — Repository support file.
+- `content/encounters/proud-traveler-errands.yaml` — Repository support file.
 - `content/encounters/unlawful-bridge-custom.yaml` — Repository support file.
 - `content/encounters/wounded-courier.yaml` — Repository support file.
 - `content/encounters/wounded-knight-linden.yaml` — Repository support file.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -123,10 +123,13 @@ special-cased by the transition dispatcher.
 `proud_traveler_errands_v1` places a proud mortal traveler and his exhausted
 household at a muddy causeway. The party may render unpriced service, bargain
 as equals, organize the household, rebuke the master through Christian duty,
-or steal an unsuspectingly entrusted purse; passing by remains free because
-the road is not blocked. Each active route consumes a bounded amount of travel
-time and yields the same physical observation that mail-clad riders are slow
-in soft ground. Honest routes express Courtesy, Justice, Prudence, or Faith,
+or falsely claim household experience and abscond with the haulers' entrusted
+wage purse; passing by remains free because the road is not blocked. The
+opening discloses only a mired cart and exhausted workers. Each active route
+consumes a bounded amount of travel time and earns the deeper physical
+observation that mid-shin mud arrests effective movement by mail-burdened
+riders and horses while lightly burdened haulers remain mobile. Honest routes
+express Courtesy, Justice, Prudence, or Faith,
 while the materially richest theft lowers Honesty without publicly exemplifying
 it. The encounter is travel-only, goal-neutral, entirely mortal, and requires
 no runtime catalog special case.
@@ -181,7 +184,9 @@ name, text and supernatural styling, choice ID/label/availability, and the
 chosen response after resolution. Catalog provenance, review flags, hidden
 effects, personality changes, reward tags and quest bindings never cross it.
 Only after generic effects and personality development may it append a quest
-reward. Rewards are real items, currency, or information; generic boss BPS and
+reward. The addendum tells the player to consult what was learned or recovered
+without guessing whether a granted item is itself the tactical carrier.
+Rewards are real items, currency, or information; generic boss BPS and
 magical buffs are forbidden. Physical application of finale information is
 deferred to each finale's tactical implementation; tactical tick state never
 belongs in SpacetimeDB.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -120,6 +120,17 @@ development never publicly exemplifies Courage. The practical information is
 the quest boon; the combatant is not arbitrarily weakened. No catalog ID is
 special-cased by the transition dispatcher.
 
+`proud_traveler_errands_v1` places a proud mortal traveler and his exhausted
+household at a muddy causeway. The party may render unpriced service, bargain
+as equals, organize the household, rebuke the master through Christian duty,
+or steal an unsuspectingly entrusted purse; passing by remains free because
+the road is not blocked. Each active route consumes a bounded amount of travel
+time and yields the same physical observation that mail-clad riders are slow
+in soft ground. Honest routes express Courtesy, Justice, Prudence, or Faith,
+while the materially richest theft lowers Honesty without publicly exemplifying
+it. The encounter is travel-only, goal-neutral, entirely mortal, and requires
+no runtime catalog special case.
+
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source
 mapped at build time. YAML owns stable ID/version/weight, trigger eligibility,


### PR DESCRIPTION
## Summary
- add proud_traveler_errands_v1, a travel-only mortal roadside scene inspired by proud-traveler and testing-service motifs in chivalric romance
- offer six grounded responses: courteous service, fair bargaining, household command, Christian rebuke, wage-purse fraud, or passing by
- make close participation reveal a concrete physical observation: mid-shin mud arrests mail-burdened riders and horses while lightly burdened haulers remain mobile
- keep the dishonest wage-purse route materially richest while applying negative Honesty development and no exemplified virtue
- make quest reward addenda carrier-neutral so unrelated granted items are never misidentified as tactical tokens

## Stack
- base: codex/romance-encounter-02-unlawful-bridge / #346
- this is encounter 03 in the sequential romance-road-encounter stack

## Verification
- road encounter catalog: 13/13
- content compiler: 4 encounter definitions
- full workspace just check
- formatting, project-map, and diff checks
- two independent correctness/maintainability reviews, clean after remediation

## Deliberate follow-up
- the physical information is persisted and quest-tagged; consuming it in finale preparation remains part of the broader finale-information integration rather than an arbitrary boss debuff