### PR TITLE
Add ferryman disputed tribute encounter

### DIFF
--- a/content/encounters/ferryman-disputed-tribute.yaml
+++ b/content/encounters/ferryman-disputed-tribute.yaml
@@ -16,7 +16,7 @@
       "opening": [
         {
           "speaker": "ferryman",
-          "text": "Good travelers, the river hath swollen beyond its wont, and my west oar lieth split. Some hand hath newly cut this toll board above its elder marks, yet twelve groschen is the fare I claim. The upper ford standeth three rough hours from hence.",
+          "text": "Good travelers, the river hath swollen beyond its wont, and the blade of my west oar lieth split. A mixed company waiteth upon either bank, with foot travelers, mail-clad riders, and their horses all among them. Some hand hath newly cut this toll board above its elder marks, yet twelve groschen is the fare I claim. The upper ford standeth three rough hours from hence.",
           "reviewed_shakespearean": true
         }
       ],
@@ -24,8 +24,8 @@
         {
           "id": "pay_tribute",
           "label": "Pay the twelve-groschen tribute",
-          "response": [{ "speaker": "ferryman", "text": "Thy silver spareth thee the harsher bank. Sit steady whilst I work the sound oar, and heed how this swollen water useth those who bear great weight.", "reviewed_shakespearean": true }],
-          "result": "Thou payest twelve groschen and crossest in fifteen minutes. From the ferry thou seest that the deep current driveth mail-burdened riders toward the shallow gravel margins, where alone they can keep their footing.",
+          "response": [{ "speaker": "ferryman", "text": "Thy silver spareth thee the harsher bank. Sit steady whilst I scull us slowly with the sound oar, and heed how this swollen water useth those who bear great weight.", "reviewed_shakespearean": true }],
+          "result": "Thou payest twelve groschen and crossest in fifteen minutes beneath the ferryman's slow sculling. From the ferry thou witnessest a mail-clad rider urge his horse into the deep current; the water forceth both back until they take the shallow gravel margin.",
           "deed": "pay_ferrymans_disputed_tribute",
           "outcome_tags": ["prudence", "peaceful_passage", "physical_observation"],
           "requirements": [{ "kind": "currency", "amount": 12 }],
@@ -40,8 +40,8 @@
         {
           "id": "barter_provisions",
           "label": "Barter four travel rations for passage",
-          "response": [{ "speaker": "ferryman", "text": "Bread keepeth strength when swollen waters idle honest hands. Lay down four rations, and I shall bear thy company across.", "reviewed_shakespearean": true }],
-          "result": "Thou barterest four travel rations and crossest in twenty minutes. From the ferry thou seest the deep current confine mail-burdened riders to the shallow gravel margins, where alone they can keep their footing.",
+          "response": [{ "speaker": "ferryman", "text": "Bread keepeth strength when swollen waters idle honest hands. Lay down four rations, and I shall scull thy company slowly across with the sound oar.", "reviewed_shakespearean": true }],
+          "result": "Thou barterest four travel rations and crossest in twenty minutes beneath the ferryman's slow sculling. From the ferry thou witnessest a mail-clad rider urge his horse into the deep current; the water forceth both back until they take the shallow gravel margin.",
           "deed": "barter_provisions_for_ferry_passage",
           "outcome_tags": ["courtesy", "barter", "physical_observation"],
           "requirements": [{ "kind": "item", "item_id": "travel_ration", "minimum_quantity": 4 }],
@@ -55,9 +55,9 @@
         },
         {
           "id": "row_in_lieu",
-          "label": "Take the spare oar and row in lieu of payment",
-          "response": [{ "speaker": "ferryman", "text": "Thy back may pay where purse will not. Take thou the sound oar; pull when I command, and fight not the middle stream as though it were a man.", "reviewed_shakespearean": true }],
-          "result": "Under the ferryman's direction, thou spendest forty-five minutes at the oar. Its resistance teacheth thee that the deep current confineth mail-burdened riders to the shallow gravel margins.",
+          "label": "Relieve the ferryman at the sound sculling oar",
+          "response": [{ "speaker": "ferryman", "text": "Thy back may pay where purse will not. Relieve me at the sound sculling oar; work it when I command, whilst I tend the landing cable and call thy stroke.", "reviewed_shakespearean": true }],
+          "result": "Under the ferryman's direction, thou spendest forty-five minutes working the sound sculling oar whilst he tendeth the landing cable and calleth each stroke. During thy labor thou witnessest a mail-clad rider urge his horse into the deep current; the water forceth both back until they take the shallow gravel margin.",
           "deed": "row_ferry_in_lieu_of_tribute",
           "outcome_tags": ["courage", "labor", "physical_observation"],
           "checks": [{ "kind": "attribute", "attribute": "endurance", "difficulty_milli": 1200 }],
@@ -70,7 +70,7 @@
           "id": "expose_altered_tally",
           "label": "Read the elder cuts and expose the altered tally",
           "response": [{ "speaker": "ferryman", "text": "Thine eye hath found the witness-mark beneath the fresher knife. Four groschen was the lawful fare; pay that sum, and I shall gainsay thee no further.", "reviewed_shakespearean": true }],
-          "result": "Thou matchest the elder cuts to their witness-mark, payest the lawful four-groschen fare, and crossest in thirty minutes. The passage showeth that deep current confineth mail-burdened riders to the shallow gravel margins.",
+          "result": "Thou matchest the elder cuts to their witness-mark, payest the lawful four-groschen fare, and crossest in thirty minutes beneath the ferryman's slow sculling. During the passage thou witnessest a mail-clad rider urge his horse into the deep current; the water forceth both back until they take the shallow gravel margin.",
           "deed": "expose_ferrymans_altered_toll_tally",
           "outcome_tags": ["justice", "fraud_exposed", "physical_observation"],
           "requirements": [{ "kind": "currency", "amount": 4 }],
@@ -86,8 +86,8 @@
         {
           "id": "organize_repair",
           "label": "Organize the stranded travelers to repair the oar",
-          "response": [{ "speaker": "ferryman", "text": "I have spare ash, cord, and iron, and know the binding that will hold. Set thou these idle travelers to ordered work, and we shall mend the blade together.", "reviewed_shakespearean": true }],
-          "result": "The ferryman provideth materials and craft while thou spendest an hour ordering the stranded travelers. During the repaired ferry's trial, thou learnest that deep current confineth mail-burdened riders to the shallow gravel margins.",
+          "response": [{ "speaker": "ferryman", "text": "I have raw ash, cord, and iron, and know a binding that shall serve awhile. Set thou these waiting travelers to ordered work; beneath my hand we shall splint the west blade for the crossings presently before us.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest an hour ordering the waiting company whilst the ferryman shapeth raw ash, cord, and iron into a temporary splint for the west blade, sufficient only for the immediate queued crossings. During that work thou witnessest a mail-clad rider urge his horse into the deep current; the water forceth both back until they take the shallow gravel margin.",
           "deed": "organize_stranded_travelers_to_repair_ferry_oar",
           "outcome_tags": ["prudence", "command", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
@@ -100,8 +100,8 @@
         {
           "id": "steal_till",
           "label": "Win his trust, collect the fares, and steal the till",
-          "response": [{ "speaker": "ferryman", "text": "Thou hast kept a noble landing and knowest the tally well. Hold thou my till and gather each fare whilst I fetch the hidden oar; I trust the charge unto thee.", "reviewed_shakespearean": true }],
-          "result": "Thou falsely claimest service at a noble landing, spendest ninety minutes collecting fares, and observest that deep current confineth mail-burdened riders to the shallow gravel margins; then thou abscondest with forty-eight groschen from the entrusted till.",
+          "response": [{ "speaker": "ferryman", "text": "Thou hast kept a noble landing and knowest the tally well. Hold thou my till ashore and gather each fare whilst I scull the queue, tend the cable, and shape my repair stock; I trust the charge unto thee.", "reviewed_shakespearean": true }],
+          "result": "Thou falsely claimest service at a noble landing and spendest ninety minutes keeping the shore tally whilst the ferryman repeatedly sculleth queued crossings, tendeth the cable, and shapeth repair stock. There thou witnessest a mail-clad rider urge his horse into the deep current; the water forceth both back until they take the shallow gravel margin. Then thou abscondest with forty-eight groschen from the entrusted till.",
           "deed": "steal_ferrymans_entrusted_till",
           "outcome_tags": ["deception", "theft", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],

--- a/content/encounters/ferryman-disputed-tribute.yaml
+++ b/content/encounters/ferryman-disputed-tribute.yaml
@@ -1,0 +1,130 @@
+{
+  "encounters": [
+    {
+      "id": "ferryman_disputed_tribute_v1",
+      "version": 1,
+      "weight": 70,
+      "triggers": { "travel": true, "rest": false },
+      "provenance": {
+        "works": ["Parzival", "Wigalois", "Lanzelet", "Le Morte d'Arthur"],
+        "motifs": ["disputed_ferry_toll", "swollen_river", "broken_oar", "entrusted_till"],
+        "adaptation_note": "An original synthesis of ferries, disputed road customs, difficult crossings, and betrayed trust common in chivalric romance; it does not reproduce a particular episode."
+      },
+      "cast": [
+        { "id": "ferryman", "name": "Ferryman", "nature": "mortal" }
+      ],
+      "opening": [
+        {
+          "speaker": "ferryman",
+          "text": "Good travelers, the river hath swollen beyond its wont, and my west oar lieth split. Some hand hath newly cut this toll board above its elder marks, yet twelve groschen is the fare I claim. The upper ford standeth three rough hours from hence.",
+          "reviewed_shakespearean": true
+        }
+      ],
+      "choices": [
+        {
+          "id": "pay_tribute",
+          "label": "Pay the twelve-groschen tribute",
+          "response": [{ "speaker": "ferryman", "text": "Thy silver spareth thee the harsher bank. Sit steady whilst I work the sound oar, and heed how this swollen water useth those who bear great weight.", "reviewed_shakespearean": true }],
+          "result": "Thou payest twelve groschen and crossest in fifteen minutes. From the ferry thou seest that the deep current driveth mail-burdened riders toward the shallow gravel margins, where alone they can keep their footing.",
+          "deed": "pay_ferrymans_disputed_tribute",
+          "outcome_tags": ["prudence", "peaceful_passage", "physical_observation"],
+          "requirements": [{ "kind": "currency", "amount": 12 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": -12 },
+            { "kind": "information", "information_id": "deep_current_confines_mail_riders_to_shallows" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 50, "virtue": "prudence" }],
+          "quest_reward_tags": ["heavy_attackers_confined_to_shallow_gravel"],
+          "transition": { "kind": "travel_delay", "minutes": 15 }
+        },
+        {
+          "id": "barter_provisions",
+          "label": "Barter four travel rations for passage",
+          "response": [{ "speaker": "ferryman", "text": "Bread keepeth strength when swollen waters idle honest hands. Lay down four rations, and I shall bear thy company across.", "reviewed_shakespearean": true }],
+          "result": "Thou barterest four travel rations and crossest in twenty minutes. From the ferry thou seest the deep current confine mail-burdened riders to the shallow gravel margins, where alone they can keep their footing.",
+          "deed": "barter_provisions_for_ferry_passage",
+          "outcome_tags": ["courtesy", "barter", "physical_observation"],
+          "requirements": [{ "kind": "item", "item_id": "travel_ration", "minimum_quantity": 4 }],
+          "effects": [
+            { "kind": "consume_item", "item_id": "travel_ration", "quantity": 4 },
+            { "kind": "information", "information_id": "deep_current_confines_mail_riders_to_shallows" }
+          ],
+          "personality": [{ "axis": "sociability", "delta": 70, "virtue": "courtesy" }],
+          "quest_reward_tags": ["heavy_attackers_confined_to_shallow_gravel"],
+          "transition": { "kind": "travel_delay", "minutes": 20 }
+        },
+        {
+          "id": "row_in_lieu",
+          "label": "Take the spare oar and row in lieu of payment",
+          "response": [{ "speaker": "ferryman", "text": "Thy back may pay where purse will not. Take thou the sound oar; pull when I command, and fight not the middle stream as though it were a man.", "reviewed_shakespearean": true }],
+          "result": "Under the ferryman's direction, thou spendest forty-five minutes at the oar. Its resistance teacheth thee that the deep current confineth mail-burdened riders to the shallow gravel margins.",
+          "deed": "row_ferry_in_lieu_of_tribute",
+          "outcome_tags": ["courage", "labor", "physical_observation"],
+          "checks": [{ "kind": "attribute", "attribute": "endurance", "difficulty_milli": 1200 }],
+          "effects": [{ "kind": "information", "information_id": "deep_current_confines_mail_riders_to_shallows" }],
+          "personality": [{ "axis": "nerve", "delta": 100, "virtue": "courage" }],
+          "quest_reward_tags": ["heavy_attackers_confined_to_shallow_gravel"],
+          "transition": { "kind": "travel_delay", "minutes": 45 }
+        },
+        {
+          "id": "expose_altered_tally",
+          "label": "Read the elder cuts and expose the altered tally",
+          "response": [{ "speaker": "ferryman", "text": "Thine eye hath found the witness-mark beneath the fresher knife. Four groschen was the lawful fare; pay that sum, and I shall gainsay thee no further.", "reviewed_shakespearean": true }],
+          "result": "Thou matchest the elder cuts to their witness-mark, payest the lawful four-groschen fare, and crossest in thirty minutes. The passage showeth that deep current confineth mail-burdened riders to the shallow gravel margins.",
+          "deed": "expose_ferrymans_altered_toll_tally",
+          "outcome_tags": ["justice", "fraud_exposed", "physical_observation"],
+          "requirements": [{ "kind": "currency", "amount": 4 }],
+          "checks": [{ "kind": "skill", "skill": "insight", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": -4 },
+            { "kind": "information", "information_id": "deep_current_confines_mail_riders_to_shallows" }
+          ],
+          "personality": [{ "axis": "conscience", "delta": 100, "virtue": "justice" }],
+          "quest_reward_tags": ["heavy_attackers_confined_to_shallow_gravel"],
+          "transition": { "kind": "travel_delay", "minutes": 30 }
+        },
+        {
+          "id": "organize_repair",
+          "label": "Organize the stranded travelers to repair the oar",
+          "response": [{ "speaker": "ferryman", "text": "I have spare ash, cord, and iron, and know the binding that will hold. Set thou these idle travelers to ordered work, and we shall mend the blade together.", "reviewed_shakespearean": true }],
+          "result": "The ferryman provideth materials and craft while thou spendest an hour ordering the stranded travelers. During the repaired ferry's trial, thou learnest that deep current confineth mail-burdened riders to the shallow gravel margins.",
+          "deed": "organize_stranded_travelers_to_repair_ferry_oar",
+          "outcome_tags": ["prudence", "command", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1000 }],
+          "effects": [{ "kind": "information", "information_id": "deep_current_confines_mail_riders_to_shallows" }],
+          "personality": [{ "axis": "drive", "delta": 90, "virtue": "prudence" }],
+          "quest_reward_tags": ["heavy_attackers_confined_to_shallow_gravel"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "steal_till",
+          "label": "Win his trust, collect the fares, and steal the till",
+          "response": [{ "speaker": "ferryman", "text": "Thou hast kept a noble landing and knowest the tally well. Hold thou my till and gather each fare whilst I fetch the hidden oar; I trust the charge unto thee.", "reviewed_shakespearean": true }],
+          "result": "Thou falsely claimest service at a noble landing, spendest ninety minutes collecting fares, and observest that deep current confineth mail-burdened riders to the shallow gravel margins; then thou abscondest with forty-eight groschen from the entrusted till.",
+          "deed": "steal_ferrymans_entrusted_till",
+          "outcome_tags": ["deception", "theft", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1100 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
+            { "kind": "information", "information_id": "deep_current_confines_mail_riders_to_shallows" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": -220, "virtue": "honesty" }],
+          "quest_reward_tags": ["heavy_attackers_confined_to_shallow_gravel"],
+          "transition": { "kind": "travel_delay", "minutes": 90 }
+        },
+        {
+          "id": "ignore",
+          "label": "Seek the rough upper ford",
+          "response": [],
+          "result": "Thou leavest the ferry and spendest three hours reaching and crossing the rough upper ford.",
+          "deed": "take_upper_ford_past_disputed_ferry",
+          "outcome_tags": [],
+          "transition": { "kind": "travel_delay", "minutes": 180 }
+        }
+      ],
+      "quest_reward_eligibility": ["physical_tactical_information"]
+    }
+  ]
+}

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1295,11 +1295,18 @@ mod tests {
             .collect::<Vec<_>>()
             .join(" ")
             .to_lowercase();
-        for withheld_observation in ["mail", "shallow", "gravel", "deep current"] {
+        assert!(opening.contains("mixed company waiteth upon either bank"));
+        assert!(opening.contains("mail-clad riders"));
+        assert!(opening.contains("their horses"));
+        assert!(opening.contains("blade of my west oar lieth split"));
+        for withheld_observation in ["shallow", "gravel", "deep current", "forceth both back"] {
             assert!(!opening.contains(withheld_observation));
         }
         assert!(opening.contains("twelve groschen"));
         assert!(opening.contains("elder marks"));
+        let authored_prose = serde_json::to_string(definition).unwrap().to_lowercase();
+        assert!(!authored_prose.contains("spare oar"));
+        assert!(!authored_prose.contains("hidden oar"));
 
         let choice = |id| {
             definition
@@ -1342,9 +1349,12 @@ mod tests {
                     .any(|tag| tag == "physical_observation")
         }));
         assert!(active.iter().all(|choice| {
-            choice.result.contains("deep current")
-                && choice.result.contains("mail-burdened riders")
-                && choice.result.contains("shallow gravel")
+            choice.result.contains("witnessest a mail-clad rider")
+                && choice
+                    .result
+                    .contains("urge his horse into the deep current")
+                && choice.result.contains("forceth both back")
+                && choice.result.contains("shallow gravel margin")
         }));
 
         for (route, minutes) in [
@@ -1397,6 +1407,15 @@ mod tests {
                 difficulty_milli: 1200
             }
         ));
+        assert!(choice("row_in_lieu").label.contains("sound sculling oar"));
+        assert!(
+            choice("row_in_lieu").response[0]
+                .text
+                .contains("tend the landing cable and call thy stroke")
+        );
+        for route in ["pay_tribute", "barter_provisions"] {
+            assert!(choice(route).result.contains("slow sculling"));
+        }
         let lawful_fare = choice("expose_altered_tally");
         assert!(lawful_fare.response[0].text.contains("Four groschen"));
         assert!(lawful_fare.response[0].text.contains("witness-mark"));
@@ -1418,7 +1437,17 @@ mod tests {
         assert!(
             choice("organize_repair").response[0]
                 .text
-                .contains("spare ash, cord, and iron")
+                .contains("raw ash, cord, and iron")
+        );
+        assert!(
+            choice("organize_repair")
+                .result
+                .contains("temporary splint")
+        );
+        assert!(
+            choice("organize_repair")
+                .result
+                .contains("sufficient only for the immediate queued crossings")
         );
 
         for (route, virtue) in [
@@ -1432,6 +1461,13 @@ mod tests {
         }
         let theft = choice("steal_till");
         assert!(theft.response[0].text.contains("trust the charge"));
+        assert!(theft.response[0].text.contains("till ashore"));
+        assert!(theft.result.contains("keeping the shore tally"));
+        assert!(
+            theft
+                .result
+                .contains("repeatedly sculleth queued crossings")
+        );
         assert!(
             theft
                 .result

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1266,6 +1266,186 @@ mod tests {
     }
 
     #[test]
+    fn ferryman_disputed_tribute_routes_are_grounded_distinct_and_balanced() {
+        let definition = encounter("ferryman_disputed_tribute_v1").unwrap();
+        assert!(definition.triggers.travel && !definition.triggers.rest);
+        assert_eq!(definition.weight, 70);
+        assert!(
+            definition
+                .cast
+                .iter()
+                .all(|speaker| speaker.nature == SpeakerNature::Mortal)
+        );
+        assert!(
+            definition
+                .opening
+                .iter()
+                .chain(
+                    definition
+                        .choices
+                        .iter()
+                        .flat_map(|choice| &choice.response)
+                )
+                .all(|line| line.reviewed_shakespearean && !line.reviewed_iambic_pentameter)
+        );
+        let opening = definition
+            .opening
+            .iter()
+            .map(|line| line.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase();
+        for withheld_observation in ["mail", "shallow", "gravel", "deep current"] {
+            assert!(!opening.contains(withheld_observation));
+        }
+        assert!(opening.contains("twelve groschen"));
+        assert!(opening.contains("elder marks"));
+
+        let choice = |id| {
+            definition
+                .choices
+                .iter()
+                .find(|choice| choice.id == id)
+                .unwrap()
+        };
+        let active = definition
+            .choices
+            .iter()
+            .filter(|choice| choice.id != "ignore")
+            .collect::<Vec<_>>();
+        assert_eq!(definition.choices.len(), 7);
+        let signatures = active
+            .iter()
+            .map(|choice| {
+                serde_json::to_string(&(
+                    &choice.requirements,
+                    &choice.checks,
+                    &choice.effects,
+                    &choice.personality,
+                    &choice.transition,
+                ))
+                .unwrap()
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(signatures.len(), 6);
+        assert!(active.iter().all(|choice| {
+            choice.effects.iter().any(|effect| {
+                matches!(
+                    effect,
+                    Effect::Information { information_id }
+                        if information_id == "deep_current_confines_mail_riders_to_shallows"
+                )
+            }) && choice.quest_reward_tags == ["heavy_attackers_confined_to_shallow_gravel"]
+                && choice
+                    .outcome_tags
+                    .iter()
+                    .any(|tag| tag == "physical_observation")
+        }));
+        assert!(active.iter().all(|choice| {
+            choice.result.contains("deep current")
+                && choice.result.contains("mail-burdened riders")
+                && choice.result.contains("shallow gravel")
+        }));
+
+        for (route, minutes) in [
+            ("pay_tribute", 15),
+            ("barter_provisions", 20),
+            ("row_in_lieu", 45),
+            ("expose_altered_tally", 30),
+            ("organize_repair", 60),
+            ("steal_till", 90),
+        ] {
+            assert!(matches!(
+                choice(route).transition.as_ref(),
+                Some(EncounterTransition::TravelDelay { minutes: actual }) if *actual == minutes
+            ));
+        }
+        assert!(matches!(
+            choice("ignore").transition.as_ref(),
+            Some(EncounterTransition::TravelDelay { minutes: 180 })
+        ));
+        assert!(choice("ignore").effects.is_empty());
+        assert!(choice("ignore").personality.is_empty());
+        assert!(choice("ignore").quest_reward_tags.is_empty());
+
+        assert!(matches!(
+            choice("pay_tribute").requirements[0],
+            Requirement::Currency { amount: 12 }
+        ));
+        assert!(matches!(
+            choice("pay_tribute").effects[0],
+            Effect::Currency { amount: -12, .. }
+        ));
+        assert!(matches!(
+            choice("barter_provisions").requirements[0],
+            Requirement::Item {
+                ref item_id,
+                minimum_quantity: 4
+            } if item_id == "travel_ration"
+        ));
+        assert_eq!(
+            crate::item_catalog::definition("travel_ration")
+                .unwrap()
+                .base_value
+                * 4,
+            12
+        );
+        assert!(matches!(
+            choice("row_in_lieu").checks[0],
+            Check::Attribute {
+                attribute: AttributeId::Endurance,
+                difficulty_milli: 1200
+            }
+        ));
+        let lawful_fare = choice("expose_altered_tally");
+        assert!(lawful_fare.response[0].text.contains("Four groschen"));
+        assert!(lawful_fare.response[0].text.contains("witness-mark"));
+        assert!(matches!(
+            lawful_fare.requirements[0],
+            Requirement::Currency { amount: 4 }
+        ));
+        assert!(matches!(
+            lawful_fare.effects[0],
+            Effect::Currency { amount: -4, .. }
+        ));
+        assert!(matches!(
+            choice("organize_repair").checks[0],
+            Check::Skill {
+                skill: SkillId::Command,
+                difficulty_milli: 1000
+            }
+        ));
+        assert!(
+            choice("organize_repair").response[0]
+                .text
+                .contains("spare ash, cord, and iron")
+        );
+
+        for (route, virtue) in [
+            ("pay_tribute", VirtueId::Prudence),
+            ("barter_provisions", VirtueId::Courtesy),
+            ("row_in_lieu", VirtueId::Courage),
+            ("expose_altered_tally", VirtueId::Justice),
+            ("organize_repair", VirtueId::Prudence),
+        ] {
+            assert_eq!(exemplified_virtue(&choice(route).personality), Some(virtue));
+        }
+        let theft = choice("steal_till");
+        assert!(theft.response[0].text.contains("trust the charge"));
+        assert!(
+            theft
+                .result
+                .contains("abscondest with forty-eight groschen")
+        );
+        assert!(matches!(
+            theft.effects[0],
+            Effect::Currency { amount: 48, .. }
+        ));
+        assert!(theft.personality[0].delta < 0);
+        assert_eq!(exemplified_virtue(&theft.personality), None);
+    }
+
+    #[test]
     fn combat_transition_rejects_unsafe_counts() {
         let mut definition = encounter("unlawful_bridge_custom_v1").unwrap().clone();
         let choice = definition

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1653)
+## Files (1654)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -35,6 +35,7 @@ development, or other wiki document before changing a subsystem.
 - `content/dialogue/examples.yaml` — Repository support file.
 - `content/dialogue/organizations.yaml` — Repository support file.
 - `content/dialogue/services.yaml` — Repository support file.
+- `content/encounters/ferryman-disputed-tribute.yaml` — Repository support file.
 - `content/encounters/proud-traveler-errands.yaml` — Repository support file.
 - `content/encounters/unlawful-bridge-custom.yaml` — Repository support file.
 - `content/encounters/wounded-courier.yaml` — Repository support file.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -135,14 +135,16 @@ it. The encounter is travel-only, goal-neutral, entirely mortal, and requires
 no runtime catalog special case.
 
 `ferryman_disputed_tribute_v1` places a mortal ferryman beside a swollen river,
-a split oar, and a toll board cut over older marks. The party may pay the
-claimed twelve-groschen fare, barter four equally valued travel rations, row
-under the ferryman's direction, expose the lawful four-groschen tally, organize
-stranded travelers while the ferryman supplies the craft and materials, or win
-his trust and steal the entrusted till; the rough upper ford remains a costly
-way to ignore the encounter. Every active route earns the same grounded
-observation: the deep current confines mail-burdened riders to shallow gravel,
-which can inform later physical preparation without weakening any opponent.
+the split blade of his west oar, a waiting company on both banks, and a toll
+board cut over older marks. The party may pay the claimed twelve-groschen fare,
+barter four equally valued travel rations, relieve him at the one sound sculling
+oar, expose the lawful four-groschen tally, organize the waiting travelers while
+he fashions a temporary splint for the immediate queued crossings, or win his
+trust at the shore tally and steal the entrusted till; the rough upper ford
+remains a costly way to ignore the encounter. Every active route concretely
+witnesses a mail-clad rider urge his horse into the deep current and be forced
+back onto shallow gravel, which can inform later physical preparation without
+weakening any opponent.
 Honest routes express Prudence, Courtesy, Courage, or Justice, while the
 materially richest theft lowers Honesty without publicly exemplifying it. The
 opening discloses the dangerous crossing and disputed fare, but withholds that

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -134,6 +134,21 @@ while the materially richest theft lowers Honesty without publicly exemplifying
 it. The encounter is travel-only, goal-neutral, entirely mortal, and requires
 no runtime catalog special case.
 
+`ferryman_disputed_tribute_v1` places a mortal ferryman beside a swollen river,
+a split oar, and a toll board cut over older marks. The party may pay the
+claimed twelve-groschen fare, barter four equally valued travel rations, row
+under the ferryman's direction, expose the lawful four-groschen tally, organize
+stranded travelers while the ferryman supplies the craft and materials, or win
+his trust and steal the entrusted till; the rough upper ford remains a costly
+way to ignore the encounter. Every active route earns the same grounded
+observation: the deep current confines mail-burdened riders to shallow gravel,
+which can inform later physical preparation without weakening any opponent.
+Honest routes express Prudence, Courtesy, Courage, or Justice, while the
+materially richest theft lowers Honesty without publicly exemplifying it. The
+opening discloses the dangerous crossing and disputed fare, but withholds that
+deeper tactical conclusion. The encounter is travel-only, goal-neutral,
+entirely mortal, and uses no runtime catalog special case.
+
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source
 mapped at build time. YAML owns stable ID/version/weight, trigger eligibility,


### PR DESCRIPTION
## Summary
- add erryman_disputed_tribute_v1, a travel-only swollen-river crossing with seven grounded responses
- support payment, equal-value ration barter, endurance rowing, exposing an altered tally, organizing a temporary oar splint, entrusted-till fraud, and a three-hour upper-ford detour
- establish one coherent ferry system: one split blade, one sound sculling oar, a landing cable, and a ferryman-led temporary repair for immediate queued crossings
- make every active route witness a concrete physical fact: deep current forces mail-burdened riders and horses onto a predictable shallow gravel margin
- keep the fraudulent shore-tally route materially richest while applying negative Honesty development and no exemplified virtue

## Stack
- base: codex/romance-encounter-03-proud-traveler-errands / #347
- this is encounter 04 in the sequential romance-road-encounter stack

## Verification
- road encounter catalog: 14/14
- content compiler: 5 encounter definitions
- full workspace just check
- formatting, project-map, and diff checks
- two independent correctness/maintainability reviews, clean after remediation

## Deliberate follow-up
- elapsed rowing, repair, and detour currently use the generic active travel-delay mechanic; exertion-specific activity costs can be modeled later without changing this content contract