### PR TITLE
Add rash cliff-hunt encounter

### DIFF
--- a/content/encounters/rash-cliff-hunt.yaml
+++ b/content/encounters/rash-cliff-hunt.yaml
@@ -1,0 +1,134 @@
+{
+  "encounters": [
+    {
+      "id": "rash_cliff_hunt_v1",
+      "version": 1,
+      "weight": 70,
+      "triggers": { "travel": true, "rest": false },
+      "provenance": {
+        "works": ["Parzival", "Wigalois", "Lanzelet", "Theuerdank", "Le Morte d'Arthur"],
+        "motifs": ["rash_noble_hunt", "mountain_quarry", "perilous_ascent", "unjust_wager", "betrayed_trust"],
+        "adaptation_note": "An original synthesis of hazardous noble hunts, proud wagers, imperiled attendants, and mountain trials common in chivalric romance; it does not reproduce a particular episode."
+      },
+      "cast": [
+        { "id": "young_lord", "name": "Young lord", "nature": "mortal" }
+      ],
+      "opening": [
+        {
+          "speaker": "young_lord",
+          "text": "Good travelers, a mountain buck hath mocked my hunt among these heights. My mail-clad squire and lightly burdened beaters wait below a shale ascent where one false foot promiseth a grievous fall. I wager twenty groschen that I shall reach the upper cairn before any champion among you. If the buck escapeth us, every servant here shall forfeit his wages.",
+          "reviewed_shakespearean": true
+        }
+      ],
+      "choices": [
+        {
+          "id": "stalk_safe_switchback",
+          "label": "Stalk the safer switchback and prove the sounder ascent",
+          "response": [{ "speaker": "young_lord", "text": "Thou readest these hills more soberly than I. Take the safer winding path, and twelve groschen shall answer thy better judgment if thou reachest the station.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest ninety minutes stalking the safer switchback and earnest twelve groschen. From thy station thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "deed": "stalk_safe_switchback_at_cliff_hunt",
+          "outcome_tags": ["prudence", "hillcraft", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "terrain_hills", "difficulty_milli": 1100 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 12 },
+            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 110, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "transition": { "kind": "travel_delay", "minutes": 90 }
+        },
+        {
+          "id": "climb_with_hunting_spear",
+          "label": "Climb the shale using thy hunting spear for purchase",
+          "response": [{ "speaker": "young_lord", "text": "Thy hunting spear may serve as staff and brace where shale betrayeth boots. Win thou the upper cairn by strength, and the full twenty-groschen wager shall be thine.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest an hour climbing with thy hunting spear as staff and brace, keepest possession of it, and winnest twenty groschen. From the cairn thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "deed": "climb_cliff_hunt_with_hunting_spear",
+          "outcome_tags": ["courage", "arduous_ascent", "physical_observation"],
+          "requirements": [{ "kind": "item", "item_id": "hunting_spear", "minimum_quantity": 1 }],
+          "checks": [{ "kind": "attribute", "attribute": "endurance", "difficulty_milli": 1250 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 20 },
+            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+          ],
+          "personality": [{ "axis": "nerve", "delta": 110, "virtue": "courage" }],
+          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "order_belayed_drive",
+          "label": "Order a belayed drive with the hunt's cords and poles",
+          "response": [{ "speaker": "young_lord", "text": "My train beareth cords and stout poles, though no man hath ordered their use. Command the beaters, and I shall pay eight groschen for a drive that hazardeth no needless fall.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest seventy-five minutes ordering the hunt's beaters into belayed stations whilst they use its cords and poles. Thou receivest eight groschen and witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "deed": "order_belayed_drive_at_cliff_hunt",
+          "outcome_tags": ["prudence", "command", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 8 },
+            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 100, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "transition": { "kind": "travel_delay", "minutes": 75 }
+        },
+        {
+          "id": "persuade_fair_terms",
+          "label": "Persuade the lord to stake his own purse, not servant wages",
+          "response": [{ "speaker": "young_lord", "text": "Thy tongue hath made my wager seem unworthy of my rank. My servants shall retain their wages; inspect thou their stations, and sixteen groschen from mine own purse shall reward fair counsel.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest forty minutes securing the servants' wages and inspecting their stations, and receivest sixteen groschen from the lord's purse. There thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "deed": "persuade_fair_terms_at_cliff_hunt",
+          "outcome_tags": ["justice", "fair_wager", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1100 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 16 },
+            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+          ],
+          "personality": [{ "axis": "conscience", "delta": 90, "virtue": "justice" }],
+          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "transition": { "kind": "travel_delay", "minutes": 40 }
+        },
+        {
+          "id": "rebuke_vainglory",
+          "label": "Rebuke his vainglory and the threatened servants' wages",
+          "response": [{ "speaker": "young_lord", "text": "Thy rebuke recallest me that vainglory maketh poor sport of another man's bread. My servants shall keep their wages; remain and show me how a worthier hunt is ordered.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest thirty-five minutes recalling the young lord to his Christian duty toward servants whose bread he threatened. Whilst the chastened hunt resumeth, thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "deed": "rebuke_vainglory_at_cliff_hunt",
+          "outcome_tags": ["faith", "christian_duty", "physical_observation"],
+          "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
+          "checks": [{ "kind": "religion", "religion": "roman_catholic", "difficulty_milli": 1050 }],
+          "effects": [{ "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }],
+          "personality": [{ "axis": "conviction", "delta": 110, "virtue": "faith" }],
+          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "transition": { "kind": "travel_delay", "minutes": 35 }
+        },
+        {
+          "id": "rig_station_and_steal_stakes",
+          "label": "Claim hunt service, rig a station, and steal the side stakes",
+          "response": [{ "speaker": "young_lord", "text": "Thou hast served great hunts and knowest the side stakes? Take this entrusted purse, mark the lower station, and pay the waiting wagers when the drive is done.", "reviewed_shakespearean": true }],
+          "result": "Thou falsely claimest great-hunt service, takest the entrusted side stakes, and spendest an hour shifting the station marker behind a rock and across the wind. From the real lower-spur lane thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot. Then thou abscondest with forty-eight groschen.",
+          "deed": "rig_cliff_hunt_station_and_steal_stakes",
+          "outcome_tags": ["deception", "theft", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
+            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": -250, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "ignore",
+          "label": "Continue along the open road",
+          "response": [],
+          "result": "Thou leavest the rash young lord and his hunt upon the shale heights, for the road remaineth open.",
+          "deed": "ignore_rash_cliff_hunt",
+          "outcome_tags": []
+        }
+      ],
+      "quest_reward_eligibility": ["physical_tactical_information"]
+    }
+  ]
+}

--- a/content/encounters/rash-cliff-hunt.yaml
+++ b/content/encounters/rash-cliff-hunt.yaml
@@ -16,7 +16,7 @@
       "opening": [
         {
           "speaker": "young_lord",
-          "text": "Good travelers, a mountain buck hath mocked my hunt among these heights. My mail-clad squire and lightly burdened beaters wait below a shale ascent where one false foot promiseth a grievous fall. I wager twenty groschen that I shall reach the upper cairn before any champion among you. If the buck escapeth us, every servant here shall forfeit his wages.",
+          "text": "Good travelers, a mountain buck hath mocked my hunt among these heights. My mail-clad squire and chief beater stand among a frightened company of lightly burdened beaters below a shale ascent, where one false foot promiseth a grievous fall. The chief saith he knoweth safe anchors and a belayed order, yet lacketh rank to command the disordered company. I wager twenty groschen that I shall reach the upper cairn before any champion among you. If the buck escapeth us, every servant here shall forfeit his wages.",
           "reviewed_shakespearean": true
         }
       ],
@@ -25,98 +25,98 @@
           "id": "stalk_safe_switchback",
           "label": "Stalk the safer switchback and prove the sounder ascent",
           "response": [{ "speaker": "young_lord", "text": "Thou readest these hills more soberly than I. Take the safer winding path, and twelve groschen shall answer thy better judgment if thou reachest the station.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest ninety minutes stalking the safer switchback and earnest twelve groschen. From thy station thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "result": "Thou spendest ninety minutes scouting the safer switchback and earnest twelve groschen. From a prepared bow lane upon the lower spur, thou watchest a lightly equipped, bow-bearing beater engage the buck as it crosseth the exposed upper traverse. Across the gap, the mail-clad squire, armed only for melee with a hunting spear, cannot answer the bowman.",
           "deed": "stalk_safe_switchback_at_cliff_hunt",
           "outcome_tags": ["prudence", "hillcraft", "physical_observation"],
           "checks": [{ "kind": "skill", "skill": "terrain_hills", "difficulty_milli": 1100 }],
           "effects": [
             { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 12 },
-            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
           ],
           "personality": [{ "axis": "drive", "delta": 110, "virtue": "prudence" }],
-          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
           "transition": { "kind": "travel_delay", "minutes": 90 }
         },
         {
           "id": "climb_with_hunting_spear",
           "label": "Climb the shale using thy hunting spear for purchase",
           "response": [{ "speaker": "young_lord", "text": "Thy hunting spear may serve as staff and brace where shale betrayeth boots. Win thou the upper cairn by strength, and the full twenty-groschen wager shall be thine.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest an hour climbing with thy hunting spear as staff and brace, keepest possession of it, and winnest twenty groschen. From the cairn thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "result": "Thou spendest an hour climbing with thy hunting spear as staff and brace, keepest possession of it, and winnest twenty groschen. From the cairn thou seest the chief place a lightly equipped bow-bearer in the prepared lower-spur lane. When the buck entereth the exposed traverse, that beater can engage it; the mail-clad squire, armed only for melee with his hunting spear, cannot answer across the gap.",
           "deed": "climb_cliff_hunt_with_hunting_spear",
           "outcome_tags": ["courage", "arduous_ascent", "physical_observation"],
           "requirements": [{ "kind": "item", "item_id": "hunting_spear", "minimum_quantity": 1 }],
           "checks": [{ "kind": "attribute", "attribute": "endurance", "difficulty_milli": 1250 }],
           "effects": [
             { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 20 },
-            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
           ],
           "personality": [{ "axis": "nerve", "delta": 110, "virtue": "courage" }],
-          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
           "transition": { "kind": "travel_delay", "minutes": 60 }
         },
         {
           "id": "order_belayed_drive",
           "label": "Order a belayed drive with the hunt's cords and poles",
-          "response": [{ "speaker": "young_lord", "text": "My train beareth cords and stout poles, though no man hath ordered their use. Command the beaters, and I shall pay eight groschen for a drive that hazardeth no needless fall.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest seventy-five minutes ordering the hunt's beaters into belayed stations whilst they use its cords and poles. Thou receivest eight groschen and witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "response": [{ "speaker": "young_lord", "text": "My chief beater knoweth the safe anchors and belayed order, and my train beareth cords and stout poles, yet these frightened hands heed him not. Lend him thine authority, enforce his plan, and eight groschen shall reward thy command.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest seventy-five minutes enforcing and coordinating the chief beater's belay plan whilst he chooseth the safe anchors and directeth the mountain work. At his prepared lower-spur bow lane, a lightly equipped beater engageth the buck upon the exposed traverse. The mail-clad squire, armed only for melee with a hunting spear, cannot answer that bowman across the gap. Thou receivest eight groschen.",
           "deed": "order_belayed_drive_at_cliff_hunt",
           "outcome_tags": ["prudence", "command", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
           "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1050 }],
           "effects": [
             { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 8 },
-            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
           ],
           "personality": [{ "axis": "drive", "delta": 100, "virtue": "prudence" }],
-          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
           "transition": { "kind": "travel_delay", "minutes": 75 }
         },
         {
           "id": "persuade_fair_terms",
           "label": "Persuade the lord to stake his own purse, not servant wages",
           "response": [{ "speaker": "young_lord", "text": "Thy tongue hath made my wager seem unworthy of my rank. My servants shall retain their wages; inspect thou their stations, and sixteen groschen from mine own purse shall reward fair counsel.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest forty minutes securing the servants' wages and inspecting their stations, and receivest sixteen groschen from the lord's purse. There thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "result": "Thou spendest forty minutes securing the servants' wages and inspecting their stations, and receivest sixteen groschen from the lord's purse. At the fair lower-spur station thou seest a lightly equipped bow-bearing beater engage the buck upon the exposed traverse. Across the gap, the mail-clad squire, armed only for melee with his hunting spear, cannot answer him.",
           "deed": "persuade_fair_terms_at_cliff_hunt",
           "outcome_tags": ["justice", "fair_wager", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
           "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1100 }],
           "effects": [
             { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 16 },
-            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
           ],
           "personality": [{ "axis": "conscience", "delta": 90, "virtue": "justice" }],
-          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
           "transition": { "kind": "travel_delay", "minutes": 40 }
         },
         {
           "id": "rebuke_vainglory",
           "label": "Rebuke his vainglory and the threatened servants' wages",
-          "response": [{ "speaker": "young_lord", "text": "Thy rebuke recallest me that vainglory maketh poor sport of another man's bread. My servants shall keep their wages; remain and show me how a worthier hunt is ordered.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest thirty-five minutes recalling the young lord to his Christian duty toward servants whose bread he threatened. Whilst the chastened hunt resumeth, thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot.",
+          "response": [{ "speaker": "young_lord", "text": "Thy rebuke doth recall me that vainglory maketh poor sport of another man's bread. My servants shall keep their wages; remain and show me how a worthier hunt is ordered.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest thirty-five minutes recalling the young lord to his Christian duty and allowing the chief beater to lead a careful drive. From his prepared lower-spur lane, a lightly equipped bow-bearing beater engageth the buck upon the exposed traverse. The mail-clad squire, armed only for melee with a hunting spear, cannot answer across the gap, and no servant's bread is forfeit.",
           "deed": "rebuke_vainglory_at_cliff_hunt",
           "outcome_tags": ["faith", "christian_duty", "physical_observation"],
           "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
           "checks": [{ "kind": "religion", "religion": "roman_catholic", "difficulty_milli": 1050 }],
-          "effects": [{ "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }],
+          "effects": [{ "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }],
           "personality": [{ "axis": "conviction", "delta": 110, "virtue": "faith" }],
-          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
           "transition": { "kind": "travel_delay", "minutes": 35 }
         },
         {
           "id": "rig_station_and_steal_stakes",
           "label": "Claim hunt service, rig a station, and steal the side stakes",
           "response": [{ "speaker": "young_lord", "text": "Thou hast served great hunts and knowest the side stakes? Take this entrusted purse, mark the lower station, and pay the waiting wagers when the drive is done.", "reviewed_shakespearean": true }],
-          "result": "Thou falsely claimest great-hunt service, takest the entrusted side stakes, and spendest an hour shifting the station marker behind a rock and across the wind. From the real lower-spur lane thou witnessest the light beaters drive the buck onto the sole upper scree traverse. It passeth broadside above the lower spur, with neither brush nor rock to mask a ranged shot. Then thou abscondest with forty-eight groschen.",
+          "result": "Thou falsely claimest great-hunt service, takest the entrusted side stakes, and spendest an hour shifting the station marker behind a rock and across the wind. From the real prepared lower-spur lane thou seest a lightly equipped bow-bearing beater engage the buck upon the exposed traverse. The mail-clad squire, armed only for melee with a hunting spear, cannot answer that sightline across the gap. Then thou abscondest with forty-eight groschen.",
           "deed": "rig_cliff_hunt_station_and_steal_stakes",
           "outcome_tags": ["deception", "theft", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
           "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1200 }],
           "effects": [
             { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
-            { "kind": "information", "information_id": "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse" }
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
           ],
           "personality": [{ "axis": "transparency", "delta": -250, "virtue": "honesty" }],
-          "quest_reward_tags": ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
           "transition": { "kind": "travel_delay", "minutes": 60 }
         },
         {

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1482,6 +1482,275 @@ mod tests {
     }
 
     #[test]
+    fn rash_cliff_hunt_routes_are_mortal_observational_and_balanced() {
+        let definition = encounter("rash_cliff_hunt_v1").unwrap();
+        assert!(definition.triggers.travel && !definition.triggers.rest);
+        assert_eq!(definition.weight, 70);
+        assert!(
+            definition
+                .cast
+                .iter()
+                .all(|speaker| speaker.nature == SpeakerNature::Mortal)
+        );
+        assert!(
+            definition
+                .opening
+                .iter()
+                .chain(
+                    definition
+                        .choices
+                        .iter()
+                        .flat_map(|choice| &choice.response)
+                )
+                .all(|line| line.reviewed_shakespearean && !line.reviewed_iambic_pentameter)
+        );
+
+        let opening = definition
+            .opening
+            .iter()
+            .map(|line| line.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase();
+        for premise in [
+            "mountain buck",
+            "mail-clad squire",
+            "lightly burdened beaters",
+            "shale ascent",
+            "grievous fall",
+            "twenty groschen",
+            "upper cairn",
+            "forfeit his wages",
+        ] {
+            assert!(opening.contains(premise));
+        }
+        for withheld in ["lower spur", "sole upper", "broadside", "ranged shot"] {
+            assert!(!opening.contains(withheld));
+        }
+
+        let choice = |id| {
+            definition
+                .choices
+                .iter()
+                .find(|choice| choice.id == id)
+                .unwrap()
+        };
+        let active = definition
+            .choices
+            .iter()
+            .filter(|choice| choice.id != "ignore")
+            .collect::<Vec<_>>();
+        assert_eq!(definition.choices.len(), 7);
+        let signatures = definition
+            .choices
+            .iter()
+            .map(|choice| {
+                serde_json::to_string(&(
+                    &choice.requirements,
+                    &choice.checks,
+                    &choice.effects,
+                    &choice.personality,
+                    &choice.transition,
+                ))
+                .unwrap()
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(signatures.len(), 7);
+        assert!(active.iter().all(|choice| {
+            choice.effects.iter().any(|effect| {
+                matches!(
+                    effect,
+                    Effect::Information { information_id }
+                        if information_id
+                            == "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse"
+                )
+            }) && choice.quest_reward_tags
+                == ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"]
+                && choice
+                    .outcome_tags
+                    .iter()
+                    .any(|tag| tag == "physical_observation")
+        }));
+        assert!(active.iter().all(|choice| {
+            choice
+                .result
+                .contains("witnessest the light beaters drive the buck")
+                && choice.result.contains("sole upper scree traverse")
+                && choice
+                    .result
+                    .contains("passeth broadside above the lower spur")
+                && choice
+                    .result
+                    .contains("neither brush nor rock to mask a ranged shot")
+        }));
+
+        for (route, minutes, coin) in [
+            ("stalk_safe_switchback", 90, 12),
+            ("climb_with_hunting_spear", 60, 20),
+            ("order_belayed_drive", 75, 8),
+            ("persuade_fair_terms", 40, 16),
+            ("rebuke_vainglory", 35, 0),
+            ("rig_station_and_steal_stakes", 60, 48),
+        ] {
+            assert!(matches!(
+                choice(route).transition.as_ref(),
+                Some(EncounterTransition::TravelDelay { minutes: actual }) if *actual == minutes
+            ));
+            let awarded = choice(route)
+                .effects
+                .iter()
+                .filter_map(|effect| match effect {
+                    Effect::Currency { amount, .. } if *amount > 0 => Some(*amount),
+                    _ => None,
+                })
+                .sum::<i32>();
+            assert_eq!(awarded, coin);
+        }
+        assert!(matches!(
+            choice("stalk_safe_switchback").checks[0],
+            Check::Skill {
+                skill: SkillId::TerrainHills,
+                difficulty_milli: 1100
+            }
+        ));
+        let spear = choice("climb_with_hunting_spear");
+        assert!(matches!(
+            spear.requirements[0],
+            Requirement::Item {
+                ref item_id,
+                minimum_quantity: 1
+            } if item_id == "hunting_spear"
+        ));
+        assert!(matches!(
+            spear.checks[0],
+            Check::Attribute {
+                attribute: AttributeId::Endurance,
+                difficulty_milli: 1250
+            }
+        ));
+        assert!(!spear.effects.iter().any(|effect| matches!(
+            effect,
+            Effect::ConsumeItem { item_id, .. } if item_id == "hunting_spear"
+        )));
+        assert!(spear.result.contains("keepest possession of it"));
+        assert!(matches!(
+            choice("order_belayed_drive").requirements[0],
+            Requirement::Skill {
+                skill: SkillId::Command,
+                minimum_hours: 1
+            }
+        ));
+        assert!(matches!(
+            choice("order_belayed_drive").checks[0],
+            Check::Skill {
+                skill: SkillId::Command,
+                difficulty_milli: 1050
+            }
+        ));
+        assert!(matches!(
+            choice("persuade_fair_terms").requirements[0],
+            Requirement::Skill {
+                skill: SkillId::Charm,
+                minimum_hours: 1
+            }
+        ));
+        assert!(matches!(
+            choice("persuade_fair_terms").checks[0],
+            Check::Skill {
+                skill: SkillId::Charm,
+                difficulty_milli: 1100
+            }
+        ));
+        assert!(
+            choice("persuade_fair_terms")
+                .result
+                .contains("securing the servants' wages and inspecting their stations")
+        );
+        assert!(matches!(
+            choice("rebuke_vainglory").requirements[0],
+            Requirement::Religion {
+                religion: ReligionId::RomanCatholic
+            }
+        ));
+        assert!(matches!(
+            choice("rebuke_vainglory").checks[0],
+            Check::Religion {
+                religion: ReligionId::RomanCatholic,
+                difficulty_milli: 1050
+            }
+        ));
+
+        for (route, virtue) in [
+            ("stalk_safe_switchback", VirtueId::Prudence),
+            ("climb_with_hunting_spear", VirtueId::Courage),
+            ("order_belayed_drive", VirtueId::Prudence),
+            ("persuade_fair_terms", VirtueId::Justice),
+            ("rebuke_vainglory", VirtueId::Faith),
+        ] {
+            assert_eq!(exemplified_virtue(&choice(route).personality), Some(virtue));
+        }
+        let theft = choice("rig_station_and_steal_stakes");
+        assert!(matches!(
+            theft.requirements[0],
+            Requirement::Skill {
+                skill: SkillId::Deception,
+                minimum_hours: 1
+            }
+        ));
+        assert!(matches!(
+            theft.checks[0],
+            Check::Skill {
+                skill: SkillId::Deception,
+                difficulty_milli: 1200
+            }
+        ));
+        for grounded_theft_detail in [
+            "falsely claimest great-hunt service",
+            "entrusted side stakes",
+            "station marker behind a rock and across the wind",
+            "real lower-spur lane",
+            "abscondest with forty-eight groschen",
+        ] {
+            assert!(theft.result.contains(grounded_theft_detail));
+        }
+        assert!(theft.personality[0].delta < 0);
+        assert_eq!(exemplified_virtue(&theft.personality), None);
+        let largest_honest_coin = active
+            .iter()
+            .filter(|choice| choice.id != "rig_station_and_steal_stakes")
+            .flat_map(|choice| &choice.effects)
+            .filter_map(|effect| match effect {
+                Effect::Currency { amount, .. } if *amount > 0 => Some(*amount),
+                _ => None,
+            })
+            .max()
+            .unwrap();
+        assert!(48 > largest_honest_coin);
+
+        assert!(choice("ignore").transition.is_none());
+        assert!(choice("ignore").effects.is_empty());
+        assert!(choice("ignore").personality.is_empty());
+        let authored = serde_json::to_string(definition).unwrap().to_lowercase();
+        for prohibited_claim in [
+            "buck is slain",
+            "buck dieth",
+            "quarry item",
+            "equipment damage",
+            "injureth",
+        ] {
+            assert!(!authored.contains(prohibited_claim));
+        }
+        assert!(
+            active
+                .iter()
+                .flat_map(|choice| &choice.effects)
+                .all(|effect| {
+                    matches!(effect, Effect::Currency { .. } | Effect::Information { .. })
+                })
+        );
+    }
+
+    #[test]
     fn combat_transition_rejects_unsafe_counts() {
         let mut definition = encounter("unlawful_bridge_custom_v1").unwrap().clone();
         let choice = definition

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1485,46 +1485,13 @@ mod tests {
     fn rash_cliff_hunt_routes_are_mortal_observational_and_balanced() {
         let definition = encounter("rash_cliff_hunt_v1").unwrap();
         assert!(definition.triggers.travel && !definition.triggers.rest);
-        assert_eq!(definition.weight, 70);
-        assert!(
-            definition
-                .cast
-                .iter()
-                .all(|speaker| speaker.nature == SpeakerNature::Mortal)
-        );
-        assert!(
-            definition
-                .opening
-                .iter()
-                .chain(
-                    definition
-                        .choices
-                        .iter()
-                        .flat_map(|choice| &choice.response)
-                )
-                .all(|line| line.reviewed_shakespearean && !line.reviewed_iambic_pentameter)
-        );
+        assert_eq!(definition.cast[0].nature, SpeakerNature::Mortal);
 
-        let opening = definition
-            .opening
-            .iter()
-            .map(|line| line.text.as_str())
-            .collect::<Vec<_>>()
-            .join(" ")
-            .to_lowercase();
-        for premise in [
-            "mountain buck",
-            "mail-clad squire",
-            "lightly burdened beaters",
-            "shale ascent",
-            "grievous fall",
-            "twenty groschen",
-            "upper cairn",
-            "forfeit his wages",
-        ] {
-            assert!(opening.contains(premise));
-        }
-        for withheld in ["lower spur", "sole upper", "broadside", "ranged shot"] {
+        let opening = definition.opening[0].text.to_lowercase();
+        assert!(opening.contains("chief beater"));
+        assert!(opening.contains("safe anchors and a belayed order"));
+        assert!(opening.contains("lacketh rank to command"));
+        for withheld in ["lower spur", "bow", "ranged", "melee", "across the gap"] {
             assert!(!opening.contains(withheld));
         }
 
@@ -1540,184 +1507,72 @@ mod tests {
             .iter()
             .filter(|choice| choice.id != "ignore")
             .collect::<Vec<_>>();
-        assert_eq!(definition.choices.len(), 7);
-        let signatures = definition
-            .choices
-            .iter()
-            .map(|choice| {
-                serde_json::to_string(&(
-                    &choice.requirements,
-                    &choice.checks,
-                    &choice.effects,
-                    &choice.personality,
-                    &choice.transition,
-                ))
-                .unwrap()
-            })
-            .collect::<BTreeSet<_>>();
-        assert_eq!(signatures.len(), 7);
+        assert_eq!(active.len(), 6);
         assert!(active.iter().all(|choice| {
             choice.effects.iter().any(|effect| {
                 matches!(
                     effect,
                     Effect::Information { information_id }
-                        if information_id
-                            == "lower_spur_gives_clear_ranged_flank_on_upper_scree_traverse"
+                        if information_id == "melee_only_opposition_cannot_answer_prepared_bow_lane"
                 )
-            }) && choice.quest_reward_tags
-                == ["prepare_ranged_weapons_for_exposed_upper_scree_traverse"]
-                && choice
-                    .outcome_tags
-                    .iter()
-                    .any(|tag| tag == "physical_observation")
+            }) && choice.quest_reward_tags == ["prepare_bows_against_melee_only_opposition"]
         }));
         assert!(active.iter().all(|choice| {
-            choice
-                .result
-                .contains("witnessest the light beaters drive the buck")
-                && choice.result.contains("sole upper scree traverse")
-                && choice
-                    .result
-                    .contains("passeth broadside above the lower spur")
-                && choice
-                    .result
-                    .contains("neither brush nor rock to mask a ranged shot")
+            let result = choice.result.to_lowercase().replace('-', " ");
+            result.contains("lower spur")
+                && result.contains("bow")
+                && result.contains("exposed")
+                && result.contains("mail clad squire")
+                && result.contains("melee")
+                && result.contains("cannot answer")
+                && result.contains("gap")
         }));
 
-        for (route, minutes, coin) in [
-            ("stalk_safe_switchback", 90, 12),
-            ("climb_with_hunting_spear", 60, 20),
-            ("order_belayed_drive", 75, 8),
-            ("persuade_fair_terms", 40, 16),
-            ("rebuke_vainglory", 35, 0),
-            ("rig_station_and_steal_stakes", 60, 48),
-        ] {
-            assert!(matches!(
-                choice(route).transition.as_ref(),
-                Some(EncounterTransition::TravelDelay { minutes: actual }) if *actual == minutes
-            ));
-            let awarded = choice(route)
-                .effects
-                .iter()
-                .filter_map(|effect| match effect {
-                    Effect::Currency { amount, .. } if *amount > 0 => Some(*amount),
-                    _ => None,
-                })
-                .sum::<i32>();
-            assert_eq!(awarded, coin);
-        }
-        assert!(matches!(
-            choice("stalk_safe_switchback").checks[0],
-            Check::Skill {
-                skill: SkillId::TerrainHills,
-                difficulty_milli: 1100
-            }
-        ));
         let spear = choice("climb_with_hunting_spear");
         assert!(matches!(
-            spear.requirements[0],
-            Requirement::Item {
-                ref item_id,
+            spear.requirements.as_slice(),
+            [Requirement::Item {
+                item_id,
                 minimum_quantity: 1
-            } if item_id == "hunting_spear"
-        ));
-        assert!(matches!(
-            spear.checks[0],
-            Check::Attribute {
-                attribute: AttributeId::Endurance,
-                difficulty_milli: 1250
-            }
+            }] if item_id == "hunting_spear"
         ));
         assert!(!spear.effects.iter().any(|effect| matches!(
             effect,
             Effect::ConsumeItem { item_id, .. } if item_id == "hunting_spear"
         )));
         assert!(spear.result.contains("keepest possession of it"));
-        assert!(matches!(
-            choice("order_belayed_drive").requirements[0],
-            Requirement::Skill {
-                skill: SkillId::Command,
-                minimum_hours: 1
-            }
-        ));
-        assert!(matches!(
-            choice("order_belayed_drive").checks[0],
-            Check::Skill {
-                skill: SkillId::Command,
-                difficulty_milli: 1050
-            }
-        ));
-        assert!(matches!(
-            choice("persuade_fair_terms").requirements[0],
-            Requirement::Skill {
-                skill: SkillId::Charm,
-                minimum_hours: 1
-            }
-        ));
-        assert!(matches!(
-            choice("persuade_fair_terms").checks[0],
-            Check::Skill {
-                skill: SkillId::Charm,
-                difficulty_milli: 1100
-            }
-        ));
-        assert!(
-            choice("persuade_fair_terms")
-                .result
-                .contains("securing the servants' wages and inspecting their stations")
-        );
-        assert!(matches!(
-            choice("rebuke_vainglory").requirements[0],
-            Requirement::Religion {
-                religion: ReligionId::RomanCatholic
-            }
-        ));
-        assert!(matches!(
-            choice("rebuke_vainglory").checks[0],
-            Check::Religion {
-                religion: ReligionId::RomanCatholic,
-                difficulty_milli: 1050
-            }
-        ));
 
-        for (route, virtue) in [
-            ("stalk_safe_switchback", VirtueId::Prudence),
-            ("climb_with_hunting_spear", VirtueId::Courage),
-            ("order_belayed_drive", VirtueId::Prudence),
-            ("persuade_fair_terms", VirtueId::Justice),
-            ("rebuke_vainglory", VirtueId::Faith),
-        ] {
-            assert_eq!(exemplified_virtue(&choice(route).personality), Some(virtue));
-        }
+        let command = choice("order_belayed_drive");
+        assert!(
+            command.response[0]
+                .text
+                .contains("chief beater knoweth the safe anchors")
+        );
+        assert!(
+            command.response[0]
+                .text
+                .contains("Lend him thine authority")
+        );
+        assert!(
+            command
+                .result
+                .contains("enforcing and coordinating the chief beater's belay plan")
+        );
+        assert!(command.result.contains("he chooseth the safe anchors"));
+
+        assert!(
+            choice("rebuke_vainglory").response[0]
+                .text
+                .starts_with("Thy rebuke doth recall me")
+        );
         let theft = choice("rig_station_and_steal_stakes");
         assert!(matches!(
-            theft.requirements[0],
-            Requirement::Skill {
-                skill: SkillId::Deception,
-                minimum_hours: 1
-            }
+            theft.effects[0],
+            Effect::Currency { amount: 48, .. }
         ));
-        assert!(matches!(
-            theft.checks[0],
-            Check::Skill {
-                skill: SkillId::Deception,
-                difficulty_milli: 1200
-            }
-        ));
-        for grounded_theft_detail in [
-            "falsely claimest great-hunt service",
-            "entrusted side stakes",
-            "station marker behind a rock and across the wind",
-            "real lower-spur lane",
-            "abscondest with forty-eight groschen",
-        ] {
-            assert!(theft.result.contains(grounded_theft_detail));
-        }
-        assert!(theft.personality[0].delta < 0);
-        assert_eq!(exemplified_virtue(&theft.personality), None);
         let largest_honest_coin = active
             .iter()
-            .filter(|choice| choice.id != "rig_station_and_steal_stakes")
+            .filter(|choice| choice.id != theft.id)
             .flat_map(|choice| &choice.effects)
             .filter_map(|effect| match effect {
                 Effect::Currency { amount, .. } if *amount > 0 => Some(*amount),
@@ -1726,28 +1581,23 @@ mod tests {
             .max()
             .unwrap();
         assert!(48 > largest_honest_coin);
+        assert!(theft.personality.iter().all(|change| change.delta < 0));
+        assert_eq!(exemplified_virtue(&theft.personality), None);
 
-        assert!(choice("ignore").transition.is_none());
-        assert!(choice("ignore").effects.is_empty());
-        assert!(choice("ignore").personality.is_empty());
+        let ignore = choice("ignore");
+        assert!(ignore.transition.is_none());
+        assert!(ignore.effects.is_empty());
+        assert!(ignore.personality.is_empty());
         let authored = serde_json::to_string(definition).unwrap().to_lowercase();
-        for prohibited_claim in [
+        for prohibited in [
             "buck is slain",
             "buck dieth",
             "quarry item",
             "equipment damage",
             "injureth",
         ] {
-            assert!(!authored.contains(prohibited_claim));
+            assert!(!authored.contains(prohibited));
         }
-        assert!(
-            active
-                .iter()
-                .flat_map(|choice| &choice.effects)
-                .all(|effect| {
-                    matches!(effect, Effect::Currency { .. } | Effect::Information { .. })
-                })
-        );
     }
 
     #[test]

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1654)
+## Files (1655)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -37,6 +37,7 @@ development, or other wiki document before changing a subsystem.
 - `content/dialogue/services.yaml` — Repository support file.
 - `content/encounters/ferryman-disputed-tribute.yaml` — Repository support file.
 - `content/encounters/proud-traveler-errands.yaml` — Repository support file.
+- `content/encounters/rash-cliff-hunt.yaml` — Repository support file.
 - `content/encounters/unlawful-bridge-custom.yaml` — Repository support file.
 - `content/encounters/wounded-courier.yaml` — Repository support file.
 - `content/encounters/wounded-knight-linden.yaml` — Repository support file.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -151,6 +151,23 @@ opening discloses the dangerous crossing and disputed fare, but withholds that
 deeper tactical conclusion. The encounter is travel-only, goal-neutral,
 entirely mortal, and uses no runtime catalog special case.
 
+`rash_cliff_hunt_v1` places a rash mortal young lord, his mail-clad squire, and
+light beaters below a dangerous shale ascent. The lord stakes twenty groschen
+on reaching an upper cairn and threatens his servants' wages if the mountain
+buck escapes. The party may stalk a safer switchback, use an owned hunting
+spear as a climbing brace without consuming it, order a belayed drive from the
+hunt's cords and poles, negotiate fair terms that preserve the servants' wages,
+rebuke the lord's vainglory through Christian duty, or falsely claim hunt
+service, rig a station, and abscond with the entrusted side stakes; the open
+road permits a consequence-free refusal. Every active route concretely
+witnesses light beaters drive the living buck onto its sole upper scree
+traverse, where it passes broadside above the lower spur without brush or rock
+to mask a ranged shot. This physical observation informs weapon preparation
+without granting quarry, killing or persisting the buck, damaging equipment,
+or weakening any opponent. The materially richest theft lowers Honesty without
+publicly exemplifying it. The encounter is travel-only, goal-neutral, entirely
+mortal, and requires no runtime catalog special case.
+
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source
 mapped at build time. YAML owns stable ID/version/weight, trigger eligibility,

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -151,22 +151,25 @@ opening discloses the dangerous crossing and disputed fare, but withholds that
 deeper tactical conclusion. The encounter is travel-only, goal-neutral,
 entirely mortal, and uses no runtime catalog special case.
 
-`rash_cliff_hunt_v1` places a rash mortal young lord, his mail-clad squire, and
-light beaters below a dangerous shale ascent. The lord stakes twenty groschen
-on reaching an upper cairn and threatens his servants' wages if the mountain
-buck escapes. The party may stalk a safer switchback, use an owned hunting
-spear as a climbing brace without consuming it, order a belayed drive from the
-hunt's cords and poles, negotiate fair terms that preserve the servants' wages,
-rebuke the lord's vainglory through Christian duty, or falsely claim hunt
-service, rig a station, and abscond with the entrusted side stakes; the open
-road permits a consequence-free refusal. Every active route concretely
-witnesses light beaters drive the living buck onto its sole upper scree
-traverse, where it passes broadside above the lower spur without brush or rock
-to mask a ranged shot. This physical observation informs weapon preparation
-without granting quarry, killing or persisting the buck, damaging equipment,
-or weakening any opponent. The materially richest theft lowers Honesty without
-publicly exemplifying it. The encounter is travel-only, goal-neutral, entirely
-mortal, and requires no runtime catalog special case.
+`rash_cliff_hunt_v1` places a rash mortal young lord, his mail-clad squire, a
+knowledgeable but outranked chief beater, and frightened light beaters below a
+dangerous shale ascent. The lord stakes twenty groschen on reaching an upper
+cairn and threatens his servants' wages if the mountain buck escapes. The
+party may stalk a safer switchback, use an owned hunting spear as a climbing
+brace without consuming it, lend the chief beater enough authority to execute
+his own safe-anchor and belay plan, negotiate fair terms that preserve the
+servants' wages, rebuke the lord's vainglory through Christian duty, or falsely
+claim hunt service, rig a station, and abscond with the entrusted side stakes;
+the open road permits a consequence-free refusal. From a different grounded
+perspective, every active route demonstrates the same portable physical fact:
+a lightly equipped bow-bearing beater in a prepared lower-spur lane can engage
+the exposed traverse, while the mail-clad squire, armed only for melee with a
+hunting spear, cannot answer across the gap. This informs preparation of bows
+and arrows against known melee-only opposition—including the modeled armed
+retainer finale—without granting quarry, killing or persisting the buck,
+damaging equipment, or weakening any opponent. The materially richest theft
+lowers Honesty without publicly exemplifying it. The encounter is travel-only,
+goal-neutral, entirely mortal, and requires no runtime catalog special case.
 
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source


### PR DESCRIPTION
## Summary
- add ash_cliff_hunt_v1, a travel-only mortal mountain-hunt scene with six active approaches and a clean open-road ignore
- support safe hillcraft, a spear-braced ascent, commanding a chief beater’s safe plan, negotiating fair stakes, a Christian rebuke of vainglory, and fraudulent station-rigging with stake theft
- keep the dishonest route materially richest while applying negative Honesty development and no exemplified virtue
- teach a portable physical preparation fact compatible with the fixed errantry finale: a prepared bow lane can engage melee-only opposition across a gap it cannot answer
- ground technical anchor/belay knowledge in the chief beater while Command supplies authority and coordination
- keep encounter-specific Rust coverage compact so flavor remains YAML-owned

## Stack
- base: codex/romance-encounter-04-ferryman-disputed-tribute / #348
- this is encounter 05 in the sequential romance-road-encounter stack

## Verification
- road encounter catalog: 15/15
- content compiler: 6 encounter definitions
- full workspace just check
- formatting, project-map, and diff checks
- two independent correctness/maintainability reviews, clean after remediation

## Deliberate follow-up
- tactical information is persisted/tagged and matches the armed-retainer no-missile profile; explicit finale-preparation UI/consumption remains part of the broader finale-information integration