### PR TITLE
Add envious captain false-directions encounter

### DIFF
--- a/content/encounters/envious-captain-false-directions.yaml
+++ b/content/encounters/envious-captain-false-directions.yaml
@@ -1,0 +1,134 @@
+{
+  "encounters": [
+    {
+      "id": "envious_captain_false_directions_v1",
+      "version": 1,
+      "weight": 65,
+      "triggers": { "travel": true, "rest": false },
+      "provenance": {
+        "works": ["Parzival", "Wigalois", "Lanzelet", "Theuerdank", "Le Morte d'Arthur"],
+        "motifs": ["false_directions", "envious_captain", "roadside_oath", "merchant_payroll", "betrayed_trust"],
+        "adaptation_note": "An original synthesis of false guides, jealous retainers, contested roads, sworn claims, and payroll treachery common in chivalric romance; it does not reproduce a particular episode."
+      },
+      "cast": [
+        { "id": "escort_captain", "name": "Escort captain", "nature": "mortal" }
+      ],
+      "opening": [
+        {
+          "speaker": "escort_captain",
+          "text": "By the Holy Rood I swear the lower road standeth sound, though yon elder stone pointeth toward the ridge. This pale ridge chalk upon our boots came from yesterday's march, and signifieth naught. A richer merchant train followeth us with the quarrymen's payroll; let them heed my guidance when they arrive.",
+          "reviewed_shakespearean": true
+        }
+      ],
+      "choices": [
+        {
+          "id": "read_false_waymarks",
+          "label": "Read the chalk, elder stone, and flood marks together",
+          "response": [{ "speaker": "escort_captain", "text": "Thine eye maketh much of chalk and weathered stone. If thou canst prove the lower way false before the train arriveth, twelve groschen shall purchase my shame and silence.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest twenty-five minutes matching fresh ridge chalk to the elder pointing stone and reading flood marks across the lower road, and receivest twelve groschen. When the company taketh the ridge, a prepared bow guard upon the opposite shelf covereth the washed ridge cleft. The captain's mailed escort, bearing swords and spears for melee, cannot answer him across the gap and must yield the lane.",
+          "deed": "read_false_waymarks_before_merchant_train",
+          "outcome_tags": ["justice", "fraud_exposed", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "insight", "difficulty_milli": 1150 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 12 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "conscience", "delta": 100, "virtue": "justice" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 25 }
+        },
+        {
+          "id": "scout_both_roads",
+          "label": "Scout both roads before either company committeth",
+          "response": [{ "speaker": "escort_captain", "text": "Ride or climb as pleaseth thee, and compare both ways. Eight groschen shall be thine if thy hillcraft findeth safer passage than my sworn counsel.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest ninety minutes scouting the flooded lower road and the ridge approach, and receivest eight groschen for proving the ridge passable. From its flank thou seest a prepared bow guard command the washed ridge cleft from the opposite shelf. The captain's mailed swordsmen and spearmen, equipped only for melee, cannot answer across the gap; they yield the lane before the train advanceth.",
+          "deed": "scout_both_roads_before_false_guidance",
+          "outcome_tags": ["prudence", "hillcraft", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "terrain_hills", "difficulty_milli": 1100 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 8 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 110, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 90 }
+        },
+        {
+          "id": "expose_before_companies",
+          "label": "Expose the contradiction before both companies",
+          "response": [{ "speaker": "escort_captain", "text": "Thou wouldst arraign my oath before merchant and retainer alike? Speak then, and if both companies credit thee, sixteen groschen shall answer the honor thou hast stripped from me.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest forty-five minutes setting the captain's chalked boots, the elder stone, and the arriving train's witnesses before both companies, and receivest sixteen groschen. The payroll guard prepareth his bow upon the opposite shelf of the washed ridge cleft. Faced across the gap, the captain's mailed escort with swords and spears cannot answer that lane by melee and yieldeth it.",
+          "deed": "expose_false_directions_before_both_companies",
+          "outcome_tags": ["honesty", "public_truth", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1150 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 16 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": 110, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 45 }
+        },
+        {
+          "id": "organize_ridge_passage",
+          "label": "Organize the train under the factor's ridge plan",
+          "response": [{ "speaker": "escort_captain", "text": "The merchant's factor and ridge guard claim knowledge of every shelf and anchor. If thou canst inventory the wagons and place the company beneath their plan, twenty groschen shall reward thy command.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest seventy-five minutes inventorying wagons and positioning the convoy while the factor and ridge guard choose the route and anchors, and receivest twenty groschen. Their prepared bow guard holdeth the opposite shelf above the washed ridge cleft. The captain's mailed escort, armed with swords and spears for melee, cannot answer across the gap and yieldeth the lane until the convoy passeth.",
+          "deed": "organize_convoy_under_ridge_experts_plan",
+          "outcome_tags": ["prudence", "command", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 20 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 100, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 75 }
+        },
+        {
+          "id": "demand_oath_at_cross",
+          "label": "Demand that he repeat his Holy Rood oath at the wayside cross",
+          "response": [{ "speaker": "escort_captain", "text": "I shall not swear it twice beneath the carven Cross. The lower road is drowned, and my counsel was false. Let the train take the ridge, and speak no further of my oath.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest thirty-five minutes confronting the captain with his own Holy Rood oath at the wayside cross; he refuseth to repeat it and recanteth without any supernatural judgment. As the train taketh the ridge, its prepared bow guard covereth the washed cleft from the opposite shelf. The captain's mailed swordsmen and spearmen cannot answer across the gap by melee and yield the lane.",
+          "deed": "demand_repeat_of_false_holy_rood_oath",
+          "outcome_tags": ["faith", "oath_recalled", "physical_observation"],
+          "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
+          "checks": [{ "kind": "religion", "religion": "roman_catholic", "difficulty_milli": 1050 }],
+          "effects": [{ "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }],
+          "personality": [{ "axis": "conviction", "delta": 110, "virtue": "faith" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 35 }
+        },
+        {
+          "id": "collude_and_split_payroll",
+          "label": "Collude in the false guidance and split the payroll",
+          "response": [{ "speaker": "escort_captain", "text": "Then hear the truth I hid: envy biteth me whenever that richer train passeth mine. Lead its first wagon into the lower-road mire under color of aid, and we shall divide the quarrymen's ninety-six-groschen payroll equally.", "reviewed_shakespearean": true }],
+          "result": "After the captain admitteth his envy, thou spendest ninety minutes lending false aid until the payroll wagon boggeth upright in the lower-road mire, without overturn or injury. Its prepared bow guard remaineth upon the opposite shelf beyond the washed ridge cleft; the captain's mailed escort, bearing only swords and spears for melee, cannot answer him across the gap and yieldeth the lane. Trusted beside the wagon, thou stealest the ninety-six-groschen purse and dividest it equally with the captain, keeping forty-eight groschen.",
+          "deed": "collude_in_false_directions_and_split_payroll",
+          "outcome_tags": ["deception", "theft", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": -250, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 90 }
+        },
+        {
+          "id": "ignore",
+          "label": "Wait until both companies clear the crossing",
+          "response": [],
+          "result": "Thou waitest an hour until the escort and the following merchant train have cleared the crossing, then continuest upon the open road.",
+          "deed": "wait_past_false_directions_dispute",
+          "outcome_tags": [],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        }
+      ],
+      "quest_reward_eligibility": ["physical_tactical_information"]
+    }
+  ]
+}

--- a/content/encounters/envious-captain-false-directions.yaml
+++ b/content/encounters/envious-captain-false-directions.yaml
@@ -11,12 +11,18 @@
         "adaptation_note": "An original synthesis of false guides, jealous retainers, contested roads, sworn claims, and payroll treachery common in chivalric romance; it does not reproduce a particular episode."
       },
       "cast": [
-        { "id": "escort_captain", "name": "Escort captain", "nature": "mortal" }
+        { "id": "escort_captain", "name": "Escort captain", "nature": "mortal" },
+        { "id": "merchant_factor", "name": "Merchant factor", "nature": "mortal" }
       ],
       "opening": [
         {
           "speaker": "escort_captain",
-          "text": "By the Holy Rood I swear the lower road standeth sound, though yon elder stone pointeth toward the ridge. This pale ridge chalk upon our boots came from yesterday's march, and signifieth naught. A richer merchant train followeth us with the quarrymen's payroll; let them heed my guidance when they arrive.",
+          "text": "By the Holy Rood I swear the lower road standeth sound, though yon elder stone pointeth toward the ridge and pale ridge chalk marketh our boots. If any man contest my counsel, my mailed escort shall hold first passage at the narrow ridge and its washed cleft. Let the richer merchant train heed me when it arriveth.",
+          "reviewed_shakespearean": true
+        },
+        {
+          "speaker": "merchant_factor",
+          "text": "Our train approacheth with the quarrymen's payroll, and our light, ridge-wise advance guard walketh before it. The wayside cross beside this fork beareth Saint Christopher's road-brotherhood mark, the same seal that bindeth this captain's escort contract.",
           "reviewed_shakespearean": true
         }
       ],
@@ -24,8 +30,8 @@
         {
           "id": "read_false_waymarks",
           "label": "Read the chalk, elder stone, and flood marks together",
-          "response": [{ "speaker": "escort_captain", "text": "Thine eye maketh much of chalk and weathered stone. If thou canst prove the lower way false before the train arriveth, twelve groschen shall purchase my shame and silence.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest twenty-five minutes matching fresh ridge chalk to the elder pointing stone and reading flood marks across the lower road, and receivest twelve groschen. When the company taketh the ridge, a prepared bow guard upon the opposite shelf covereth the washed ridge cleft. The captain's mailed escort, bearing swords and spears for melee, cannot answer him across the gap and must yield the lane.",
+          "response": [{ "speaker": "merchant_factor", "text": "Thy reading of chalk, elder stone, and flood mark may save my train from false guidance. Prove the safer way before our wagons commit, and twelve groschen from our purse shall reward the warning.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest twenty-five minutes matching fresh ridge chalk to the elder pointing stone and reading flood marks across the lower road, and the merchant factor payeth twelve groschen for thy warning. Exposed, the captain's wounded pride maketh him order his mailed escort to bar the train and claim first ridge passage. The merchant advance guard gaineth the opposite shelf and revealeth a prepared bow above the washed cleft; the escort's melee-only swords and spears cannot answer across the gap, so the captain yieldeth the lane.",
           "deed": "read_false_waymarks_before_merchant_train",
           "outcome_tags": ["justice", "fraud_exposed", "physical_observation"],
           "checks": [{ "kind": "skill", "skill": "insight", "difficulty_milli": 1150 }],
@@ -40,8 +46,8 @@
         {
           "id": "scout_both_roads",
           "label": "Scout both roads before either company committeth",
-          "response": [{ "speaker": "escort_captain", "text": "Ride or climb as pleaseth thee, and compare both ways. Eight groschen shall be thine if thy hillcraft findeth safer passage than my sworn counsel.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest ninety minutes scouting the flooded lower road and the ridge approach, and receivest eight groschen for proving the ridge passable. From its flank thou seest a prepared bow guard command the washed ridge cleft from the opposite shelf. The captain's mailed swordsmen and spearmen, equipped only for melee, cannot answer across the gap; they yield the lane before the train advanceth.",
+          "response": [{ "speaker": "merchant_factor", "text": "Scout both ways before our train committeth, and eight groschen shall reward a true account of flood and ridge. My advance guard knoweth the heights and shall receive thy finding.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest ninety minutes scouting the flooded lower road and sound ridge approach, and the merchant factor payeth eight groschen for thy guidance. The captain's pride maketh him order his mailed escort to claim precedence and obstruct the merchant train. Its light advance guard taketh the opposite shelf and revealeth a prepared bow across the washed cleft; the melee-only escort's swords and spears cannot answer across the gap, and it yieldeth the passage.",
           "deed": "scout_both_roads_before_false_guidance",
           "outcome_tags": ["prudence", "hillcraft", "physical_observation"],
           "checks": [{ "kind": "skill", "skill": "terrain_hills", "difficulty_milli": 1100 }],
@@ -56,8 +62,8 @@
         {
           "id": "expose_before_companies",
           "label": "Expose the contradiction before both companies",
-          "response": [{ "speaker": "escort_captain", "text": "Thou wouldst arraign my oath before merchant and retainer alike? Speak then, and if both companies credit thee, sixteen groschen shall answer the honor thou hast stripped from me.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest forty-five minutes setting the captain's chalked boots, the elder stone, and the arriving train's witnesses before both companies, and receivest sixteen groschen. The payroll guard prepareth his bow upon the opposite shelf of the washed ridge cleft. Faced across the gap, the captain's mailed escort with swords and spears cannot answer that lane by melee and yieldeth it.",
+          "response": [{ "speaker": "merchant_factor", "text": "Set his oath, chalked boots, and the elder stone plainly before both companies. If thy honest speech keepeth my payroll from the mire, sixteen groschen from the train shall reward the exposure.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest forty-five minutes exposing the contradiction before both companies, and the merchant factor payeth sixteen groschen. Envious of the richer train and shamed before witnesses, the captain ordereth his mailed escort to bar its ridge passage. The merchant advance guard mounteth the opposite shelf and revealeth a prepared bow over the washed cleft; the escort's melee-only swords and spears cannot answer across the gap, and the captain yieldeth his claimed precedence.",
           "deed": "expose_false_directions_before_both_companies",
           "outcome_tags": ["honesty", "public_truth", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
@@ -73,8 +79,8 @@
         {
           "id": "organize_ridge_passage",
           "label": "Organize the train under the factor's ridge plan",
-          "response": [{ "speaker": "escort_captain", "text": "The merchant's factor and ridge guard claim knowledge of every shelf and anchor. If thou canst inventory the wagons and place the company beneath their plan, twenty groschen shall reward thy command.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest seventy-five minutes inventorying wagons and positioning the convoy while the factor and ridge guard choose the route and anchors, and receivest twenty groschen. Their prepared bow guard holdeth the opposite shelf above the washed ridge cleft. The captain's mailed escort, armed with swords and spears for melee, cannot answer across the gap and yieldeth the lane until the convoy passeth.",
+          "response": [{ "speaker": "merchant_factor", "text": "My advance guard knoweth every shelf and anchor, yet the wagons and porters lack one ordering voice. Inventory and place the convoy beneath their ridge plan, and twenty groschen from our purse shall reward thy command.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest seventy-five minutes inventorying wagons and positioning the convoy while the factor and advance guard choose the route and anchors, and the factor payeth twenty groschen. The captain then ordereth his mailed escort to obstruct the ordered train and seize first passage. The advance guard secureth the opposite shelf and revealeth its prepared bow above the washed cleft; melee-only swords and spears cannot answer across the gap, so the escort yieldeth the lane until the convoy passeth.",
           "deed": "organize_convoy_under_ridge_experts_plan",
           "outcome_tags": ["prudence", "command", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
@@ -90,8 +96,8 @@
         {
           "id": "demand_oath_at_cross",
           "label": "Demand that he repeat his Holy Rood oath at the wayside cross",
-          "response": [{ "speaker": "escort_captain", "text": "I shall not swear it twice beneath the carven Cross. The lower road is drowned, and my counsel was false. Let the train take the ridge, and speak no further of my oath.", "reviewed_shakespearean": true }],
-          "result": "Thou spendest thirty-five minutes confronting the captain with his own Holy Rood oath at the wayside cross; he refuseth to repeat it and recanteth without any supernatural judgment. As the train taketh the ridge, its prepared bow guard covereth the washed cleft from the opposite shelf. The captain's mailed swordsmen and spearmen cannot answer across the gap by melee and yield the lane.",
+          "response": [{ "speaker": "merchant_factor", "text": "Thou hast read Saint Christopher's road-brotherhood rule aright. False guidance sworn before its witnessed Cross forfeiteth an escort's wages and standing unless the captain publicly recant and undertake penance.", "reviewed_shakespearean": true }, { "speaker": "escort_captain", "text": "I shall not swear it twice. My counsel was false, and before these witnesses I recant it and accept the brotherhood's penance; yet my escort shall claim first ridge passage.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest thirty-five minutes invoking the mortal road contract and Saint Christopher brotherhood rule before the factor and witnesses. To preserve his escort's wages and standing, the captain publicly recanteth without supernatural judgment, but pride still maketh him order his mailed escort to claim first ridge passage. The merchant advance guard revealeth a prepared bow from the opposite shelf above the washed cleft; melee-only swords and spears cannot answer across the gap, and the escort yieldeth the lane.",
           "deed": "demand_repeat_of_false_holy_rood_oath",
           "outcome_tags": ["faith", "oath_recalled", "physical_observation"],
           "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
@@ -105,7 +111,7 @@
           "id": "collude_and_split_payroll",
           "label": "Collude in the false guidance and split the payroll",
           "response": [{ "speaker": "escort_captain", "text": "Then hear the truth I hid: envy biteth me whenever that richer train passeth mine. Lead its first wagon into the lower-road mire under color of aid, and we shall divide the quarrymen's ninety-six-groschen payroll equally.", "reviewed_shakespearean": true }],
-          "result": "After the captain admitteth his envy, thou spendest ninety minutes lending false aid until the payroll wagon boggeth upright in the lower-road mire, without overturn or injury. Its prepared bow guard remaineth upon the opposite shelf beyond the washed ridge cleft; the captain's mailed escort, bearing only swords and spears for melee, cannot answer him across the gap and yieldeth the lane. Trusted beside the wagon, thou stealest the ninety-six-groschen purse and dividest it equally with the captain, keeping forty-eight groschen.",
+          "result": "Whilst thou and the captain plan, the merchant advance guard scouteth ahead and taketh the opposite shelf above the washed ridge cleft, revealing a prepared bow. The captain's mailed escort, bearing melee-only swords and spears, cannot answer across the gap and yieldeth the lane, abandoning direct seizure. That failure moveth thee to the lower-road deceit: thou spendest ninety minutes redirecting the lead payroll wagon under color of aid until it boggeth upright without overturn or injury. Thou stealest its ninety-six-groschen purse and dividest it equally with the captain, keeping forty-eight groschen.",
           "deed": "collude_in_false_directions_and_split_payroll",
           "outcome_tags": ["deception", "theft", "physical_observation"],
           "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1603,23 +1603,15 @@ mod tests {
     #[test]
     fn envious_captain_routes_ground_oath_trust_and_portable_bow_lesson() {
         let definition = encounter("envious_captain_false_directions_v1").unwrap();
-        assert!(definition.triggers.travel && !definition.triggers.rest);
-        assert_eq!(definition.cast[0].nature, SpeakerNature::Mortal);
-        assert!(definition.opening[0].reviewed_shakespearean);
-        assert!(!definition.opening[0].reviewed_iambic_pentameter);
-
-        let opening = definition.opening[0].text.to_lowercase();
-        for premise in [
-            "holy rood",
-            "lower road",
-            "elder stone",
-            "pale ridge chalk",
-            "richer merchant train",
-            "quarrymen's payroll",
-        ] {
-            assert!(opening.contains(premise));
-        }
-        for withheld in ["envy", "bow", "missile", "sword", "spear", "across the gap"] {
+        let opening = format!(
+            "{} {}",
+            definition.opening[0].text, definition.opening[1].text
+        )
+        .to_lowercase();
+        assert!(opening.contains("ridge-wise advance guard"));
+        assert!(opening.contains("hold first passage"));
+        assert!(opening.contains("saint christopher's road-brotherhood mark"));
+        for withheld in ["bow", "missile", "sword", "spear", "cannot answer"] {
             assert!(!opening.contains(withheld));
         }
 
@@ -1635,74 +1627,54 @@ mod tests {
             .iter()
             .filter(|choice| choice.id != "ignore")
             .collect::<Vec<_>>();
-        assert_eq!(active.len(), 6);
-        assert!(
-            active
-                .iter()
-                .flat_map(|choice| &choice.response)
-                .all(|line| { line.reviewed_shakespearean && !line.reviewed_iambic_pentameter })
-        );
-        assert!(active.iter().all(|choice| {
-            choice.effects.iter().any(|effect| {
-                matches!(
-                    effect,
-                    Effect::Information { information_id }
-                        if information_id == "melee_only_opposition_cannot_answer_prepared_bow_lane"
-                )
-            }) && choice.quest_reward_tags == ["prepare_bows_against_melee_only_opposition"]
-                && choice
-                    .outcome_tags
-                    .iter()
-                    .any(|tag| tag == "physical_observation")
-        }));
-        assert!(active.iter().all(|choice| {
-            let result = choice.result.to_lowercase().replace('-', " ");
-            result.contains("bow")
-                && result.contains("opposite shelf")
-                && result.contains("washed")
-                && result.contains("cleft")
-                && result.contains("mailed")
-                && result.contains("sword")
-                && result.contains("spear")
-                && result.contains("melee")
-                && result.contains("cannot answer")
-                && result.contains("gap")
-                && result.contains("yield")
-        }));
-        assert_eq!(
-            active
-                .iter()
-                .map(|choice| &choice.result)
-                .collect::<BTreeSet<_>>()
-                .len(),
-            6
-        );
-
-        let command = choice("organize_ridge_passage");
-        let command_prose = format!("{} {}", command.response[0].text, command.result);
-        for grounded in [
-            "factor and ridge guard claim knowledge",
-            "inventorying wagons and positioning the convoy",
-            "factor and ridge guard choose the route and anchors",
-        ] {
-            assert!(command_prose.contains(grounded));
+        for route in &active {
+            assert!(route.effects.iter().any(|effect| matches!(
+                effect,
+                Effect::Information { information_id }
+                    if information_id == "melee_only_opposition_cannot_answer_prepared_bow_lane"
+            )));
+            assert_eq!(
+                route.quest_reward_tags,
+                ["prepare_bows_against_melee_only_opposition"]
+            );
+            assert!(route.result.contains("prepared bow"));
+            assert!(route.result.contains("cannot answer across the gap"));
+            assert!(route.result.contains("yield"));
         }
 
+        for id in [
+            "read_false_waymarks",
+            "scout_both_roads",
+            "expose_before_companies",
+            "organize_ridge_passage",
+        ] {
+            let route = choice(id);
+            assert_eq!(route.response[0].speaker, "merchant_factor");
+            assert!(route.result.contains("factor payeth"));
+        }
         let oath = choice("demand_oath_at_cross");
-        assert!(opening.contains("swear the lower road standeth sound"));
-        assert!(oath.response[0].text.contains("shall not swear it twice"));
-        assert!(oath.response[0].text.contains("my counsel was false"));
-        assert!(oath.result.contains("without any supernatural judgment"));
+        let oath_prose = format!("{} {}", oath.response[0].text, oath.result).to_lowercase();
+        for mortal_consequence in [
+            "road-brotherhood rule",
+            "wages and standing",
+            "publicly recant",
+            "without supernatural judgment",
+        ] {
+            assert!(oath_prose.contains(mortal_consequence));
+        }
 
         let theft = choice("collude_and_split_payroll");
-        assert!(theft.response[0].text.contains("envy biteth me"));
-        assert!(
-            theft.response[0]
-                .text
-                .contains("ninety-six-groschen payroll equally")
-        );
-        assert!(theft.result.contains("without overturn or injury"));
-        assert!(theft.result.contains("keeping forty-eight groschen"));
+        let mut cursor = 0;
+        for event in [
+            "advance guard scouteth ahead",
+            "abandoning direct seizure",
+            "lower-road deceit",
+            "boggeth upright without overturn or injury",
+            "stealest its ninety-six-groschen purse",
+        ] {
+            let found = theft.result[cursor..].find(event).unwrap();
+            cursor += found + event.len();
+        }
         assert!(matches!(
             theft.effects[0],
             Effect::Currency { amount: 48, .. }
@@ -1726,10 +1698,8 @@ mod tests {
             ignore.transition.as_ref(),
             Some(EncounterTransition::TravelDelay { minutes: 60 })
         ));
-        assert!(ignore.response.is_empty());
-        assert!(ignore.effects.is_empty());
-        assert!(ignore.outcome_tags.is_empty());
-        assert!(ignore.personality.is_empty());
+        assert!(ignore.response.is_empty() && ignore.effects.is_empty());
+        assert!(ignore.outcome_tags.is_empty() && ignore.personality.is_empty());
     }
 
     #[test]

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1601,6 +1601,138 @@ mod tests {
     }
 
     #[test]
+    fn envious_captain_routes_ground_oath_trust_and_portable_bow_lesson() {
+        let definition = encounter("envious_captain_false_directions_v1").unwrap();
+        assert!(definition.triggers.travel && !definition.triggers.rest);
+        assert_eq!(definition.cast[0].nature, SpeakerNature::Mortal);
+        assert!(definition.opening[0].reviewed_shakespearean);
+        assert!(!definition.opening[0].reviewed_iambic_pentameter);
+
+        let opening = definition.opening[0].text.to_lowercase();
+        for premise in [
+            "holy rood",
+            "lower road",
+            "elder stone",
+            "pale ridge chalk",
+            "richer merchant train",
+            "quarrymen's payroll",
+        ] {
+            assert!(opening.contains(premise));
+        }
+        for withheld in ["envy", "bow", "missile", "sword", "spear", "across the gap"] {
+            assert!(!opening.contains(withheld));
+        }
+
+        let choice = |id| {
+            definition
+                .choices
+                .iter()
+                .find(|choice| choice.id == id)
+                .unwrap()
+        };
+        let active = definition
+            .choices
+            .iter()
+            .filter(|choice| choice.id != "ignore")
+            .collect::<Vec<_>>();
+        assert_eq!(active.len(), 6);
+        assert!(
+            active
+                .iter()
+                .flat_map(|choice| &choice.response)
+                .all(|line| { line.reviewed_shakespearean && !line.reviewed_iambic_pentameter })
+        );
+        assert!(active.iter().all(|choice| {
+            choice.effects.iter().any(|effect| {
+                matches!(
+                    effect,
+                    Effect::Information { information_id }
+                        if information_id == "melee_only_opposition_cannot_answer_prepared_bow_lane"
+                )
+            }) && choice.quest_reward_tags == ["prepare_bows_against_melee_only_opposition"]
+                && choice
+                    .outcome_tags
+                    .iter()
+                    .any(|tag| tag == "physical_observation")
+        }));
+        assert!(active.iter().all(|choice| {
+            let result = choice.result.to_lowercase().replace('-', " ");
+            result.contains("bow")
+                && result.contains("opposite shelf")
+                && result.contains("washed")
+                && result.contains("cleft")
+                && result.contains("mailed")
+                && result.contains("sword")
+                && result.contains("spear")
+                && result.contains("melee")
+                && result.contains("cannot answer")
+                && result.contains("gap")
+                && result.contains("yield")
+        }));
+        assert_eq!(
+            active
+                .iter()
+                .map(|choice| &choice.result)
+                .collect::<BTreeSet<_>>()
+                .len(),
+            6
+        );
+
+        let command = choice("organize_ridge_passage");
+        let command_prose = format!("{} {}", command.response[0].text, command.result);
+        for grounded in [
+            "factor and ridge guard claim knowledge",
+            "inventorying wagons and positioning the convoy",
+            "factor and ridge guard choose the route and anchors",
+        ] {
+            assert!(command_prose.contains(grounded));
+        }
+
+        let oath = choice("demand_oath_at_cross");
+        assert!(opening.contains("swear the lower road standeth sound"));
+        assert!(oath.response[0].text.contains("shall not swear it twice"));
+        assert!(oath.response[0].text.contains("my counsel was false"));
+        assert!(oath.result.contains("without any supernatural judgment"));
+
+        let theft = choice("collude_and_split_payroll");
+        assert!(theft.response[0].text.contains("envy biteth me"));
+        assert!(
+            theft.response[0]
+                .text
+                .contains("ninety-six-groschen payroll equally")
+        );
+        assert!(theft.result.contains("without overturn or injury"));
+        assert!(theft.result.contains("keeping forty-eight groschen"));
+        assert!(matches!(
+            theft.effects[0],
+            Effect::Currency { amount: 48, .. }
+        ));
+        let honest_max = active
+            .iter()
+            .filter(|choice| choice.id != theft.id)
+            .flat_map(|choice| &choice.effects)
+            .filter_map(|effect| match effect {
+                Effect::Currency { amount, .. } if *amount > 0 => Some(*amount),
+                _ => None,
+            })
+            .max()
+            .unwrap();
+        assert!(48 > honest_max);
+        assert!(theft.personality.iter().all(|change| change.delta < 0));
+        assert_eq!(exemplified_virtue(&theft.personality), None);
+
+        let ignore = choice("ignore");
+        assert!(matches!(
+            ignore.transition.as_ref(),
+            Some(EncounterTransition::TravelDelay { minutes: 60 })
+        ));
+        assert!(ignore.response.is_empty());
+        assert!(ignore.effects.is_empty());
+        assert!(ignore.outcome_tags.is_empty());
+        assert!(ignore.personality.is_empty());
+    }
+
+    #[test]
     fn combat_transition_rejects_unsafe_counts() {
         let mut definition = encounter("unlawful_bridge_custom_v1").unwrap().clone();
         let choice = definition

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1655)
+## Files (1656)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -35,6 +35,7 @@ development, or other wiki document before changing a subsystem.
 - `content/dialogue/examples.yaml` — Repository support file.
 - `content/dialogue/organizations.yaml` — Repository support file.
 - `content/dialogue/services.yaml` — Repository support file.
+- `content/encounters/envious-captain-false-directions.yaml` — Repository support file.
 - `content/encounters/ferryman-disputed-tribute.yaml` — Repository support file.
 - `content/encounters/proud-traveler-errands.yaml` — Repository support file.
 - `content/encounters/rash-cliff-hunt.yaml` — Repository support file.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -171,6 +171,26 @@ damaging equipment, or weakening any opponent. The materially richest theft
 lowers Honesty without publicly exemplifying it. The encounter is travel-only,
 goal-neutral, entirely mortal, and requires no runtime catalog special case.
 
+`envious_captain_false_directions_v1` places a mortal escort captain at a
+fork, where his Holy Rood oath favors the lower road despite an elder
+ridge-pointing stone and fresh ridge chalk on his escort's boots. A richer
+merchant train carrying the quarrymen's payroll followeth behind. The party may
+read chalk, stone, and flood marks together, scout both roads, expose the
+contradiction before both companies, organize the convoy beneath the merchant
+factor and ridge guard's own expertise, demand that the captain repeat his oath
+at a wayside cross, or collude after he privately confesseth envy and steal half
+the ninety-six-groschen payroll; waiting for both companies to clear costs an
+hour but nothing else. Each active route reaches the same portable physical
+lesson through different causality: a prepared bow guard upon the opposite
+shelf controls a washed ridge cleft, while the captain's mailed escort, armed
+only with swords and spears for melee, cannot answer across the gap and must
+yield the lane. The observation concerns melee-only equipment, not armor in
+general, and reinforces preparation of bows and arrows without weakening an
+opponent. The theft leaves the lead wagon upright and all travelers uninjured,
+but pays more than twice the richest honest route and lowers Honesty without
+publicly exemplifying it. The encounter is travel-only, goal-neutral, entirely
+mortal, and requires no runtime catalog special case.
+
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source
 mapped at build time. YAML owns stable ID/version/weight, trigger eligibility,

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -171,25 +171,34 @@ damaging equipment, or weakening any opponent. The materially richest theft
 lowers Honesty without publicly exemplifying it. The encounter is travel-only,
 goal-neutral, entirely mortal, and requires no runtime catalog special case.
 
-`envious_captain_false_directions_v1` places a mortal escort captain at a
-fork, where his Holy Rood oath favors the lower road despite an elder
-ridge-pointing stone and fresh ridge chalk on his escort's boots. A richer
-merchant train carrying the quarrymen's payroll followeth behind. The party may
-read chalk, stone, and flood marks together, scout both roads, expose the
-contradiction before both companies, organize the convoy beneath the merchant
-factor and ridge guard's own expertise, demand that the captain repeat his oath
-at a wayside cross, or collude after he privately confesseth envy and steal half
-the ninety-six-groschen payroll; waiting for both companies to clear costs an
-hour but nothing else. Each active route reaches the same portable physical
-lesson through different causality: a prepared bow guard upon the opposite
-shelf controls a washed ridge cleft, while the captain's mailed escort, armed
-only with swords and spears for melee, cannot answer across the gap and must
-yield the lane. The observation concerns melee-only equipment, not armor in
-general, and reinforces preparation of bows and arrows without weakening an
-opponent. The theft leaves the lead wagon upright and all travelers uninjured,
-but pays more than twice the richest honest route and lowers Honesty without
-publicly exemplifying it. The encounter is travel-only, goal-neutral, entirely
-mortal, and requires no runtime catalog special case.
+`envious_captain_false_directions_v1` places a mortal escort captain and mortal
+merchant factor at a fork, where the captain's Holy Rood oath favors the lower
+road despite an elder ridge-pointing stone and fresh ridge chalk on his escort's
+boots. The approaching train carries the quarrymen's payroll behind a known
+light, ridge-wise advance guard. A Saint Christopher road-brotherhood mark
+binds the wayside cross and escort contract, while the captain declares that
+his men will claim first passage at the washed ridge cleft if his counsel is
+contested. The party may read chalk, stone, and flood marks together, scout both
+roads, expose the contradiction before both companies, marshal the convoy
+beneath the factor and advance guard's own route expertise, enforce public
+recantation and penance under the mortal road contract, or collude after the
+captain privately confesseth envy. The threatened factor or train pays every
+honest coin reward; the captain never purchases silence or exposure.
+
+After each honest intervention, the captain's envy or pride makes him order his
+mailed escort to obstruct the merchant train and claim precedence. The advance
+guard then gains the opposite shelf and reveals a prepared bow: the escort's
+melee-only swords and spears cannot answer across the gap, so it yields the
+lane. In the evil route that same failure occurs first and causes the captain
+and player to abandon direct seizure. Only then do they redirect the lead wagon
+into lower-road mire under false color of aid; it bogs upright without injury,
+and they split the stolen ninety-six-groschen payroll equally. The observation
+concerns melee-only equipment, not armor in general, and reinforces preparation
+of bows and arrows without weakening an opponent. The theft pays more than
+twice the richest honest route and lowers Honesty without publicly exemplifying
+it. Waiting for both companies to clear costs an hour but nothing else. The
+encounter is travel-only, goal-neutral, entirely mortal, and requires no runtime
+catalog special case.
 
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source


### PR DESCRIPTION
## Summary
- add envious_captain_false_directions_v1, a travel-only mortal crossroads scene with six active solutions and a one-hour wait-clear option
- support reading contradictory waymarks, scouting both roads, public exposure, convoy command under the factor’s route expertise, enforcing a witnessed road-brotherhood oath, and colluding in payroll theft
- make honest payments come from the threatened merchant factor rather than the captain whose fraud they defeat
- ground the shared bow-versus-melee lesson in a declared ridge-precedence conflict and a light advance guard controlling the opposite shelf
- make the religious route use explicit Saint Christopher brotherhood contract consequences, public recantation, and penance without supernatural judgment
- preserve a harmless upright bogging in the evil route while keeping its 48-groschen split materially richest

## Stack
- base: codex/romance-encounter-05-rash-cliff-hunt / #349
- this is encounter 06 in the sequential romance-road-encounter stack

## Verification
- road encounter catalog: 16/16
- content compiler: 7 encounter definitions
- full workspace just check
- formatting, project-map, and diff checks
- two independent correctness/maintainability reviews, clean after remediation

## Deliberate follow-up
- this encounter intentionally reuses the modeled prepared-bows lesson because the current fixed finale has melee-only armed retainers; later variable finales should select only compatible encounter reward facts