### PR TITLE
Encounter 07: insulting damsel and dwarf

### DIFF
--- a/content/encounters/insulting-damsel-and-dwarf.yaml
+++ b/content/encounters/insulting-damsel-and-dwarf.yaml
@@ -1,0 +1,145 @@
+{
+  "encounters": [
+    {
+      "id": "insulting_damsel_and_dwarf_v1",
+      "version": 1,
+      "weight": 65,
+      "triggers": { "travel": true, "rest": false },
+      "provenance": {
+        "works": ["Parzival", "Wigalois", "Lanzelet", "Theuerdank", "Le Morte d'Arthur"],
+        "motifs": ["sharp_tongued_damsel", "wise_steward", "tested_courage", "washed_crossing", "betrayed_trust"],
+        "adaptation_note": "An original synthesis of sharp-tongued companions, prudent household officers, contested passages, vows, and tests of courage common in chivalric romance; it does not reproduce a particular episode or direct abuse toward bodily identity."
+      },
+      "cast": [
+        { "id": "sharp_tongued_damsel", "name": "Sharp-tongued damsel", "nature": "mortal" },
+        { "id": "dwarf_steward", "name": "Dwarf steward", "nature": "mortal" }
+      ],
+      "opening": [
+        {
+          "speaker": "sharp_tongued_damsel",
+          "text": "I bear Saint Michael's candles under vow unto the chapel beyond this washed hollow, and that holy errand licenseth me to demand the private shortcut. I shall not humble my rank upon the longer public lower path merely because my steward counseleth caution. Thou lookest better dressed for status than proved in judgment or courage. Twenty groschen await one who returneth with sound proof, and twelve more shall reward one who can marshal this household without confusion.",
+          "reviewed_shakespearean": true
+        },
+        {
+          "speaker": "dwarf_steward",
+          "text": "Fresh signs mark the soft turf beside this bank, my lady, and weathered private toll cuts remain upon yon stone, though no present toll is declared. The known public lower path remaineth open. Hear my terrain judgment before any servant is sent upon the private shelf.",
+          "reviewed_shakespearean": true
+        }
+      ],
+      "choices": [
+        {
+          "id": "endure_and_verify",
+          "label": "Endure the taunt and verify the crossing carefully",
+          "response": [{ "speaker": "sharp_tongued_damsel", "text": "Thou wilt answer insult with measured proof? Go then beneath such cover as thy judgment chooseth, and the twenty-groschen wager shall stand without demand for any rash charge.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest seventy-five minutes verifying the crossing carefully beneath cover and receivest the declared twenty groschen. From concealment thou seest a light road warden reveal a prepared bow on the shelf opposite the washed gap; the retainers' visible swords and spears are melee-only and cannot answer across it, whilst the public lower path avoideth the private shelf. The steward identifies four straight household-store arrows with sound heads that he planted by hand in the soft near-bank turf as sight-line markers before thy arrival, and granteth them unto thee; no arrow is loosed during this scene.",
+          "deed": "endure_taunt_and_verify_washed_hollow",
+          "outcome_tags": ["courage", "measured_proof", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "will", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 20 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 4 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "nerve", "delta": 110, "virtue": "courage" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 75 }
+        },
+        {
+          "id": "answer_with_courtesy",
+          "label": "Answer the damsel courteously and ask the steward's counsel",
+          "response": [{ "speaker": "dwarf_steward", "text": "Thy courtesy hath won the hearing that haste denied me. Walk with me along the bank, and I shall show thee why the public lower path is wiser than the private shelf.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest forty minutes hearing the steward's terrain judgment along the bank. At his chosen lookout thou observest a lightly equipped forester with a prepared bow upon the shelf opposite the washed gap; the mailed retainers bear only swords and spears for melee and cannot answer that distance, while the public lower path passeth clear of the private shelf. In answer to thy courtesy, the steward offereth thee four straight household-store arrows with sound heads that he planted by hand in the near-bank turf as range markers before thy arrival; no arrow is loosed during this scene.",
+          "deed": "answer_damsel_with_courtesy_and_hear_steward",
+          "outcome_tags": ["courtesy", "hearing_counsel", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 4 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "sociability", "delta": 110, "virtue": "courtesy" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 40 }
+        },
+        {
+          "id": "prove_caution_from_marks",
+          "label": "Prove the steward's caution from the fresh marks",
+          "response": [{ "speaker": "dwarf_steward", "text": "Read the stopped boots, the scar in yon shaft, and the far shelf together. They are mortal signs enough for honest judgment, without recourse to wonder.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest thirty minutes reading abrupt boot-stops in the turf, a fresh shaft scar, and the far shelf, proving the steward's caution by ordinary signs. The marks lead thine eye to a light forester with a prepared bow opposite the washed gap; sword-and-spear-only mailed retainers cannot answer him by melee, and the public lower path avoideth his private shelf. Among that evidence thou findest four straight household-store arrows with sound heads that the steward planted by hand before thy arrival as sight-line markers, and he yieldeth them unto thee; no arrow is loosed during this scene.",
+          "deed": "prove_stewards_caution_from_fresh_marks",
+          "outcome_tags": ["honesty", "rational_proof", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "insight", "difficulty_milli": 1150 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 4 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": 100, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 30 }
+        },
+        {
+          "id": "lend_steward_authority",
+          "label": "Lend the steward authority to marshal the household",
+          "response": [{ "speaker": "sharp_tongued_damsel", "text": "My steward claimeth the terrain judgment, whilst thou claimest command of compliance. Marshal my retainers beneath his route plan without confusion, and the declared twelve-groschen fee is thine.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest fifty-five minutes coordinating the household beneath the steward's own terrain plan and receivest the declared twelve-groschen marshal fee. From the station he selecteth, a light road warden showeth a prepared bow opposite the washed gap; the mailed retainers' visible swords and spears serve melee only and cannot answer, so the steward leadeth them by the public lower path away from the private shelf. Under thine order the household collecteth four straight household-store arrows with sound heads that the steward planted by hand as range markers before thy arrival and granteth them unto thee; no arrow is loosed during this scene.",
+          "deed": "lend_steward_authority_to_marshal_household",
+          "outcome_tags": ["prudence", "command", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 12 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 4 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 100, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 55 }
+        },
+        {
+          "id": "rebuke_abuse_of_vow",
+          "label": "Rebuke the misuse of Saint Michael's vow",
+          "response": [{ "speaker": "sharp_tongued_damsel", "text": "Thou sayest truly that my Saint Michael candle vow granteth neither leave to demand a private shortcut nor license to hazard servants needlessly. I shall master my pride, hear the steward, and take the lawful public path.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest thirty-five minutes distinguishing the Saint Michael candle vow from any license to demand private passage or risk servants without need. During the steward's lawful survey, a light forester revealeth a prepared bow opposite the washed gap; the mailed retainers' swords and spears serve melee only and cannot answer across it, while the public lower path avoideth the private shelf. After thy rebuke the steward identifies four straight household-store arrows with sound heads that he planted by hand as sight-line markers before thy arrival and granteth them unto thee; no arrow is loosed during this scene.",
+          "deed": "rebuke_abuse_of_saint_michael_vow",
+          "outcome_tags": ["faith", "lawful_vow", "physical_observation"],
+          "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
+          "checks": [{ "kind": "religion", "religion": "roman_catholic", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 4 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "conviction", "delta": 110, "virtue": "faith" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 35 }
+        },
+        {
+          "id": "invent_forester_toll_and_keep_purse",
+          "label": "Misread the old toll cuts, invent a forester's toll, and keep the purse",
+          "response": [{ "speaker": "sharp_tongued_damsel", "text": "Those visible toll cuts support thy claim that the distant forester privately collecteth forty-eight groschen for immediate passage, and he refuseth us from beyond our hearing. Take this purse and discharge his toll in my name; I shall trust thy bold counsel above another delay upon the public road.", "reviewed_shakespearean": true }, { "speaker": "dwarf_steward", "text": "My lady, no present toll is declared. I cannot speak for the distant forester's private demand, yet neither should old cuts and pride outweigh the known public way.", "reviewed_shakespearean": true }],
+          "result": "Thou first readest the weathered toll cuts and fresh signs, then seest a light forester with a prepared bow opposite the washed gap, beyond immediate earshot; the mailed retainers' visible swords and spears are melee-only and cannot answer across it, whilst the public lower path avoideth the private shelf. Before deceiving the damsel, thou pocketest four straight household-store arrows with sound heads that the steward planted by hand as range markers before thy arrival; no arrow is loosed during this scene. Thou falsely claimest the distant forester privately collecteth forty-eight groschen for immediate private passage, receivest the entrusted purse, and abscondest with it. When the household later reacheth him, the forester denieth any private passage or toll, exposing thy lie; the steward rationally leadeth the unconfined, unharmed household along the genuinely public lower path.",
+          "deed": "invent_forester_toll_and_keep_entrusted_purse",
+          "outcome_tags": ["deception", "theft", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 4 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": -250, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 45 }
+        },
+        {
+          "id": "ignore",
+          "label": "Continue along the open road",
+          "response": [],
+          "result": "Thou leavest the damsel, steward, and halted household beside the washed hollow, for the road remaineth open.",
+          "deed": "ignore_damsel_and_steward_at_washed_hollow",
+          "outcome_tags": []
+        }
+      ],
+      "quest_reward_eligibility": ["physical_tactical_information", "material_preparation"]
+    }
+  ]
+}

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1633,10 +1633,7 @@ mod tests {
                 Effect::Information { information_id }
                     if information_id == "melee_only_opposition_cannot_answer_prepared_bow_lane"
             )));
-            assert_eq!(
-                route.quest_reward_tags,
-                ["prepare_bows_against_melee_only_opposition"]
-            );
+            assert!(route.quest_reward_tags == ["prepare_bows_against_melee_only_opposition"]);
             assert!(route.result.contains("prepared bow"));
             assert!(route.result.contains("cannot answer across the gap"));
             assert!(route.result.contains("yield"));
@@ -1700,6 +1697,66 @@ mod tests {
         ));
         assert!(ignore.response.is_empty() && ignore.effects.is_empty());
         assert!(ignore.outcome_tags.is_empty() && ignore.personality.is_empty());
+    }
+
+    #[test]
+    fn damsel_and_steward_routes_reward_grounded_counsel_without_identity_abuse() {
+        let definition = encounter("insulting_damsel_and_dwarf_v1").unwrap();
+        let choice = |id| {
+            definition
+                .choices
+                .iter()
+                .find(|choice| choice.id == id)
+                .unwrap()
+        };
+        let active = definition
+            .choices
+            .iter()
+            .filter(|choice| choice.id != "ignore")
+            .collect::<Vec<_>>();
+        for route in &active {
+            assert!(route.effects.iter().any(|effect| matches!(
+                effect,
+                Effect::Information { information_id }
+                    if information_id == "melee_only_opposition_cannot_answer_prepared_bow_lane"
+            )));
+            assert!(route.effects.iter().any(|effect| matches!(
+                effect,
+                Effect::GrantItem { item_id, quantity: 4 } if item_id == "arrow"
+            )));
+            assert!(route.quest_reward_tags == ["prepare_bows_against_melee_only_opposition"]);
+            assert!(route.result.contains("steward") && route.result.contains("planted by hand"));
+        }
+        assert!(
+            !serde_json::to_string(definition)
+                .unwrap()
+                .contains("household archers")
+        );
+
+        assert!(matches!(
+            choice("endure_and_verify").checks[0],
+            Check::Skill {
+                skill: SkillId::Will,
+                difficulty_milli: 1200
+            }
+        ));
+        let command = choice("lend_steward_authority");
+        assert!(
+            command
+                .result
+                .contains("beneath the steward's own terrain plan")
+        );
+        let theft = choice("invent_forester_toll_and_keep_purse");
+        assert!(matches!(
+            theft.effects[0],
+            Effect::Currency { amount: 48, .. }
+        ));
+        assert!(theft.personality.iter().all(|change| change.delta < 0));
+        assert_eq!(exemplified_virtue(&theft.personality), None);
+
+        let ignore = choice("ignore");
+        assert!(ignore.transition.is_none());
+        assert!(ignore.effects.is_empty() && ignore.personality.is_empty());
     }
 
     #[test]

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1656)
+## Files (1657)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -37,6 +37,7 @@ development, or other wiki document before changing a subsystem.
 - `content/dialogue/services.yaml` — Repository support file.
 - `content/encounters/envious-captain-false-directions.yaml` — Repository support file.
 - `content/encounters/ferryman-disputed-tribute.yaml` — Repository support file.
+- `content/encounters/insulting-damsel-and-dwarf.yaml` — Repository support file.
 - `content/encounters/proud-traveler-errands.yaml` — Repository support file.
 - `content/encounters/rash-cliff-hunt.yaml` — Repository support file.
 - `content/encounters/unlawful-bridge-custom.yaml` — Repository support file.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -200,6 +200,44 @@ it. Waiting for both companies to clear costs an hour but nothing else. The
 encounter is travel-only, goal-neutral, entirely mortal, and requires no runtime
 catalog special case.
 
+`insulting_damsel_and_dwarf_v1` places a sharp-tongued mortal damsel and her
+mortal dwarf steward beside a washed hollow while carrying Saint Michael's
+candles to a chapel. Her taunts concern judgment, courage, and status only;
+they never target stature or identity. She explicitly claims that her candle
+vow licenses her to demand a private shortcut and pridefully refuses the longer
+public way. The competent steward identifies fresh signs, weathered private
+toll cuts, and the genuinely public lower path, and asks that his terrain
+judgment be heard before anyone enters the private shelf. The party may use
+Will to endure the taunt and verify the crossing under cover, answer with
+courtesy, prove caution from ordinary marks, lend the steward authority to
+execute his route plan, or rebuke the actual misuse of the religious vow.
+
+Each active route observes a light forester or road warden holding the opposite
+side of the washed gap with a prepared bow, while visibly sword-and-spear-only
+mailed retainers cannot answer by melee; the public lower path avoids that
+private shelf. The four straight arrows are household-store equipment that the
+competent steward personally planted by hand in soft turf as inert sight-line
+and range markers before the player arrived. They were never loosed, imply no
+available household archer, and do not belong to the far-shelf warden. Each
+solution recovers them through its own causality: the steward identifies or
+offers them, Insight finds them as evidence, Command organizes their
+collection, Faith receives them after the rebuke, or the thief pockets them
+before absconding. No arrow is loosed during the scene. Thus every successful
+route grants four real `arrow` items alongside the portable bow-lane
+information, while the ignore route grants neither.
+
+For the evil route, visible old toll cuts support a plausible lie while the
+far-shelf forester remains beyond immediate hearing. The player accuses only
+that distant forester of privately collecting forty-eight groschen for
+immediate passage. The steward cautions that old cuts declare no present toll,
+but cannot speak for the absent forester's private demand. After pocketing the
+household arrows, the player takes the entrusted purse and absconds. The
+forester later denies any toll or private passage, exposing the lie; the
+steward then leads the unconfined, unharmed household by the public path. The
+theft lowers Honesty without publicly exemplifying it and causes no physical
+injury or captivity. The encounter is travel-only, goal-neutral, entirely
+mortal, and requires no runtime catalog special case.
+
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source
 mapped at build time. YAML owns stable ID/version/weight, trigger eligibility,


### PR DESCRIPTION
Stacked on #350. Adds the seventh romance-road encounter: a proud damsel, her competent dwarf steward, and a dangerous private shelf-road. Six grounded resolutions exercise Will, Courtesy, Insight, Command, Faith, or profitable deception; all active routes recover physical arrows and learn a real bow-versus-melee preparation lesson. Mortal dialogue uses Shakespearean English without supernatural meter. The evil route yields the largest material reward while causing no physical injury or captivity. Includes compact catalog regression coverage and updated encounter design documentation.\n\nVerification: just check; 17 road encounter catalog tests; content validator; formatting/project-map/diff checks; two independent review passes.