### PR TITLE
Encounter 08: stolen lapdog and prize horse

### DIFF
--- a/content/encounters/stolen-lapdog-prize-horse.yaml
+++ b/content/encounters/stolen-lapdog-prize-horse.yaml
@@ -1,0 +1,155 @@
+{
+  "encounters": [
+    {
+      "id": "stolen_lapdog_prize_horse_v1",
+      "version": 1,
+      "weight": 65,
+      "triggers": { "travel": true, "rest": false },
+      "provenance": {
+        "works": ["Parzival", "Wigalois", "Lanzelet", "Theuerdank", "Le Morte d'Arthur"],
+        "motifs": ["stolen_lapdog", "prize_horse", "dubious_sale", "competent_servant", "betrayed_trust"],
+        "adaptation_note": "An original synthesis of disputed animals, dubious horse dealing, household loyalty, recovered tokens, and betrayals of entrusted service common in chivalric romance; it does not reproduce a particular episode."
+      },
+      "cast": [
+        { "id": "widowed_chatelaine", "name": "Widowed chatelaine", "nature": "mortal" },
+        { "id": "kennel_master", "name": "Kennel master", "nature": "mortal" },
+        { "id": "horse_coper", "name": "Horse-coper", "nature": "mortal" }
+      ],
+      "opening": [
+        {
+          "speaker": "widowed_chatelaine",
+          "text": "That horse-coper holdeth my lapdog beneath his arm at the saddle-bow of my stolen prize bay, with two mailed grooms beside him. Here lieth the severed end of her silver leash; clay daubeth my livery brand upon the bay, and mixed dog and horse tracks run from my gate. A neutral helper who restoreth truth without blood shall receive the spare self bow and eight arrows from my hunt cart.",
+          "reviewed_shakespearean": true
+        },
+        {
+          "speaker": "horse_coper",
+          "text": "My tally saith that dog and bay were sold unto me before dawn, though the seller's name and witness mark be somewhat faint. My well-filled purse showeth I can answer honest trade. Shall a widow's accusation outweigh written dealing upon the open road?",
+          "reviewed_shakespearean": true
+        },
+        {
+          "speaker": "kennel_master",
+          "text": "I know the hound's recall, the household tracks, and a bloodless plan for bringing both beasts home, yet proof and neutral aid must govern it. Let me choose the ground and handling; lend thou honest eyes, speech, or authority.",
+          "reviewed_shakespearean": true
+        }
+      ],
+      "choices": [
+        {
+          "id": "follow_mixed_tracks",
+          "label": "Follow the mixed tracks across the plain",
+          "response": [{ "speaker": "kennel_master", "text": "Read where light paws cross the bay's shod prints and where the coper's party doubled from the gate. Follow that trail, and I shall bring witnesses by a separate way.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest an hour following mixed dog and horse tracks to the kennel master's chosen drainage ditch. There his light bowman holdeth a prepared lane across the gap; the coper's two mailed grooms visibly carry blades only and cannot answer it by melee, so they yield while the master recovereth the lapdog and prize bay without blood. For prudent aid the chatelaine granteth thee the declared spare self bow and eight arrows from her hunt cart.",
+          "deed": "follow_tracks_to_stolen_lapdog_and_bay",
+          "outcome_tags": ["prudence", "tracking", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "terrain_plains", "difficulty_milli": 1100 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "self_bow", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 8 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 110, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "compare_leash_brand_and_tally",
+          "label": "Compare the leash, hidden brand, and tally",
+          "response": [{ "speaker": "widowed_chatelaine", "text": "Set silver thread, clay-hidden brand, and doubtful witness line together before us. If common evidence answereth the coper's tally, no blade need judge my claim.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest thirty minutes matching the severed silver leash, the clay-daubed livery brand, and the tally's altered witness line. When the kennel master presents that proof beside his prepared drainage-ditch bow lane, the coper's mailed blade-only grooms cannot answer across the gap and stand aside; dog and bay return to the household without blood. The chatelaine rewardeth thy just proof with the spare self bow and eight arrows from her hunt cart.",
+          "deed": "compare_tokens_against_copers_false_tally",
+          "outcome_tags": ["justice", "evidence", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "insight", "difficulty_milli": 1150 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "self_bow", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 8 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "conscience", "delta": 110, "virtue": "justice" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 30 }
+        },
+        {
+          "id": "negotiate_face_saving_return",
+          "label": "Negotiate a face-saving return of both animals",
+          "response": [{ "speaker": "horse_coper", "text": "Call the tally a broker's error rather than my theft, let me withdraw before these witnesses, and perhaps dog and horse may return without steel or public ruin.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest forty minutes arranging a face-saving return before neutral witnesses. The coper accepteth because the kennel master's prepared bowman covereth the drainage-ditch gap, whilst his mailed grooms show blades only and cannot answer by melee; he yieldeth both animals without blood. The chatelaine honorably granteth thee the declared spare self bow and eight arrows for courteous settlement.",
+          "deed": "negotiate_face_saving_return_of_animals",
+          "outcome_tags": ["courtesy", "negotiation", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "self_bow", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 8 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "sociability", "delta": 110, "virtue": "courtesy" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 40 }
+        },
+        {
+          "id": "coordinate_bloodless_recovery",
+          "label": "Coordinate witnesses and servants beneath the kennel master's plan",
+          "response": [{ "speaker": "kennel_master", "text": "I shall choose the ditch, recall, and animal handling. Inventory our witnesses, place each servant where he may obey without confusion, and keep all hands beneath my bloodless terrain plan.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest forty-five minutes coordinating witnesses and servants while the kennel master alone selecteth terrain, recall, and handling. At his prepared drainage-ditch bow lane, the coper's mailed blade-only grooms cannot answer across the gap and yield; the master bringeth lapdog and bay home without blood. The chatelaine payeth the declared marshal reward of one spare self bow and eight arrows.",
+          "deed": "coordinate_household_beneath_kennel_masters_plan",
+          "outcome_tags": ["prudence", "command", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "self_bow", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 8 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 100, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 45 }
+        },
+        {
+          "id": "lure_dog_for_recall_proof",
+          "label": "Offer one travel ration so the kennel master may prove the recall",
+          "response": [{ "speaker": "kennel_master", "text": "One ration shall draw her attention without force. Cast it where I direct; when I give the household recall and she answereth, witnesses shall see ownership proved by known training.", "reviewed_shakespearean": true }],
+          "result": "Thou spendest twenty minutes using one travel ration exactly as the kennel master directeth; his known recall bringeth the lapdog across as public proof. His prepared bowman meanwhile covereth the drainage-ditch gap, which the coper's mailed blade-only grooms cannot answer by melee, so they release the prize bay without blood. The chatelaine rewardeth this mercy with the declared spare self bow and eight arrows.",
+          "deed": "lure_lapdog_for_known_household_recall",
+          "outcome_tags": ["mercy", "animal_handling", "physical_observation"],
+          "requirements": [{ "kind": "item", "item_id": "travel_ration", "minimum_quantity": 1 }],
+          "effects": [
+            { "kind": "consume_item", "item_id": "travel_ration", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "self_bow", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 8 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "conscience", "delta": 110, "virtue": "mercy" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 20 }
+        },
+        {
+          "id": "validate_tally_and_take_commission",
+          "label": "Claim neutral custody, validate the tally, and take commission",
+          "response": [{ "speaker": "widowed_chatelaine", "text": "Thou requirest loose weapons placed in neutral custody before judgment? I entrust my hunt cart's spare self bow and eight arrows unto thee, and shall order my ditch bowman away from his lane until the property claim be settled.", "reviewed_shakespearean": true }, { "speaker": "horse_coper", "text": "My grooms shall seal their loose blades within my baggage beneath thy mark. Come, inspect this tally's faded witness-mark apart, that thy judgment rest upon a close reading.", "reviewed_shakespearean": true }],
+          "result": "Thou first learnest the kennel master's prepared drainage-ditch bow position and seest that the coper's two mailed grooms visibly bear blades only and cannot answer across its gap. Under color of neutral custody, thou receivest the chatelaine's spare self bow and eight arrows; the grooms seal their blades in the coper's baggage beneath thy mark. With both sides thus committed, the chatelaine ordereth her ditch bowman away from the lane. Pretending to show thee the tally's faded witness-mark, the coper draweth thee aside beyond the chatelaine's hearing and quietly offereth forty-eight groschen from his already-visible purse if thou uphold his claim. Thou returnest and falsely rulest the dubious tally valid. The coper discreetly payeth the promised forty-eight groschen, and thou stealest the entrusted bow and arrows and departest. Dog and bay pass away with the coper; neither ever cometh into thy keeping.",
+          "deed": "validate_false_tally_and_take_copers_commission",
+          "outcome_tags": ["deception", "betrayal", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
+            { "kind": "grant_item", "item_id": "self_bow", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "arrow", "quantity": 8 },
+            { "kind": "information", "information_id": "melee_only_opposition_cannot_answer_prepared_bow_lane" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": -250, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_bows_against_melee_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "ignore",
+          "label": "Leave the disputed animals to the roadside parties",
+          "response": [],
+          "result": "Thou leavest chatelaine, kennel master, horse-coper, grooms, lapdog, and prize bay upon the open roadside.",
+          "deed": "ignore_stolen_lapdog_and_prize_horse_dispute",
+          "outcome_tags": []
+        }
+      ],
+      "quest_reward_eligibility": ["physical_tactical_information", "material_preparation"]
+    }
+  ]
+}

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1760,6 +1760,83 @@ mod tests {
     }
 
     #[test]
+    fn stolen_animals_routes_share_real_bow_preparation_without_persisting_animals() {
+        let definition = encounter("stolen_lapdog_prize_horse_v1").unwrap();
+        let choice = |id| {
+            definition
+                .choices
+                .iter()
+                .find(|choice| choice.id == id)
+                .unwrap()
+        };
+        let active = definition
+            .choices
+            .iter()
+            .filter(|choice| choice.id != "ignore")
+            .collect::<Vec<_>>();
+        for route in &active {
+            assert!(route.effects.iter().any(|effect| matches!(
+                effect,
+                Effect::Information { information_id }
+                    if information_id == "melee_only_opposition_cannot_answer_prepared_bow_lane"
+            )));
+            assert!(route.effects.iter().any(|effect| matches!(
+                effect,
+                Effect::GrantItem { item_id, quantity: 1 } if item_id == "self_bow"
+            )));
+            assert!(route.effects.iter().any(|effect| matches!(
+                effect,
+                Effect::GrantItem { item_id, quantity: 8 } if item_id == "arrow"
+            )));
+            assert!(route.quest_reward_tags == ["prepare_bows_against_melee_only_opposition"]);
+        }
+        let bow = crate::item_catalog::definition("self_bow").unwrap();
+        let arrow = crate::item_catalog::definition("arrow").unwrap();
+        assert_eq!(bow.base_value + arrow.base_value * 8, 16);
+        let command = choice("coordinate_bloodless_recovery");
+        let command_prose = format!("{} {}", command.response[0].text, command.result);
+        assert!(command_prose.contains("I shall choose the ditch, recall, and animal handling"));
+        assert!(command_prose.contains("coordinating witnesses and servants"));
+        let ration = choice("lure_dog_for_recall_proof");
+        assert!(matches!(
+            ration.requirements[0],
+            Requirement::Item { ref item_id, minimum_quantity: 1 } if item_id == "travel_ration"
+        ));
+        assert!(matches!(
+            ration.effects[0],
+            Effect::ConsumeItem { ref item_id, quantity: 1 } if item_id == "travel_ration"
+        ));
+        let theft = choice("validate_tally_and_take_commission");
+        assert!(matches!(
+            theft.effects[0],
+            Effect::Currency { amount: 48, .. }
+        ));
+        assert!(theft.personality.iter().all(|change| change.delta < 0));
+        assert_eq!(exemplified_virtue(&theft.personality), None);
+        let mut cursor = 0;
+        for event in [
+            "Under color of neutral custody",
+            "ordereth her ditch bowman away",
+            "draweth thee aside beyond the chatelaine's hearing and quietly offereth forty-eight",
+            "falsely rulest",
+            "discreetly payeth the promised forty-eight",
+            "stealest the entrusted bow and arrows and departest. Dog and bay pass away with the coper",
+        ] {
+            let found = theft.result[cursor..].find(event).unwrap();
+            cursor += found + event.len();
+        }
+        let effects = active
+            .iter()
+            .flat_map(|route| &route.effects)
+            .collect::<Vec<_>>();
+        let effects = serde_json::to_string(&effects).unwrap();
+        assert!(!effects.contains("dog") && !effects.contains("horse") && !effects.contains("bay"));
+        let ignore = choice("ignore");
+        assert!(ignore.transition.is_none());
+        assert!(ignore.effects.is_empty() && ignore.personality.is_empty());
+    }
+
+    #[test]
     fn combat_transition_rejects_unsafe_counts() {
         let mut definition = encounter("unlawful_bridge_custom_v1").unwrap().clone();
         let choice = definition

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1657)
+## Files (1658)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -40,6 +40,7 @@ development, or other wiki document before changing a subsystem.
 - `content/encounters/insulting-damsel-and-dwarf.yaml` — Repository support file.
 - `content/encounters/proud-traveler-errands.yaml` — Repository support file.
 - `content/encounters/rash-cliff-hunt.yaml` — Repository support file.
+- `content/encounters/stolen-lapdog-prize-horse.yaml` — Repository support file.
 - `content/encounters/unlawful-bridge-custom.yaml` — Repository support file.
 - `content/encounters/wounded-courier.yaml` — Repository support file.
 - `content/encounters/wounded-knight-linden.yaml` — Repository support file.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -238,6 +238,37 @@ theft lowers Honesty without publicly exemplifying it and causes no physical
 injury or captivity. The encounter is travel-only, goal-neutral, entirely
 mortal, and requires no runtime catalog special case.
 
+`stolen_lapdog_prize_horse_v1` places a widowed mortal chatelaine and her
+competent mortal kennel master against a mortal horse-coper who holds her
+lapdog and stolen prize bay beside two mailed grooms. A severed silver leash,
+clay-daubed livery brand, mixed tracks, and dubious tally establish the dispute.
+The kennel master owns the tracking, known recall, terrain choice, and
+bloodless animal-handling plan; neutral help supplies evidence, negotiation,
+or authority. The party may follow the tracks, compare the physical tokens,
+negotiate a face-saving return, coordinate servants and witnesses beneath the
+master's plan, or consume one travel ration so his known recall proves the
+lapdog's training. The animals are narrative-only property and never become
+items or persistent strategic state.
+
+Every active route reveals the same physical preparation lesson at the kennel
+master's drainage-ditch position: a prepared bow lane controls a gap that the
+coper's two mailed, blade-only grooms cannot answer by melee. Each route grants
+the chatelaine's declared spare `self_bow` and eight `arrow` items from her hunt
+cart, a real material value of sixteen groschen. In the evil route the coper's
+well-filled purse is visible from the opening. The player poses as a neutral
+adjudicator and requires both parties' loose weapons in custody: the chatelaine
+entrusts the hunt cart's spare bow and eight arrows and withdraws her ditch
+bowman, while the coper's grooms seal their blades in his baggage beneath the
+player's mark. Only after that custody and withdrawal does the coper draw the
+player aside under the pretext of inspecting the tally, privately offer forty-
+eight groschen from the established purse beyond the chatelaine's hearing, and
+await judgment. The player returns, falsely validates the tally, takes the
+payment discreetly, and steals the entrusted gear. The animals leave with the
+coper and never enter player inventory or persistent state. That materially
+richer betrayal lowers Honesty without publicly exemplifying it. The encounter
+is travel-only, goal-neutral, entirely mortal, and requires no runtime catalog
+special case.
+
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source
 mapped at build time. YAML owns stable ID/version/weight, trigger eligibility,


### PR DESCRIPTION
Stacked on #351. Adds a reusable romance-road encounter in which a widowed chatelaine and her competent kennel master confront a horse-coper holding her lapdog and prize bay. Six grounded resolutions use tracking, evidence, negotiation, command, animal recall, or corrupt adjudication. The animals remain narrative property rather than persistent inventory; successful routes grant a real self bow, eight arrows, and actionable bow-versus-melee knowledge. The evil route is a fully sequenced confidence trick yielding four times the honest material value. Includes compact semantic catalog coverage and documentation.\n\nVerification: just check; 18 road encounter catalog tests; content validator; formatting/project-map/diff checks; two independent review passes.