### PR TITLE
Encounter 10: maiden judged at a roadside court

### DIFF
--- a/content/encounters/maiden-roadside-court.yaml
+++ b/content/encounters/maiden-roadside-court.yaml
@@ -1,0 +1,155 @@
+{
+  "encounters": [
+    {
+      "id": "maiden_roadside_court_v1",
+      "version": 1,
+      "weight": 60,
+      "triggers": { "travel": true, "rest": true },
+      "provenance": {
+        "works": ["Parzival", "Wigalois", "Lanzelet", "Theuerdank", "Le Morte d'Arthur"],
+        "motifs": ["maiden_judged_at_roadside_court", "disputed_custom", "shifted_boundary", "protected_alms", "armed_intimidation", "betrayed_arbitration"],
+        "adaptation_note": "An original synthesis of imperiled maidens, improvised judgments, disputed road customs, protected alms, armed pressure, and corrupt bargains common in chivalric romance; it does not reproduce a particular episode."
+      },
+      "cast": [
+        { "id": "accused_noble_maiden", "name": "Accused young noble maiden", "nature": "mortal" },
+        { "id": "toll_sergeant", "name": "Toll sergeant", "nature": "mortal" },
+        { "id": "traveling_clerk", "name": "Traveling clerk", "nature": "mortal" },
+        { "id": "veteran_shield_bearer", "name": "Veteran shield-bearer", "nature": "mortal" }
+      ],
+      "opening": [
+        {
+          "speaker": "accused_noble_maiden",
+          "text": "This sergeant accuseth me of shifting his lord's verge stone to evade a lawful toll and seeketh my mule, wagon, and alms load as pledge. The proper bench lieth distant, and our attendants stood near fighting; therefore I freely sealed the traveling clerk's temporary arbitration compact and entrusted judgment unto him. I shall abide his award. My veteran shield-bearer now holdeth the sergeant's pressing men apart, and my retinue's spare heater shield shall reward a neutral champion who keepeth this hearing true and bloodless. The episcopal safe-conduct standeth visibly sealed upon my alms chest.",
+          "reviewed_shakespearean": true
+        },
+        {
+          "speaker": "toll_sergeant",
+          "text": "Her wheels passed beyond the standing verge, and my witnesses saw her people meddle there. My two mailed toll men bear swords and press only that none remove disputed proof or pledge. I too freely sealed the compact and shall accept the clerk's award.",
+          "reviewed_shakespearean": true
+        },
+        {
+          "speaker": "traveling_clerk",
+          "text": "By both parties' consent I preside beneath this boundary oak and wayside cross, not as sovereign bench. I alone keep and apply their compact, the elder verge record, seals, handwriting, and road custom. The writing inventories the maiden's mule, wagon, and load as disputed pledge; the sergeant's sealed personal forty-eight-groschen purse remaineth visibly at his belt and outside the bond. Bring me ordered facts, and I shall judge their legal force.",
+          "reviewed_shakespearean": true
+        },
+        {
+          "speaker": "veteran_shield_bearer",
+          "text": "His mailed swordsmen crowd my lady's unarmed carters and those who would inspect the stone. I shall brace between them and the hearing, yet need a neutral hand to gather proof or keep the agreed order whilst I contain their pressure.",
+          "reviewed_shakespearean": true
+        }
+      ],
+      "choices": [
+        {
+          "id": "recover_shifted_verge_evidence",
+          "label": "Read the flood ruts and recover what lieth beneath the shifted verge",
+          "response": [{ "speaker": "traveling_clerk", "text": "Mark the elder socket, fresh drag, and wagon ruts where flood brake the common road. What thou recoverest from beneath the stone shall I compare unto mine office record and the parties' compact.", "reviewed_shakespearean": true }],
+          "result": "For thirty-five minutes thou inspectest flood wash and bent wagon ruts while the veteran's heater shield screeneth thee from the mailed toll men. When one swordsman thrusteth a blade shove around that screen, the veteran catcheth it upon the shield and holdeth without injury. Beneath the freshly shifted verge thou recoverest an office-stamped iron setting wedge snagged with torn sergeant's livery. The clerk correctly matchest both to his elder record, acquitteth the accused maiden under the compact, and leaveth mule, wagon, and alms load in her keeping. She granteth thee the declared spare heater shield for just aid.",
+          "deed": "recover_decisive_proof_beneath_shifted_verge_stone",
+          "outcome_tags": ["justice", "physical_evidence", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "insight", "difficulty_milli": 1150 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "heater_shield", "quantity": 1 },
+            { "kind": "information", "information_id": "heater_shield_holds_blade_only_assault" }
+          ],
+          "personality": [{ "axis": "conscience", "delta": 110, "virtue": "justice" }],
+          "quest_reward_tags": ["prepare_heater_shield_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 35 }
+        },
+        {
+          "id": "separate_sergeants_witnesses",
+          "label": "Question the sergeant's witnesses separately beneath shielded calm",
+          "response": [{ "speaker": "traveling_clerk", "text": "Question each man beyond his fellows' prompting, yet leave the written order unto my hand. I shall record every answer against the compact, verge record, and witness marks.", "reviewed_shakespearean": true }],
+          "result": "For forty-five minutes thou bringest each witness separately behind the veteran shield-bearer's guarded side, where mailed companions cannot prompt or frighten him. One toll man striketh at the barrier with his sword; the veteran receiveth the stroke upon the heater shield and keepeth witness and carters unhurt. Their rehearsed story breaketh upon when the stone moved. The clerk recordeth the contradictions, faithfully applieth the compact, and acquitteth the maiden. Her mule, wagon, and alms remain hers, and she granteth thee the shield for honest questioning.",
+          "deed": "separate_false_witnesses_against_accused_maiden",
+          "outcome_tags": ["honesty", "witness_examination", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "heater_shield", "quantity": 1 },
+            { "kind": "information", "information_id": "heater_shield_holds_blade_only_assault" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": 110, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_heater_shield_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 45 }
+        },
+        {
+          "id": "order_hearing_under_clerks_judgment",
+          "label": "Order witness turns and weapon custody beneath the clerk's judgment",
+          "response": [{ "speaker": "traveling_clerk", "text": "Set thou witness sequence, turns of speech, and custody for every loose weapon. I alone shall judge seals, handwriting, custom, and the compact's legal force, then pronounce mine award.", "reviewed_shakespearean": true }],
+          "result": "For fifty minutes thou orderest the hearing while the clerk alone judgeth seals and custom. The veteran setteth his heater shield as the barrier where each loose sword must enter custody. One mailed toll man answereth with a blade shove instead; the veteran catcheth it upon the shield, holdeth the custody line without injury, and the second man yieldeth both weapons. Unpressured testimony and the clerk's record clear the accused maiden. He awardeth her pledge back, and she payeth thy prudent service with the spare shield.",
+          "deed": "order_voluntary_hearing_beneath_traveling_clerks_expertise",
+          "outcome_tags": ["prudence", "command", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "heater_shield", "quantity": 1 },
+            { "kind": "information", "information_id": "heater_shield_holds_blade_only_assault" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 100, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_heater_shield_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 50 }
+        },
+        {
+          "id": "authenticate_maidens_alms_safe_conduct",
+          "label": "Recognize the maiden's ordinary episcopal alms safe-conduct",
+          "response": [{ "speaker": "traveling_clerk", "text": "Thou knowest the ordinary form borne by episcopal alms. Help my hand reach the visible chest beneath shielded guard; I shall authenticate mitre, counterseal, handwriting, and earthly scope, then apply them unto the compact.", "reviewed_shakespearean": true }],
+          "result": "For thirty minutes thou recognizest the visible episcopal alms safe-conduct while the veteran screeneth clerk and accused maiden on their passage to the chest. A mailed toll man slash-shoveth at the document, but the heater shield turneth the blade and the veteran holdeth all behind him unhurt. No miracle speaketh and no divine judgment changeth the proof: the clerk authenticateth the ordinary seal and applieth its mundane exemption. He acquitteth the maiden and restoreth her pledge; she granteth thee the spare shield for faithful learning.",
+          "deed": "authenticate_accused_maidens_ordinary_alms_safe_conduct",
+          "outcome_tags": ["faith", "safe_conduct", "physical_observation"],
+          "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
+          "checks": [{ "kind": "religion", "religion": "roman_catholic", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "heater_shield", "quantity": 1 },
+            { "kind": "information", "information_id": "heater_shield_holds_blade_only_assault" }
+          ],
+          "personality": [{ "axis": "conviction", "delta": 110, "virtue": "faith" }],
+          "quest_reward_tags": ["prepare_heater_shield_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 30 }
+        },
+        {
+          "id": "champion_maiden_in_controlled_blade_test",
+          "label": "Stand as the maiden's surety in a controlled blade test",
+          "response": [{ "speaker": "veteran_shield_bearer", "text": "Take thou the spare heater shield and stand upon the marked line before one toll sword. Hold against a single measured stroke; I shall contain the second man, and the clerk shall keep this proof within the voluntary compact.", "reviewed_shakespearean": true }],
+          "result": "For forty minutes thou standest as the accused maiden's neutral surety in the clerk's controlled test. One mailed toll man delivereth a measured sword-blade shove; thou bindest thy will, catchest it upon the spare heater shield, and holdest the marked line without injury while the veteran containeth his fellow. The failed intimidation lets testimony finish openly. The clerk applieth his record and acquitteth the maiden, who granteth thee the shield already in thy hand for courageous service.",
+          "deed": "champion_accused_maiden_in_controlled_blade_test",
+          "outcome_tags": ["courage", "steadfastness", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "will", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "heater_shield", "quantity": 1 },
+            { "kind": "information", "information_id": "heater_shield_holds_blade_only_assault" }
+          ],
+          "personality": [{ "axis": "nerve", "delta": 110, "virtue": "courage" }],
+          "quest_reward_tags": ["prepare_heater_shield_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 40 }
+        },
+        {
+          "id": "suppress_verge_proof_against_maiden",
+          "label": "Inspect beneath the shifted verge, then give a false neutral report",
+          "response": [{ "speaker": "toll_sergeant", "text": "The clerk should hear no half-made charge. Step with me beyond the oak and compare the searched ground and witness stations apart; then return and give him one settled account.", "reviewed_shakespearean": true }],
+          "result": "Thou servest as neutral inspector for an hour while ongoing mailed pressure keepeth clerk and maiden from the stone. Beneath the veteran's shield cover, one toll man's blade shove is caught without injury; only thou canst then reach under the freshly shifted verge and retrieve an office-stamped iron wedge with torn sergeant's livery. Afterward the sergeant draweth thee privately beyond the hearing of clerk and maiden under the innocent pretext of comparing its place. There, and only there, he offereth his separately established personal forty-eight-groschen purse to suppress the proof. Thou acceptest, concealest wedge and cloth, and falsely reportest that the inspection found naught while misstating the witness order. The competent clerk correctly applieth law and compact to that deliberately falsified factual record, condemneth the accused maiden, and awardeth mule, wagon, alms chest, and load unto the sergeant as pledge. Still deceived concerning thy neutrality, she honorably payeth the promised spare shield fee. She suffereth no bodily harm, yet loseth transport, livelihood, and the poor's entrusted goods without present remedy.",
+          "deed": "suppress_decisive_verge_evidence_against_accused_maiden",
+          "outcome_tags": ["deception", "betrayal", "physical_observation", "exclusive_physical_evidence", "private_personal_bribe", "clerk_applied_corrupted_record", "material_harm_to_accused_maiden"],
+          "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 48 },
+            { "kind": "grant_item", "item_id": "heater_shield", "quantity": 1 },
+            { "kind": "information", "information_id": "heater_shield_holds_blade_only_assault" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": -250, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_heater_shield_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "ignore",
+          "label": "Leave the maiden's voluntarily paused hearing beneath the oak",
+          "response": [],
+          "result": "Thou leavest accused maiden and sergeant at their voluntarily paused arbitration beneath the boundary oak. The common road and nearby resting ground remain open.",
+          "deed": "leave_accused_maidens_roadside_arbitration_paused",
+          "outcome_tags": []
+        }
+      ],
+      "quest_reward_eligibility": ["physical_tactical_information", "material_preparation"]
+    }
+  ]
+}

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1907,6 +1907,83 @@ mod tests {
     }
 
     #[test]
+    fn maiden_roadside_court_routes_share_real_shield_preparation() {
+        let definition = encounter("maiden_roadside_court_v1").unwrap();
+        assert!(definition.triggers.travel && definition.triggers.rest);
+        assert!(definition.opening[0].text.contains("sergeant accuseth me"));
+        let choice = |id| {
+            definition
+                .choices
+                .iter()
+                .find(|choice| choice.id == id)
+                .unwrap()
+        };
+        let active = definition
+            .choices
+            .iter()
+            .filter(|choice| choice.id != "ignore")
+            .collect::<Vec<_>>();
+        for route in &active {
+            let effects = serde_json::to_string(&route.effects).unwrap();
+            assert!(effects.contains(r#""item_id":"heater_shield","quantity":1"#));
+            assert!(effects.contains("heater_shield_holds_blade_only_assault"));
+            assert_eq!(
+                route.quest_reward_tags,
+                ["prepare_heater_shield_against_blade_only_opposition"]
+            );
+        }
+        let shield = crate::item_catalog::definition("heater_shield").unwrap();
+        assert!(matches!(
+            &shield.kind,
+            crate::item_catalog::ItemKind::Shield { block, .. } if *block > 0.0
+        ));
+        assert_eq!(shield.base_value, 12);
+        let retainer = crate::bestiary::ThreatId::ArmedRetainer.profile();
+        assert_eq!(retainer.combat.attack, crate::bestiary::AttackStyle::Blade);
+        assert!(!retainer.combat.ranged);
+        let command = choice("order_hearing_under_clerks_judgment");
+        assert!(command.response[0].text.contains("I alone shall judge"));
+        let religion = choice("authenticate_maidens_alms_safe_conduct");
+        assert!(religion.result.contains("ordinary seal"));
+        assert_eq!(religion.effects.len(), 2);
+        let surety = choice("champion_maiden_in_controlled_blade_test");
+        assert!(matches!(
+            surety.checks[0],
+            Check::Skill {
+                skill: SkillId::Will,
+                difficulty_milli: 1200
+            }
+        ));
+        let evil = choice("suppress_verge_proof_against_maiden");
+        assert!(
+            evil.effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::Currency { amount: 48, .. }))
+        );
+        assert!(evil.personality.len() == 1 && evil.personality[0].delta < 0);
+        assert_eq!(48 + shield.base_value, 5 * shield.base_value);
+        let response = evil.response[0].text.to_lowercase();
+        assert!(
+            !["wedge", "purse", "suppress", "under color"]
+                .iter()
+                .any(|term| response.contains(term))
+        );
+        for tag in [
+            "exclusive_physical_evidence",
+            "private_personal_bribe",
+            "clerk_applied_corrupted_record",
+            "material_harm_to_accused_maiden",
+        ] {
+            assert!(evil.outcome_tags.iter().any(|found| found == tag));
+        }
+        let evil_effects = serde_json::to_string(&evil.effects).unwrap();
+        assert!(!evil_effects.contains("wagon") && !evil_effects.contains("person"));
+        let ignore = choice("ignore");
+        assert!(ignore.transition.is_none());
+        assert!(ignore.effects.is_empty() && ignore.personality.is_empty());
+    }
+
+    #[test]
     fn combat_transition_rejects_unsafe_counts() {
         let mut definition = encounter("unlawful_bridge_custom_v1").unwrap().clone();
         let choice = definition

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1659)
+## Files (1660)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -39,6 +39,7 @@ development, or other wiki document before changing a subsystem.
 - `content/encounters/envious-captain-false-directions.yaml` — Repository support file.
 - `content/encounters/ferryman-disputed-tribute.yaml` — Repository support file.
 - `content/encounters/insulting-damsel-and-dwarf.yaml` — Repository support file.
+- `content/encounters/maiden-roadside-court.yaml` — Repository support file.
 - `content/encounters/proud-traveler-errands.yaml` — Repository support file.
 - `content/encounters/rash-cliff-hunt.yaml` — Repository support file.
 - `content/encounters/stolen-lapdog-prize-horse.yaml` — Repository support file.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -294,6 +294,43 @@ color, and steals both the same gear and their previously declared forty-eight-
 groschen wage purse; reeve and charges still emerge safely. Ignoring the event
 waits 180 minutes for the occurrence fog to thin and grants nothing.
 
+`maiden_roadside_court_v1` may interrupt travel or rest at a boundary oak and
+wayside cross. A toll sergeant accuses a young noble maiden of shifting the
+verge stone to evade toll and seeks her mule, wagon, alms chest, and load as
+pledge. Because the lawful bench is distant and their attendants nearly fought,
+both parties freely seal a traveling clerk's temporary arbitration compact and
+agree to his award. The clerk presides by consent rather than sovereign
+jurisdiction and exclusively owns the compact, elder verge record, seals,
+handwriting, boundary custom, and legal application. All disputed property and
+physical evidence remain narrative-only and never become items or persistent
+strategic state.
+
+Two mailed, sword-bearing toll men press the maiden's unarmed carters and
+inspectors from the opening while her veteran shield-bearer contains them.
+Different routes use that native pressure differently: his shield screens the
+verge inspection, protects separated witnesses, forms a weapon-custody barrier,
+guards clerk and maiden while the safe-conduct is applied, or passes to the
+player for a controlled blade test. The religious route invokes no miracle or
+divine judgment; the clerk authenticates an ordinary visible episcopal
+safe-conduct. Each active route witnesses a real `heater_shield` catch a blade
+shove or stroke without injury. The granted spare shield has positive block
+mechanics and prepares against the fixed `armed_retainer` profile's blade
+attack and lack of ranged capability. Honest routes therefore grant twelve
+groschen of material value rather than a magical buff or enemy weakening.
+
+For the betrayal, ongoing shield pressure lets only the player retrieve a
+decisive office-stamped iron wedge and torn sergeant's livery from beneath the
+freshly shifted stone. Only afterward does the sergeant draw the player beyond
+clerk and maiden hearing under an innocent comparison pretext and privately
+offer his visibly established personal forty-eight-groschen purse. The player
+conceals the evidence and falsifies the factual report; the competent clerk
+correctly applies law and compact to that corrupted record and condemns the
+maiden. Still deceived about the helper's neutrality, she honors the promised
+shield fee but loses her mule, transport, livelihood, and entrusted alms
+without bodily harm or present remedy. None of those persons or properties
+becomes an effect payload. This sixty-groschen outcome is five times the honest
+material reward and lowers Honesty alone.
+
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source
 mapped at build time. YAML owns stable ID/version/weight, trigger eligibility,


### PR DESCRIPTION
Stacked on #353. Adds a travel- and rest-eligible romantic roadside judgment in which an accused maiden voluntarily submits to temporary arbitration rather than permit an armed clash. Six grounded resolutions use evidence, witnesses, orderly command, ordinary religious safe-conduct, courageous surety, or corrupt evidence suppression. A competent clerk retains legal expertise; shield pressure is native to the dispute and resolved differently by each route. Successful routes grant a real heater shield and actionable blade-defense knowledge. The evil route privately suppresses exclusive evidence, causes lasting material loss, and pays five times the honest material value. Structured outcome tags preserve causality without pinning authored prose.\n\nVerification: just check; 20 road encounter catalog tests; content validator; formatting/project-map/diff checks; two independent review passes.