### PR TITLE
Encounter 11: brachet and slain knight

### DIFF
--- a/content/encounters/brachet-slain-knight.yaml
+++ b/content/encounters/brachet-slain-knight.yaml
@@ -1,0 +1,155 @@
+{
+  "encounters": [
+    {
+      "id": "brachet_leads_to_slain_knight_v1",
+      "version": 1,
+      "weight": 60,
+      "triggers": { "travel": true, "rest": true },
+      "provenance": {
+        "works": ["Le Morte d'Arthur, Volume I, Book VI, Chapter XIV"],
+        "motifs": ["black_brachet", "blood_trail", "slain_knight", "faithful_hound", "body_recovery", "grave_stripping"],
+        "adaptation_note": "A direct adaptation of Malory's image in Volume I, Book VI, Chapter XIV: Launcelot follows a black brachet along a blood trail and finds a dead knight. This version relocates that image to a goal-neutral roadside recovery, adds the slain lord's veteran kennel master, and replaces Malory's subsequent supernatural adventure with grounded body care, armor observation, and the possibility of material desecration."
+      },
+      "cast": [
+        { "id": "kennel_master", "name": "Veteran kennel master", "nature": "mortal" }
+      ],
+      "opening": [
+        {
+          "speaker": "kennel_master",
+          "text": "This black brachet caught me upon the road as thou drewest near, then led us both hither along my lord's blood trail; now she croucheth beside his slain mailed body in yon alder hollow. I trained her these nine years, and I alone know her leash, cast, and handling, as I alone shall choose bier lashings and govern his body's removal. I have touched neither corpse nor the separate spoor departing from the hollow. His mail shirt remaineth upon him, his war hammer lieth at hand, and his household seal and tally identify the ninety-six-groschen pay-purse at his belt. Help me recover him without disorder, and the common spare arming doublet in my pack shall be thy modest hire.",
+          "reviewed_shakespearean": true
+        }
+      ],
+      "choices": [
+        {
+          "id": "read_departing_spoor",
+          "label": "Read the departing spoor without disturbing the master's scene",
+          "response": [{ "speaker": "kennel_master", "text": "Read thou the prints beyond his fallen hand and leave body, hound, and blood as found. I shall hold her cast and choose when the bier may enter.", "reviewed_shakespearean": true }],
+          "result": "For an hour thou readest heel turns, alder scuffs, and departing prints beyond the untouched hollow while the kennel master restraineth the brachet and governeth access. The spoor establisheth the assailant's hurried departure without moving the corpse. As the master setteth his bier, several close blade cuts lie stopped across the lord's mail and layered arming doublet, while the lethal cut entered the uncovered neck. He recovereth body and hound in order and granteth thee the promised spare doublet for prudent fieldcraft.",
+          "deed": "read_departing_spoor_beside_black_brachet",
+          "outcome_tags": ["prudence", "forestcraft", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "terrain_forest", "difficulty_milli": 1200 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arming_doublet", "quantity": 1 },
+            { "kind": "information", "information_id": "arming_doublet_resists_close_blade_hits_on_covered_chest" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 110, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_arming_doublet_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "examine_blade_wounds",
+          "label": "Examine the stopped chest cuts and lethal uncovered wound",
+          "response": [{ "speaker": "kennel_master", "text": "Examine him where he lieth, but lift no limb until I bind the brachet and set the bier. Name what steel overcame and what his layered harness stayed.", "reviewed_shakespearean": true }],
+          "result": "For forty-five minutes thou examinest the lord before the kennel master alone turneth and bindeth him for the bier. Several close sword cuts scored mail yet spent themselves across the covered chest, where the layered arming doublet supplied padding beneath; the mortal wound entered the uncovered neck. This physical distinction, not sentiment, governeth thy finding. The master then recovereth his lord and brachet and payeth the declared spare doublet for prudent knowledge.",
+          "deed": "distinguish_stopped_chest_cuts_from_uncovered_neck_wound",
+          "outcome_tags": ["prudence", "physiology", "physical_observation"],
+          "checks": [{ "kind": "skill", "skill": "physiology", "difficulty_milli": 1250 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arming_doublet", "quantity": 1 },
+            { "kind": "information", "information_id": "arming_doublet_resists_close_blade_hits_on_covered_chest" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 100, "virtue": "prudence" }],
+          "quest_reward_tags": ["prepare_arming_doublet_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 45 }
+        },
+        {
+          "id": "hold_watch_during_body_recovery",
+          "label": "Hold watch while the kennel master binds hound, bier, and body",
+          "response": [{ "speaker": "kennel_master", "text": "Watch thou alder rim and open track whilst I leash my brachet, choose the bier cast, and bind my lord. Cry warning, but meddle not with hound or lashings.", "reviewed_shakespearean": true }],
+          "result": "For fifty minutes thine eyes hold the hollow's rim while the kennel master alone leasheth the brachet and chooseth the bier cast. Once thou hast secured the perimeter, he calleth thee inward before he bindeth chest and neck. At his direction thou seest repeated close blade cuts stopped across the mail-covered, doublet-padded chest, yet one cut reached the bare neck and slew. With the rim safe, he alone handleth and secureth the body, then granteth thee the common spare arming doublet for courageous watch.",
+          "deed": "hold_watch_while_kennel_master_recovers_slain_lord",
+          "outcome_tags": ["courage", "watchfulness", "physical_observation"],
+          "checks": [{ "kind": "attribute", "attribute": "eyesight", "difficulty_milli": 1150 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arming_doublet", "quantity": 1 },
+            { "kind": "information", "information_id": "arming_doublet_resists_close_blade_hits_on_covered_chest" }
+          ],
+          "personality": [{ "axis": "nerve", "delta": 110, "virtue": "courage" }],
+          "quest_reward_tags": ["prepare_arming_doublet_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 50 }
+        },
+        {
+          "id": "rally_orderly_recovery",
+          "label": "Rally available hands beneath the kennel master's recovery plan",
+          "response": [{ "speaker": "kennel_master", "text": "I alone shall choose leash, cast, bier lashings, and handling of my lord. Number the willing hands, order their turns, and keep each beneath my recovery plan.", "reviewed_shakespearean": true }],
+          "result": "For forty-five minutes thou coordinatest bearers and sequence while the veteran master exclusively chooseth the brachet's leash and cast, the bier lashings, and every touch upon the body. His ordered lift exposeth several close blade marks stopped upon the mail and padded arming doublet across the chest, beside the single lethal entry at the uncovered neck. The company secureth body and hound without confusion; the master granteth thee the promised spare doublet for loyal command.",
+          "deed": "coordinate_hands_beneath_kennel_masters_recovery_plan",
+          "outcome_tags": ["loyalty", "command", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "command", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "command", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arming_doublet", "quantity": 1 },
+            { "kind": "information", "information_id": "arming_doublet_resists_close_blade_hits_on_covered_chest" }
+          ],
+          "personality": [{ "axis": "drive", "delta": 110, "virtue": "loyalty" }],
+          "quest_reward_tags": ["prepare_arming_doublet_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 45 }
+        },
+        {
+          "id": "steady_grieving_kennel_master",
+          "label": "Steady the grieving master so he may execute his own plan",
+          "response": [{ "speaker": "kennel_master", "text": "Thy measured speech recalleth me unto the work mine office requireth. Stand near and name each task once; my hands shall govern brachet, bier, and lord as they have long been trained.", "reviewed_shakespearean": true }],
+          "result": "For thirty-five minutes thy courteous words let grief pass without displacing the kennel master's competence. He resumeth his own practiced sequence, calming the brachet and setting bier and body. As he looseth the outer mail for sound binding, ye observe close blade cuts that stopped upon the layered, doublet-covered chest and the fatal wound that entered the unguarded neck. He completeth the recovery and honorably granteth thee the declared spare arming doublet.",
+          "deed": "steady_grieving_master_for_competent_body_recovery",
+          "outcome_tags": ["courtesy", "consolation", "physical_observation"],
+          "requirements": [{ "kind": "skill", "skill": "charm", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "charm", "difficulty_milli": 1100 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arming_doublet", "quantity": 1 },
+            { "kind": "information", "information_id": "arming_doublet_resists_close_blade_hits_on_covered_chest" }
+          ],
+          "personality": [{ "axis": "sociability", "delta": 110, "virtue": "courtesy" }],
+          "quest_reward_tags": ["prepare_arming_doublet_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 35 }
+        },
+        {
+          "id": "keep_ordinary_christian_vigil",
+          "label": "Keep the ordinary Christian vigil and office for the body",
+          "response": [{ "speaker": "kennel_master", "text": "Keep thou the accustomed vigil and speak the common office whilst I leash the brachet and bind the bier. Prayer shall order our mortal duty; it needeth work no marvel upon the dead.", "reviewed_shakespearean": true }],
+          "result": "For forty minutes thou keepest the ordinary Christian vigil as the kennel master performeth every physical task of hound and body recovery. No miracle altereth corpse, wounds, or harness. In the bier preparation, several close blade cuts prove stopped upon the mail and arming doublet over the covered chest, while the lethal steel entered the uncovered neck. The master completeth his earthly duty and granteth thee the common spare doublet for faithful fellowship.",
+          "deed": "keep_ordinary_christian_vigil_over_slain_knight",
+          "outcome_tags": ["faith", "ordinary_body_office", "physical_observation"],
+          "requirements": [{ "kind": "religion", "religion": "roman_catholic" }],
+          "checks": [{ "kind": "religion", "religion": "roman_catholic", "difficulty_milli": 1050 }],
+          "effects": [
+            { "kind": "grant_item", "item_id": "arming_doublet", "quantity": 1 },
+            { "kind": "information", "information_id": "arming_doublet_resists_close_blade_hits_on_covered_chest" }
+          ],
+          "personality": [{ "axis": "conviction", "delta": 110, "virtue": "faith" }],
+          "quest_reward_tags": ["prepare_arming_doublet_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 40 }
+        },
+        {
+          "id": "misdirect_master_and_strip_dead",
+          "label": "Misdirect the master with false spoor and strip the dead",
+          "response": [{ "speaker": "kennel_master", "text": "Thou sayest a bloodied man brake the hazel upon that branch? Keep my lord and pack beneath thy watch. I shall take the brachet leashed along that short cast and return when the sign proveth true or false.", "reviewed_shakespearean": true }],
+          "result": "For an hour thou pretendest to read a plausible departing branch and waitest until the trusting kennel master taketh his black brachet leashed upon the false cast. Alone after they depart, thou liftest the lord's mail to strip it and thereby discoverest several close blade cuts stopped upon mail and the common arming doublet over the covered chest, while the lethal cut entered the uncovered neck. Thou stealest the declared ninety-six-groschen household pay-purse, mail shirt, and war hammer from the slain lord and takest the common spare arming doublet from the entrusted pack. Thou leavest the body materially desecrated and deprived of household property. Master and hound may return unharmed when the false spoor faileth, but their loss remaineth real.",
+          "deed": "misdirect_kennel_master_and_strip_slain_lord",
+          "outcome_tags": ["deception", "theft", "physical_observation", "misdirected_kennel_master", "stripped_slain_knight", "material_desecration"],
+          "requirements": [{ "kind": "skill", "skill": "deception", "minimum_hours": 1 }],
+          "checks": [{ "kind": "skill", "skill": "deception", "difficulty_milli": 1300 }],
+          "effects": [
+            { "kind": "currency", "currency_id": "brandenburg_groschen", "amount": 96 },
+            { "kind": "grant_item", "item_id": "mail_shirt", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "war_hammer", "quantity": 1 },
+            { "kind": "grant_item", "item_id": "arming_doublet", "quantity": 1 },
+            { "kind": "information", "information_id": "arming_doublet_resists_close_blade_hits_on_covered_chest" }
+          ],
+          "personality": [{ "axis": "transparency", "delta": -250, "virtue": "honesty" }],
+          "quest_reward_tags": ["prepare_arming_doublet_against_blade_only_opposition"],
+          "transition": { "kind": "travel_delay", "minutes": 60 }
+        },
+        {
+          "id": "ignore",
+          "label": "Leave the black brachet and her master beside the hollow",
+          "response": [],
+          "result": "Thou leavest the veteran master with black brachet and slain lord beside the alder hollow. The open road and nearby resting ground remain free.",
+          "deed": "leave_black_brachet_and_slain_knight_untouched",
+          "outcome_tags": []
+        }
+      ],
+      "quest_reward_eligibility": ["physical_tactical_information", "material_preparation"]
+    }
+  ]
+}

--- a/crates/adventuresim-core/src/road_encounter_catalog.rs
+++ b/crates/adventuresim-core/src/road_encounter_catalog.rs
@@ -1984,6 +1984,83 @@ mod tests {
     }
 
     #[test]
+    fn brachet_routes_share_grounded_doublet_preparation_and_real_loot() {
+        let definition = encounter("brachet_leads_to_slain_knight_v1").unwrap();
+        assert!(definition.triggers.travel && definition.triggers.rest);
+        assert_eq!(definition.cast.len(), 1);
+        assert_eq!(definition.cast[0].nature, SpeakerNature::Mortal);
+        let authored = serde_json::to_string(definition).unwrap();
+        assert!(!authored.contains(r#""reviewed_shakespearean":false"#));
+        assert!(!authored.contains(r#""reviewed_iambic_pentameter":true"#));
+        let choice = |id| {
+            definition
+                .choices
+                .iter()
+                .find(|choice| choice.id == id)
+                .unwrap()
+        };
+        let active = definition
+            .choices
+            .iter()
+            .filter(|choice| choice.id != "ignore")
+            .collect::<Vec<_>>();
+        for route in &active {
+            let effects = serde_json::to_string(&route.effects).unwrap();
+            assert!(effects.contains(r#""item_id":"arming_doublet","quantity":1"#));
+            assert!(effects.contains("arming_doublet_resists_close_blade_hits_on_covered_chest"));
+            assert!(
+                !["dog", "brachet", "corpse", "body"]
+                    .iter()
+                    .any(|id| effects.contains(id))
+            );
+            assert_eq!(
+                route.quest_reward_tags,
+                ["prepare_arming_doublet_against_blade_only_opposition"]
+            );
+        }
+        let doublet = crate::item_catalog::definition("arming_doublet").unwrap();
+        assert_eq!(doublet.base_value, 12);
+        assert!(matches!(&doublet.kind,
+            crate::item_catalog::ItemKind::Armor { coverage, resistance, padding, .. }
+                if *coverage > 0.0 && *resistance > 0.0 && *padding > 0.0));
+        let topology = serde_json::to_string(&doublet.equipment).unwrap();
+        assert!(topology.contains(r#""location":"chest","channel":"padding"#));
+        assert!(topology.contains(r#""protection":["chest"]"#));
+        let retainer = crate::bestiary::ThreatId::ArmedRetainer.profile();
+        assert_eq!(retainer.combat.attack, crate::bestiary::AttackStyle::Blade);
+        assert!(!retainer.combat.ranged);
+        let command = choice("rally_orderly_recovery");
+        assert!(command.response[0].text.contains("I alone shall choose"));
+        let faith = choice("keep_ordinary_christian_vigil");
+        assert_eq!(faith.effects.len(), 2);
+        assert!(
+            faith
+                .outcome_tags
+                .iter()
+                .any(|tag| tag == "ordinary_body_office")
+        );
+        let evil = choice("misdirect_master_and_strip_dead");
+        assert!(matches!(
+            evil.effects[0],
+            Effect::Currency { amount: 96, .. }
+        ));
+        let evil_effects = serde_json::to_string(&evil.effects).unwrap();
+        assert!(evil_effects.contains("mail_shirt") && evil_effects.contains("war_hammer"));
+        assert!(evil.personality.len() == 1 && evil.personality[0].delta < 0);
+        assert_eq!(exemplified_virtue(&evil.personality), None);
+        let mail = crate::item_catalog::definition("mail_shirt").unwrap();
+        let hammer = crate::item_catalog::definition("war_hammer").unwrap();
+        assert_eq!(
+            96 + mail.base_value + hammer.base_value + doublet.base_value,
+            177
+        );
+        assert!(177 > 14 * doublet.base_value);
+        let ignore = choice("ignore");
+        assert!(ignore.transition.is_none());
+        assert!(ignore.effects.is_empty() && ignore.personality.is_empty());
+    }
+
+    #[test]
     fn combat_transition_rejects_unsafe_counts() {
         let mut definition = encounter("unlawful_bridge_custom_v1").unwrap().clone();
         let choice = definition

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1660)
+## Files (1661)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -35,6 +35,7 @@ development, or other wiki document before changing a subsystem.
 - `content/dialogue/examples.yaml` — Repository support file.
 - `content/dialogue/organizations.yaml` — Repository support file.
 - `content/dialogue/services.yaml` — Repository support file.
+- `content/encounters/brachet-slain-knight.yaml` — Repository support file.
 - `content/encounters/enchanted-fog-lost-forester.yaml` — Repository support file.
 - `content/encounters/envious-captain-false-directions.yaml` — Repository support file.
 - `content/encounters/ferryman-disputed-tribute.yaml` — Repository support file.

--- a/wiki/reference/romance-road-encounters.md
+++ b/wiki/reference/romance-road-encounters.md
@@ -331,6 +331,39 @@ without bodily harm or present remedy. None of those persons or properties
 becomes an effect payload. This sixty-groschen outcome is five times the honest
 material reward and lowers Honesty alone.
 
+`brachet_leads_to_slain_knight_v1` directly adapts the initiating image from
+Malory's [*Le Morte d'Arthur*, Volume I, Book VI, Chapter
+XIV](https://www.gutenberg.org/files/1251/1251-h/1251-h.htm): Launcelot follows
+a black brachet along a blood trail and finds a dead knight. The encounter
+relocates that image to a goal-neutral alder-hollow recovery: the black brachet
+meets master and player upon the road and leads both along the inward blood
+trail, which remains distinct from untouched spoor departing the corpse. A
+veteran kennel master who trained the brachet for nine years replaces Malory's
+subsequent supernatural adventure and alone owns the hound's leash and cast,
+the bier, and all handling of the slain body.
+
+Seven active routes read departing spoor, examine wounds, hold perimeter
+watch, coordinate hands beneath the master's plan, restore his composure, keep
+an ordinary Christian vigil, or betray his trust. Each route physically
+distinguishes close blade cuts stopped across the lord's mail and layered,
+covered chest from the lethal cut entering his uncovered neck. Every active
+route grants the already-declared spare `arming_doublet` from the master's
+pack, plus practical information that its real chest coverage, resistance, and
+padding oppose the fixed blade-only, non-ranged `armed_retainer` profile. The
+vigil works no miracle and creates no magical state.
+
+The perimeter watcher sees the wounds only after securing the rim and being
+called inward by the master. The thief instead discovers the same physical
+lesson while lifting the mail to strip it after master and hound have departed.
+
+The evil route sends master and leashed brachet briefly down plausible false
+spoor, then strips the declared ninety-six-groschen household pay-purse,
+`mail_shirt`, `war_hammer`, and common spare doublet from corpse and entrusted
+pack. Those items total 177 groschen against twelve for an honest route, while
+master and hound may return physically unharmed to a materially desecrated
+body. Dog and body remain narrative-only property and never become items,
+effects, or persistent strategic state.
+
 `content/encounters/*.yaml` is sorted, strictly deserialized with unknown
 fields denied, semantically validated, SHA-256 digested, embedded, and source
 mapped at build time. YAML owns stable ID/version/weight, trigger eligibility,


### PR DESCRIPTION
Stacked on #354. Adds a travel- and rest-eligible roadside recovery adapted from Malory Book VI, Chapter XIV: a black brachet leads travelers along a blood trail to her slain lord. Seven grounded resolutions cover spoor, wounds, watch, command, consolation, vigil, and grave robbery without opening a deferred settlement investigation. A competent kennel master retains hound, bier, and body expertise. Successful routes grant a real arming doublet and knowledge of its covered-chest protection; the evil route strips declared mail, hammer, and wages for 177 groschen of material value versus 12 honestly. Body and hound remain narrative-local.\n\nVerification: just check; 21 road encounter catalog tests; content validator; formatting/project-map/diff checks; two independent review passes.