### PR TITLE
Add offensive tactical melee AI

### DIFF
--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -48,7 +48,6 @@ const BODY_PART_HITBOXES: &[(BodyPart, Vec3, Vec3)] = &[
 const HITBOX_LAYER: LayerMask = LayerMask(1 << 1);
 const PRE_HIT_DELAY: f32 = 0.3;
 const HIT_PRECISION: f32 = 1.0;
-const HANDS_REACH: f32 = 1.5;
 
 pub struct PlayerPlugin;
 
@@ -249,7 +248,7 @@ fn update_attack_state_system(
         let origin = camera_transform.translation;
         let direction = camera_transform.forward();
         let filter = SpatialQueryFilter::from_mask(HITBOX_LAYER);
-        let reach = state.reach + HANDS_REACH;
+        let reach = melee_interaction_range(state.reach);
 
         if let Some(hit) = spatial.cast_ray(origin, direction, reach, true, &filter) {
             let Ok((target, body_part)) = q_collider.get(hit.entity).map(|(c, h)| (c.body, h.0))

--- a/crates/adventuresim-tactical-core/src/combat.rs
+++ b/crates/adventuresim-tactical-core/src/combat.rs
@@ -1,5 +1,15 @@
 use bevy_enhanced_input::prelude::InputAction;
 
+/// The attacker's body-and-arms contribution to melee interaction range.
+/// Equipped weapon reach is added to this value for both client hit detection
+/// and server-owned AI engagement decisions.
+pub const HANDS_REACH: f32 = 1.5;
+
+#[must_use]
+pub fn melee_interaction_range(weapon_reach: f32) -> f32 {
+    HANDS_REACH + weapon_reach.max(0.0)
+}
+
 #[derive(Debug, InputAction, Default)]
 #[action_output(f32)]
 pub struct Attack;

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -16,7 +16,7 @@ pub use avian3d;
 
 pub mod prelude {
     pub use crate::AdventureSimulatorCorePlugins;
-    pub use crate::combat::{Attack, Dodge, Parry};
+    pub use crate::combat::{Attack, Dodge, HANDS_REACH, Parry, melee_interaction_range};
     pub use crate::inventory::{
         ArmorItem, ArmorSide, ArmorSlot, EquipSlot, EquipmentTopology, EquipmentTopologyOccupancy,
         InventoryItems, ItemOf, ItemProperties, ItemQuantity, ShieldItem, WeaponItem,

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -4,8 +4,14 @@ use adventuresim_tactical_netcode::{
     message::{AttackStartedRequest, DefendRequest},
 };
 use bevy::prelude::*;
+use std::cmp::Ordering;
 
-use crate::{MissionState, combat::PendingDefenderResponse};
+use crate::{
+    MissionState,
+    combat::{
+        MeleeAttackIntent, MeleeAttackStartedIntent, PendingDefenderResponse, TacticalCombatSide,
+    },
+};
 
 /// Chance that a bot notices an incoming attack in time to parry it.
 const PARRY_CHANCE: f64 = 0.2;
@@ -19,11 +25,40 @@ const FRONTAL_FLANKING_MAX: f32 = 0.01;
 /// delay may end up committing its reaction only after the attack has
 /// already been resolved, i.e. reacting too late to matter.
 const REACTION_DELAY_SECS: std::ops::Range<f32> = 0.05..0.6;
+/// AI attacks are intentionally deterministic until animation-driven precision
+/// can be authored for server-controlled actors.
+const AI_HIT_PRECISION: f32 = 1.0;
+const AI_BODY_PART: BodyPart = BodyPart::Chest;
+const AI_WINDUP_SECS: f32 = 0.5;
+const AI_COOLDOWN_SECS: f32 = 1.0;
 
 /// Marks a server-controlled bot filling in for a temporary (non-connected)
 /// mission character.
 #[derive(Component)]
 pub struct MissionEnemy;
+
+/// Enables server-owned, direct-pursuit melee control for a combatant.
+#[derive(Component, Debug)]
+pub struct OffensiveMeleeAi {
+    target: Option<Entity>,
+    phase: OffensiveMeleePhase,
+}
+
+impl Default for OffensiveMeleeAi {
+    fn default() -> Self {
+        Self {
+            target: None,
+            phase: OffensiveMeleePhase::Pursuing,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum OffensiveMeleePhase {
+    Pursuing,
+    Windup(Timer),
+    Cooldown(Timer),
+}
 
 #[derive(Component)]
 pub struct CountedEnemyDeath;
@@ -49,7 +84,8 @@ impl Plugin for BotPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(on_authoritative_enemy_death)
             .add_observer(on_attack_started)
-            .add_systems(Update, tick_bot_reactions);
+            .add_observer(on_targeted_attack_started)
+            .add_systems(Update, (drive_offensive_melee_ai, tick_bot_reactions));
     }
 }
 
@@ -71,8 +107,8 @@ pub fn mission_objective_satisfied(required: u32, killed: u32) -> bool {
     killed >= required
 }
 
-/// Predicts, for every bot facing the attacker head-on, whether it notices
-/// this attack starting and, primitively, decides to dodge or parry it.
+/// Predicts whether the nearest opposing AI facing a client attacker notices
+/// the untargeted client windup and decides to dodge or parry it.
 ///
 /// A bot has no real reflexes: it only ever gets a chance to react when it is
 /// facing its attacker (`flanking <= FRONTAL_FLANKING_MAX`), and even then it
@@ -81,31 +117,180 @@ pub fn mission_objective_satisfied(required: u32, killed: u32) -> bool {
 fn on_attack_started(
     event: On<FromClient<AttackStartedRequest>>,
     mut cmd: Commands,
-    q_character: Query<&CharacterLook>,
-    q_bots: Query<(Entity, &CharacterLook), With<MissionEnemy>>,
+    q_character: Query<(&CharacterLook, &Transform, &TacticalCombatSide)>,
+    q_bots: Query<
+        (Entity, &CharacterLook, &Transform, &TacticalCombatSide),
+        With<OffensiveMeleeAi>,
+    >,
 ) {
     let Some(attacker) = event.client_id.entity() else {
         return;
     };
-    let Ok(attacker_look) = q_character.get(attacker) else {
+    let Ok((attacker_look, attacker_transform, attacker_side)) = q_character.get(attacker) else {
         return;
     };
+    let nearest = q_bots
+        .iter()
+        .filter(|(_, _, _, side)| **side != *attacker_side)
+        .min_by(|(a, _, a_transform, _), (b, _, b_transform, _)| {
+            compare_target(attacker_transform, a_transform, *a, b_transform, *b)
+        });
+    let Some((bot, bot_look, _, _)) = nearest else {
+        return;
+    };
+    try_start_reaction(&mut cmd, bot, attacker_look, bot_look);
+}
+
+fn on_targeted_attack_started(
+    event: On<MeleeAttackStartedIntent>,
+    mut cmd: Commands,
+    q_character: Query<&CharacterLook>,
+    q_ai: Query<&CharacterLook, With<OffensiveMeleeAi>>,
+) {
+    let Ok([attacker_look, defender_look]) = q_character.get_many([event.attacker, event.target])
+    else {
+        return;
+    };
+    if q_ai.get(event.target).is_ok() {
+        try_start_reaction(&mut cmd, event.target, attacker_look, defender_look);
+    }
+}
+
+fn try_start_reaction(
+    cmd: &mut Commands,
+    defender: Entity,
+    attacker_look: &CharacterLook,
+    defender_look: &CharacterLook,
+) {
     let (a2, a1) = attacker_look.yaw.sin_cos();
+    let (d2, d1) = defender_look.yaw.sin_cos();
+    if flanking_from_dir((a1, a2), (d1, d2)) > FRONTAL_FLANKING_MAX {
+        return;
+    }
+    let Some(choice) = roll_defend_choice() else {
+        return;
+    };
+    cmd.entity(defender).insert(PendingBotReaction {
+        timer: Timer::from_seconds(rand::random_range(REACTION_DELAY_SECS), TimerMode::Once),
+        choice,
+    });
+}
 
-    for (bot, bot_look) in &q_bots {
-        let (d2, d1) = bot_look.yaw.sin_cos();
-        if flanking_from_dir((a1, a2), (d1, d2)) > FRONTAL_FLANKING_MAX {
-            continue;
+fn compare_target(
+    origin: &Transform,
+    a_transform: &Transform,
+    a: Entity,
+    b_transform: &Transform,
+    b: Entity,
+) -> Ordering {
+    let a_distance_squared = origin
+        .translation
+        .xz()
+        .distance_squared(a_transform.translation.xz());
+    let b_distance_squared = origin
+        .translation
+        .xz()
+        .distance_squared(b_transform.translation.xz());
+    a_distance_squared
+        .total_cmp(&b_distance_squared)
+        .then_with(|| a.to_bits().cmp(&b.to_bits()))
+}
+
+fn drive_offensive_melee_ai(
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    viewer: TacticalPlayerViewer,
+    candidates: Query<(Entity, &Transform, &TacticalCombatSide), With<Player>>,
+    mut ai: Query<(
+        Entity,
+        &Transform,
+        &TacticalCombatSide,
+        &mut CharacterLook,
+        &mut input::AccumulatedInput,
+        &mut OffensiveMeleeAi,
+    )>,
+) {
+    for (entity, transform, side, mut look, mut input, mut controller) in &mut ai {
+        let target = candidates
+            .iter()
+            .filter(|(candidate, _, candidate_side)| {
+                *candidate != entity && **candidate_side != *side
+            })
+            .min_by(|(a, a_transform, _), (b, b_transform, _)| {
+                compare_target(transform, a_transform, *a, b_transform, *b)
+            })
+            .map(|(target, _, _)| target);
+
+        if target != controller.target {
+            controller.target = target;
+            controller.phase = OffensiveMeleePhase::Pursuing;
         }
-
-        let Some(choice) = roll_defend_choice() else {
+        let Some(target) = target else {
+            input.last_movement = None;
+            continue;
+        };
+        let Ok((_, target_transform, _)) = candidates.get(target) else {
             continue;
         };
 
-        cmd.entity(bot).insert(PendingBotReaction {
-            timer: Timer::from_seconds(rand::random_range(REACTION_DELAY_SECS), TimerMode::Once),
-            choice,
-        });
+        let offset = target_transform.translation.xz() - transform.translation.xz();
+        let distance = offset.length();
+        if distance > f32::EPSILON {
+            look.yaw = (-offset.x).atan2(-offset.y);
+        }
+        let weapon_reach = viewer
+            .get(entity)
+            .map(|view| view.weapon_reach())
+            .unwrap_or_default();
+        let interaction_range = melee_interaction_range(weapon_reach);
+
+        if !matches!(&controller.phase, OffensiveMeleePhase::Pursuing)
+            && (weapon_reach <= 0.0 || distance > interaction_range)
+        {
+            controller.phase = OffensiveMeleePhase::Pursuing;
+        }
+
+        match &mut controller.phase {
+            OffensiveMeleePhase::Pursuing
+                if weapon_reach > 0.0 && distance <= interaction_range =>
+            {
+                input.last_movement = None;
+                cmd.trigger(MeleeAttackStartedIntent {
+                    attacker: entity,
+                    target,
+                });
+                controller.phase = OffensiveMeleePhase::Windup(Timer::from_seconds(
+                    AI_WINDUP_SECS,
+                    TimerMode::Once,
+                ));
+            }
+            OffensiveMeleePhase::Pursuing => {
+                input.last_movement = Some(Vec2::Y);
+            }
+            OffensiveMeleePhase::Windup(timer) => {
+                input.last_movement = None;
+                timer.tick(time.delta());
+                if timer.is_finished() {
+                    cmd.trigger(MeleeAttackIntent {
+                        attacker: entity,
+                        target,
+                        body_part: AI_BODY_PART,
+                        hit_precision: AI_HIT_PRECISION,
+                    });
+                    controller.phase = OffensiveMeleePhase::Cooldown(Timer::from_seconds(
+                        AI_COOLDOWN_SECS,
+                        TimerMode::Once,
+                    ));
+                }
+            }
+            OffensiveMeleePhase::Cooldown(timer) => {
+                input.last_movement = None;
+                timer.tick(time.delta());
+                if timer.is_finished() {
+                    controller.phase = OffensiveMeleePhase::Pursuing;
+                }
+            }
+        }
     }
 }
 
@@ -142,7 +327,54 @@ fn tick_bot_reactions(
 
 #[cfg(test)]
 mod tests {
-    use super::mission_objective_satisfied;
+    use std::time::Duration;
+
+    use super::*;
+
+    #[derive(Resource, Default)]
+    struct RecordedAttacks(Vec<(Entity, Entity)>);
+
+    fn record_attack(event: On<MeleeAttackIntent>, mut attacks: ResMut<RecordedAttacks>) {
+        attacks.0.push((event.attacker, event.target));
+    }
+
+    fn spawn_test_ai(world: &mut World, side: TacticalCombatSide, position: Vec3) -> Entity {
+        // Temporary characters receive this production loadout from
+        // `insert_new_character` when no authored starting package is given.
+        const KATZBALGER_REACH: f32 = 0.8;
+        let actor = world
+            .spawn((
+                Player::default(),
+                Transform::from_translation(position),
+                side,
+                CharacterLook::default(),
+                input::AccumulatedInput::default(),
+                OffensiveMeleeAi::default(),
+            ))
+            .id();
+        let weapon = world.spawn(ItemOf(actor)).id();
+        // Match production's insertion order: the equip hook must see both
+        // the owning inventory relationship and the weapon classification.
+        world.entity_mut(weapon).insert(WeaponItem {
+            skill_weights: [0.0; 9],
+            accuracy: 1.0,
+            penetration: 1.0,
+            reach: KATZBALGER_REACH,
+            balance: 0.0,
+            precise: false,
+        });
+        world.entity_mut(weapon).insert(EquipSlot::HoldingRight);
+        actor
+    }
+
+    fn test_app() -> App {
+        let mut app = App::new();
+        app.insert_resource(Time::<()>::default())
+            .init_resource::<RecordedAttacks>()
+            .add_observer(record_attack)
+            .add_systems(Update, drive_offensive_melee_ai);
+        app
+    }
 
     #[test]
     fn mission_success_requires_the_full_authoritative_objective() {
@@ -151,5 +383,136 @@ mod tests {
         assert!(!mission_objective_satisfied(3, 2));
         assert!(mission_objective_satisfied(3, 3));
         assert!(mission_objective_satisfied(3, 4));
+    }
+
+    #[test]
+    fn opposing_ai_approach_face_stop_and_both_attack() {
+        let mut app = test_app();
+        let party = spawn_test_ai(
+            app.world_mut(),
+            TacticalCombatSide::Party,
+            Vec3::new(0.0, 0.0, -3.0),
+        );
+        let enemy = spawn_test_ai(
+            app.world_mut(),
+            TacticalCombatSide::Enemy,
+            Vec3::new(0.0, 0.0, 3.0),
+        );
+
+        // Simulate only the small, deterministic movement seam driven by the
+        // existing controller input. No physics, wall clock, spawn randomness,
+        // or global RNG is involved in this headless behavior test.
+        for _ in 0..20 {
+            app.world_mut()
+                .resource_mut::<Time<()>>()
+                .advance_by(Duration::from_millis(100));
+            app.update();
+
+            let snapshots: Vec<_> = [party, enemy]
+                .into_iter()
+                .map(|actor| {
+                    let entity = app.world().entity(actor);
+                    (
+                        actor,
+                        entity
+                            .get::<input::AccumulatedInput>()
+                            .unwrap()
+                            .last_movement,
+                        entity.get::<CharacterLook>().unwrap().yaw,
+                    )
+                })
+                .collect();
+            for (actor, movement, yaw) in snapshots {
+                if movement.is_some() {
+                    let forward = Vec3::new(-yaw.sin(), 0.0, -yaw.cos());
+                    app.world_mut()
+                        .entity_mut(actor)
+                        .get_mut::<Transform>()
+                        .unwrap()
+                        .translation += forward * 0.5;
+                }
+            }
+        }
+
+        let party_transform = app.world().entity(party).get::<Transform>().unwrap();
+        let enemy_transform = app.world().entity(enemy).get::<Transform>().unwrap();
+        let separation = party_transform
+            .translation
+            .xz()
+            .distance(enemy_transform.translation.xz());
+        const KATZBALGER_REACH: f32 = 0.8;
+        const TWO_CHARACTER_COLLIDER_RADII: f32 = 0.8;
+        assert!(
+            separation <= melee_interaction_range(KATZBALGER_REACH),
+            "AI stopped outside melee interaction range: {separation}"
+        );
+        assert!(
+            separation >= TWO_CHARACTER_COLLIDER_RADII,
+            "AI test movement collapsed production-sized character colliders: {separation}"
+        );
+        for (actor, target) in [(party, enemy), (enemy, party)] {
+            let entity = app.world().entity(actor);
+            let target_entity = app.world().entity(target);
+            let yaw = entity.get::<CharacterLook>().unwrap().yaw;
+            let forward = Vec2::new(-yaw.sin(), -yaw.cos());
+            let toward_target = (target_entity.get::<Transform>().unwrap().translation.xz()
+                - entity.get::<Transform>().unwrap().translation.xz())
+            .normalize();
+            let facing = forward.dot(toward_target);
+            assert!(
+                facing > 0.999,
+                "AI {actor:?} yaw {yaw} faces {forward:?}, target direction {toward_target:?}, dot {facing}, separation {separation}"
+            );
+        }
+        assert_eq!(
+            app.world()
+                .entity(party)
+                .get::<input::AccumulatedInput>()
+                .unwrap()
+                .last_movement,
+            None
+        );
+        assert_eq!(
+            app.world()
+                .entity(enemy)
+                .get::<input::AccumulatedInput>()
+                .unwrap()
+                .last_movement,
+            None
+        );
+
+        let attacks = &app.world().resource::<RecordedAttacks>().0;
+        assert!(attacks.contains(&(party, enemy)));
+        assert!(attacks.contains(&(enemy, party)));
+    }
+
+    #[test]
+    fn nearest_target_ties_use_entity_identity() {
+        let mut app = test_app();
+        let actor = spawn_test_ai(app.world_mut(), TacticalCombatSide::Party, Vec3::ZERO);
+        let first = spawn_test_ai(
+            app.world_mut(),
+            TacticalCombatSide::Enemy,
+            Vec3::new(-2.0, 0.0, 0.0),
+        );
+        let second = spawn_test_ai(
+            app.world_mut(),
+            TacticalCombatSide::Enemy,
+            Vec3::new(2.0, 0.0, 0.0),
+        );
+        app.update();
+
+        let selected = app
+            .world()
+            .entity(actor)
+            .get::<OffensiveMeleeAi>()
+            .unwrap()
+            .target;
+        let expected = if first.to_bits() < second.to_bits() {
+            first
+        } else {
+            second
+        };
+        assert_eq!(selected, Some(expected));
     }
 }

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -22,11 +22,40 @@ pub struct PendingDefenderResponse {
     pub set_at: f32,
 }
 
+/// Transient allegiance used by the tactical server to identify opponents.
+///
+/// This is deliberately independent from player connectivity and bot control:
+/// tests and future mission types can put server-controlled combatants on
+/// either side.
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TacticalCombatSide {
+    Party,
+    Enemy,
+}
+
+/// A server-internal melee request. Both network clients and server-owned AI
+/// enter combat resolution through this seam.
+#[derive(Event, Clone, Copy, Debug)]
+pub struct MeleeAttackIntent {
+    pub attacker: Entity,
+    pub target: Entity,
+    pub body_part: BodyPart,
+    pub hit_precision: f32,
+}
+
+/// Announces a targeted windup so the intended defender alone can react.
+#[derive(Event, Clone, Copy, Debug)]
+pub struct MeleeAttackStartedIntent {
+    pub attacker: Entity,
+    pub target: Entity,
+}
+
 pub struct CombatPlugin;
 
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(on_attack_action_triggered)
+            .add_observer(resolve_melee_attack)
             .add_observer(on_defender_response);
     }
 }
@@ -78,8 +107,28 @@ fn resolve_defender_response(
     }
 }
 
-fn on_attack_action_triggered(
-    event: On<FromClient<AttackRequest>>,
+fn on_attack_action_triggered(event: On<FromClient<AttackRequest>>, mut cmd: Commands) {
+    let Some(attacker) = event.client_id.entity() else {
+        warn!(
+            "Got attack request from an unknown client: {:?}",
+            event.client_id
+        );
+        return;
+    };
+
+    // `hit_precision` is intentionally accepted as reported by the client.
+    // Animation and secondary-physics fidelity belongs on the rendering
+    // client; character stats continue to bound the resolved exchange.
+    cmd.trigger(MeleeAttackIntent {
+        attacker,
+        target: event.target,
+        body_part: event.body_part,
+        hit_precision: event.hit_precision,
+    });
+}
+
+fn resolve_melee_attack(
+    event: On<MeleeAttackIntent>,
     mut cmd: Commands,
     viewer: TacticalPlayerViewer,
     q_character: Query<&CharacterLook>,
@@ -87,13 +136,7 @@ fn on_attack_action_triggered(
     q_pending: Query<&PendingDefenderResponse>,
     time: Res<Time<()>>,
 ) {
-    let Some(entity) = event.client_id.entity() else {
-        warn!(
-            "Got attack request from an unknown client: {:?}",
-            event.client_id
-        );
-        return;
-    };
+    let entity = event.attacker;
 
     let Ok(attacker_view) = viewer.get(entity).inspect_err(|err| {
         error!("Can't get a view for attacker {entity:?}: {err}",);

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -21,7 +21,8 @@ use bevy::time::Stopwatch;
 use clap::{ArgAction, Parser};
 
 use crate::{
-    bot::MissionEnemy,
+    bot::{MissionEnemy, OffensiveMeleeAi},
+    combat::TacticalCombatSide,
     stdb::{SpacetimeDb, SpacetimeDbReady},
     terrain::TerrainGenerator,
 };
@@ -218,7 +219,12 @@ fn spawn_connected_player(
     q_scene: &Query<&SceneTerrain>,
 ) {
     let entity = if player.mission_side == TacticalMissionSide::Enemy {
-        cmd.spawn(MissionEnemy).id()
+        cmd.spawn((
+            MissionEnemy,
+            OffensiveMeleeAi::default(),
+            TacticalCombatSide::Enemy,
+        ))
+        .id()
     } else {
         let Some((entity, _)) = q_loading
             .iter()
@@ -397,6 +403,11 @@ fn spawn_connected_player(
         stats,
         MissionOpeningAwareness {
             party_has_surprise: player.party_has_surprise,
+        },
+        if player.mission_side == TacticalMissionSide::Enemy {
+            TacticalCombatSide::Enemy
+        } else {
+            TacticalCombatSide::Party
         },
         Transform::from_xyz(spawn_position.x, spawn_height, spawn_position.y),
         (

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -271,10 +271,21 @@ identity is available, then installs reducer subscriptions and opens the
 tactical WebSocket listener. Bot creation and player joins use that cached
 ready identity and never call the SDK's panicking pre-handshake accessor.
 
+Tactical combatants carry an explicit transient Party or Enemy allegiance,
+independent of whether a client or the server controls them. Temporary mission
+characters are Enemy melee AI and connected adventurers are Party. Offensive
+AI deterministically selects the nearest opposing combatant, turns and pursues
+in a straight line through normal controller input, stops at the same shared
+body-and-arms plus weapon interaction range used by client hit detection, then
+uses a server-owned windup and cooldown to enter the same internal
+melee-resolution seam as client requests. This direct pursuit intentionally has
+no pathfinding yet.
+
 The current combat prototype calculates attacks but does not yet apply tactical
-damage, so no client-controlled path can emit authoritative enemy deaths.
+damage or incapacitation, so no attack path can emit authoritative enemy deaths.
 Required-kill missions therefore fail closed unless the server's future combat
-pipeline emits the internal authoritative death event.
+pipeline emits the internal authoritative death event. Ranged AI and durable
+combat consequences also remain unimplemented.
 
 Mission, hostile-group, battle, and outcome-source identities are separate.
 Tactical success never chooses a case objective, capture subject, contract

--- a/wiki/tactical/combat.md
+++ b/wiki/tactical/combat.md
@@ -12,6 +12,32 @@ field changes real-time behavior; tactical enemy state remains transient.
 ## Attacking
 When the player clicks the [Attack button](../client/controls.md#direct-controls), initiating an attack animation, we run a shapecast in front of the player character. If there is an intersection between the attacker's hitreg and some other actor's hitbox, we calculate [input precision](../client/controls.md#direct-controls). Then comes the skill check algorithm.
 
+Client melee requests and server-controlled melee AI feed one internal server
+attack-intent path. Client-reported input precision is preserved: reproducing
+full animation and secondary physics on the headless server is not an intended
+authority boundary, while character and equipment statistics still bound the
+combat calculation.
+
+### Current offensive AI
+
+Each AI melee combatant has an explicit Party or Enemy allegiance and chooses
+the nearest opposing combatant, breaking exact distance ties by stable Bevy
+entity identity. It faces that target, walks directly toward it using the
+normal character-controller input, stops once the target is within the shared
+body-and-arms plus equipped-weapon interaction range, and attacks after a
+server-owned windup followed by a cooldown.
+Its provisional deterministic attack aims at the chest with full input
+precision. Targeted AI windups notify only their intended defender; because
+the existing client windup message does not yet identify a target, that legacy
+path offers a defensive reaction only to the nearest opposing AI instead of
+every frontal AI.
+
+This is an iteration harness rather than complete enemy decision-making. It
+does not pathfind around terrain or other combatants, handle ranged weapons,
+apply damage, recognize incapacitation, validate every attack condition, or
+persist tactical state. Targets therefore remain viable until they despawn or
+change allegiance.
+
 ### Skill check algorithm
 Broadly speaking, the flow goes like this:
 1. Calculate accuracy based on:


### PR DESCRIPTION
## Summary

Add the first offensive tactical enemy AI slice and a deterministic AI-vs-AI iteration harness.

Temporary mission enemies now identify Party combatants, pursue the nearest viable opponent, stop within shared melee interaction range, and issue melee attacks through the same internal resolution path used by network clients.

Part of #360. Stacked on #333 (`tactical/dodge`).

## Notable choices

- Introduce transient `Party` and `Enemy` tactical allegiance independently of connectivity or AI control.
- Route client and AI melee attacks through a shared server-internal intent.
- Preserve client-reported hit precision without reconstructing animation or secondary physics server-side.
- Select targets deterministically by planar distance with entity identity as the exact-tie fallback.
- Use existing character-controller input for direct pursuit.
- Give AI a server-owned windup and cooldown.
- Use deterministic provisional AI attacks targeting the chest at full input precision.
- Scope AI windup reactions to the intended defender.
- Restrict legacy untargeted client-windup reactions to the nearest opposing AI.
- Share one `melee_interaction_range` helper between client hit registration and AI, including hands reach.

## Review remediation

Independent review identified that weapon reach alone could leave colliding AI permanently outside the windup threshold. The branch now uses the same hands-plus-weapon interaction range as the client, with production katzbalger reach and collider spacing represented in the duel regression test.

A separate review claim that temporary enemies were unarmed was rejected after tracing `create_temporary_character` through the default character bootstrap, which equips a buckler and katzbalger.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p adventuresim-tactical-server` — 3 passed
- `cargo check -p adventuresim-tactical-client`
- `git diff --check`

## Limitations

This slice intentionally does not add pathfinding, damage, incapacitation, ranged combat, persistence, or comprehensive attack validation. Client windups do not yet report a target, so their defensive reaction scope uses the nearest opposing AI.

## Demo

Use the existing isolated tactical workflow:

```powershell
just tactical-isolated
just tactical
just client
```

Enemies will pursue and attempt melee attacks, but damage is intentionally deferred to the next stack branch.
