### PR TITLE
Apply tactical damage and incapacitation

### DIFF
--- a/crates/adventuresim-core/src/autoresolve.rs
+++ b/crates/adventuresim-core/src/autoresolve.rs
@@ -5,7 +5,6 @@ use adventuresim_world_schema::{BestiaryCategory, BestiaryHours};
 
 const MAX_COMBAT_ROUNDS: usize = 256;
 const MAX_RANGED_ATTACKS_PER_PHASE: usize = 64;
-const BLOOD_LOSS_PER_HEALTH_DAMAGE: f32 = 0.5;
 const FORMATION_SPACING_METERS: f32 = 2.0;
 const COMBAT_ROUND_SECONDS: f32 = 1.0;
 const REFERENCE_MELEE_ATTACK_SECONDS: f32 = 1.0;
@@ -82,9 +81,7 @@ impl CombatBody {
 
     pub fn apply_damage(&mut self, part: BodyPart, damage: f32) -> f32 {
         let health = &mut self.health[body_part_index(part)];
-        let applied = damage.max(0.0).min(health.max(0.0));
-        *health = (*health - applied).max(0.0);
-        applied
+        apply_clamped_limb_damage(health, damage)
     }
 
     pub fn total_damage(&self) -> f32 {
@@ -454,11 +451,14 @@ impl Combatant {
             &self.equipment,
             LimbWeights::all_equal(),
         );
-        let pain = pain_incapacitation(self.body.total_damage(), will);
-        let remaining_blood =
-            (self.starting_blood_fraction - self.blood_loss_fraction).clamp(0.0, 1.0);
-        let blood_loss = blood_loss_incapacitation(remaining_blood, 1.0);
-        self.starting_incapacitation + pain + blood_loss + self.imbalance
+        combat_incapacitation(
+            self.starting_incapacitation,
+            self.starting_blood_fraction,
+            self.blood_loss_fraction,
+            self.body.total_damage(),
+            will,
+            self.imbalance,
+        )
     }
 
     pub fn is_incapacitated(&self) -> bool {
@@ -474,7 +474,7 @@ impl Combatant {
             &self.equipment,
             LimbWeights::both_legs(),
         );
-        self.imbalance = (self.imbalance - 0.03 * balance.max(0.25)).max(0.0);
+        self.imbalance = recover_combat_imbalance(self.imbalance, balance, COMBAT_ROUND_SECONDS);
     }
 
     fn can_attack_ranged(&self) -> bool {

--- a/crates/adventuresim-core/src/combat.rs
+++ b/crates/adventuresim-core/src/combat.rs
@@ -4,9 +4,66 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     body::{BodyPart, BodySide, LimbWeights, PlayerBody},
+    morale::{blood_loss_incapacitation, pain_incapacitation},
     prelude::{LimbAttribute, PlayerAttributes, PlayerEquipment, PlayerEssentials},
     skill::{PlayerSkills, Skill},
 };
+
+/// Blood-volume fraction lost per point of limb health removed by combat.
+pub const BLOOD_LOSS_PER_HEALTH_DAMAGE: f32 = 0.5;
+/// Combat recovers this much imbalance per second for each effective point of
+/// Balance skill.
+pub const BALANCE_RECOVERY_PER_SKILL_SECOND: f32 = 0.03;
+
+#[must_use]
+pub fn apply_clamped_limb_damage(health: &mut f32, damage: f32) -> f32 {
+    let applied = damage.max(0.0).min(health.max(0.0));
+    *health = (*health - applied).max(0.0);
+    applied
+}
+
+#[must_use]
+pub fn recover_combat_imbalance(imbalance: f32, balance_check: f32, seconds: f32) -> f32 {
+    (imbalance - BALANCE_RECOVERY_PER_SKILL_SECOND * balance_check.max(0.25) * seconds.max(0.0))
+        .max(0.0)
+}
+
+#[must_use]
+pub fn combat_incapacitation(
+    starting_incapacitation: f32,
+    starting_blood_fraction: f32,
+    blood_loss_fraction: f32,
+    total_limb_damage: f32,
+    will_check: f32,
+    imbalance: f32,
+) -> f32 {
+    let pain = pain_incapacitation(total_limb_damage, will_check);
+    let remaining_blood = (starting_blood_fraction - blood_loss_fraction).clamp(0.0, 1.0);
+    starting_incapacitation.max(0.0)
+        + pain
+        + blood_loss_incapacitation(remaining_blood, 1.0)
+        + imbalance.max(0.0)
+}
+
+/// Derives tactical/autoresolve starting state from the authoritative strategic
+/// snapshot without double-counting pain or blood loss, which combat recomputes.
+#[must_use]
+pub fn derive_combat_starting_condition(
+    strategic_incapacitation: f32,
+    strategic_pain: f32,
+    strategic_blood_loss: f32,
+    current_blood: f32,
+    maximum_blood: f32,
+) -> (f32, f32) {
+    let starting_incapacitation =
+        (strategic_incapacitation - strategic_pain - strategic_blood_loss).max(0.0);
+    let starting_blood_fraction = if maximum_blood.is_finite() && maximum_blood > 0.0 {
+        (current_blood / maximum_blood).clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
+    (starting_incapacitation, starting_blood_fraction)
+}
 
 const UPPER_MUSCLE_KG_PER_STRENGTH: f32 = 5.0;
 const MUSCLE_KG_TO_JOULES: f32 = 2.0;
@@ -653,5 +710,17 @@ mod tests {
         assert_eq!(precision_damage_multiplier(6.0, 0.0), 2.0);
         assert_eq!(precision_damage_multiplier(6.0, 3.5), 3.5);
         assert_eq!(precision_damage_multiplier(1.25, 7.0), 1.25);
+    }
+
+    #[test]
+    fn depleted_strategic_snapshot_excludes_recomputed_sources() {
+        let (starting, blood_fraction) =
+            derive_combat_starting_condition(1.35, 0.25, 0.5, 2_500.0, 5_000.0);
+        assert!((starting - 0.6).abs() < 0.0001);
+        assert!((blood_fraction - 0.5).abs() < 0.0001);
+        assert_eq!(
+            derive_combat_starting_condition(0.2, 0.3, 0.4, 1.0, 0.0),
+            (0.0, 1.0)
+        );
     }
 }

--- a/crates/adventuresim-stdb-client/src/connected_player_type.rs
+++ b/crates/adventuresim-stdb-client/src/connected_player_type.rs
@@ -26,6 +26,12 @@ pub struct ConnectedPlayer {
     pub enemy_combat_scale_bps: u32,
     pub countermeasure_multiplier_bps: u32,
     pub party_has_surprise: bool,
+    pub body_weight_kg: f32,
+    pub current_blood_ml: f32,
+    pub maximum_blood_ml: f32,
+    pub strategic_incapacitation: f32,
+    pub strategic_pain: f32,
+    pub strategic_blood_loss: f32,
 }
 
 impl __sdk::InModule for ConnectedPlayer {
@@ -47,6 +53,12 @@ pub struct ConnectedPlayerCols {
     pub enemy_combat_scale_bps: __sdk::__query_builder::Col<ConnectedPlayer, u32>,
     pub countermeasure_multiplier_bps: __sdk::__query_builder::Col<ConnectedPlayer, u32>,
     pub party_has_surprise: __sdk::__query_builder::Col<ConnectedPlayer, bool>,
+    pub body_weight_kg: __sdk::__query_builder::Col<ConnectedPlayer, f32>,
+    pub current_blood_ml: __sdk::__query_builder::Col<ConnectedPlayer, f32>,
+    pub maximum_blood_ml: __sdk::__query_builder::Col<ConnectedPlayer, f32>,
+    pub strategic_incapacitation: __sdk::__query_builder::Col<ConnectedPlayer, f32>,
+    pub strategic_pain: __sdk::__query_builder::Col<ConnectedPlayer, f32>,
+    pub strategic_blood_loss: __sdk::__query_builder::Col<ConnectedPlayer, f32>,
 }
 
 impl __sdk::__query_builder::HasCols for ConnectedPlayer {
@@ -70,6 +82,18 @@ impl __sdk::__query_builder::HasCols for ConnectedPlayer {
                 "countermeasure_multiplier_bps",
             ),
             party_has_surprise: __sdk::__query_builder::Col::new(table_name, "party_has_surprise"),
+            body_weight_kg: __sdk::__query_builder::Col::new(table_name, "body_weight_kg"),
+            current_blood_ml: __sdk::__query_builder::Col::new(table_name, "current_blood_ml"),
+            maximum_blood_ml: __sdk::__query_builder::Col::new(table_name, "maximum_blood_ml"),
+            strategic_incapacitation: __sdk::__query_builder::Col::new(
+                table_name,
+                "strategic_incapacitation",
+            ),
+            strategic_pain: __sdk::__query_builder::Col::new(table_name, "strategic_pain"),
+            strategic_blood_loss: __sdk::__query_builder::Col::new(
+                table_name,
+                "strategic_blood_loss",
+            ),
         }
     }
 }

--- a/crates/adventuresim-stdb-module/src/capability.rs
+++ b/crates/adventuresim-stdb-module/src/capability.rs
@@ -792,6 +792,14 @@ pub(crate) fn load_combatant(
     let combat_equipment = equipment.combat_equipment();
     let initial_ammunition = combat_equipment.ammunition;
 
+    let (starting_incapacitation, starting_blood_fraction) = derive_combat_starting_condition(
+        strategic_incapacitation,
+        strategic_pain,
+        strategic_blood_loss,
+        condition.current_blood_ml,
+        condition.maximum_blood_ml,
+    );
+
     Ok(Combatant {
         id: character_id,
         attributes: CombatAttributes {
@@ -855,13 +863,8 @@ pub(crate) fn load_combatant(
             tailoring_hours: skills.tailoring_hours,
             smithing_hours: skills.smithing_hours,
         },
-        starting_incapacitation: (strategic_incapacitation - strategic_pain - strategic_blood_loss)
-            .max(0.0),
-        starting_blood_fraction: if condition.maximum_blood_ml > 0.0 {
-            (condition.current_blood_ml / condition.maximum_blood_ml).clamp(0.0, 1.0)
-        } else {
-            1.0
-        },
+        starting_incapacitation,
+        starting_blood_fraction,
         initial_ammunition,
         ..Combatant::new(character_id)
     })

--- a/crates/adventuresim-stdb-module/src/tactical.rs
+++ b/crates/adventuresim-stdb-module/src/tactical.rs
@@ -9,6 +9,7 @@ use crate::{
     character::character,
     character__view, character_attributes__view, character_equipped_item__view,
     character_limbs__view, character_skills__view, character_stats__view,
+    condition::{character_condition__view, character_strategic_condition__view},
     equipment_occupancy__view, inventory_item__view,
     investigation::case_site_authority,
     item__view, party_authority,
@@ -206,6 +207,12 @@ pub struct ConnectedPlayer {
     pub enemy_combat_scale_bps: u32,
     pub countermeasure_multiplier_bps: u32,
     pub party_has_surprise: bool,
+    pub body_weight_kg: f32,
+    pub current_blood_ml: f32,
+    pub maximum_blood_ml: f32,
+    pub strategic_incapacitation: f32,
+    pub strategic_pain: f32,
+    pub strategic_blood_loss: f32,
 }
 
 #[derive(SpacetimeType, Clone, Copy, Debug, PartialEq, Eq)]
@@ -258,6 +265,16 @@ pub fn connected_players(ctx: &ViewContext) -> Vec<ConnectedPlayer> {
                 .character_id()
                 .find(character.id)?;
             let stats = ctx.db.character_stats().character_id().find(character.id)?;
+            let condition = ctx
+                .db
+                .character_condition()
+                .character_id()
+                .find(character.id)?;
+            let strategic = ctx
+                .db
+                .character_strategic_condition()
+                .character_id()
+                .find(character.id)?;
             let items = connected_player_items(ctx, character.id).collect();
 
             let server = ctx
@@ -287,6 +304,12 @@ pub fn connected_players(ctx: &ViewContext) -> Vec<ConnectedPlayer> {
                 party_has_surprise: server
                     .as_ref()
                     .is_some_and(|server| server.party_has_surprise),
+                body_weight_kg: condition.body_weight_kg,
+                current_blood_ml: condition.current_blood_ml,
+                maximum_blood_ml: condition.maximum_blood_ml,
+                strategic_incapacitation: strategic.incapacitation,
+                strategic_pain: strategic.pain,
+                strategic_blood_loss: strategic.blood_loss,
             })
         })
         .collect()

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -1,8 +1,7 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::ClientTriggerExt,
-    message::{AttackStartedRequest, DefendRequest},
-    prelude::AttackRequest,
+    message::{DefendRequest, MeleeActionRequest},
 };
 use bevy::prelude::*;
 
@@ -256,11 +255,11 @@ fn update_attack_state_system(
                 break;
             };
 
-            cmd.client_trigger(AttackRequest {
+            cmd.client_trigger(MeleeActionRequest::complete(
                 target,
                 body_part,
-                hit_precision: HIT_PRECISION,
-            });
+                HIT_PRECISION,
+            ));
             cmd.trigger(HitPerformed {
                 entity: attacker,
                 direction,
@@ -298,7 +297,7 @@ fn on_attack_fired_hook(
 
     cmd.entity(event.context)
         .insert(AttackState::new(PRE_HIT_DELAY, reach));
-    cmd.client_trigger(AttackStartedRequest);
+    cmd.client_trigger(MeleeActionRequest::start());
 }
 
 fn update_character_look_rotation(

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -23,7 +23,7 @@ pub mod prelude {
     };
     pub use crate::player::{
         Attributes, BestiaryCategories, ControlledPlayer, Limbs, Player, PlayerId, Skills, Stats,
-        TacticalPlayerView, TacticalPlayerViewer,
+        TacticalCombatState, TacticalPlayerView, TacticalPlayerViewer,
     };
     pub use crate::scene::{SceneId, SceneTerrain};
     pub use adventuresim_core::prelude::*;

--- a/crates/adventuresim-tactical-core/src/player.rs
+++ b/crates/adventuresim-tactical-core/src/player.rs
@@ -82,9 +82,35 @@ impl PlayerEssentials for Stats {
     }
 }
 
+/// Live, server-authoritative combat effects. This component is replicated for
+/// presentation but remains transient and is never written to SpacetimeDB.
+#[derive(Component, Serialize, Deserialize, Debug, Reflect, Clone, PartialEq)]
+pub struct TacticalCombatState {
+    pub starting_incapacitation: f32,
+    pub starting_blood_fraction: f32,
+    pub blood_loss_fraction: f32,
+    pub imbalance: f32,
+    pub incapacitation: f32,
+    pub incapacitated: bool,
+}
+
+impl Default for TacticalCombatState {
+    fn default() -> Self {
+        Self {
+            starting_incapacitation: 0.0,
+            starting_blood_fraction: 1.0,
+            blood_loss_fraction: 0.0,
+            imbalance: 0.0,
+            incapacitation: 0.0,
+            incapacitated: false,
+        }
+    }
+}
+
 /// Limb health status.
 #[derive(Component, Serialize, Deserialize, Debug, Reflect, Clone, PartialEq)]
 pub struct Limbs {
+    pub body_weight_kg: f32,
     pub left_arm: f32,
     pub right_arm: f32,
     pub left_leg: f32,
@@ -97,6 +123,7 @@ pub struct Limbs {
 impl Default for Limbs {
     fn default() -> Self {
         Self {
+            body_weight_kg: 70.0,
             left_arm: 1.0,
             right_arm: 1.0,
             left_leg: 1.0,
@@ -105,6 +132,35 @@ impl Default for Limbs {
             stomach: 1.0,
             head: 1.0,
         }
+    }
+}
+
+impl Limbs {
+    pub fn health_mut(&mut self, part: BodyPart) -> &mut f32 {
+        match part {
+            BodyPart::LeftArm => &mut self.left_arm,
+            BodyPart::RightArm => &mut self.right_arm,
+            BodyPart::LeftLeg => &mut self.left_leg,
+            BodyPart::RightLeg => &mut self.right_leg,
+            BodyPart::Chest => &mut self.chest,
+            BodyPart::Stomach => &mut self.stomach,
+            BodyPart::Head => &mut self.head,
+        }
+    }
+
+    pub fn total_damage(&self) -> f32 {
+        [
+            self.left_arm,
+            self.right_arm,
+            self.left_leg,
+            self.right_leg,
+            self.chest,
+            self.stomach,
+            self.head,
+        ]
+        .into_iter()
+        .map(|health| (1.0 - health).max(0.0))
+        .sum()
     }
 }
 
@@ -122,8 +178,7 @@ impl PlayerBody for Limbs {
     }
 
     fn body_weight(&self) -> f32 {
-        // TODO: this should be stored in DB ?
-        10.0
+        self.body_weight_kg
     }
 
     fn primary_side(&self) -> BodySide {

--- a/crates/adventuresim-tactical-netcode/src/lib.rs
+++ b/crates/adventuresim-tactical-netcode/src/lib.rs
@@ -18,7 +18,7 @@ pub mod prelude {
     #[cfg(feature = "client")]
     pub use crate::client::AdventureSimulatorClient;
     pub use crate::message::{
-        AttackRequest, AttackStartedRequest, DefendRequest, JoinRequest, PlayerInputRequest,
+        DefendRequest, JoinRequest, MeleeActionPhase, MeleeActionRequest, PlayerInputRequest,
     };
     #[cfg(feature = "server")]
     pub use crate::server::AdventureSimulatorServer;

--- a/crates/adventuresim-tactical-netcode/src/message.rs
+++ b/crates/adventuresim-tactical-netcode/src/message.rs
@@ -12,12 +12,8 @@ pub enum DefendRequest {
     Parry,
 }
 
-/// Sent by the client the moment it starts a melee attack windup, before the
-/// hit itself is resolved. Carries no data of its own — the attacker is the
-/// message sender.
-#[derive(Debug, Clone, Copy, Event, Serialize, Deserialize)]
-pub struct AttackStartedRequest;
-
+/// Requests enrollment of a strategic character in the tactical mission.
+/// The sender remains the authoritative network identity.
 #[derive(Debug, Clone, Copy, Event, Serialize, Deserialize)]
 pub struct JoinRequest {
     pub player_id: u64,
@@ -30,12 +26,41 @@ pub struct PlayerInputRequest {
     pub jump: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MeleeActionPhase {
+    Start,
+    Complete,
+}
+
+/// Both melee phases share one mapped ordered stream, so a completion cannot
+/// overtake its server-observed start.
 #[derive(Debug, Clone, Copy, Event, Serialize, Deserialize, MapEntities)]
-pub struct AttackRequest {
+pub struct MeleeActionRequest {
+    pub phase: MeleeActionPhase,
     #[entities]
-    pub target: Entity,
+    pub target: Option<Entity>,
     pub body_part: BodyPart,
     pub hit_precision: f32,
+}
+
+impl MeleeActionRequest {
+    pub fn start() -> Self {
+        Self {
+            phase: MeleeActionPhase::Start,
+            target: None,
+            body_part: BodyPart::Chest,
+            hit_precision: 0.0,
+        }
+    }
+
+    pub fn complete(target: Entity, body_part: BodyPart, hit_precision: f32) -> Self {
+        Self {
+            phase: MeleeActionPhase::Complete,
+            target: Some(target),
+            body_part,
+            hit_precision,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Event, Serialize, Deserialize, MapEntities)]

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -5,8 +5,7 @@ use bevy_replicon::prelude::*;
 
 use crate::FIXED_TIMESTEP_HZ;
 use crate::message::{
-    AttackRequest, AttackStartedRequest, DefendRequest, JoinRequest, PlayerInputRequest,
-    SuccessfulAttackResponse,
+    DefendRequest, JoinRequest, MeleeActionRequest, PlayerInputRequest, SuccessfulAttackResponse,
 };
 
 #[derive(Default)]
@@ -25,6 +24,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .replicate::<Limbs>()
             .replicate::<Skills>()
             .replicate::<Stats>()
+            .replicate::<TacticalCombatState>()
             .replicate::<Attributes>()
             .replicate::<Transform>()
             .replicate::<CharacterLook>()
@@ -40,8 +40,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .add_client_event::<JoinRequest>(Channel::Ordered)
             .add_client_event::<PlayerInputRequest>(Channel::Unreliable)
             .add_client_event::<DefendRequest>(Channel::Unreliable)
-            .add_client_event::<AttackStartedRequest>(Channel::Unreliable)
-            .add_mapped_client_event::<AttackRequest>(Channel::Ordered)
+            .add_mapped_client_event::<MeleeActionRequest>(Channel::Ordered)
             .add_mapped_server_event::<SuccessfulAttackResponse>(Channel::Ordered);
 
         // Replicating physics components since those don't change and

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -1,7 +1,7 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::FromClient,
-    message::{AttackStartedRequest, DefendRequest},
+    message::{DefendRequest, MeleeActionPhase, MeleeActionRequest},
 };
 use bevy::prelude::*;
 use std::cmp::Ordering;
@@ -9,7 +9,8 @@ use std::cmp::Ordering;
 use crate::{
     MissionState,
     combat::{
-        MeleeAttackIntent, MeleeAttackStartedIntent, PendingDefenderResponse, TacticalCombatSide,
+        Incapacitated, MeleeAttackIntent, MeleeAttackStartedIntent, PendingDefenderResponse,
+        TacticalCombatSide,
     },
 };
 
@@ -63,9 +64,8 @@ enum OffensiveMeleePhase {
 #[derive(Component)]
 pub struct CountedEnemyDeath;
 
-/// Emitted only by the server's authoritative combat/death pipeline. Combat
-/// damage is not implemented yet, so no client-controlled path can emit it and
-/// incomplete missions fail closed at timeout.
+/// Reserved for the future terminal-outcome pipeline. Incapacitation is now
+/// authoritative but is not counted as a mission death in this branch.
 #[derive(Event)]
 pub struct AuthoritativeEnemyDeath(pub Entity);
 
@@ -115,14 +115,17 @@ pub fn mission_objective_satisfied(required: u32, killed: u32) -> bool {
 /// correctly reads the attack only some of the time. A decision to react is
 /// committed only after a random delay (see [`REACTION_DELAY_SECS`]).
 fn on_attack_started(
-    event: On<FromClient<AttackStartedRequest>>,
+    event: On<FromClient<MeleeActionRequest>>,
     mut cmd: Commands,
     q_character: Query<(&CharacterLook, &Transform, &TacticalCombatSide)>,
     q_bots: Query<
         (Entity, &CharacterLook, &Transform, &TacticalCombatSide),
-        With<OffensiveMeleeAi>,
+        (With<OffensiveMeleeAi>, Without<Incapacitated>),
     >,
 ) {
+    if event.phase != MeleeActionPhase::Start {
+        return;
+    }
     let Some(attacker) = event.client_id.entity() else {
         return;
     };
@@ -145,7 +148,7 @@ fn on_targeted_attack_started(
     event: On<MeleeAttackStartedIntent>,
     mut cmd: Commands,
     q_character: Query<&CharacterLook>,
-    q_ai: Query<&CharacterLook, With<OffensiveMeleeAi>>,
+    q_ai: Query<&CharacterLook, (With<OffensiveMeleeAi>, Without<Incapacitated>)>,
 ) {
     let Ok([attacker_look, defender_look]) = q_character.get_many([event.attacker, event.target])
     else {
@@ -200,15 +203,21 @@ fn drive_offensive_melee_ai(
     mut cmd: Commands,
     time: Res<Time<()>>,
     viewer: TacticalPlayerViewer,
-    candidates: Query<(Entity, &Transform, &TacticalCombatSide), With<Player>>,
-    mut ai: Query<(
-        Entity,
-        &Transform,
-        &TacticalCombatSide,
-        &mut CharacterLook,
-        &mut input::AccumulatedInput,
-        &mut OffensiveMeleeAi,
-    )>,
+    candidates: Query<
+        (Entity, &Transform, &TacticalCombatSide),
+        (With<Player>, Without<Incapacitated>),
+    >,
+    mut ai: Query<
+        (
+            Entity,
+            &Transform,
+            &TacticalCombatSide,
+            &mut CharacterLook,
+            &mut input::AccumulatedInput,
+            &mut OffensiveMeleeAi,
+        ),
+        Without<Incapacitated>,
+    >,
 ) {
     for (entity, transform, side, mut look, mut input, mut controller) in &mut ai {
         let target = candidates
@@ -258,6 +267,7 @@ fn drive_offensive_melee_ai(
                 cmd.trigger(MeleeAttackStartedIntent {
                     attacker: entity,
                     target,
+                    windup_secs: AI_WINDUP_SECS,
                 });
                 controller.phase = OffensiveMeleePhase::Windup(Timer::from_seconds(
                     AI_WINDUP_SECS,
@@ -308,7 +318,7 @@ fn roll_defend_choice() -> Option<DefendRequest> {
 fn tick_bot_reactions(
     mut cmd: Commands,
     time: Res<Time<()>>,
-    mut q_reacting: Query<(Entity, &mut PendingBotReaction)>,
+    mut q_reacting: Query<(Entity, &mut PendingBotReaction), Without<Incapacitated>>,
 ) {
     for (bot, mut reaction) in &mut q_reacting {
         reaction.timer.tick(time.delta());
@@ -338,6 +348,31 @@ mod tests {
         attacks.0.push((event.attacker, event.target));
     }
 
+    fn apply_deterministic_test_hit(
+        event: On<MeleeAttackIntent>,
+        mut combatants: Query<(&mut Limbs, &mut TacticalCombatState)>,
+    ) {
+        let Ok([attacker, defender]) = combatants.get_many_mut([event.attacker, event.target])
+        else {
+            return;
+        };
+        let (_, mut attacker_state) = attacker;
+        let (mut defender_limbs, mut defender_state) = defender;
+        crate::combat::apply_transient_attack_result(
+            &mut attacker_state,
+            &mut defender_limbs,
+            &mut defender_state,
+            AttackResult::ToDefender {
+                cut_damage: 160.0,
+                blunt_damage: 0.0,
+                balance_damage: 0.0,
+                contact_force: 160.0,
+                armor_contact: false,
+            },
+            BodyPart::Chest,
+        );
+    }
+
     fn spawn_test_ai(world: &mut World, side: TacticalCombatSide, position: Vec3) -> Entity {
         // Temporary characters receive this production loadout from
         // `insert_new_character` when no authored starting package is given.
@@ -350,6 +385,7 @@ mod tests {
                 CharacterLook::default(),
                 input::AccumulatedInput::default(),
                 OffensiveMeleeAi::default(),
+                TacticalCombatState::default(),
             ))
             .id();
         let weapon = world.spawn(ItemOf(actor)).id();
@@ -514,5 +550,94 @@ mod tests {
             second
         };
         assert_eq!(selected, Some(expected));
+    }
+
+    #[test]
+    fn ai_duel_stops_incapacitated_combatants() {
+        let mut app = App::new();
+        app.insert_resource(Time::<()>::default())
+            .init_resource::<RecordedAttacks>()
+            .add_observer(record_attack)
+            .add_observer(apply_deterministic_test_hit)
+            .add_systems(
+                Update,
+                (
+                    drive_offensive_melee_ai,
+                    crate::combat::update_tactical_combat_state,
+                )
+                    .chain(),
+            );
+        let party = spawn_test_ai(
+            app.world_mut(),
+            TacticalCombatSide::Party,
+            Vec3::new(0.0, 0.0, -3.0),
+        );
+        let enemy = spawn_test_ai(
+            app.world_mut(),
+            TacticalCombatSide::Enemy,
+            Vec3::new(0.0, 0.0, 3.0),
+        );
+
+        for _ in 0..30 {
+            app.world_mut()
+                .resource_mut::<Time<()>>()
+                .advance_by(Duration::from_millis(100));
+            app.update();
+            let snapshots: Vec<_> = [party, enemy]
+                .into_iter()
+                .map(|actor| {
+                    let entity = app.world().entity(actor);
+                    (
+                        actor,
+                        entity
+                            .get::<input::AccumulatedInput>()
+                            .unwrap()
+                            .last_movement,
+                        entity.get::<CharacterLook>().unwrap().yaw,
+                    )
+                })
+                .collect();
+            for (actor, movement, yaw) in snapshots {
+                if movement.is_some() {
+                    let forward = Vec3::new(-yaw.sin(), 0.0, -yaw.cos());
+                    app.world_mut()
+                        .entity_mut(actor)
+                        .get_mut::<Transform>()
+                        .unwrap()
+                        .translation += forward * 0.5;
+                }
+            }
+            if [party, enemy].into_iter().any(|actor| {
+                app.world()
+                    .entity(actor)
+                    .get::<TacticalCombatState>()
+                    .is_some_and(|state| state.incapacitated)
+            }) {
+                break;
+            }
+        }
+
+        let incapacitated: Vec<_> = [party, enemy]
+            .into_iter()
+            .filter(|actor| {
+                app.world()
+                    .entity(*actor)
+                    .get::<TacticalCombatState>()
+                    .unwrap()
+                    .incapacitated
+            })
+            .collect();
+        assert!(!incapacitated.is_empty());
+        for actor in incapacitated {
+            assert_eq!(
+                app.world()
+                    .entity(actor)
+                    .get::<input::AccumulatedInput>()
+                    .unwrap()
+                    .last_movement,
+                None
+            );
+        }
+        assert!(!app.world().resource::<RecordedAttacks>().0.is_empty());
     }
 }

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -1,8 +1,7 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::{FromClient, SendMode, ServerTriggerExt, ToClients},
-    message::{DefendRequest, SuccessfulAttackResponse},
-    prelude::AttackRequest,
+    message::{DefendRequest, MeleeActionPhase, MeleeActionRequest, SuccessfulAttackResponse},
 };
 use bevy::prelude::*;
 
@@ -10,6 +9,14 @@ use bevy::prelude::*;
 /// is still considered valid. A fresh press gives `input_reflex = 1.0`;
 /// a press older than this window is treated as no response.
 const MAX_REFLEX_WINDOW: f32 = 0.5;
+const CLIENT_MELEE_WINDUP_SECS: f32 = 0.3;
+const MELEE_COOLDOWN_SECS: f32 = 0.3;
+/// Completion must arrive within this bounded ordered-network allowance after
+/// the windup becomes ready; old starts cannot authorize replayed completions.
+const MELEE_WINDUP_NETWORK_ALLOWANCE_SECS: f32 = 1.0;
+/// Allows bounded movement between the authoritative physics snapshot and an
+/// ordered attack request arriving at the server.
+const MELEE_RANGE_LATENCY_TOLERANCE: f32 = 0.25;
 
 /// Stores the defender's most recent dodge/parry choice along with the
 /// server timestamp when it was received. Consumed on each attack resolution.
@@ -33,6 +40,37 @@ pub enum TacticalCombatSide {
     Enemy,
 }
 
+#[derive(Debug)]
+struct ObservedMeleeWindup {
+    target: Option<Entity>,
+    ready_at: f32,
+    expires_at: f32,
+}
+
+#[derive(Component, Debug, Default)]
+pub(crate) struct MeleeAttackAuthority {
+    windup: Option<ObservedMeleeWindup>,
+    cooldown_until: f32,
+}
+
+fn consume_melee_authority(authority: &mut MeleeAttackAuthority, target: Entity, now: f32) -> bool {
+    let valid = authority.windup.as_ref().is_some_and(|windup| {
+        windup.target.map_or(true, |observed| observed == target)
+            && now >= windup.ready_at
+            && now <= windup.expires_at
+            && now >= authority.cooldown_until
+    });
+    if valid {
+        authority.windup = None;
+        authority.cooldown_until = now + MELEE_COOLDOWN_SECS;
+    }
+    valid
+}
+
+/// Present while transient combat effects meet the incapacitation threshold.
+#[derive(Component, Debug)]
+pub struct Incapacitated;
+
 /// A server-internal melee request. Both network clients and server-owned AI
 /// enter combat resolution through this seam.
 #[derive(Event, Clone, Copy, Debug)]
@@ -48,15 +86,110 @@ pub struct MeleeAttackIntent {
 pub struct MeleeAttackStartedIntent {
     pub attacker: Entity,
     pub target: Entity,
+    pub windup_secs: f32,
+}
+
+#[derive(Event, Clone, Copy, Debug)]
+struct ApplyMeleeAttackResult {
+    attacker: Entity,
+    target: Entity,
+    body_part: BodyPart,
+    result: AttackResult,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MeleeIntentRejection {
+    SelfTarget,
+    MissingSide,
+    MissingCombatState,
+    FriendlyTarget,
+    Incapacitated,
+    NonFinitePrecision,
+    Unarmed,
+    OutOfRange,
+    Windup,
+    Cooldown,
+    BlockedLineOfSight,
+}
+
+#[derive(Clone, Copy)]
+struct MeleeIntentFacts {
+    attacker: Entity,
+    target: Entity,
+    attacker_side: Option<TacticalCombatSide>,
+    target_side: Option<TacticalCombatSide>,
+    attacker_incapacitated: Option<bool>,
+    target_incapacitated: Option<bool>,
+    hit_precision: f32,
+    weapon_reach: f32,
+    separation: f32,
+    windup_target: Option<Option<Entity>>,
+    windup_ready: bool,
+    windup_unexpired: bool,
+    cooldown_ready: bool,
+}
+
+fn validate_melee_intent_cheap(facts: MeleeIntentFacts) -> Result<(), MeleeIntentRejection> {
+    if facts.attacker == facts.target {
+        return Err(MeleeIntentRejection::SelfTarget);
+    }
+    let (Some(attacker_side), Some(target_side)) = (facts.attacker_side, facts.target_side) else {
+        return Err(MeleeIntentRejection::MissingSide);
+    };
+    if attacker_side == target_side {
+        return Err(MeleeIntentRejection::FriendlyTarget);
+    }
+    let (Some(attacker_incapacitated), Some(target_incapacitated)) =
+        (facts.attacker_incapacitated, facts.target_incapacitated)
+    else {
+        return Err(MeleeIntentRejection::MissingCombatState);
+    };
+    if attacker_incapacitated || target_incapacitated {
+        return Err(MeleeIntentRejection::Incapacitated);
+    }
+    if !facts.hit_precision.is_finite() {
+        return Err(MeleeIntentRejection::NonFinitePrecision);
+    }
+    if !facts.weapon_reach.is_finite() || facts.weapon_reach <= 0.0 {
+        return Err(MeleeIntentRejection::Unarmed);
+    }
+    if !facts.separation.is_finite()
+        || facts.separation
+            > melee_interaction_range(facts.weapon_reach) + MELEE_RANGE_LATENCY_TOLERANCE
+    {
+        return Err(MeleeIntentRejection::OutOfRange);
+    }
+    let Some(windup_target) = facts.windup_target else {
+        return Err(MeleeIntentRejection::Windup);
+    };
+    if windup_target.is_some_and(|target| target != facts.target)
+        || !facts.windup_ready
+        || !facts.windup_unexpired
+    {
+        return Err(MeleeIntentRejection::Windup);
+    }
+    if !facts.cooldown_ready {
+        return Err(MeleeIntentRejection::Cooldown);
+    }
+    Ok(())
+}
+
+fn validate_melee_line_of_sight(line_of_sight: bool) -> Result<(), MeleeIntentRejection> {
+    line_of_sight
+        .then_some(())
+        .ok_or(MeleeIntentRejection::BlockedLineOfSight)
 }
 
 pub struct CombatPlugin;
 
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(on_attack_action_triggered)
+        app.add_observer(on_melee_action_request)
+            .add_observer(on_melee_attack_started)
             .add_observer(resolve_melee_attack)
-            .add_observer(on_defender_response);
+            .add_observer(apply_melee_attack_result)
+            .add_observer(on_defender_response)
+            .add_systems(Update, update_tactical_combat_state);
     }
 }
 
@@ -64,6 +197,7 @@ fn on_defender_response(
     event: On<FromClient<DefendRequest>>,
     mut cmd: Commands,
     time: Res<Time<()>>,
+    states: Query<&TacticalCombatState>,
 ) {
     let Some(entity) = event.client_id.entity() else {
         warn!(
@@ -73,9 +207,30 @@ fn on_defender_response(
         return;
     };
 
+    if states.get(entity).is_ok_and(|state| state.incapacitated) {
+        return;
+    }
+
     cmd.entity(entity).insert(PendingDefenderResponse {
         choice: **event,
         set_at: time.elapsed_secs(),
+    });
+}
+
+fn on_melee_attack_started(
+    event: On<MeleeAttackStartedIntent>,
+    mut authorities: Query<&mut MeleeAttackAuthority>,
+    time: Res<Time<()>>,
+) {
+    let Ok(mut authority) = authorities.get_mut(event.attacker) else {
+        return;
+    };
+    authority.windup = Some(ObservedMeleeWindup {
+        target: Some(event.target),
+        ready_at: time.elapsed_secs() + event.windup_secs.max(0.0),
+        expires_at: time.elapsed_secs()
+            + event.windup_secs.max(0.0)
+            + MELEE_WINDUP_NETWORK_ALLOWANCE_SECS,
     });
 }
 
@@ -107,31 +262,75 @@ fn resolve_defender_response(
     }
 }
 
-fn on_attack_action_triggered(event: On<FromClient<AttackRequest>>, mut cmd: Commands) {
+fn on_melee_action_request(
+    event: On<FromClient<MeleeActionRequest>>,
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    mut authorities: Query<&mut MeleeAttackAuthority>,
+) {
     let Some(attacker) = event.client_id.entity() else {
-        warn!(
-            "Got attack request from an unknown client: {:?}",
+        debug!(
+            "Ignoring melee action from unknown client: {:?}",
             event.client_id
         );
         return;
     };
+    match event.phase {
+        MeleeActionPhase::Start => {
+            let Ok(mut authority) = authorities.get_mut(attacker) else {
+                return;
+            };
+            let ready_at = time.elapsed_secs() + CLIENT_MELEE_WINDUP_SECS;
+            authority.windup = Some(ObservedMeleeWindup {
+                target: None,
+                ready_at,
+                expires_at: ready_at + MELEE_WINDUP_NETWORK_ALLOWANCE_SECS,
+            });
+        }
+        MeleeActionPhase::Complete => {
+            let Some(target) = event.target else {
+                debug!("Ignoring malformed melee completion from {attacker:?}");
+                return;
+            };
+            // Finite precision is intentionally accepted as reported. Full
+            // animation and secondary physics remain client-owned.
+            cmd.trigger(MeleeAttackIntent {
+                attacker,
+                target,
+                body_part: event.body_part,
+                hit_precision: event.hit_precision,
+            });
+        }
+    }
+}
 
-    // `hit_precision` is intentionally accepted as reported by the client.
-    // Animation and secondary-physics fidelity belongs on the rendering
-    // client; character stats continue to bound the resolved exchange.
-    cmd.trigger(MeleeAttackIntent {
-        attacker,
-        target: event.target,
-        body_part: event.body_part,
-        hit_precision: event.hit_precision,
-    });
+fn authoritative_line_of_sight(
+    spatial: &SpatialQuery,
+    attacker: Entity,
+    target: Entity,
+    origin: Vec3,
+    target_position: Vec3,
+) -> bool {
+    let offset = target_position - origin;
+    let distance = offset.length();
+    let Ok(direction) = Dir3::new(offset) else {
+        return false;
+    };
+    let filter = SpatialQueryFilter::from_excluded_entities([attacker]);
+    spatial
+        .cast_ray(origin, direction, distance, true, &filter)
+        .is_some_and(|hit| hit.entity == target)
 }
 
 fn resolve_melee_attack(
     event: On<MeleeAttackIntent>,
     mut cmd: Commands,
     viewer: TacticalPlayerViewer,
-    q_character: Query<&CharacterLook>,
+    spatial: SpatialQuery,
+    q_character: Query<(&CharacterLook, &Transform)>,
+    q_sides: Query<&TacticalCombatSide>,
+    q_states: Query<&TacticalCombatState>,
+    mut q_authorities: Query<&mut MeleeAttackAuthority>,
     q_bestiary_categories: Query<&BestiaryCategories>,
     q_pending: Query<&PendingDefenderResponse>,
     time: Res<Time<()>>,
@@ -139,30 +338,87 @@ fn resolve_melee_attack(
     let entity = event.attacker;
 
     let Ok(attacker_view) = viewer.get(entity).inspect_err(|err| {
-        error!("Can't get a view for attacker {entity:?}: {err}",);
+        debug!("Rejected attacker view for {entity:?}: {err}");
     }) else {
         return;
     };
     let Ok(defender_view) = viewer.get(event.target).inspect_err(|err| {
-        error!("Can't get a view for defender {:?}: {err}", event.target);
+        debug!("Rejected defender view for {:?}: {err}", event.target);
     }) else {
         return;
     };
 
-    let Ok([attacker_look, defender_look]) = q_character
+    let Ok([attacker_character, defender_character]) = q_character
         .get_many([entity, event.target])
         .inspect_err(|err| {
-            error!("Can't get character look for attacker/defender: {err}",);
+            debug!("Rejected attacker/defender transform: {err}");
         })
     else {
         return;
     };
+    let (attacker_look, attacker_transform) = attacker_character;
+    let (defender_look, defender_transform) = defender_character;
+
+    let weapon_reach = attacker_view.weapon_reach();
+    let now = time.elapsed_secs();
+    let Ok(mut authority) = q_authorities.get_mut(entity) else {
+        return;
+    };
+    let windup = authority.windup.as_ref();
+    let facts = MeleeIntentFacts {
+        attacker: entity,
+        target: event.target,
+        attacker_side: q_sides.get(entity).ok().copied(),
+        target_side: q_sides.get(event.target).ok().copied(),
+        attacker_incapacitated: q_states.get(entity).ok().map(|state| state.incapacitated),
+        target_incapacitated: q_states
+            .get(event.target)
+            .ok()
+            .map(|state| state.incapacitated),
+        hit_precision: event.hit_precision,
+        weapon_reach,
+        separation: attacker_transform
+            .translation
+            .distance(defender_transform.translation),
+        windup_target: windup.map(|windup| windup.target),
+        windup_ready: windup.is_some_and(|windup| now >= windup.ready_at),
+        windup_unexpired: windup.is_some_and(|windup| now <= windup.expires_at),
+        cooldown_ready: now >= authority.cooldown_until,
+    };
+    if let Err(reason) = validate_melee_intent_cheap(facts) {
+        debug!(
+            "Rejected melee intent from {entity:?} to {:?}: {reason:?}",
+            event.target
+        );
+        return;
+    }
+    let line_of_sight = authoritative_line_of_sight(
+        &spatial,
+        entity,
+        event.target,
+        attacker_transform.translation,
+        defender_transform.translation,
+    );
+    if let Err(reason) = validate_melee_line_of_sight(line_of_sight) {
+        debug!(
+            "Rejected melee intent from {entity:?} to {:?}: {reason:?}",
+            event.target
+        );
+        return;
+    }
+    // Mutate the pre-existing authority component synchronously. A later
+    // completion in this same message flush observes the consumed windup and
+    // active cooldown instead of reusing deferred Commands state.
+    if !consume_melee_authority(&mut authority, event.target, now) {
+        debug!("Rejected already-consumed melee authorization for {entity:?}");
+        return;
+    }
     let (a2, a1) = attacker_look.yaw.sin_cos();
     let (d2, d1) = defender_look.yaw.sin_cos();
     let flanking = flanking_from_dir((a1, a2), (d1, d2));
 
     let Some(attacker_side) = attacker_view.weapon_holding_side() else {
-        warn!("Attacker isn't holding any weapon!");
+        debug!("Rejected attacker without a held weapon");
         return;
     };
 
@@ -187,7 +443,13 @@ fn resolve_melee_attack(
         event.body_part,
     );
 
-    // TODO: apply damage
+    cmd.trigger(ApplyMeleeAttackResult {
+        attacker: entity,
+        target: event.target,
+        body_part: event.body_part,
+        result,
+    });
+
     match result {
         AttackResult::ToAttacker { balance_damage, .. } => {
             info!(
@@ -221,4 +483,369 @@ fn resolve_melee_attack(
             defender_response,
         },
     });
+}
+
+fn apply_melee_attack_result(
+    event: On<ApplyMeleeAttackResult>,
+    mut combatants: Query<(&mut Limbs, &mut TacticalCombatState)>,
+) {
+    let Ok([attacker, defender]) = combatants.get_many_mut([event.attacker, event.target]) else {
+        return;
+    };
+    let (_, mut attacker_state) = attacker;
+    let (mut defender_limbs, mut defender_state) = defender;
+    apply_transient_attack_result(
+        &mut attacker_state,
+        &mut defender_limbs,
+        &mut defender_state,
+        event.result,
+        event.body_part,
+    );
+}
+
+pub(crate) fn apply_transient_attack_result(
+    attacker_state: &mut TacticalCombatState,
+    defender_limbs: &mut Limbs,
+    defender_state: &mut TacticalCombatState,
+    result: AttackResult,
+    body_part: BodyPart,
+) {
+    match result {
+        AttackResult::ToAttacker { balance_damage, .. } => {
+            attacker_state.imbalance += balance_damage.max(0.0);
+        }
+        AttackResult::ToDefender { balance_damage, .. } => {
+            defender_state.imbalance += balance_damage.max(0.0);
+            let damage = health_damage_from_attack(result, body_part);
+            let applied = apply_clamped_limb_damage(defender_limbs.health_mut(body_part), damage);
+            defender_state.blood_loss_fraction = (defender_state.blood_loss_fraction
+                + applied * BLOOD_LOSS_PER_HEALTH_DAMAGE)
+                .clamp(0.0, 1.0);
+        }
+    }
+}
+
+pub(crate) fn update_tactical_combat_state(
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    viewer: TacticalPlayerViewer,
+    limbs: Query<&Limbs>,
+    mut states: Query<(
+        Entity,
+        &mut TacticalCombatState,
+        Option<&mut input::AccumulatedInput>,
+    )>,
+) {
+    for (entity, mut state, mut input) in &mut states {
+        let was_incapacitated = state.incapacitated;
+        let Ok(view) = viewer.get(entity) else {
+            continue;
+        };
+        let balance = view.skill_check(Skill::Balance, LimbWeights::both_legs());
+        state.imbalance = recover_combat_imbalance(state.imbalance, balance, time.delta_secs());
+        let Ok(limbs) = limbs.get(entity) else {
+            continue;
+        };
+        let will = view.skill_check(Skill::Will, LimbWeights::all_equal());
+        state.incapacitation = combat_incapacitation(
+            state.starting_incapacitation,
+            state.starting_blood_fraction,
+            state.blood_loss_fraction,
+            limbs.total_damage(),
+            will,
+            state.imbalance,
+        );
+        state.incapacitated = state.incapacitation >= 1.0;
+        if state.incapacitated {
+            if let Some(input) = input.as_deref_mut() {
+                input.last_movement = None;
+                input.jumped = None;
+            }
+            cmd.entity(entity)
+                .remove::<PendingDefenderResponse>()
+                .insert(Incapacitated);
+        } else if was_incapacitated {
+            cmd.entity(entity).remove::<Incapacitated>();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use adventuresim_tactical_netcode::bevy_replicon::prelude::ClientId;
+
+    #[derive(Resource)]
+    struct BatchedCompletions {
+        attacker: Entity,
+        target: Entity,
+    }
+
+    #[derive(Resource, Default)]
+    struct AcceptedCompletions(u32);
+
+    fn emit_batched_completions(mut cmd: Commands, batch: Res<BatchedCompletions>) {
+        for _ in 0..3 {
+            cmd.trigger(FromClient {
+                client_id: ClientId::Client(batch.attacker),
+                message: MeleeActionRequest::complete(batch.target, BodyPart::Chest, 1.0),
+            });
+        }
+    }
+
+    fn apply_if_authorized(
+        event: On<MeleeAttackIntent>,
+        time: Res<Time<()>>,
+        mut authorities: Query<&mut MeleeAttackAuthority>,
+        mut limbs: Query<&mut Limbs>,
+        mut accepted: ResMut<AcceptedCompletions>,
+    ) {
+        let Ok(mut authority) = authorities.get_mut(event.attacker) else {
+            return;
+        };
+        if consume_melee_authority(&mut authority, event.target, time.elapsed_secs()) {
+            accepted.0 += 1;
+            if let Ok(mut limbs) = limbs.get_mut(event.target) {
+                limbs.chest -= 0.1;
+            }
+        }
+    }
+
+    fn valid_facts(world: &mut World) -> MeleeIntentFacts {
+        MeleeIntentFacts {
+            attacker: world.spawn_empty().id(),
+            target: world.spawn_empty().id(),
+            attacker_side: Some(TacticalCombatSide::Party),
+            target_side: Some(TacticalCombatSide::Enemy),
+            attacker_incapacitated: Some(false),
+            target_incapacitated: Some(false),
+            hit_precision: 1.0,
+            weapon_reach: 0.8,
+            separation: 2.0,
+            windup_target: Some(None),
+            windup_ready: true,
+            windup_unexpired: true,
+            cooldown_ready: true,
+        }
+    }
+
+    #[test]
+    fn authoritative_gate_rejects_invalid_relationship_state_and_geometry() {
+        let mut world = World::new();
+        let valid = valid_facts(&mut world);
+        assert_eq!(validate_melee_intent_cheap(valid), Ok(()));
+        assert_eq!(validate_melee_line_of_sight(true), Ok(()));
+        assert_eq!(
+            validate_melee_line_of_sight(false),
+            Err(MeleeIntentRejection::BlockedLineOfSight)
+        );
+
+        let cases = [
+            (
+                MeleeIntentFacts {
+                    target: valid.attacker,
+                    ..valid
+                },
+                MeleeIntentRejection::SelfTarget,
+            ),
+            (
+                MeleeIntentFacts {
+                    attacker_side: None,
+                    ..valid
+                },
+                MeleeIntentRejection::MissingSide,
+            ),
+            (
+                MeleeIntentFacts {
+                    target_side: valid.attacker_side,
+                    ..valid
+                },
+                MeleeIntentRejection::FriendlyTarget,
+            ),
+            (
+                MeleeIntentFacts {
+                    attacker_incapacitated: None,
+                    ..valid
+                },
+                MeleeIntentRejection::MissingCombatState,
+            ),
+            (
+                MeleeIntentFacts {
+                    target_incapacitated: Some(true),
+                    ..valid
+                },
+                MeleeIntentRejection::Incapacitated,
+            ),
+            (
+                MeleeIntentFacts {
+                    hit_precision: f32::NAN,
+                    ..valid
+                },
+                MeleeIntentRejection::NonFinitePrecision,
+            ),
+            (
+                MeleeIntentFacts {
+                    separation: 4.0,
+                    ..valid
+                },
+                MeleeIntentRejection::OutOfRange,
+            ),
+            (
+                MeleeIntentFacts {
+                    windup_ready: false,
+                    ..valid
+                },
+                MeleeIntentRejection::Windup,
+            ),
+            (
+                MeleeIntentFacts {
+                    windup_target: Some(Some(valid.attacker)),
+                    ..valid
+                },
+                MeleeIntentRejection::Windup,
+            ),
+            (
+                MeleeIntentFacts {
+                    windup_unexpired: false,
+                    ..valid
+                },
+                MeleeIntentRejection::Windup,
+            ),
+            (
+                MeleeIntentFacts {
+                    cooldown_ready: false,
+                    ..valid
+                },
+                MeleeIntentRejection::Cooldown,
+            ),
+        ];
+        for (facts, expected) in cases {
+            assert_eq!(validate_melee_intent_cheap(facts), Err(expected));
+        }
+    }
+
+    #[test]
+    fn damage_clamps_limb_and_accumulates_blood_and_imbalance() {
+        let mut attacker = TacticalCombatState::default();
+        let mut defender = TacticalCombatState::default();
+        let mut limbs = Limbs {
+            chest: 0.2,
+            ..default()
+        };
+        apply_transient_attack_result(
+            &mut attacker,
+            &mut limbs,
+            &mut defender,
+            AttackResult::ToDefender {
+                cut_damage: 100.0,
+                blunt_damage: 0.0,
+                balance_damage: 0.4,
+                contact_force: 100.0,
+                armor_contact: false,
+            },
+            BodyPart::Chest,
+        );
+        assert_eq!(limbs.chest, 0.0);
+        assert!((defender.blood_loss_fraction - 0.1).abs() < 0.0001);
+        assert!((defender.imbalance - 0.4).abs() < 0.0001);
+
+        apply_transient_attack_result(
+            &mut attacker,
+            &mut limbs,
+            &mut defender,
+            AttackResult::ToAttacker {
+                balance_damage: 0.25,
+                contact_force: 0.0,
+                physical_contact: false,
+            },
+            BodyPart::Chest,
+        );
+        assert!((attacker.imbalance - 0.25).abs() < 0.0001);
+    }
+
+    #[test]
+    fn blood_pain_imbalance_and_recovery_share_autoresolve_rules() {
+        assert!(combat_incapacitation(0.0, 1.0, 0.3, 0.0, 1.0, 0.0) >= 1.0);
+        assert!(combat_incapacitation(0.2, 1.0, 0.0, 1.0, 0.0, 0.0) >= 1.0);
+        assert!(combat_incapacitation(0.0, 1.0, 0.0, 0.0, 1.0, 1.0) >= 1.0);
+        assert!((recover_combat_imbalance(0.5, 2.0, 2.0) - 0.38).abs() < 0.0001);
+        assert_eq!(recover_combat_imbalance(0.01, 5.0, 1.0), 0.0);
+    }
+
+    #[test]
+    fn imbalance_only_incapacitation_recovers_and_removes_marker() {
+        let mut app = App::new();
+        app.insert_resource(Time::<()>::default())
+            .add_systems(Update, update_tactical_combat_state);
+        let actor = app
+            .world_mut()
+            .spawn((
+                Player::default(),
+                TacticalCombatState {
+                    imbalance: 1.01,
+                    ..default()
+                },
+                input::AccumulatedInput {
+                    last_movement: Some(Vec2::Y),
+                    ..default()
+                },
+            ))
+            .id();
+        app.update();
+        assert!(
+            app.world()
+                .entity(actor)
+                .get::<TacticalCombatState>()
+                .unwrap()
+                .incapacitated
+        );
+        assert!(app.world().entity(actor).contains::<Incapacitated>());
+        assert_eq!(
+            app.world()
+                .entity(actor)
+                .get::<input::AccumulatedInput>()
+                .unwrap()
+                .last_movement,
+            None
+        );
+
+        app.world_mut()
+            .resource_mut::<Time<()>>()
+            .advance_by(Duration::from_secs(2));
+        app.update();
+        assert!(
+            !app.world()
+                .entity(actor)
+                .get::<TacticalCombatState>()
+                .unwrap()
+                .incapacitated
+        );
+        assert!(!app.world().entity(actor).contains::<Incapacitated>());
+    }
+
+    #[test]
+    fn batched_completions_consume_one_windup_once() {
+        let mut app = App::new();
+        app.insert_resource(Time::<()>::default())
+            .init_resource::<AcceptedCompletions>()
+            .add_observer(on_melee_action_request)
+            .add_observer(apply_if_authorized);
+        let attacker = app.world_mut().spawn(MeleeAttackAuthority::default()).id();
+        let target = app.world_mut().spawn(Limbs::default()).id();
+        app.world_mut().trigger(FromClient {
+            client_id: ClientId::Client(attacker),
+            message: MeleeActionRequest::start(),
+        });
+        app.world_mut()
+            .resource_mut::<Time<()>>()
+            .advance_by(Duration::from_secs_f32(CLIENT_MELEE_WINDUP_SECS));
+        app.insert_resource(BatchedCompletions { attacker, target })
+            .add_systems(Update, emit_batched_completions);
+        app.update();
+
+        assert_eq!(app.world().resource::<AcceptedCompletions>().0, 1);
+        assert!((app.world().entity(target).get::<Limbs>().unwrap().chest - 0.9).abs() < 0.0001);
+    }
 }

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -22,7 +22,7 @@ use clap::{ArgAction, Parser};
 
 use crate::{
     bot::{MissionEnemy, OffensiveMeleeAi},
-    combat::TacticalCombatSide,
+    combat::{MeleeAttackAuthority, TacticalCombatSide},
     stdb::{SpacetimeDb, SpacetimeDbReady},
     terrain::TerrainGenerator,
 };
@@ -293,6 +293,7 @@ fn spawn_connected_player(
         smithing_hours: player.skills.smithing_hours,
     };
     let mut limbs = Limbs {
+        body_weight_kg: player.body_weight_kg,
         left_arm: player.limbs.left_arm_health,
         right_arm: player.limbs.right_arm_health,
         left_leg: player.limbs.left_leg_health,
@@ -389,6 +390,14 @@ fn spawn_connected_player(
     };
     let name = format!("{tag}#{} {}", player.character.id, player.character.name);
 
+    let (starting_incapacitation, starting_blood_fraction) = derive_combat_starting_condition(
+        player.strategic_incapacitation,
+        player.strategic_pain,
+        player.strategic_blood_loss,
+        player.current_blood_ml,
+        player.maximum_blood_ml,
+    );
+
     cmd.entity(entity).remove::<LoadingPlayer>().insert((
         Name::new(name),
         Replicated,
@@ -404,6 +413,12 @@ fn spawn_connected_player(
         MissionOpeningAwareness {
             party_has_surprise: player.party_has_surprise,
         },
+        TacticalCombatState {
+            starting_incapacitation,
+            starting_blood_fraction,
+            ..default()
+        },
+        MeleeAttackAuthority::default(),
         if player.mission_side == TacticalMissionSide::Enemy {
             TacticalCombatSide::Enemy
         } else {
@@ -677,15 +692,27 @@ fn on_join_request(
 
 fn on_player_input(
     input: On<FromClient<PlayerInputRequest>>,
-    mut players: Query<(&mut AccumulatedInput, &mut CharacterLook), With<Player>>,
+    mut players: Query<
+        (
+            &mut AccumulatedInput,
+            &mut CharacterLook,
+            &TacticalCombatState,
+        ),
+        With<Player>,
+    >,
 ) {
     let Some(entity) = input.client_id.entity() else {
         return;
     };
 
-    let Ok((mut accumulated_input, mut look)) = players.get_mut(entity) else {
+    let Ok((mut accumulated_input, mut look, combat_state)) = players.get_mut(entity) else {
         return;
     };
+    if combat_state.incapacitated {
+        accumulated_input.last_movement = None;
+        accumulated_input.jumped = None;
+        return;
+    }
 
     look.yaw = input.look.x;
     look.pitch = input.look.y.clamp(-1.5, 1.5);

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -281,11 +281,24 @@ uses a server-owned windup and cooldown to enter the same internal
 melee-resolution seam as client requests. This direct pursuit intentionally has
 no pathfinding yet.
 
-The current combat prototype calculates attacks but does not yet apply tactical
-damage or incapacitation, so no attack path can emit authoritative enemy deaths.
-Required-kill missions therefore fail closed unless the server's future combat
-pipeline emits the internal authoritative death event. Ranged AI and durable
-combat consequences also remain unimplemented.
+The client sends windup start and completion through one mapped ordered melee
+protocol. The tactical server validates melee allegiance, state, range, a fresh
+observed windup and cooldown, then authoritative physics line of sight before resolving an
+attack. Finite client-reported precision remains trusted because reconstructing
+animation and secondary physics is intentionally outside the headless server.
+Accepted results mutate replicated limb health plus transient blood loss and
+imbalance. Shared autoresolve rules derive pain, blood-loss, and imbalance
+incapacitation and recover balance over time. Tactical enrollment projects
+authoritative body weight, current/maximum blood, and strategic condition
+contributions; the same shared derivation as autoresolve excludes pain and blood
+from starting incapacitation before recomputing them live. Actors currently
+over the threshold stop moving, attacking, defending, and participating in
+offensive AI target selection; imbalance-only incapacitation can recover.
+
+These per-tick effects remain in memory only. Incapacitation does not yet emit a
+terminal mission result or persist strategic wounds; required-kill missions
+still await the outcome and receipt branches. Ranged AI and durable combat
+consequences also remain unimplemented.
 
 Mission, hostile-group, battle, and outcome-source identities are separate.
 Tactical success never chooses a case objective, capture subject, contract

--- a/wiki/tactical/combat.md
+++ b/wiki/tactical/combat.md
@@ -18,6 +18,11 @@ full animation and secondary physics on the headless server is not an intended
 authority boundary, while character and equipment statistics still bound the
 combat calculation.
 
+Client windup start and completion are variants of one mapped ordered melee
+action protocol, so completion cannot overtake start on a separate event
+stream. An observed windup expires one second after it becomes ready, bounding
+delayed or replayed completions.
+
 ### Current offensive AI
 
 Each AI melee combatant has an explicit Party or Enemy allegiance and chooses
@@ -32,11 +37,29 @@ the existing client windup message does not yet identify a target, that legacy
 path offers a defensive reaction only to the nearest opposing AI instead of
 every frontal AI.
 
-This is an iteration harness rather than complete enemy decision-making. It
-does not pathfind around terrain or other combatants, handle ranged weapons,
-apply damage, recognize incapacitation, validate every attack condition, or
-persist tactical state. Targets therefore remain viable until they despawn or
-change allegiance.
+Before resolution, the headless server rejects self or friendly attacks,
+missing allegiance or combat state, incapacitated participants, non-finite
+precision, missing weapons, attacks beyond shared interaction range plus a
+small 0.25-meter network-motion allowance, requests outside a fresh
+server-observed windup/cooldown, and blocked authoritative physics line of
+sight. Cheap state, timing, and range checks run before the physics cast. Finite
+client-reported precision remains trusted rather than reconstructed.
+
+Accepted contacts clamp damage against the targeted limb's remaining health
+and accumulate blood loss and imbalance. Incapacitation is the shared
+autoresolve sum of projected strategic starting condition, pain, blood loss,
+and temporary imbalance. Tactical enrollment carries authoritative body weight,
+blood volume, and strategic condition inputs; pain and blood are recomputed in
+combat instead of double-counted. Balance skill recovers imbalance continuously.
+An actor over the threshold stops moving, attacking, defending, and being
+selected by offensive AI; an imbalance-only incapacitation can recover and
+return the actor to combat. Limb and live combat-state replication provide
+basic client feedback, but all of this remains transient server memory.
+
+This is still an iteration harness rather than complete enemy decision-making.
+It does not pathfind around terrain or other combatants, handle ranged weapons,
+finish missions from incapacitation, persist injuries, or create strategic
+outcome receipts.
 
 ### Skill check algorithm
 Broadly speaking, the flow goes like this:


### PR DESCRIPTION
## Summary

Add authoritative transient tactical damage and incapacitation on top of #361.

The headless server now validates shared melee actions, applies combat results to live limb/blood/imbalance state, derives incapacitation using shared autoresolve rules, and prevents incapacitated actors from continuing to move, attack, defend, or participate in AI targeting.

Part of #360. This PR targets `codex/tactical-offensive-ai` and should be reviewed as the second stack layer.

## Authority checks

Melee completions are rejected for:

- self or friendly targets;
- missing tactical allegiance or combat state;
- incapacitated participants;
- non-finite reported precision;
- missing equipped melee weapon;
- excess authoritative separation;
- missing, premature, expired, consumed, or target-mismatched windup;
- active cooldown;
- blocked authoritative Avian-physics line of sight.

Finite client-reported precision remains trusted and is not reconstructed server-side.

Start and completion now use one mapped ordered `MeleeActionRequest` stream. Successful completion synchronously consumes its windup and activates cooldown, preventing batched completions from reusing one authorization.

## Combat state

Accepted exchanges:

- apply failed-contact balance damage to the attacker;
- clamp defender damage against remaining targeted-limb health;
- accumulate defender blood loss and imbalance;
- continuously recover imbalance using Balance skill;
- derive incapacitation from starting condition, pain, blood loss, and imbalance using shared core rules;
- add or remove incapacitation as temporary imbalance crosses the threshold;
- clear movement and defense while incapacitated.

Live state is replicated but remains transient server memory. Nothing is written to SpacetimeDB in this branch.

## Strategic bootstrap

The `ConnectedPlayer` projection now carries authoritative body weight, blood volume, and strategic incapacitation contributions. Tactical and autoresolve use one shared derivation that excludes pain/blood from the baseline before recomputing those live sources. The pre-launch schema changes directly with no migration or compatibility shim.

Generated SpacetimeDB client bindings were regenerated through the repository workflow.

## Independent review remediation

- Bound windups with an ordered-network completion allowance and stale replay rejection.
- Run cheap validation before authoritative physics LOS and use debug-level expected rejection logging.
- Allow imbalance-only incapacitation to recover and remove its marker.
- Project authoritative starting body/blood/condition state into tactical enrollment.
- Consolidate start/completion into one ordered protocol stream.
- Synchronously consume windup/cooldown authority; a regression test submits three completions in one update and authorizes exactly one.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p adventuresim-core combat::tests` — 6 passed
- `cargo test -p adventuresim-tactical-server` — 9 passed
- `cargo check -p adventuresim-tactical-client`
- `just verify-db-client`
- SpacetimeDB module release compilation during binding generation
- `git diff --check`

The module crate's direct filtered test build remains blocked by pre-existing unrelated test-fragment `include_str!` and `STRATEGIC_SOURCE` errors; the production module itself compiles successfully.

## Limitations

This branch does not finish missions, issue terminal consequence receipts, persist tactical injuries, or add ranged combat. Those are subsequent layers in #360.
