### PR TITLE
Resolve tactical missions from incapacitation

### DIFF
--- a/crates/adventuresim-stdb-client/src/tactical_server_request_type.rs
+++ b/crates/adventuresim-stdb-client/src/tactical_server_request_type.rs
@@ -12,6 +12,7 @@ pub struct TacticalServerRequest {
     pub scene_key: String,
     pub party_id: String,
     pub requested_by: u64,
+    pub expected_party_members: u32,
     pub required_enemy_kills: u32,
     pub enemy_difficulty: i32,
     pub enemy_combat_scale_bps: u32,
@@ -34,6 +35,7 @@ pub struct TacticalServerRequestCols {
     pub scene_key: __sdk::__query_builder::Col<TacticalServerRequest, String>,
     pub party_id: __sdk::__query_builder::Col<TacticalServerRequest, String>,
     pub requested_by: __sdk::__query_builder::Col<TacticalServerRequest, u64>,
+    pub expected_party_members: __sdk::__query_builder::Col<TacticalServerRequest, u32>,
     pub required_enemy_kills: __sdk::__query_builder::Col<TacticalServerRequest, u32>,
     pub enemy_difficulty: __sdk::__query_builder::Col<TacticalServerRequest, i32>,
     pub enemy_combat_scale_bps: __sdk::__query_builder::Col<TacticalServerRequest, u32>,
@@ -52,6 +54,10 @@ impl __sdk::__query_builder::HasCols for TacticalServerRequest {
             scene_key: __sdk::__query_builder::Col::new(table_name, "scene_key"),
             party_id: __sdk::__query_builder::Col::new(table_name, "party_id"),
             requested_by: __sdk::__query_builder::Col::new(table_name, "requested_by"),
+            expected_party_members: __sdk::__query_builder::Col::new(
+                table_name,
+                "expected_party_members",
+            ),
             required_enemy_kills: __sdk::__query_builder::Col::new(
                 table_name,
                 "required_enemy_kills",

--- a/crates/adventuresim-stdb-client/src/tactical_server_type.rs
+++ b/crates/adventuresim-stdb-client/src/tactical_server_type.rs
@@ -14,6 +14,7 @@ pub struct TacticalServer {
     pub party_id: String,
     pub addr: String,
     pub cert_digest: String,
+    pub expected_party_members: u32,
     pub required_enemy_kills: u32,
     pub enemy_difficulty: i32,
     pub enemy_combat_scale_bps: u32,
@@ -38,6 +39,7 @@ pub struct TacticalServerCols {
     pub party_id: __sdk::__query_builder::Col<TacticalServer, String>,
     pub addr: __sdk::__query_builder::Col<TacticalServer, String>,
     pub cert_digest: __sdk::__query_builder::Col<TacticalServer, String>,
+    pub expected_party_members: __sdk::__query_builder::Col<TacticalServer, u32>,
     pub required_enemy_kills: __sdk::__query_builder::Col<TacticalServer, u32>,
     pub enemy_difficulty: __sdk::__query_builder::Col<TacticalServer, i32>,
     pub enemy_combat_scale_bps: __sdk::__query_builder::Col<TacticalServer, u32>,
@@ -58,6 +60,10 @@ impl __sdk::__query_builder::HasCols for TacticalServer {
             party_id: __sdk::__query_builder::Col::new(table_name, "party_id"),
             addr: __sdk::__query_builder::Col::new(table_name, "addr"),
             cert_digest: __sdk::__query_builder::Col::new(table_name, "cert_digest"),
+            expected_party_members: __sdk::__query_builder::Col::new(
+                table_name,
+                "expected_party_members",
+            ),
             required_enemy_kills: __sdk::__query_builder::Col::new(
                 table_name,
                 "required_enemy_kills",

--- a/crates/adventuresim-stdb-module/README.md
+++ b/crates/adventuresim-stdb-module/README.md
@@ -37,8 +37,9 @@ player-identity-to-character ownership model.
 
 ## Tactical completion
 
-Mission requests bind a party, scene, one-use tactical-server claim, and private
-strategic mission authority. The registered tactical child keeps live
+Mission requests bind a party, its expected living member count, a scene, a
+one-use tactical-server claim, and private strategic mission authority. The
+registered tactical child keeps live
 simulation state in memory and calls `end_tactical_server` with its terminal
 resolution.
 

--- a/crates/adventuresim-stdb-module/src/strategic/mission_bootstrap.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/mission_bootstrap.rs
@@ -604,6 +604,12 @@ pub fn seed_standalone_tactical_mission(
                 capture_custody_version: None,
             });
     }
+    let expected_party_members =
+        u32::try_from(crate::strategic::living_party_member_ids(ctx, &party_id).len())
+            .map_err(|_| "Party is too large for tactical enrollment")?;
+    if expected_party_members == 0 {
+        return Err("A tactical mission requires at least one living party member".into());
+    }
     ctx.db
         .tactical_server_request_authority()
         .insert(crate::tactical::TacticalServerRequest {
@@ -612,6 +618,7 @@ pub fn seed_standalone_tactical_mission(
             scene_key,
             party_id,
             requested_by: character_id,
+            expected_party_members,
             required_enemy_kills,
             enemy_difficulty: mission.enemy_difficulty,
             enemy_combat_scale_bps: mission.enemy_combat_scale_bps,

--- a/crates/adventuresim-stdb-module/src/tactical.rs
+++ b/crates/adventuresim-stdb-module/src/tactical.rs
@@ -50,6 +50,8 @@ pub struct TacticalServerRequest {
     pub scene_key: String,
     pub party_id: String,
     pub requested_by: u64,
+    /// Living strategic party members bound when the mission is requested.
+    pub expected_party_members: u32,
     pub required_enemy_kills: u32,
     pub enemy_difficulty: i32,
     pub enemy_combat_scale_bps: u32,
@@ -74,6 +76,7 @@ pub struct TacticalServer {
     pub party_id: String,
     pub addr: String,
     pub cert_digest: String,
+    pub expected_party_members: u32,
     pub required_enemy_kills: u32,
     pub enemy_difficulty: i32,
     pub enemy_combat_scale_bps: u32,
@@ -647,6 +650,12 @@ pub fn request_tactical_server(
         return Err("Tactical mission roster does not match bound mission authority".into());
     }
     log::info!("Tactical server for '{mission_id}' requested");
+    let expected_party_members =
+        u32::try_from(crate::strategic::living_party_member_ids(ctx, &party_id).len())
+            .map_err(|_| "Party is too large for tactical enrollment")?;
+    if expected_party_members == 0 {
+        return Err("A tactical mission requires at least one living party member".into());
+    }
     ctx.db
         .tactical_server_request_authority()
         .insert(TacticalServerRequest {
@@ -655,6 +664,7 @@ pub fn request_tactical_server(
             scene_key,
             party_id,
             requested_by: character_id,
+            expected_party_members,
             required_enemy_kills: mission.enemy_count,
             enemy_difficulty: mission.enemy_difficulty,
             enemy_combat_scale_bps: mission.enemy_combat_scale_bps,
@@ -722,6 +732,7 @@ pub fn create_tactical_server_for_request(
         request.mission_id,
         request.scene_key,
         request.party_id,
+        request.expected_party_members,
         request.required_enemy_kills,
         request.enemy_difficulty,
         request.enemy_combat_scale_bps,
@@ -743,6 +754,7 @@ fn insert_tactical_server(
     mission_id: String,
     scene_key: String,
     party_id: String,
+    expected_party_members: u32,
     required_enemy_kills: u32,
     enemy_difficulty: i32,
     enemy_combat_scale_bps: u32,
@@ -783,6 +795,7 @@ fn insert_tactical_server(
         party_id,
         addr,
         cert_digest,
+        expected_party_members,
         required_enemy_kills,
         enemy_difficulty,
         enemy_combat_scale_bps,
@@ -967,6 +980,25 @@ mod authority_tests {
         assert!(source.contains(".tactical_server_claim()"));
         assert!(source.contains(".delete(&mission_id)"));
         assert!(!source.contains("pub claim:"));
+    }
+
+    #[test]
+    fn strategic_request_binds_expected_party_members_into_the_server() {
+        let source = include_str!("tactical.rs");
+        for schema in ["TacticalServerRequest", "TacticalServer"] {
+            let body = source
+                .split(&format!("pub struct {schema}"))
+                .nth(1)
+                .and_then(|tail| tail.split('}').next())
+                .expect("schema body");
+            assert!(body.contains("pub expected_party_members: u32"));
+        }
+        let create = source
+            .split("pub fn create_tactical_server_for_request")
+            .nth(1)
+            .and_then(|tail| tail.split("/// Creates a new").next())
+            .expect("create reducer");
+        assert!(create.contains("request.expected_party_members"));
     }
 
     #[test]

--- a/crates/adventuresim-tactical-server-dispatcher/src/main.rs
+++ b/crates/adventuresim-tactical-server-dispatcher/src/main.rs
@@ -125,6 +125,7 @@ fn main() {
             let claim_hash = Sha256::digest(claim.as_bytes()).to_vec();
             let mission_id = request.mission_id.clone();
             let scene_key = request.scene_key.clone();
+            let expected_party_members = request.expected_party_members.to_string();
             let required_enemy_kills = request.required_enemy_kills.to_string();
             let enemy_combat_scale_bps = request.enemy_combat_scale_bps.to_string();
             let spawned = spawned_clone.clone();
@@ -148,6 +149,8 @@ fn main() {
                                 &mission_id,
                                 "--scene-key",
                                 &scene_key,
+                                "--expected-party-members",
+                                &expected_party_members,
                                 "--required-enemy-kills",
                                 &required_enemy_kills,
                                 "--enemy-combat-scale-bps",

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -10,7 +10,7 @@ use crate::{
     MissionState,
     combat::{
         Incapacitated, MeleeAttackIntent, MeleeAttackStartedIntent, PendingDefenderResponse,
-        TacticalCombatSide,
+        TacticalCombatSide, TacticalCombatantDefeated,
     },
 };
 
@@ -62,12 +62,7 @@ enum OffensiveMeleePhase {
 }
 
 #[derive(Component)]
-pub struct CountedEnemyDeath;
-
-/// Reserved for the future terminal-outcome pipeline. Incapacitation is now
-/// authoritative but is not counted as a mission death in this branch.
-#[derive(Event)]
-pub struct AuthoritativeEnemyDeath(pub Entity);
+pub struct CountedEnemyDefeat;
 
 /// A bot's yet-to-commit reaction to a noticed attack. Ticks down for
 /// [`REACTION_DELAY_SECS`] before becoming a [`PendingDefenderResponse`],
@@ -82,29 +77,25 @@ pub struct BotPlugin;
 
 impl Plugin for BotPlugin {
     fn build(&self, app: &mut App) {
-        app.add_observer(on_authoritative_enemy_death)
+        app.add_observer(on_tactical_combatant_defeated)
             .add_observer(on_attack_started)
             .add_observer(on_targeted_attack_started)
             .add_systems(Update, (drive_offensive_melee_ai, tick_bot_reactions));
     }
 }
 
-fn on_authoritative_enemy_death(
-    death: On<AuthoritativeEnemyDeath>,
-    enemies: Query<(), (With<MissionEnemy>, Without<CountedEnemyDeath>)>,
+fn on_tactical_combatant_defeated(
+    defeated: On<TacticalCombatantDefeated>,
+    enemies: Query<(), (With<MissionEnemy>, Without<CountedEnemyDefeat>)>,
     mut commands: Commands,
     mut state: ResMut<MissionState>,
 ) {
-    let entity = death.0;
+    let entity = defeated.0;
     if enemies.get(entity).is_err() {
         return;
     }
-    commands.entity(entity).insert(CountedEnemyDeath);
-    state.enemies_killed = state.enemies_killed.saturating_add(1);
-}
-
-pub fn mission_objective_satisfied(required: u32, killed: u32) -> bool {
-    killed >= required
+    commands.entity(entity).insert(CountedEnemyDefeat);
+    state.enemies_defeated = state.enemies_defeated.saturating_add(1);
 }
 
 /// Predicts whether the nearest opposing AI facing a client attacker notices
@@ -413,12 +404,31 @@ mod tests {
     }
 
     #[test]
-    fn mission_success_requires_the_full_authoritative_objective() {
-        assert!(mission_objective_satisfied(0, 0));
-        assert!(!mission_objective_satisfied(3, 0));
-        assert!(!mission_objective_satisfied(3, 2));
-        assert!(mission_objective_satisfied(3, 3));
-        assert!(mission_objective_satisfied(3, 4));
+    fn enemy_defeat_is_counted_only_once() {
+        let mut app = App::new();
+        app.insert_resource(MissionState {
+            timeout: None,
+            enemies_defeated: 0,
+            required_enemy_defeats: 1,
+            expected_party_members: 1,
+            seen_party_members: Default::default(),
+            enrollment_begun: false,
+            enrollment_sealed: false,
+            abandonment_elapsed: Default::default(),
+            terminal_retry_not_before: Default::default(),
+            pending_resolution: None,
+            committed: false,
+        })
+        .add_observer(on_tactical_combatant_defeated);
+        let enemy = app.world_mut().spawn(MissionEnemy).id();
+
+        app.world_mut().trigger(TacticalCombatantDefeated(enemy));
+        app.update();
+        app.world_mut().trigger(TacticalCombatantDefeated(enemy));
+        app.update();
+
+        assert_eq!(app.world().resource::<MissionState>().enemies_defeated, 1);
+        assert!(app.world().entity(enemy).contains::<CountedEnemyDefeat>());
     }
 
     #[test]
@@ -639,5 +649,32 @@ mod tests {
             );
         }
         assert!(!app.world().resource::<RecordedAttacks>().0.is_empty());
+
+        let party_defeated = app
+            .world()
+            .entity(party)
+            .get::<TacticalCombatState>()
+            .unwrap()
+            .incapacitated;
+        let enemy_defeated = app
+            .world()
+            .entity(enemy)
+            .get::<TacticalCombatState>()
+            .unwrap()
+            .incapacitated;
+        let resolution = crate::terminal_resolution(crate::TerminalCombatSnapshot {
+            required_enemies: 1,
+            loaded_enemies: 1,
+            defeated_enemies: u32::from(enemy_defeated),
+            loaded_party: 1,
+            incapacitated_party: u32::from(party_defeated),
+            enrollment_sealed: true,
+        });
+        let expected = if party_defeated {
+            Some(crate::TacticalMissionResolution::Failed)
+        } else {
+            Some(crate::TacticalMissionResolution::Defeated)
+        };
+        assert_eq!(resolution, expected);
     }
 }

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -71,6 +71,11 @@ fn consume_melee_authority(authority: &mut MeleeAttackAuthority, target: Entity,
 #[derive(Component, Debug)]
 pub struct Incapacitated;
 
+/// Emitted once per transition from active to incapacitated. Mission systems
+/// decide whether that transition constitutes a counted tactical defeat.
+#[derive(Event, Clone, Copy, Debug)]
+pub struct TacticalCombatantDefeated(pub Entity);
+
 /// A server-internal melee request. Both network clients and server-owned AI
 /// enter combat resolution through this seam.
 #[derive(Event, Clone, Copy, Debug)]
@@ -561,9 +566,12 @@ pub(crate) fn update_tactical_combat_state(
                 input.last_movement = None;
                 input.jumped = None;
             }
-            cmd.entity(entity)
-                .remove::<PendingDefenderResponse>()
-                .insert(Incapacitated);
+            if !was_incapacitated {
+                cmd.entity(entity)
+                    .remove::<PendingDefenderResponse>()
+                    .insert(Incapacitated);
+                cmd.trigger(TacticalCombatantDefeated(entity));
+            }
         } else if was_incapacitated {
             cmd.entity(entity).remove::<Incapacitated>();
         }

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -5,7 +5,7 @@ mod combat;
 mod stdb;
 mod terrain;
 
-use std::{net::SocketAddr, num::NonZeroU32};
+use std::{collections::HashSet, net::SocketAddr, num::NonZeroU32, time::Duration};
 
 use adventuresim_stdb_client::*;
 use adventuresim_tactical_core::{
@@ -30,6 +30,10 @@ use input::AccumulatedInput;
 
 /// Default [`Args::timeout`] time.
 const MISSION_TIMEOUT_SECS: f32 = 300.0;
+/// Retry interval after a synchronous terminal reducer submission error.
+const TERMINAL_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+/// Time a sealed, empty Party has to reconnect before the mission is abandoned.
+const PARTY_RECONNECT_GRACE: Duration = Duration::from_secs(10);
 
 /// Level map size.
 const TERRAIN_SIZE: usize = 100;
@@ -95,6 +99,10 @@ struct Args {
     #[arg(long)]
     required_enemy_kills: u32,
 
+    /// Living Party members bound by strategic authority for this mission.
+    #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
+    expected_party_members: u32,
+
     /// Observer-safe combat scale copied from the trusted mission request.
     /// The strategic reducer independently derives the authoritative value.
     #[arg(long)]
@@ -146,15 +154,25 @@ fn main() {
             timeout: (!args.no_timeout)
                 .then_some(args.timeout)
                 .map(|duration| Timer::from_seconds(duration, TimerMode::Once)),
-            enemies_killed: 0,
-            required_enemy_kills: args.required_enemy_kills,
+            enemies_defeated: 0,
+            required_enemy_defeats: args.required_enemy_kills,
+            expected_party_members: args.expected_party_members,
+            seen_party_members: HashSet::new(),
+            enrollment_begun: false,
+            enrollment_sealed: false,
+            abandonment_elapsed: Duration::ZERO,
+            terminal_retry_not_before: Duration::ZERO,
+            pending_resolution: None,
             committed: false,
         })
         .insert_resource(args)
         .add_systems(
             Update,
             (
-                check_mission_timeout,
+                (check_terminal_combat_outcome, check_mission_timeout)
+                    .chain()
+                    .after(combat::update_tactical_combat_state)
+                    .after(spawn_connected_players),
                 spawn_connected_players.after(stdb::update_spacetimedb),
                 (setup_server, setup_stdb_callbacks).run_if(resource_added::<SpacetimeDbReady>),
             ),
@@ -174,9 +192,87 @@ struct LoadingPlayer {
 #[derive(Resource)]
 pub struct MissionState {
     timeout: Option<Timer>,
-    pub enemies_killed: u32,
-    required_enemy_kills: u32,
+    pub enemies_defeated: u32,
+    required_enemy_defeats: u32,
+    expected_party_members: u32,
+    seen_party_members: HashSet<u64>,
+    enrollment_begun: bool,
+    enrollment_sealed: bool,
+    abandonment_elapsed: Duration,
+    terminal_retry_not_before: Duration,
+    pending_resolution: Option<TacticalMissionResolution>,
     committed: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TerminalCombatSnapshot {
+    pub required_enemies: u32,
+    pub loaded_enemies: u32,
+    pub defeated_enemies: u32,
+    pub loaded_party: u32,
+    pub incapacitated_party: u32,
+    pub enrollment_sealed: bool,
+}
+
+pub(crate) fn terminal_resolution(
+    snapshot: TerminalCombatSnapshot,
+) -> Option<TacticalMissionResolution> {
+    if snapshot.required_enemies == 0
+        || snapshot.loaded_enemies < snapshot.required_enemies
+        || !snapshot.enrollment_sealed
+        || snapshot.loaded_party == 0
+    {
+        return None;
+    }
+    let enemies_defeated = snapshot.defeated_enemies >= snapshot.required_enemies;
+    let party_defeated = snapshot.incapacitated_party >= snapshot.loaded_party;
+    match (enemies_defeated, party_defeated) {
+        // Simultaneous defeat fails closed, matching autoresolve's lack of an
+        // allied victory when both sides are unable to continue.
+        (_, true) => Some(TacticalMissionResolution::Failed),
+        (true, false) => Some(TacticalMissionResolution::Defeated),
+        (false, false) => None,
+    }
+}
+
+fn abandonment_due(
+    elapsed: &mut Duration,
+    enrollment_begun: bool,
+    loaded_party: u32,
+    has_loading_player: bool,
+    delta: Duration,
+) -> bool {
+    if enrollment_begun && loaded_party == 0 && !has_loading_player {
+        *elapsed = elapsed.saturating_add(delta);
+    } else {
+        *elapsed = Duration::ZERO;
+    }
+    *elapsed >= PARTY_RECONNECT_GRACE
+}
+
+fn enrollment_ready(expected: u32, seen: usize, has_loading_player: bool) -> bool {
+    expected > 0 && seen >= expected as usize && !has_loading_player
+}
+
+impl MissionState {
+    fn submit_terminal<E>(
+        &mut self,
+        resolution: TacticalMissionResolution,
+        now: Duration,
+        mut send: impl FnMut(TacticalMissionResolution) -> Result<(), E>,
+    ) -> Result<bool, E> {
+        if self.committed || now < self.terminal_retry_not_before {
+            return Ok(false);
+        }
+        let resolution = *self.pending_resolution.get_or_insert(resolution);
+        if let Err(error) = send(resolution) {
+            self.terminal_retry_not_before = now.saturating_add(TERMINAL_RETRY_BACKOFF);
+            return Err(error);
+        }
+        self.committed = true;
+        self.pending_resolution = None;
+        Ok(true)
+    }
 }
 
 fn setup_server(mut commands: Commands, args: Res<Args>) {
@@ -544,11 +640,114 @@ fn spawn_connected_player(
     );
 }
 
+fn commit_terminal_resolution(
+    resolution: TacticalMissionResolution,
+    now: Duration,
+    conn: Res<SpacetimeDb>,
+    mut state: ResMut<MissionState>,
+    mut exit: MessageWriter<AppExit>,
+) -> Result {
+    let submitted = match state.submit_terminal(resolution, now, |resolution| {
+        // Strategic authority ignores this observer-supplied XP value and
+        // derives durable consequences from the bound mission.
+        conn.reducers().end_tactical_server(resolution, 0)
+    }) {
+        Ok(submitted) => submitted,
+        Err(error) => {
+            warn!(
+                "Terminal result submission failed; retrying in {}s: {error}",
+                TERMINAL_RETRY_BACKOFF.as_secs()
+            );
+            return Ok(());
+        }
+    };
+    if !submitted {
+        return Ok(());
+    }
+    info!(
+        ?resolution,
+        "Mission terminal result committed; shutting down"
+    );
+    exit.write(AppExit::Success);
+    Ok(())
+}
+
+fn check_terminal_combat_outcome(
+    time: Res<Time>,
+    conn: Res<SpacetimeDb>,
+    mut state: ResMut<MissionState>,
+    exit: MessageWriter<AppExit>,
+    enemies: Query<(), (With<bot::MissionEnemy>, With<Player>)>,
+    combatants: Query<(&TacticalCombatSide, &TacticalCombatState, &PlayerId), With<Player>>,
+    loading_players: Query<(), With<LoadingPlayer>>,
+) -> Result {
+    if state.committed {
+        return Ok(());
+    }
+    // A result whose first submission failed is already decided. Retry it
+    // before observing recoveries, disconnects, or any newly terminal state.
+    if let Some(resolution) = state.pending_resolution {
+        return commit_terminal_resolution(resolution, time.elapsed(), conn, state, exit);
+    }
+    let mut loaded_party = 0;
+    let mut incapacitated_party = 0;
+    for (side, combat_state, player_id) in &combatants {
+        if *side == TacticalCombatSide::Party {
+            loaded_party += 1;
+            incapacitated_party += u32::from(combat_state.incapacitated);
+            state.seen_party_members.insert(player_id.0);
+        }
+    }
+    let has_loading_player = !loading_players.is_empty();
+    state.enrollment_begun |= has_loading_player || !state.seen_party_members.is_empty();
+    if !state.enrollment_sealed
+        && enrollment_ready(
+            state.expected_party_members,
+            state.seen_party_members.len(),
+            has_loading_player,
+        )
+    {
+        state.enrollment_sealed = true;
+        info!(
+            expected = state.expected_party_members,
+            "Party enrollment sealed"
+        );
+    }
+    let enrollment_begun = state.enrollment_begun;
+    if abandonment_due(
+        &mut state.abandonment_elapsed,
+        enrollment_begun,
+        loaded_party,
+        has_loading_player,
+        time.delta(),
+    ) {
+        return commit_terminal_resolution(
+            TacticalMissionResolution::Failed,
+            time.elapsed(),
+            conn,
+            state,
+            exit,
+        );
+    }
+    let snapshot = TerminalCombatSnapshot {
+        required_enemies: state.required_enemy_defeats,
+        loaded_enemies: enemies.iter().count() as u32,
+        defeated_enemies: state.enemies_defeated,
+        loaded_party,
+        incapacitated_party,
+        enrollment_sealed: state.enrollment_sealed && !has_loading_player,
+    };
+    let Some(resolution) = terminal_resolution(snapshot) else {
+        return Ok(());
+    };
+    commit_terminal_resolution(resolution, time.elapsed(), conn, state, exit)
+}
+
 fn check_mission_timeout(
     time: Res<Time>,
     conn: Res<SpacetimeDb>,
     mut state: ResMut<MissionState>,
-    mut exit: MessageWriter<AppExit>,
+    exit: MessageWriter<AppExit>,
 ) -> Result {
     let is_timeout = match state.timeout {
         Some(ref mut timer) => {
@@ -562,24 +761,14 @@ fn check_mission_timeout(
         return Ok(());
     }
 
-    info!("Mission timeout, committing results...");
-    state.committed = true;
-
-    let success =
-        bot::mission_objective_satisfied(state.required_enemy_kills, state.enemies_killed);
-    let xp_gained = (state.enemies_killed * 25) as i32;
-
-    let resolution = if success {
-        TacticalMissionResolution::Defeated
-    } else {
-        TacticalMissionResolution::Failed
-    };
-    conn.reducers().end_tactical_server(resolution, xp_gained)?;
-
-    info!("Mission ended successfully");
-    info!("Shutting down");
-    exit.write(AppExit::Success);
-    Ok(())
+    info!("Mission timeout, committing bounded failure fallback");
+    commit_terminal_resolution(
+        TacticalMissionResolution::Failed,
+        time.elapsed(),
+        conn,
+        state,
+        exit,
+    )
 }
 
 fn on_server_started(
@@ -657,6 +846,7 @@ fn on_server_started(
 fn on_join_request(
     join: On<FromClient<JoinRequest>>,
     mut commands: Commands,
+    mut state: ResMut<MissionState>,
     loading_players: Query<(), With<LoadingPlayer>>,
     players: Query<(), With<Player>>,
     conn: Res<SpacetimeDb>,
@@ -678,6 +868,7 @@ fn on_join_request(
     conn.reducers()
         .enter_mission(join.player_id, ready.identity())?;
 
+    state.enrollment_begun = true;
     commands.entity(client).insert(LoadingPlayer {
         requested_player_id: join.player_id,
     });
@@ -767,8 +958,8 @@ fn player_spawn_offset(collider: &Collider) -> f32 {
 }
 
 #[cfg(test)]
-mod mission_projection_tests {
-    use super::mission_enemy_scale;
+mod tests {
+    use super::*;
 
     #[test]
     fn same_durable_enemy_identity_projects_different_mission_strength() {
@@ -778,5 +969,255 @@ mod mission_projection_tests {
         assert_eq!(baseline, 1.0);
         assert!(escalated > baseline);
         assert!(countered < escalated);
+    }
+
+    fn snapshot() -> TerminalCombatSnapshot {
+        TerminalCombatSnapshot {
+            required_enemies: 2,
+            loaded_enemies: 2,
+            defeated_enemies: 0,
+            loaded_party: 2,
+            incapacitated_party: 0,
+            enrollment_sealed: true,
+        }
+    }
+
+    #[test]
+    fn terminal_resolution_waits_for_both_sides_to_load() {
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                loaded_enemies: 1,
+                ..snapshot()
+            }),
+            None
+        );
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                loaded_party: 0,
+                ..snapshot()
+            }),
+            None
+        );
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                enrollment_sealed: false,
+                ..snapshot()
+            }),
+            None
+        );
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                required_enemies: 0,
+                loaded_enemies: 0,
+                ..snapshot()
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn terminal_resolution_reports_immediate_victory() {
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                defeated_enemies: 2,
+                ..snapshot()
+            }),
+            Some(TacticalMissionResolution::Defeated)
+        );
+    }
+
+    #[test]
+    fn terminal_resolution_reports_immediate_party_defeat() {
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                incapacitated_party: 2,
+                ..snapshot()
+            }),
+            Some(TacticalMissionResolution::Failed)
+        );
+    }
+
+    #[test]
+    fn simultaneous_defeat_deterministically_fails() {
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                defeated_enemies: 2,
+                incapacitated_party: 2,
+                ..snapshot()
+            }),
+            Some(TacticalMissionResolution::Failed)
+        );
+    }
+
+    #[test]
+    fn no_timeout_mission_can_claim_exactly_one_terminal_result() {
+        let mut state = MissionState {
+            timeout: None,
+            enemies_defeated: 2,
+            required_enemy_defeats: 2,
+            expected_party_members: 1,
+            seen_party_members: HashSet::from([7]),
+            enrollment_begun: true,
+            enrollment_sealed: true,
+            abandonment_elapsed: Duration::ZERO,
+            terminal_retry_not_before: Duration::ZERO,
+            pending_resolution: None,
+            committed: false,
+        };
+        let resolution = terminal_resolution(TerminalCombatSnapshot {
+            defeated_enemies: state.enemies_defeated,
+            ..snapshot()
+        })
+        .unwrap();
+
+        assert_eq!(
+            state.submit_terminal(resolution, Duration::ZERO, |_| Ok::<_, ()>(())),
+            Ok(true)
+        );
+        assert_eq!(
+            state.submit_terminal(resolution, Duration::ZERO, |_| Ok::<_, ()>(())),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    fn failed_submission_retries_frozen_result_after_predicate_clears() {
+        let mut state = MissionState {
+            timeout: None,
+            enemies_defeated: 1,
+            required_enemy_defeats: 1,
+            expected_party_members: 1,
+            seen_party_members: HashSet::from([7]),
+            enrollment_begun: true,
+            enrollment_sealed: true,
+            abandonment_elapsed: Duration::ZERO,
+            terminal_retry_not_before: Duration::ZERO,
+            pending_resolution: None,
+            committed: false,
+        };
+        let mut attempts = 0;
+        let mut reports = Vec::new();
+        let mut sender = |resolution| {
+            attempts += 1;
+            reports.push(resolution);
+            (attempts > 1).then_some(()).ok_or("offline")
+        };
+
+        assert_eq!(
+            state.submit_terminal(
+                TacticalMissionResolution::Defeated,
+                Duration::ZERO,
+                &mut sender
+            ),
+            Err("offline")
+        );
+        let current_resolution = terminal_resolution(TerminalCombatSnapshot {
+            defeated_enemies: 0,
+            ..snapshot()
+        });
+        assert_eq!(current_resolution, None, "the original predicate recovered");
+        let retry_resolution = state
+            .pending_resolution
+            .or(current_resolution)
+            .expect("failed submission remains pending");
+        assert_eq!(
+            state.submit_terminal(retry_resolution, Duration::from_millis(999), &mut sender),
+            Ok(false)
+        );
+        assert_eq!(
+            state.submit_terminal(retry_resolution, Duration::from_secs(1), &mut sender),
+            Ok(true)
+        );
+        assert_eq!(
+            state.submit_terminal(
+                TacticalMissionResolution::Defeated,
+                Duration::from_secs(2),
+                &mut sender
+            ),
+            Ok(false)
+        );
+        assert_eq!(attempts, 2);
+        assert_eq!(
+            reports,
+            vec![
+                TacticalMissionResolution::Defeated,
+                TacticalMissionResolution::Defeated
+            ]
+        );
+    }
+
+    #[test]
+    fn sealed_empty_party_fails_only_after_reconnection_grace() {
+        let mut elapsed = Duration::ZERO;
+        assert!(!abandonment_due(
+            &mut elapsed,
+            true,
+            0,
+            false,
+            Duration::from_secs(9)
+        ));
+        assert!(!abandonment_due(
+            &mut elapsed,
+            true,
+            0,
+            true,
+            Duration::from_secs(1)
+        ));
+        assert_eq!(elapsed, Duration::ZERO);
+        assert!(abandonment_due(
+            &mut elapsed,
+            true,
+            0,
+            false,
+            PARTY_RECONNECT_GRACE
+        ));
+    }
+
+    #[test]
+    fn pending_second_party_member_prevents_enrollment_seal() {
+        assert!(!enrollment_ready(2, 1, false));
+        assert!(!enrollment_ready(2, 2, true));
+        assert!(enrollment_ready(2, 2, false));
+    }
+
+    #[test]
+    fn partially_enrolled_party_abandons_after_every_client_disconnects() {
+        let expected = 2;
+        let seen = HashSet::from([7]);
+        assert!(!enrollment_ready(expected, seen.len(), true));
+
+        let enrollment_begun = !seen.is_empty();
+        let mut elapsed = Duration::ZERO;
+        // B is still represented by LoadingPlayer, so its disconnect resets
+        // rather than advances the grace period.
+        assert!(!abandonment_due(
+            &mut elapsed,
+            enrollment_begun,
+            1,
+            true,
+            Duration::from_secs(5)
+        ));
+        // B's LoadingPlayer and then A's loaded entity disappear. Enrollment
+        // was already begun, so the same bounded abandonment policy applies.
+        assert!(abandonment_due(
+            &mut elapsed,
+            enrollment_begun,
+            0,
+            false,
+            PARTY_RECONNECT_GRACE
+        ));
+    }
+
+    #[test]
+    fn never_joined_timeout_disabled_server_does_not_abandon() {
+        let mut elapsed = Duration::ZERO;
+        assert!(!abandonment_due(
+            &mut elapsed,
+            false,
+            0,
+            false,
+            PARTY_RECONNECT_GRACE.saturating_mul(2)
+        ));
+        assert_eq!(elapsed, Duration::ZERO);
     }
 }

--- a/justfile
+++ b/justfile
@@ -283,7 +283,7 @@ _spawner-stop:
 # (written by `tactical-isolated`) when present, otherwise from the canonical
 # stack - so a bare `just tactical` targets whichever is currently running.
 tactical mission_id=env_var_or_default("TACTICAL_MISSION_ID", "test-mission") scene_key=env_var_or_default("TACTICAL_SCENE_KEY", "hills") bots=env_var_or_default("TACTICAL_BOTS", "3") port=env_var_or_default("TACTICAL_PORT", tactical_port) url=env_var_or_default("TACTICAL_SPACETIMEDB_URL", spacetime_url) module=env_var_or_default("TACTICAL_SPACETIMEDB_MODULE", spacetime_module):
-    @cargo run --package adventuresim-tactical-server --features "debug" -- --addr "0.0.0.0:{{ port }}" --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --spacetimedb-url {{ url }} --spacetimedb-module {{ module }} --required-enemy-kills {{ bots }} --enemy-combat-scale-bps 10000 --no-timeout
+    @cargo run --package adventuresim-tactical-server --features "debug" -- --addr "0.0.0.0:{{ port }}" --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --spacetimedb-url {{ url }} --spacetimedb-module {{ module }} --expected-party-members 1 --required-enemy-kills {{ bots }} --enemy-combat-scale-bps 10000 --no-timeout
 
 # Run a native tactical client (for testing `just tactical`). Defaults come
 # from `.env.tactical` when present, same as `tactical` above.

--- a/scripts/just_tasks.py
+++ b/scripts/just_tasks.py
@@ -529,7 +529,8 @@ def win_dev() -> int:
         server = subprocess.Popen([
             str(stage / "adventuresim-tactical-server.exe"), "--addr", "0.0.0.0:6000",
             "--mission-id", "test-mission", "--scene-key", "hills", "--spacetimedb-url",
-            SPACETIME_URL, "--spacetimedb-module", SPACETIME_DATABASE, "--bots", "3", "--no-timeout",
+            SPACETIME_URL, "--spacetimedb-module", SPACETIME_DATABASE,
+            "--expected-party-members", "1", "--bots", "3", "--no-timeout",
         ], cwd=stage)
         time.sleep(3)
         client = subprocess.Popen([

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -295,10 +295,27 @@ from starting incapacitation before recomputing them live. Actors currently
 over the threshold stop moving, attacking, defending, and participating in
 offensive AI target selection; imbalance-only incapacitation can recover.
 
-These per-tick effects remain in memory only. Incapacitation does not yet emit a
-terminal mission result or persist strategic wounds; required-kill missions
-still await the outcome and receipt branches. Ranged AI and durable combat
-consequences also remain unimplemented.
+These per-tick effects remain in memory only. A mission enemy's first transition
+into incapacitation counts as its defeat; recovery and later incapacitation do
+not count it again. Once all required enemies are defeated, the tactical server
+immediately reports `Defeated`. Once every loaded Party combatant is
+incapacitated, it immediately reports `Failed`; simultaneous defeat also fails
+deterministically. Strategic authority binds the expected living Party count
+into the request and active server records, and the trusted dispatcher passes
+it to the child. Resolution waits until every expected adventurer has loaded at
+least once, no player is still loading, and all required enemies have loaded.
+Enrollment is then sealed. Once enrollment has begun, an empty Party has a
+ten-second reconnection grace before `Failed`, including when every client
+disconnects before the seal. A timeout-disabled development server where nobody
+ever joins remains available. Terminal submission retries a frozen result after
+synchronous errors no more than once per second, before reevaluating combat
+predicates, and exits only after successful submission. A configured timeout
+remains a bounded `Failed` fallback.
+
+The strategic reducer selects and commits the durable outcome; the tactical
+server's XP argument is deliberately ignored. Tactical combat still does not
+persist strategic wounds or create an authenticated combat receipt. Ranged AI
+and durable combat consequences also remain unimplemented.
 
 Mission, hostile-group, battle, and outcome-source identities are separate.
 Tactical success never chooses a case objective, capture subject, contract

--- a/wiki/tactical/combat.md
+++ b/wiki/tactical/combat.md
@@ -56,10 +56,24 @@ selected by offensive AI; an imbalance-only incapacitation can recover and
 return the actor to combat. Limb and live combat-state replication provide
 basic client feedback, but all of this remains transient server memory.
 
+An enemy's first transition into incapacitation counts as its defeat, even if
+temporary imbalance later lets it recover. The server immediately ends the
+mission as `Defeated` after all required enemies have been defeated, or as
+`Failed` after all loaded Party combatants are incapacitated. Simultaneous
+defeat is a failure. Strategic authority binds the expected living Party size;
+the decision waits until every expected adventurer has loaded at least once,
+no player is still loading, and all required enemies are loaded. After that
+enrollment begins, an empty Party has a ten-second reconnection grace before the
+mission fails as abandoned, even if everyone disconnects before the seal. A
+timeout-disabled development server where nobody ever joins stays available.
+Terminal submission freezes the decided result and retries synchronous failures
+at one-second intervals before reevaluating combat, commits only after successful
+submission, and does not depend on the optional mission timeout; a configured
+timeout is only a bounded failure fallback.
+
 This is still an iteration harness rather than complete enemy decision-making.
 It does not pathfind around terrain or other combatants, handle ranged weapons,
-finish missions from incapacitation, persist injuries, or create strategic
-outcome receipts.
+persist injuries, or create strategic outcome receipts.
 
 ### Skill check algorithm
 Broadly speaking, the flow goes like this:


### PR DESCRIPTION
## Summary

Resolve tactical missions immediately from authoritative incapacitation state.

Mission enemies now count as defeated once when they transition into incapacitation. The tactical server reports `Defeated` when the required enemy objective is satisfied and `Failed` when the enrolled Party is incapacitated or abandons the mission. Simultaneous defeat deterministically fails.

Part of #360. Third stack layer; targets `codex/tactical-damage-incapacitation` (#363).

## Lifecycle and enrollment

- Strategic authority snapshots the expected living party count into the tactical request/server.
- The dispatcher and direct/isolated launchers pass that bound count to the child.
- Outcome evaluation waits until all expected party members have loaded at least once and no `LoadingPlayer` remains.
- Once enrollment begins, a fully disconnected party receives a ten-second reconnection grace, before or after the enrollment seal; a server with no join attempt does not abandon itself under `--no-timeout`.
- Required enemies must also be loaded before victory can resolve.

## One-shot terminal commit

Combat and timeout share one terminal-submission path. The first terminal result is frozen; synchronous reducer-send errors remain retryable with one-second backoff, even if mutable combat predicates later clear. `committed` and `AppExit` occur only after successful submission.

Configured timeout remains a `Failed` fallback. `--no-timeout` still resolves immediately from combat or post-enrollment abandonment.

The tactical child reports no arbitrary progression: XP is zero and strategically ignored, while strategic authority continues to select mission meaning and rewards.

## Independent review remediation

- Added authority-bound expected-party enrollment to prevent premature defeat while another member loads.
- Added bounded pre/post-seal disconnection handling so `--no-timeout` cannot strand after enrollment begins.
- Preserved zero-ever-joined no-timeout development servers.
- Made failed terminal submissions retryable independently of later combat-state recovery.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p adventuresim-tactical-server` — 19 passed
- `cargo check -p adventuresim-tactical-server-dispatcher`
- `cargo check -p strategic-web`
- `just verify-db-client`
- `just test-dev-stack` — 53 passed
- SpacetimeDB module release compilation during binding generation
- `git diff --check`

The generated project-map check has the same pre-existing stale result; this branch adds, removes, or repurposes no files.

## Limitations

This layer does not yet submit or persist the bounded tactical injury/equipment consequence receipt and does not add ranged combat.
