### PR TITLE
Add authoritative tactical ranged combat

### DIFF
--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -1,7 +1,7 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::ClientTriggerExt,
-    message::{DefendRequest, MeleeActionRequest},
+    message::{DefendRequest, MeleeActionRequest, RangedActionRequest},
 };
 use bevy::prelude::*;
 
@@ -84,14 +84,16 @@ pub struct LimbHitbox(pub BodyPart);
 pub struct AttackState {
     pub pre_hit_timer: Timer,
     pub reach: f32,
+    pub ranged: bool,
 }
 
 impl AttackState {
-    pub fn new(pre_hit_delay: f32, reach: f32) -> Self {
+    pub fn new(pre_hit_delay: f32, reach: f32, ranged: bool) -> Self {
         let pre_hit_timer = Timer::from_seconds(pre_hit_delay, TimerMode::Once);
         Self {
             pre_hit_timer,
             reach,
+            ranged,
         }
     }
 
@@ -247,7 +249,11 @@ fn update_attack_state_system(
         let origin = camera_transform.translation;
         let direction = camera_transform.forward();
         let filter = SpatialQueryFilter::from_mask(HITBOX_LAYER);
-        let reach = melee_interaction_range(state.reach);
+        let reach = if state.ranged {
+            state.reach
+        } else {
+            melee_interaction_range(state.reach)
+        };
 
         if let Some(hit) = spatial.cast_ray(origin, direction, reach, true, &filter) {
             let Ok((target, body_part)) = q_collider.get(hit.entity).map(|(c, h)| (c.body, h.0))
@@ -255,11 +261,19 @@ fn update_attack_state_system(
                 break;
             };
 
-            cmd.client_trigger(MeleeActionRequest::complete(
-                target,
-                body_part,
-                HIT_PRECISION,
-            ));
+            if state.ranged {
+                cmd.client_trigger(RangedActionRequest::complete(
+                    Some(target),
+                    body_part,
+                    HIT_PRECISION,
+                ));
+            } else {
+                cmd.client_trigger(MeleeActionRequest::complete(
+                    target,
+                    body_part,
+                    HIT_PRECISION,
+                ));
+            }
             cmd.trigger(HitPerformed {
                 entity: attacker,
                 direction,
@@ -267,6 +281,13 @@ fn update_attack_state_system(
                 length: hit.distance,
             });
         } else {
+            if state.ranged {
+                cmd.client_trigger(RangedActionRequest::complete(
+                    None,
+                    BodyPart::Chest,
+                    HIT_PRECISION,
+                ));
+            }
             cmd.trigger(HitPerformed {
                 entity: attacker,
                 direction,
@@ -287,17 +308,28 @@ fn on_attack_fired_hook(
         // already in attack
         return;
     }
-    let Ok(reach) = viewer
-        .get(event.context)
-        .map(|character| character.weapon_reach())
-    else {
+    let Ok((reach, ranged, melee)) = viewer.get(event.context).map(|character| {
+        (
+            character.weapon_reach(),
+            character.weapon_is_ranged(),
+            character.weapon_is_melee(),
+        )
+    }) else {
         warn!("Trying to attack, but can't get weapon reach. Not holding any weapons ?");
         return;
     };
 
+    if reach <= 0.0 || (!ranged && !melee) {
+        warn!("Trying to attack without a usable equipped weapon");
+        return;
+    }
     cmd.entity(event.context)
-        .insert(AttackState::new(PRE_HIT_DELAY, reach));
-    cmd.client_trigger(MeleeActionRequest::start());
+        .insert(AttackState::new(PRE_HIT_DELAY, reach, ranged));
+    if ranged {
+        cmd.client_trigger(RangedActionRequest::start());
+    } else {
+        cmd.client_trigger(MeleeActionRequest::start());
+    }
 }
 
 fn update_character_look_rotation(

--- a/crates/adventuresim-tactical-core/src/inventory.rs
+++ b/crates/adventuresim-tactical-core/src/inventory.rs
@@ -201,6 +201,13 @@ impl InventoryView<'_, '_, '_> {
         self.q_item.iter_many(items)
     }
 
+    /// Returns whether this actor owns a non-empty stack of the requested
+    /// tactical item without scanning other actors' inventories.
+    pub fn has_item_id(&self, item_id: &str) -> bool {
+        self.iter()
+            .any(|item| item.properties.id == item_id && item.quantity.0.get() > 0)
+    }
+
     fn equipped_weapon(&self) -> Option<ItemQueryItem<'_, '_>> {
         self.q_inventory
             .get(self.entity)

--- a/crates/adventuresim-tactical-core/src/inventory.rs
+++ b/crates/adventuresim-tactical-core/src/inventory.rs
@@ -71,6 +71,11 @@ pub struct WeaponItem {
     pub reach: f32,
     pub balance: f32,
     pub precise: bool,
+    pub melee: bool,
+    pub ranged: bool,
+    pub blunt: bool,
+    pub slash: bool,
+    pub pierce: bool,
 }
 
 #[derive(Component, Reflect, Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
@@ -271,6 +276,36 @@ impl PlayerEquipment for InventoryView<'_, '_, '_> {
             .and_then(|item| item.weapon)
             .map(|weapon| weapon.accuracy)
             .unwrap_or_default()
+    }
+
+    fn weapon_is_melee(&self) -> bool {
+        self.equipped_weapon()
+            .and_then(|item| item.weapon)
+            .is_some_and(|weapon| weapon.melee)
+    }
+
+    fn weapon_is_ranged(&self) -> bool {
+        self.equipped_weapon()
+            .and_then(|item| item.weapon)
+            .is_some_and(|weapon| weapon.ranged)
+    }
+
+    fn weapon_does_blunt(&self) -> bool {
+        self.equipped_weapon()
+            .and_then(|item| item.weapon)
+            .is_some_and(|weapon| weapon.blunt)
+    }
+
+    fn weapon_does_slash(&self) -> bool {
+        self.equipped_weapon()
+            .and_then(|item| item.weapon)
+            .is_some_and(|weapon| weapon.slash)
+    }
+
+    fn weapon_does_pierce(&self) -> bool {
+        self.equipped_weapon()
+            .and_then(|item| item.weapon)
+            .is_some_and(|weapon| weapon.pierce)
     }
 
     fn weapon_holding_side(&self) -> Option<BodySide> {

--- a/crates/adventuresim-tactical-netcode/src/lib.rs
+++ b/crates/adventuresim-tactical-netcode/src/lib.rs
@@ -19,6 +19,7 @@ pub mod prelude {
     pub use crate::client::AdventureSimulatorClient;
     pub use crate::message::{
         DefendRequest, JoinRequest, MeleeActionPhase, MeleeActionRequest, PlayerInputRequest,
+        RangedActionPhase, RangedActionRequest,
     };
     #[cfg(feature = "server")]
     pub use crate::server::AdventureSimulatorServer;

--- a/crates/adventuresim-tactical-netcode/src/message.rs
+++ b/crates/adventuresim-tactical-netcode/src/message.rs
@@ -63,6 +63,43 @@ impl MeleeActionRequest {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RangedActionPhase {
+    Start,
+    Complete,
+}
+
+/// Both ranged phases share one mapped ordered stream. A completion may omit
+/// a target when the client-fired shot missed, but it still consumes ammo.
+#[derive(Debug, Clone, Copy, Event, Serialize, Deserialize, MapEntities)]
+pub struct RangedActionRequest {
+    pub phase: RangedActionPhase,
+    #[entities]
+    pub target: Option<Entity>,
+    pub body_part: BodyPart,
+    pub hit_precision: f32,
+}
+
+impl RangedActionRequest {
+    pub fn start() -> Self {
+        Self {
+            phase: RangedActionPhase::Start,
+            target: None,
+            body_part: BodyPart::Chest,
+            hit_precision: 0.0,
+        }
+    }
+
+    pub fn complete(target: Option<Entity>, body_part: BodyPart, hit_precision: f32) -> Self {
+        Self {
+            phase: RangedActionPhase::Complete,
+            target,
+            body_part,
+            hit_precision,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Event, Serialize, Deserialize, MapEntities)]
 pub struct SuccessfulAttackResponse {
     #[entities]

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -5,7 +5,8 @@ use bevy_replicon::prelude::*;
 
 use crate::FIXED_TIMESTEP_HZ;
 use crate::message::{
-    DefendRequest, JoinRequest, MeleeActionRequest, PlayerInputRequest, SuccessfulAttackResponse,
+    DefendRequest, JoinRequest, MeleeActionRequest, PlayerInputRequest, RangedActionRequest,
+    SuccessfulAttackResponse,
 };
 
 #[derive(Default)]
@@ -41,6 +42,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .add_client_event::<PlayerInputRequest>(Channel::Unreliable)
             .add_client_event::<DefendRequest>(Channel::Unreliable)
             .add_mapped_client_event::<MeleeActionRequest>(Channel::Ordered)
+            .add_mapped_client_event::<RangedActionRequest>(Channel::Ordered)
             .add_mapped_server_event::<SuccessfulAttackResponse>(Channel::Ordered);
 
         // Replicating physics components since those don't change and

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -10,7 +10,8 @@ use crate::{
     MissionState,
     combat::{
         Incapacitated, MeleeAttackIntent, MeleeAttackStartedIntent, PendingDefenderResponse,
-        TacticalCombatSide, TacticalCombatantDefeated,
+        RangedAttackIntent, RangedAttackStartedIntent, TacticalCombatSide,
+        TacticalCombatantDefeated,
     },
 };
 
@@ -32,13 +33,22 @@ const AI_HIT_PRECISION: f32 = 1.0;
 const AI_BODY_PART: BodyPart = BodyPart::Chest;
 const AI_WINDUP_SECS: f32 = 0.5;
 const AI_COOLDOWN_SECS: f32 = 1.0;
+const AI_RANGED_MIN_STANDOFF: f32 = 1.5;
+const AI_RANGED_MAX_STANDOFF: f32 = 12.0;
+const AI_RANGED_STANDOFF_SLOP: f32 = 0.5;
+const ARROW_ITEM_ID: &str = "arrow";
+
+fn ranged_weapon_needs_ammo_lookup(weapon_is_ranged: bool, weapon_reach: f32) -> bool {
+    weapon_is_ranged && weapon_reach.is_finite() && weapon_reach > 0.0
+}
 
 /// Marks a server-controlled bot filling in for a temporary (non-connected)
 /// mission character.
 #[derive(Component)]
 pub struct MissionEnemy;
 
-/// Enables server-owned, direct-pursuit melee control for a combatant.
+/// Enables server-owned offensive control, preferring ranged fire while a
+/// usable ranged weapon and arrows are available and otherwise using melee.
 #[derive(Component, Debug)]
 pub struct OffensiveMeleeAi {
     target: Option<Entity>,
@@ -57,7 +67,8 @@ impl Default for OffensiveMeleeAi {
 #[derive(Debug)]
 enum OffensiveMeleePhase {
     Pursuing,
-    Windup(Timer),
+    MeleeWindup(Timer),
+    RangedWindup(Timer),
     Cooldown(Timer),
 }
 
@@ -80,6 +91,7 @@ impl Plugin for BotPlugin {
         app.add_observer(on_tactical_combatant_defeated)
             .add_observer(on_attack_started)
             .add_observer(on_targeted_attack_started)
+            .add_observer(on_targeted_ranged_attack_started)
             .add_systems(Update, (drive_offensive_melee_ai, tick_bot_reactions));
     }
 }
@@ -147,6 +159,23 @@ fn on_targeted_attack_started(
     };
     if q_ai.get(event.target).is_ok() {
         try_start_reaction(&mut cmd, event.target, attacker_look, defender_look);
+    }
+}
+
+fn on_targeted_ranged_attack_started(
+    event: On<RangedAttackStartedIntent>,
+    mut cmd: Commands,
+    q_character: Query<&CharacterLook>,
+    q_ai: Query<&CharacterLook, (With<OffensiveMeleeAi>, Without<Incapacitated>)>,
+) {
+    let Some(target) = event.target else {
+        return;
+    };
+    let Ok([attacker_look, defender_look]) = q_character.get_many([event.attacker, target]) else {
+        return;
+    };
+    if q_ai.get(target).is_ok() {
+        try_start_reaction(&mut cmd, target, attacker_look, defender_look);
     }
 }
 
@@ -238,21 +267,57 @@ fn drive_offensive_melee_ai(
         if distance > f32::EPSILON {
             look.yaw = (-offset.x).atan2(-offset.y);
         }
-        let weapon_reach = viewer
+        let (weapon_reach, weapon_is_melee, weapon_is_ranged) = viewer
             .get(entity)
-            .map(|view| view.weapon_reach())
+            .map(|view| {
+                (
+                    view.weapon_reach(),
+                    view.weapon_is_melee(),
+                    view.weapon_is_ranged(),
+                )
+            })
             .unwrap_or_default();
+        let has_ammo = ranged_weapon_needs_ammo_lookup(weapon_is_ranged, weapon_reach)
+            && viewer.inventory.get(entity).has_item_id(ARROW_ITEM_ID);
+        let use_ranged = weapon_is_ranged && weapon_reach > 0.0 && has_ammo;
         let interaction_range = melee_interaction_range(weapon_reach);
 
-        if !matches!(&controller.phase, OffensiveMeleePhase::Pursuing)
-            && (weapon_reach <= 0.0 || distance > interaction_range)
-        {
+        let abort_windup = matches!(
+            &controller.phase,
+            OffensiveMeleePhase::MeleeWindup(_)
+                if !weapon_is_melee || weapon_reach <= 0.0 || distance > interaction_range
+        ) || matches!(
+            &controller.phase,
+            OffensiveMeleePhase::RangedWindup(_) if !use_ranged || distance > weapon_reach
+        );
+        if abort_windup {
             controller.phase = OffensiveMeleePhase::Pursuing;
         }
 
         match &mut controller.phase {
+            OffensiveMeleePhase::Pursuing if use_ranged => {
+                let standoff = (weapon_reach * 0.5)
+                    .clamp(AI_RANGED_MIN_STANDOFF, AI_RANGED_MAX_STANDOFF)
+                    .min(weapon_reach);
+                if distance > weapon_reach || distance > standoff + AI_RANGED_STANDOFF_SLOP {
+                    input.last_movement = Some(Vec2::Y);
+                } else if distance + AI_RANGED_STANDOFF_SLOP < standoff {
+                    input.last_movement = Some(-Vec2::Y);
+                } else {
+                    input.last_movement = None;
+                    cmd.trigger(RangedAttackStartedIntent {
+                        attacker: entity,
+                        target: Some(target),
+                        windup_secs: AI_WINDUP_SECS,
+                    });
+                    controller.phase = OffensiveMeleePhase::RangedWindup(Timer::from_seconds(
+                        AI_WINDUP_SECS,
+                        TimerMode::Once,
+                    ));
+                }
+            }
             OffensiveMeleePhase::Pursuing
-                if weapon_reach > 0.0 && distance <= interaction_range =>
+                if weapon_is_melee && weapon_reach > 0.0 && distance <= interaction_range =>
             {
                 input.last_movement = None;
                 cmd.trigger(MeleeAttackStartedIntent {
@@ -260,7 +325,7 @@ fn drive_offensive_melee_ai(
                     target,
                     windup_secs: AI_WINDUP_SECS,
                 });
-                controller.phase = OffensiveMeleePhase::Windup(Timer::from_seconds(
+                controller.phase = OffensiveMeleePhase::MeleeWindup(Timer::from_seconds(
                     AI_WINDUP_SECS,
                     TimerMode::Once,
                 ));
@@ -268,13 +333,29 @@ fn drive_offensive_melee_ai(
             OffensiveMeleePhase::Pursuing => {
                 input.last_movement = Some(Vec2::Y);
             }
-            OffensiveMeleePhase::Windup(timer) => {
+            OffensiveMeleePhase::MeleeWindup(timer) => {
                 input.last_movement = None;
                 timer.tick(time.delta());
                 if timer.is_finished() {
                     cmd.trigger(MeleeAttackIntent {
                         attacker: entity,
                         target,
+                        body_part: AI_BODY_PART,
+                        hit_precision: AI_HIT_PRECISION,
+                    });
+                    controller.phase = OffensiveMeleePhase::Cooldown(Timer::from_seconds(
+                        AI_COOLDOWN_SECS,
+                        TimerMode::Once,
+                    ));
+                }
+            }
+            OffensiveMeleePhase::RangedWindup(timer) => {
+                input.last_movement = None;
+                timer.tick(time.delta());
+                if timer.is_finished() {
+                    cmd.trigger(RangedAttackIntent {
+                        attacker: entity,
+                        target: Some(target),
                         body_part: AI_BODY_PART,
                         hit_precision: AI_HIT_PRECISION,
                     });
@@ -328,15 +409,27 @@ fn tick_bot_reactions(
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{num::NonZeroU32, time::Duration};
 
     use super::*;
 
     #[derive(Resource, Default)]
     struct RecordedAttacks(Vec<(Entity, Entity)>);
 
+    #[derive(Resource, Default)]
+    struct RecordedRangedAttacks(Vec<(Entity, Entity)>);
+
     fn record_attack(event: On<MeleeAttackIntent>, mut attacks: ResMut<RecordedAttacks>) {
         attacks.0.push((event.attacker, event.target));
+    }
+
+    fn record_ranged_attack(
+        event: On<RangedAttackIntent>,
+        mut attacks: ResMut<RecordedRangedAttacks>,
+    ) {
+        if let Some(target) = event.target {
+            attacks.0.push((event.attacker, target));
+        }
     }
 
     fn apply_deterministic_test_hit(
@@ -399,13 +492,121 @@ mod tests {
         actor
     }
 
+    fn spawn_test_ranged_ai(
+        world: &mut World,
+        side: TacticalCombatSide,
+        position: Vec3,
+    ) -> (Entity, Entity) {
+        const TEST_WEAPON_REACH: f32 = 8.0;
+        let actor = world
+            .spawn((
+                Player::default(),
+                Transform::from_translation(position),
+                side,
+                CharacterLook::default(),
+                input::AccumulatedInput::default(),
+                OffensiveMeleeAi::default(),
+                TacticalCombatState::default(),
+            ))
+            .id();
+        let weapon = world.spawn(ItemOf(actor)).id();
+        world.entity_mut(weapon).insert(WeaponItem {
+            skill_weights: [0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+            accuracy: 1.0,
+            penetration: 1.0,
+            reach: TEST_WEAPON_REACH,
+            balance: 0.0,
+            precise: false,
+            melee: true,
+            ranged: true,
+            blunt: false,
+            slash: false,
+            pierce: true,
+        });
+        world.entity_mut(weapon).insert(EquipSlot::HoldingRight);
+        let ammo = world
+            .spawn((
+                ItemOf(actor),
+                ItemProperties {
+                    id: ARROW_ITEM_ID.to_owned(),
+                    weight: 0.05,
+                },
+                ItemQuantity(NonZeroU32::new(1).unwrap()),
+            ))
+            .id();
+        (actor, ammo)
+    }
+
+    fn spawn_test_target(world: &mut World, side: TacticalCombatSide, position: Vec3) -> Entity {
+        world
+            .spawn((
+                Player::default(),
+                Transform::from_translation(position),
+                side,
+                CharacterLook::default(),
+                TacticalCombatState::default(),
+            ))
+            .id()
+    }
+
     fn test_app() -> App {
         let mut app = App::new();
         app.insert_resource(Time::<()>::default())
             .init_resource::<RecordedAttacks>()
+            .init_resource::<RecordedRangedAttacks>()
             .add_observer(record_attack)
+            .add_observer(record_ranged_attack)
             .add_systems(Update, drive_offensive_melee_ai);
         app
+    }
+
+    #[test]
+    fn ranged_ai_fires_then_falls_back_to_melee_when_ammo_is_exhausted() {
+        assert!(!ranged_weapon_needs_ammo_lookup(false, 1.0));
+        assert!(!ranged_weapon_needs_ammo_lookup(true, 0.0));
+        assert!(ranged_weapon_needs_ammo_lookup(true, 8.0));
+        let mut app = test_app();
+        let (actor, ammo) = spawn_test_ranged_ai(
+            app.world_mut(),
+            TacticalCombatSide::Enemy,
+            Vec3::new(0.0, 0.0, 2.0),
+        );
+        let target = spawn_test_target(
+            app.world_mut(),
+            TacticalCombatSide::Party,
+            Vec3::new(0.0, 0.0, -2.0),
+        );
+
+        for _ in 0..7 {
+            app.world_mut()
+                .resource_mut::<Time<()>>()
+                .advance_by(Duration::from_millis(100));
+            app.update();
+        }
+        assert_eq!(
+            app.world().resource::<RecordedRangedAttacks>().0,
+            vec![(actor, target)]
+        );
+        assert!(app.world().resource::<RecordedAttacks>().0.is_empty());
+
+        // Production consumes this through `resolve_ranged_attack`; removing
+        // it here isolates deterministic controller selection from physics.
+        app.world_mut().despawn(ammo);
+        for _ in 0..20 {
+            app.world_mut()
+                .resource_mut::<Time<()>>()
+                .advance_by(Duration::from_millis(100));
+            app.update();
+        }
+
+        assert!(
+            app.world()
+                .resource::<RecordedAttacks>()
+                .0
+                .contains(&(actor, target)),
+            "ammo exhaustion should return a melee-capable weapon to melee cadence"
+        );
+        assert_eq!(app.world().resource::<RecordedRangedAttacks>().0.len(), 1);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -389,6 +389,11 @@ mod tests {
             reach: KATZBALGER_REACH,
             balance: 0.0,
             precise: false,
+            melee: true,
+            ranged: false,
+            blunt: false,
+            slash: true,
+            pierce: false,
         });
         world.entity_mut(weapon).insert(EquipSlot::HoldingRight);
         actor

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -172,6 +172,15 @@ pub struct RangedAttackIntent {
     pub hit_precision: f32,
 }
 
+/// Announces a server-observed ranged windup. Clients and server-owned AI use
+/// this same seam before completing a shot.
+#[derive(Event, Clone, Copy, Debug)]
+pub struct RangedAttackStartedIntent {
+    pub attacker: Entity,
+    pub target: Option<Entity>,
+    pub windup_secs: f32,
+}
+
 #[derive(Event, Clone, Copy, Debug)]
 struct ApplyMeleeAttackResult {
     attacker: Entity,
@@ -366,6 +375,7 @@ impl Plugin for CombatPlugin {
         app.init_resource::<TacticalConsequenceAccumulator>()
             .add_observer(on_melee_action_request)
             .add_observer(on_ranged_action_request)
+            .add_observer(on_ranged_attack_started)
             .add_observer(on_melee_attack_started)
             .add_observer(resolve_melee_attack)
             .add_observer(resolve_ranged_attack)
@@ -486,12 +496,7 @@ fn on_melee_action_request(
     }
 }
 
-fn on_ranged_action_request(
-    event: On<FromClient<RangedActionRequest>>,
-    mut cmd: Commands,
-    time: Res<Time<()>>,
-    mut authorities: Query<&mut RangedAttackAuthority>,
-) {
+fn on_ranged_action_request(event: On<FromClient<RangedActionRequest>>, mut cmd: Commands) {
     let Some(attacker) = event.client_id.entity() else {
         debug!(
             "Ignoring ranged action from unknown client: {:?}",
@@ -501,13 +506,10 @@ fn on_ranged_action_request(
     };
     match event.phase {
         RangedActionPhase::Start => {
-            let Ok(mut authority) = authorities.get_mut(attacker) else {
-                return;
-            };
-            let ready_at = time.elapsed_secs() + CLIENT_RANGED_WINDUP_SECS;
-            authority.windup = Some(ObservedRangedWindup {
-                ready_at,
-                expires_at: ready_at + RANGED_NETWORK_ALLOWANCE_SECS,
+            cmd.trigger(RangedAttackStartedIntent {
+                attacker,
+                target: None,
+                windup_secs: CLIENT_RANGED_WINDUP_SECS,
             });
         }
         RangedActionPhase::Complete => {
@@ -521,6 +523,21 @@ fn on_ranged_action_request(
             });
         }
     }
+}
+
+fn on_ranged_attack_started(
+    event: On<RangedAttackStartedIntent>,
+    mut authorities: Query<&mut RangedAttackAuthority>,
+    time: Res<Time<()>>,
+) {
+    let Ok(mut authority) = authorities.get_mut(event.attacker) else {
+        return;
+    };
+    let ready_at = time.elapsed_secs() + event.windup_secs.max(0.0);
+    authority.windup = Some(ObservedRangedWindup {
+        ready_at,
+        expires_at: ready_at + RANGED_NETWORK_ALLOWANCE_SECS,
+    });
 }
 
 fn authoritative_line_of_sight(

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -1,10 +1,13 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::{FromClient, SendMode, ServerTriggerExt, ToClients},
-    message::{DefendRequest, MeleeActionPhase, MeleeActionRequest, SuccessfulAttackResponse},
+    message::{
+        DefendRequest, MeleeActionPhase, MeleeActionRequest, RangedActionPhase,
+        RangedActionRequest, SuccessfulAttackResponse,
+    },
 };
 use bevy::prelude::*;
-use std::collections::HashMap;
+use std::{collections::HashMap, num::NonZeroU32};
 
 #[derive(Clone, Debug)]
 pub(crate) struct AppliedTacticalInjury {
@@ -18,6 +21,7 @@ pub(crate) struct AppliedTacticalInjury {
 pub(crate) struct AccumulatedPartyConsequence {
     pub injuries: Vec<AppliedTacticalInjury>,
     pub blood_loss_fraction: f32,
+    pub ammunition_used: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -46,6 +50,14 @@ const MELEE_WINDUP_NETWORK_ALLOWANCE_SECS: f32 = 1.0;
 /// Allows bounded movement between the authoritative physics snapshot and an
 /// ordered attack request arriving at the server.
 const MELEE_RANGE_LATENCY_TOLERANCE: f32 = 0.25;
+const CLIENT_RANGED_WINDUP_SECS: f32 = 0.3;
+const RANGED_COOLDOWN_SECS: f32 = 0.6;
+const RANGED_NETWORK_ALLOWANCE_SECS: f32 = 1.0;
+const RANGED_RANGE_LATENCY_TOLERANCE: f32 = 0.5;
+/// The server owns yaw but not full skeletal/secondary animation. Permit a
+/// small network/input cone while still rejecting targets behind the shooter.
+const RANGED_AIM_CONE_DEGREES: f32 = 20.0;
+const ARROW_ITEM_ID: &str = "arrow";
 
 /// Stores the defender's most recent dodge/parry choice along with the
 /// server timestamp when it was received. Consumed on each attack resolution.
@@ -80,6 +92,33 @@ struct ObservedMeleeWindup {
 pub(crate) struct MeleeAttackAuthority {
     windup: Option<ObservedMeleeWindup>,
     cooldown_until: f32,
+}
+
+#[derive(Debug)]
+struct ObservedRangedWindup {
+    ready_at: f32,
+    expires_at: f32,
+}
+
+#[derive(Component, Debug, Default)]
+pub(crate) struct RangedAttackAuthority {
+    windup: Option<ObservedRangedWindup>,
+    cooldown_until: f32,
+}
+
+fn consume_ranged_authority(authority: &mut RangedAttackAuthority, now: f32) -> bool {
+    let valid = authority.windup.as_ref().is_some_and(|windup| {
+        now >= windup.ready_at && now <= windup.expires_at && now >= authority.cooldown_until
+    });
+    if valid {
+        authority.windup = None;
+        authority.cooldown_until = now + RANGED_COOLDOWN_SECS;
+    }
+    valid
+}
+
+fn remaining_ammo_after_shot(quantity: NonZeroU32) -> Option<NonZeroU32> {
+    NonZeroU32::new(quantity.get() - 1)
 }
 
 fn consume_melee_authority(authority: &mut MeleeAttackAuthority, target: Entity, now: f32) -> bool {
@@ -123,6 +162,16 @@ pub struct MeleeAttackStartedIntent {
     pub windup_secs: f32,
 }
 
+/// A server-internal fired shot. `target == None` is an authoritative miss
+/// that still consumes one projectile after the firing gate succeeds.
+#[derive(Event, Clone, Copy, Debug)]
+pub struct RangedAttackIntent {
+    pub attacker: Entity,
+    pub target: Option<Entity>,
+    pub body_part: BodyPart,
+    pub hit_precision: f32,
+}
+
 #[derive(Event, Clone, Copy, Debug)]
 struct ApplyMeleeAttackResult {
     attacker: Entity,
@@ -131,6 +180,100 @@ struct ApplyMeleeAttackResult {
     result: AttackResult,
     attacker_weapon_slot: EquipSlot,
     defender_parry_slot: Option<EquipSlot>,
+    attacker_weapon_contact: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RangedIntentRejection {
+    SelfTarget,
+    MissingSide,
+    MissingCombatState,
+    FriendlyTarget,
+    Incapacitated,
+    NonFinitePrecision,
+    NotRanged,
+    OutOfRange,
+    OutsideAimCone,
+    Windup,
+    Cooldown,
+    BlockedLineOfSight,
+}
+
+#[derive(Clone, Copy)]
+struct RangedIntentFacts {
+    attacker: Entity,
+    target: Option<Entity>,
+    attacker_side: Option<TacticalCombatSide>,
+    target_side: Option<TacticalCombatSide>,
+    attacker_incapacitated: Option<bool>,
+    target_incapacitated: Option<bool>,
+    hit_precision: f32,
+    weapon_is_ranged: bool,
+    weapon_range: f32,
+    separation: Option<f32>,
+    target_in_aim_cone: Option<bool>,
+    windup_ready: bool,
+    windup_unexpired: bool,
+    cooldown_ready: bool,
+}
+
+fn validate_ranged_intent(facts: RangedIntentFacts) -> Result<(), RangedIntentRejection> {
+    if facts.target == Some(facts.attacker) {
+        return Err(RangedIntentRejection::SelfTarget);
+    }
+    let Some(attacker_side) = facts.attacker_side else {
+        return Err(RangedIntentRejection::MissingSide);
+    };
+    let Some(attacker_incapacitated) = facts.attacker_incapacitated else {
+        return Err(RangedIntentRejection::MissingCombatState);
+    };
+    if attacker_incapacitated {
+        return Err(RangedIntentRejection::Incapacitated);
+    }
+    if !facts.hit_precision.is_finite() {
+        return Err(RangedIntentRejection::NonFinitePrecision);
+    }
+    if !facts.weapon_is_ranged || !facts.weapon_range.is_finite() || facts.weapon_range <= 0.0 {
+        return Err(RangedIntentRejection::NotRanged);
+    }
+    if let Some(_) = facts.target {
+        let Some(target_side) = facts.target_side else {
+            return Err(RangedIntentRejection::MissingSide);
+        };
+        let Some(target_incapacitated) = facts.target_incapacitated else {
+            return Err(RangedIntentRejection::MissingCombatState);
+        };
+        if attacker_side == target_side {
+            return Err(RangedIntentRejection::FriendlyTarget);
+        }
+        if target_incapacitated {
+            return Err(RangedIntentRejection::Incapacitated);
+        }
+        if !facts.separation.is_some_and(|distance| {
+            distance.is_finite() && distance <= facts.weapon_range + RANGED_RANGE_LATENCY_TOLERANCE
+        }) {
+            return Err(RangedIntentRejection::OutOfRange);
+        }
+        if facts.target_in_aim_cone != Some(true) {
+            return Err(RangedIntentRejection::OutsideAimCone);
+        }
+    }
+    if !facts.windup_ready || !facts.windup_unexpired {
+        return Err(RangedIntentRejection::Windup);
+    }
+    if !facts.cooldown_ready {
+        return Err(RangedIntentRejection::Cooldown);
+    }
+    Ok(())
+}
+
+fn ranged_target_in_aim_cone(yaw: f32, attacker: Vec3, target: Vec3) -> bool {
+    let offset = target.xz() - attacker.xz();
+    let Some(direction) = offset.try_normalize() else {
+        return false;
+    };
+    let forward = Vec2::new(-yaw.sin(), -yaw.cos());
+    direction.dot(forward) >= RANGED_AIM_CONE_DEGREES.to_radians().cos()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -222,8 +365,10 @@ impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<TacticalConsequenceAccumulator>()
             .add_observer(on_melee_action_request)
+            .add_observer(on_ranged_action_request)
             .add_observer(on_melee_attack_started)
             .add_observer(resolve_melee_attack)
+            .add_observer(resolve_ranged_attack)
             .add_observer(apply_melee_attack_result)
             .add_observer(on_defender_response)
             .add_systems(Update, update_tactical_combat_state);
@@ -334,6 +479,43 @@ fn on_melee_action_request(
             cmd.trigger(MeleeAttackIntent {
                 attacker,
                 target,
+                body_part: event.body_part,
+                hit_precision: event.hit_precision,
+            });
+        }
+    }
+}
+
+fn on_ranged_action_request(
+    event: On<FromClient<RangedActionRequest>>,
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    mut authorities: Query<&mut RangedAttackAuthority>,
+) {
+    let Some(attacker) = event.client_id.entity() else {
+        debug!(
+            "Ignoring ranged action from unknown client: {:?}",
+            event.client_id
+        );
+        return;
+    };
+    match event.phase {
+        RangedActionPhase::Start => {
+            let Ok(mut authority) = authorities.get_mut(attacker) else {
+                return;
+            };
+            let ready_at = time.elapsed_secs() + CLIENT_RANGED_WINDUP_SECS;
+            authority.windup = Some(ObservedRangedWindup {
+                ready_at,
+                expires_at: ready_at + RANGED_NETWORK_ALLOWANCE_SECS,
+            });
+        }
+        RangedActionPhase::Complete => {
+            // Finite precision is deliberately trusted. Animation and
+            // secondary physics remain client-owned and non-deterministic.
+            cmd.trigger(RangedAttackIntent {
+                attacker,
+                target: event.target,
                 body_part: event.body_part,
                 hit_precision: event.hit_precision,
             });
@@ -500,6 +682,7 @@ fn resolve_melee_attack(
         result,
         attacker_weapon_slot,
         defender_parry_slot,
+        attacker_weapon_contact: true,
     });
 
     match result {
@@ -529,6 +712,177 @@ fn resolve_melee_attack(
         message: SuccessfulAttackResponse {
             attacker: entity,
             hit: vec![event.target],
+            body_part: event.body_part,
+            result,
+            flanking,
+            defender_response,
+        },
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn resolve_ranged_attack(
+    event: On<RangedAttackIntent>,
+    mut cmd: Commands,
+    viewer: TacticalPlayerViewer,
+    spatial: SpatialQuery,
+    q_character: Query<(&CharacterLook, &Transform)>,
+    q_sides: Query<&TacticalCombatSide>,
+    q_states: Query<&TacticalCombatState>,
+    mut q_authorities: Query<&mut RangedAttackAuthority>,
+    q_bestiary_categories: Query<&BestiaryCategories>,
+    q_pending: Query<&PendingDefenderResponse>,
+    q_ammo: Query<(Entity, &ItemOf, &ItemProperties, &ItemQuantity)>,
+    q_ids: Query<&PlayerId>,
+    mut consequences: ResMut<TacticalConsequenceAccumulator>,
+    time: Res<Time<()>>,
+) {
+    let attacker = event.attacker;
+    let Ok(attacker_view) = viewer.get(attacker) else {
+        return;
+    };
+    let Ok((attacker_look, attacker_transform)) = q_character.get(attacker) else {
+        return;
+    };
+    let target_character = event.target.and_then(|target| q_character.get(target).ok());
+    let now = time.elapsed_secs();
+    let Ok(mut authority) = q_authorities.get_mut(attacker) else {
+        return;
+    };
+    let windup = authority.windup.as_ref();
+    let facts = RangedIntentFacts {
+        attacker,
+        target: event.target,
+        attacker_side: q_sides.get(attacker).ok().copied(),
+        target_side: event
+            .target
+            .and_then(|target| q_sides.get(target).ok().copied()),
+        attacker_incapacitated: q_states.get(attacker).ok().map(|state| state.incapacitated),
+        target_incapacitated: event
+            .target
+            .and_then(|target| q_states.get(target).ok().map(|state| state.incapacitated)),
+        hit_precision: event.hit_precision,
+        weapon_is_ranged: attacker_view.weapon_is_ranged(),
+        weapon_range: attacker_view.weapon_reach(),
+        separation: target_character.map(|(_, transform)| {
+            attacker_transform
+                .translation
+                .distance(transform.translation)
+        }),
+        target_in_aim_cone: target_character.map(|(_, transform)| {
+            ranged_target_in_aim_cone(
+                attacker_look.yaw,
+                attacker_transform.translation,
+                transform.translation,
+            )
+        }),
+        windup_ready: windup.is_some_and(|windup| now >= windup.ready_at),
+        windup_unexpired: windup.is_some_and(|windup| now <= windup.expires_at),
+        cooldown_ready: now >= authority.cooldown_until,
+    };
+    if let Err(reason) = validate_ranged_intent(facts) {
+        if !matches!(
+            reason,
+            RangedIntentRejection::Windup | RangedIntentRejection::Cooldown
+        ) {
+            debug!("Rejected ranged intent from {attacker:?}: {reason:?}");
+        }
+        return;
+    }
+    if let (Some(target), Some((_, target_transform))) = (event.target, target_character) {
+        let line_of_sight = authoritative_line_of_sight(
+            &spatial,
+            attacker,
+            target,
+            attacker_transform.translation,
+            target_transform.translation,
+        );
+        if !line_of_sight {
+            debug!(
+                "Rejected ranged intent from {attacker:?}: {:?}",
+                RangedIntentRejection::BlockedLineOfSight
+            );
+            return;
+        }
+    }
+    if !consume_ranged_authority(&mut authority, now) {
+        return;
+    }
+
+    // Only an otherwise-authorized shot reaches the global inventory scan.
+    // A dry fire still consumes its windup/cooldown, bounding repeated scans.
+    let ammo = q_ammo.iter().find(|(_, owner, properties, quantity)| {
+        owner.0 == attacker && properties.id == ARROW_ITEM_ID && quantity.0.get() > 0
+    });
+    let Some((ammo_entity, _, _, quantity)) = ammo else {
+        return;
+    };
+    if let Some(remaining) = remaining_ammo_after_shot(quantity.0) {
+        cmd.entity(ammo_entity).insert(ItemQuantity(remaining));
+    } else {
+        cmd.entity(ammo_entity).despawn();
+    }
+    if q_sides
+        .get(attacker)
+        .is_ok_and(|side| *side == TacticalCombatSide::Party)
+        && let Ok(player_id) = q_ids.get(attacker)
+    {
+        record_party_ammunition_use(&mut consequences, player_id.0);
+    }
+
+    let Some(target) = event.target else {
+        return;
+    };
+    let Ok(defender_view) = viewer.get(target) else {
+        return;
+    };
+    let Some((defender_look, _)) = target_character else {
+        return;
+    };
+    let (a2, a1) = attacker_look.yaw.sin_cos();
+    let (d2, d1) = defender_look.yaw.sin_cos();
+    let flanking = flanking_from_dir((a1, a2), (d1, d2));
+    let defender_response =
+        resolve_defender_response(q_pending.get(target).ok(), &time, &defender_view);
+    cmd.entity(target).remove::<PendingDefenderResponse>();
+    let fallback_categories = BestiaryCategories::default();
+    let defender_categories = q_bestiary_categories
+        .get(target)
+        .unwrap_or(&fallback_categories);
+    let result = attacker_view.resolve_ranged_attack(
+        &defender_view,
+        &defender_categories.0,
+        defender_response,
+        event.hit_precision,
+        flanking,
+        event.body_part,
+    );
+    let defender_parry_slot = matches!(defender_response, DefenderResponse::Parry { .. })
+        .then(|| defender_view.shield_holding_side())
+        .flatten()
+        .and_then(|side| match side {
+            BodySide::Left => Some(EquipSlot::HoldingLeft),
+            BodySide::Right => Some(EquipSlot::HoldingRight),
+            BodySide::Both => None,
+        });
+    let attacker_weapon_slot = match attacker_view.weapon_holding_side() {
+        Some(BodySide::Left) => EquipSlot::HoldingLeft,
+        _ => EquipSlot::HoldingRight,
+    };
+    cmd.trigger(ApplyMeleeAttackResult {
+        attacker,
+        target,
+        body_part: event.body_part,
+        result,
+        attacker_weapon_slot,
+        defender_parry_slot,
+        attacker_weapon_contact: false,
+    });
+    cmd.server_trigger(ToClients {
+        mode: SendMode::CLIENTS_ONLY,
+        message: SuccessfulAttackResponse {
+            attacker,
+            hit: vec![target],
             body_part: event.body_part,
             result,
             flanking,
@@ -583,7 +937,8 @@ fn apply_melee_attack_result(
             AttackResult::ToAttacker { contact_force, .. }
             | AttackResult::ToDefender { contact_force, .. } => contact_force.max(0.0),
         };
-        if contact_stress > 0.0
+        if event.attacker_weapon_contact
+            && contact_stress > 0.0
             && let Some((_, _, provenance, _, _, _)) = items.iter().find(|row| {
                 let (owner, slot, _, weapon, _, _) = row;
                 attacker_weapon_contact_matches(
@@ -682,6 +1037,17 @@ fn record_party_injury(
     consequence.blood_loss_fraction = (consequence.blood_loss_fraction
         + (cut_damage + blunt_damage) * BLOOD_LOSS_PER_HEALTH_DAMAGE)
         .clamp(0.0, 1.0);
+}
+
+fn record_party_ammunition_use(
+    consequences: &mut TacticalConsequenceAccumulator,
+    character_id: u64,
+) {
+    let consequence = consequences.party.entry(character_id).or_default();
+    consequence.ammunition_used = consequence
+        .ammunition_used
+        .saturating_add(1)
+        .min(adventuresim_core::mission::MAX_TACTICAL_AMMUNITION_USED);
 }
 
 fn attacker_weapon_contact_matches(
@@ -886,6 +1252,25 @@ mod tests {
         }
     }
 
+    fn valid_ranged_facts(world: &mut World) -> RangedIntentFacts {
+        RangedIntentFacts {
+            attacker: world.spawn_empty().id(),
+            target: Some(world.spawn_empty().id()),
+            attacker_side: Some(TacticalCombatSide::Party),
+            target_side: Some(TacticalCombatSide::Enemy),
+            attacker_incapacitated: Some(false),
+            target_incapacitated: Some(false),
+            hit_precision: 1.0,
+            weapon_is_ranged: true,
+            weapon_range: 120.0,
+            separation: Some(30.0),
+            target_in_aim_cone: Some(true),
+            windup_ready: true,
+            windup_unexpired: true,
+            cooldown_ready: true,
+        }
+    }
+
     #[test]
     fn authoritative_gate_rejects_invalid_relationship_state_and_geometry() {
         let mut world = World::new();
@@ -979,6 +1364,147 @@ mod tests {
         for (facts, expected) in cases {
             assert_eq!(validate_melee_intent_cheap(facts), Err(expected));
         }
+    }
+
+    #[test]
+    fn ranged_gate_validates_authority_equipment_ammo_and_target() {
+        let mut world = World::new();
+        let valid = valid_ranged_facts(&mut world);
+        assert_eq!(validate_ranged_intent(valid), Ok(()));
+        assert_eq!(
+            validate_ranged_intent(RangedIntentFacts {
+                hit_precision: 99.0,
+                ..valid
+            }),
+            Ok(()),
+            "finite client precision is intentionally trusted and core-clamped"
+        );
+        let cases = [
+            (
+                RangedIntentFacts {
+                    target: Some(valid.attacker),
+                    ..valid
+                },
+                RangedIntentRejection::SelfTarget,
+            ),
+            (
+                RangedIntentFacts {
+                    target_side: valid.attacker_side,
+                    ..valid
+                },
+                RangedIntentRejection::FriendlyTarget,
+            ),
+            (
+                RangedIntentFacts {
+                    attacker_incapacitated: Some(true),
+                    ..valid
+                },
+                RangedIntentRejection::Incapacitated,
+            ),
+            (
+                RangedIntentFacts {
+                    hit_precision: f32::NAN,
+                    ..valid
+                },
+                RangedIntentRejection::NonFinitePrecision,
+            ),
+            (
+                RangedIntentFacts {
+                    weapon_is_ranged: false,
+                    ..valid
+                },
+                RangedIntentRejection::NotRanged,
+            ),
+            (
+                RangedIntentFacts {
+                    separation: Some(121.0),
+                    ..valid
+                },
+                RangedIntentRejection::OutOfRange,
+            ),
+            (
+                RangedIntentFacts {
+                    windup_ready: false,
+                    ..valid
+                },
+                RangedIntentRejection::Windup,
+            ),
+            (
+                RangedIntentFacts {
+                    cooldown_ready: false,
+                    ..valid
+                },
+                RangedIntentRejection::Cooldown,
+            ),
+        ];
+        for (facts, expected) in cases {
+            assert_eq!(validate_ranged_intent(facts), Err(expected));
+        }
+
+        assert_eq!(
+            validate_ranged_intent(RangedIntentFacts {
+                target: None,
+                target_side: None,
+                target_incapacitated: None,
+                separation: None,
+                ..valid
+            }),
+            Ok(()),
+            "a fired miss still passes the firing gate and consumes ammo"
+        );
+    }
+
+    #[test]
+    fn ranged_aim_cone_accepts_forward_and_rejects_behind() {
+        let origin = Vec3::ZERO;
+        assert!(ranged_target_in_aim_cone(0.0, origin, Vec3::NEG_Z));
+        assert!(!ranged_target_in_aim_cone(0.0, origin, Vec3::Z));
+
+        let mut world = World::new();
+        let valid = valid_ranged_facts(&mut world);
+        assert_eq!(validate_ranged_intent(valid), Ok(()));
+        assert_eq!(
+            validate_ranged_intent(RangedIntentFacts {
+                target_in_aim_cone: Some(false),
+                ..valid
+            }),
+            Err(RangedIntentRejection::OutsideAimCone)
+        );
+    }
+
+    #[test]
+    fn ranged_rejections_happen_before_ammo_scan() {
+        let source = include_str!("combat.rs");
+        let resolver = source
+            .split("fn resolve_ranged_attack(")
+            .nth(1)
+            .and_then(|tail| tail.split("fn apply_melee_attack_result(").next())
+            .expect("ranged resolver body");
+        let validation = resolver
+            .find("validate_ranged_intent(facts)")
+            .expect("cheap validation");
+        let authorization = resolver
+            .find("consume_ranged_authority")
+            .expect("one-shot authorization");
+        let ammo_scan = resolver.find("q_ammo.iter().find").expect("ammo scan");
+        assert!(validation < authorization && authorization < ammo_scan);
+    }
+
+    #[test]
+    fn ranged_ammo_consumption_and_receipt_are_bounded() {
+        assert_eq!(remaining_ammo_after_shot(NonZeroU32::new(1).unwrap()), None);
+        assert_eq!(
+            remaining_ammo_after_shot(NonZeroU32::new(3).unwrap()).map(NonZeroU32::get),
+            Some(2)
+        );
+        let mut consequences = TacticalConsequenceAccumulator::default();
+        for _ in 0..=adventuresim_core::mission::MAX_TACTICAL_AMMUNITION_USED {
+            record_party_ammunition_use(&mut consequences, 7);
+        }
+        assert_eq!(
+            consequences.party[&7].ammunition_used,
+            adventuresim_core::mission::MAX_TACTICAL_AMMUNITION_USED
+        );
     }
 
     #[test]

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -506,41 +506,43 @@ fn spawn_connected_player(
         player.maximum_blood_ml,
     );
 
-    cmd.entity(entity).remove::<LoadingPlayer>().insert((
-        Name::new(name),
-        Replicated,
-        Player {
-            name: player.character.name.clone(),
-        },
-        PlayerId(player.character.id),
-        BestiaryCategories::default(),
-        skills,
-        limbs,
-        attributes,
-        stats,
-        MissionOpeningAwareness {
-            party_has_surprise: player.party_has_surprise,
-        },
-        TacticalCombatState {
-            starting_incapacitation,
-            starting_blood_fraction,
-            ..default()
-        },
-        MeleeAttackAuthority::default(),
-        RangedAttackAuthority::default(),
-        if player.mission_side == TacticalMissionSide::Enemy {
-            TacticalCombatSide::Enemy
-        } else {
-            TacticalCombatSide::Party
-        },
-        Transform::from_xyz(spawn_position.x, spawn_height, spawn_position.y),
-        (
+    cmd.entity(entity)
+        .remove::<LoadingPlayer>()
+        .insert((
+            Name::new(name),
+            Replicated,
+            Player {
+                name: player.character.name.clone(),
+            },
+            PlayerId(player.character.id),
+            BestiaryCategories::default(),
+            skills,
+            limbs,
+            attributes,
+            stats,
+            MissionOpeningAwareness {
+                party_has_surprise: player.party_has_surprise,
+            },
+            TacticalCombatState {
+                starting_incapacitation,
+                starting_blood_fraction,
+                ..default()
+            },
+            MeleeAttackAuthority::default(),
+            RangedAttackAuthority::default(),
+            if player.mission_side == TacticalMissionSide::Enemy {
+                TacticalCombatSide::Enemy
+            } else {
+                TacticalCombatSide::Party
+            },
+            Transform::from_xyz(spawn_position.x, spawn_height, spawn_position.y),
+        ))
+        .insert((
             player_collider.clone(),
             CollisionMargin(0.01),
             CharacterController::default(),
             CharacterLook::default(),
-        ),
-    ));
+        ));
 
     for item in &player.items {
         let Some(quantity) = NonZeroU32::new(item.quantity) else {

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -22,7 +22,10 @@ use clap::{ArgAction, Parser};
 
 use crate::{
     bot::{MissionEnemy, OffensiveMeleeAi},
-    combat::{MeleeAttackAuthority, TacticalCombatSide, TacticalConsequenceAccumulator},
+    combat::{
+        MeleeAttackAuthority, RangedAttackAuthority, TacticalCombatSide,
+        TacticalConsequenceAccumulator,
+    },
     stdb::{SpacetimeDb, SpacetimeDbReady},
     terrain::TerrainGenerator,
 };
@@ -524,6 +527,7 @@ fn spawn_connected_player(
             ..default()
         },
         MeleeAttackAuthority::default(),
+        RangedAttackAuthority::default(),
         if player.mission_side == TacticalMissionSide::Enemy {
             TacticalCombatSide::Enemy
         } else {
@@ -601,6 +605,11 @@ fn spawn_connected_player(
                     reach: item.item.reach,
                     balance: item.item.balance,
                     precise: item.item.precise,
+                    melee: item.item.melee,
+                    ranged: item.item.ranged,
+                    blunt: item.item.blunt,
+                    slash: item.item.slash,
+                    pierce: item.item.pierce,
                 });
             }
             ItemKind::Armor | ItemKind::Clothing => {}
@@ -713,7 +722,7 @@ fn tactical_consequence_receipt(
                 })
                 .collect(),
             blood_loss_fraction: consequence.blood_loss_fraction,
-            ammunition_used: 0,
+            ammunition_used: consequence.ammunition_used,
         })
         .collect();
     for contact in &accumulated.equipment_contacts {

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -321,7 +321,13 @@ record caps before transactionally applying injuries, blood loss, capability,
 filth, ammunition, equipment wear, and defeat morale. Invalid receipts reject
 the whole terminal transaction and remain retryable; tactical data cannot
 choose outcomes, capture subjects, rewards, or XP. Positions, ticks, and enemy
-state remain transient. Ranged AI and ranged receipt population remain deferred.
+state remain transient. Player-fired ranged attacks use an ordered intent,
+server-validated weapon/range/line-of-sight/timing gate, and authoritative
+transient arrow consumption. Their bounded Party ammunition use is populated
+in the terminal receipt. Hit precision is the deliberate exception: the server
+rejects non-finite values but trusts finite client reports because authoritative
+skeletal animation and secondary physics are outside the headless simulation.
+Ranged AI remains deferred.
 
 Mission, hostile-group, battle, and outcome-source identities are separate.
 Tactical success never chooses a case objective, capture subject, contract

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -327,7 +327,9 @@ transient arrow consumption. Their bounded Party ammunition use is populated
 in the terminal receipt. Hit precision is the deliberate exception: the server
 rejects non-finite values but trusts finite client reports because authoritative
 skeletal animation and secondary physics are outside the headless simulation.
-Ranged AI remains deferred.
+Server-owned offensive AI uses the same internal ranged windup/completion and
+authoritative ammo path, holds a bounded standoff distance while firing, and
+falls back to melee behavior when ranged equipment or arrows are unavailable.
 
 Mission, hostile-group, battle, and outcome-source identities are separate.
 Tactical success never chooses a case objective, capture subject, contract

--- a/wiki/tactical/combat.md
+++ b/wiki/tactical/combat.md
@@ -154,6 +154,16 @@ projectile does not unbalance its attacker. Current projectile energy defaults
 to 40 joules per kilogram of ranged weapon, giving the one-kilogram short bow a
 40-joule baseline until ammunition carries its own mass and velocity.
 
+The tactical implementation sends firing start and completion on one ordered
+stream. The server derives the attacker from the connection and validates
+opposing sides, incapacitation, a held ranged weapon, arrow availability,
+weapon range, line of sight, windup, and cooldown. A validated shot consumes one
+transient `arrow`, including a client-reported miss; Party use is carried in the
+bounded terminal consequence receipt. Finite hit precision is intentionally
+trusted from the client and remains bounded by the shared combat calculation.
+Server-controlled ranged AI is a follow-up; current offensive AI closes to
+melee range.
+
 ## Incapacitation
 A character's incapacitation represents the sum of all disabling effects on them and corresponds to the state of their animation. When above half, they are "staggered" and each additional 1% of incapacitation causes a 2% penalty to movement and attribute checks, and when above 100% they are completely incapacitated (which also causes knockdown). Most negative effects that a character has can affect their incapacitation, past a certain threshold. Your incapacitation is displayed as a wheel in the center of the screen. If it is at 0%, the wheel is invisible, and as it increases it starts from 12 o'clock and extends as an arc clockwise. Each factor that contributes to incapacitation has a different color to differentiate them.
 

--- a/wiki/tactical/combat.md
+++ b/wiki/tactical/combat.md
@@ -161,8 +161,10 @@ weapon range, line of sight, windup, and cooldown. A validated shot consumes one
 transient `arrow`, including a client-reported miss; Party use is carried in the
 bounded terminal consequence receipt. Finite hit precision is intentionally
 trusted from the client and remains bounded by the shared combat calculation.
-Server-controlled ranged AI is a follow-up; current offensive AI closes to
-melee range.
+Server-controlled offensive AI uses the same ranged windup, completion,
+validation, and ammo-consumption path. It faces the nearest viable target,
+maintains a bounded standoff distance while arrows remain, and returns to its
+melee pursuit/attack cadence when it cannot make a ranged attack.
 
 ## Incapacitation
 A character's incapacitation represents the sum of all disabling effects on them and corresponds to the state of their animation. When above half, they are "staggered" and each additional 1% of incapacitation causes a 2% penalty to movement and attribute checks, and when above 100% they are completely incapacitated (which also causes knockdown). Most negative effects that a character has can affect their incapacitation, past a certain threshold. Your incapacitation is displayed as a wheel in the center of the screen. If it is at 0%, the wheel is invisible, and as it increases it starts from 12 o'clock and extends as an arc clockwise. Each factor that contributes to incapacitation has a different color to differentiate them.


### PR DESCRIPTION
Stack layer 5 for #360. Adds complete player and offensive-AI ranged combat: ordered mapped fire messages, client raycast and honest miss reporting, deterministic AI standoff/cadence and melee-capable fallback after ammunition exhaustion, shared ranged resolution, authoritative identity/allegiance/incapacitation/equipment/ammo/range/LOS/yaw-cone/timing/cooldown gates, transient arrow consumption, damage/incapacitation integration, and bounded terminal ammo accounting. Per the product decision, the server accepts finite client-reported precision and does not attempt to reconstruct skeletal animation or secondary physics. Verification: tactical-server 27 tests, tactical-client check, formatting/diff checks, two independent review tracks with all medium+ findings remediated.