### PR TITLE
Present tactical combat status and outcomes

### DIFF
--- a/crates/adventuresim-tactical-client/assets/ui.css
+++ b/crates/adventuresim-tactical-client/assets/ui.css
@@ -72,6 +72,16 @@ text,span {
   z-index: -100;
 }
 
+#terminal-outcome {
+  position: absolute;
+  top: 28%;
+  width: 100%;
+  font-size: 64px;
+  font-weight: 800;
+  text-align: center;
+  text-shadow: #000 3px 3px;
+}
+
 #stats {
   flex-direction: column;
   position: absolute;

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -7,7 +7,7 @@ use adventuresim_tactical_netcode::{
     aeronet::io::connection::{LocalAddr, PeerAddr},
     bevy_replicon::prelude::{ClientState, ClientStats},
     client::normalize_server_url,
-    message::SuccessfulAttackResponse,
+    message::{SuccessfulAttackResponse, TacticalOutcome, TacticalOutcomeResponse},
     prelude::*,
 };
 use bevy::{
@@ -35,12 +35,14 @@ impl Plugin for UiPlugin {
                     update_connection_ui,
                     update_skills_ui.run_if(any_with_component::<ClientPlayer>),
                     update_limbs_ui.run_if(any_with_component::<ClientPlayer>),
+                    update_combat_state_ui.run_if(any_with_component::<ClientPlayer>),
                     update_items_ui.run_if(any_with_component::<ClientPlayer>),
                     update_attack_timer_ui.run_if(any_with_component::<ClientPlayer>),
                 ),
             )
             .add_observer(on_new_player_added_hook)
             .add_observer(on_successful_attack_display)
+            .add_observer(on_tactical_outcome_display)
             .add_systems(Update, update_attack_result_ui);
     }
 }
@@ -88,6 +90,12 @@ struct HeadSpan;
 struct AttackTimerSpan;
 
 #[derive(Component)]
+struct CombatStateSpan;
+
+#[derive(Component)]
+struct TacticalOutcomeBanner;
+
+#[derive(Component)]
 struct AttackResultText {
     timer: Timer,
 }
@@ -114,6 +122,13 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
         Node::default(),
         NodeStyleSheet::new(asset_server.load("ui.css")),
         children![
+            (
+                Name::new("terminal-outcome"),
+                TacticalOutcomeBanner,
+                Visibility::Hidden,
+                ClassList::new("primary"),
+                Text::default(),
+            ),
             (Name::new("crosshair"), Node::default()),
             (
                 Name::new("attack-info"),
@@ -153,6 +168,11 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                         Name::new("fps"),
                         Text::new("FPS: "),
                         children![(FpsSpan, TextSpan::default())]
+                    ),
+                    (
+                        Name::new("combat-state"),
+                        Text::new("Combat: "),
+                        children![(CombatStateSpan, TextSpan::default())]
                     ),
                 ]
             ),
@@ -318,6 +338,46 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
     ));
 }
 
+fn combat_state_label(state: &TacticalCombatState) -> String {
+    if state.incapacitated {
+        format!(
+            "INCAPACITATED | Blood loss {:.0}% | Imbalance {:.0}%",
+            state.blood_loss_fraction * 100.0,
+            state.imbalance * 100.0
+        )
+    } else {
+        format!(
+            "Active | Blood loss {:.0}% | Imbalance {:.0}%",
+            state.blood_loss_fraction * 100.0,
+            state.imbalance * 100.0
+        )
+    }
+}
+
+fn update_combat_state_ui(
+    player: Single<&TacticalCombatState, With<ClientPlayer>>,
+    mut span: Single<&mut TextSpan, With<CombatStateSpan>>,
+) {
+    span.0 = combat_state_label(&player);
+}
+
+fn tactical_outcome_label(outcome: TacticalOutcome) -> (&'static str, &'static str) {
+    match outcome {
+        TacticalOutcome::Victory => ("VICTORY", "success"),
+        TacticalOutcome::Defeat => ("DEFEAT", "error"),
+    }
+}
+
+fn on_tactical_outcome_display(
+    event: On<TacticalOutcomeResponse>,
+    mut banner: Single<(&mut Text, &mut Visibility, &mut ClassList), With<TacticalOutcomeBanner>>,
+) {
+    let (label, class) = tactical_outcome_label(event.outcome);
+    banner.0.0 = label.to_owned();
+    *banner.1 = Visibility::Visible;
+    *banner.2 = ClassList::new(class);
+}
+
 fn update_stats_ui(
     diagnostics: Res<DiagnosticsStore>,
     player: Single<(Ref<Transform>, &PlayerId), With<ClientPlayer>>,
@@ -335,7 +395,6 @@ fn update_stats_ui(
             translation.x, translation.y, translation.z
         );
     }
-
     if let Some(fps) = diagnostics
         .get(&FrameTimeDiagnosticsPlugin::FPS)
         .and_then(|fps| fps.smoothed())
@@ -635,4 +694,39 @@ fn on_new_player_added_hook(
     ));
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn combat_label_surfaces_live_and_incapacitated_state() {
+        let active = TacticalCombatState {
+            blood_loss_fraction: 0.25,
+            imbalance: 0.5,
+            ..default()
+        };
+        assert_eq!(
+            combat_state_label(&active),
+            "Active | Blood loss 25% | Imbalance 50%"
+        );
+        let incapacitated = TacticalCombatState {
+            incapacitated: true,
+            ..active
+        };
+        assert!(combat_state_label(&incapacitated).starts_with("INCAPACITATED"));
+    }
+
+    #[test]
+    fn terminal_outcome_labels_are_unambiguous() {
+        assert_eq!(
+            tactical_outcome_label(TacticalOutcome::Victory),
+            ("VICTORY", "success")
+        );
+        assert_eq!(
+            tactical_outcome_label(TacticalOutcome::Defeat),
+            ("DEFEAT", "error")
+        );
+    }
 }

--- a/crates/adventuresim-tactical-netcode/src/lib.rs
+++ b/crates/adventuresim-tactical-netcode/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
     pub use crate::client::AdventureSimulatorClient;
     pub use crate::message::{
         DefendRequest, JoinRequest, MeleeActionPhase, MeleeActionRequest, PlayerInputRequest,
-        RangedActionPhase, RangedActionRequest,
+        RangedActionPhase, RangedActionRequest, TacticalOutcome, TacticalOutcomeResponse,
     };
     #[cfg(feature = "server")]
     pub use crate::server::AdventureSimulatorServer;

--- a/crates/adventuresim-tactical-netcode/src/message.rs
+++ b/crates/adventuresim-tactical-netcode/src/message.rs
@@ -112,6 +112,19 @@ pub struct SuccessfulAttackResponse {
     pub defender_response: DefenderResponse,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TacticalOutcome {
+    Victory,
+    Defeat,
+}
+
+/// Broadcast only after strategic authority accepts the terminal tactical
+/// submission. It is presentation state, not a second outcome authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Event, Serialize, Deserialize)]
+pub struct TacticalOutcomeResponse {
+    pub outcome: TacticalOutcome,
+}
+
 impl SuccessfulAttackResponse {
     pub fn total_damage(&self) -> f32 {
         match self.result {

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -6,7 +6,7 @@ use bevy_replicon::prelude::*;
 use crate::FIXED_TIMESTEP_HZ;
 use crate::message::{
     DefendRequest, JoinRequest, MeleeActionRequest, PlayerInputRequest, RangedActionRequest,
-    SuccessfulAttackResponse,
+    SuccessfulAttackResponse, TacticalOutcomeResponse,
 };
 
 #[derive(Default)]
@@ -43,7 +43,8 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .add_client_event::<DefendRequest>(Channel::Unreliable)
             .add_mapped_client_event::<MeleeActionRequest>(Channel::Ordered)
             .add_mapped_client_event::<RangedActionRequest>(Channel::Ordered)
-            .add_mapped_server_event::<SuccessfulAttackResponse>(Channel::Ordered);
+            .add_mapped_server_event::<SuccessfulAttackResponse>(Channel::Ordered)
+            .add_server_event::<TacticalOutcomeResponse>(Channel::Ordered);
 
         // Replicating physics components since those don't change and
         // it's useful for debugging. Can be gated behind a feature flag, but

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -624,6 +624,10 @@ mod tests {
             terminal_retry_not_before: Default::default(),
             pending_resolution: None,
             pending_receipt: None,
+            terminal_in_flight: false,
+            terminal_ack_deadline: None,
+            terminal_transport_failed: false,
+            terminal_presentation: None,
             committed: false,
         })
         .add_observer(on_tactical_combatant_defeated);

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -5,7 +5,12 @@ mod combat;
 mod stdb;
 mod terrain;
 
-use std::{collections::HashSet, net::SocketAddr, num::NonZeroU32, time::Duration};
+use std::{
+    collections::HashSet,
+    net::SocketAddr,
+    num::{NonZeroU8, NonZeroU32},
+    time::Duration,
+};
 
 use adventuresim_stdb_client::*;
 use adventuresim_tactical_core::{
@@ -26,7 +31,7 @@ use crate::{
         MeleeAttackAuthority, RangedAttackAuthority, TacticalCombatSide,
         TacticalConsequenceAccumulator,
     },
-    stdb::{SpacetimeDb, SpacetimeDbReady},
+    stdb::{SpacetimeDb, SpacetimeDbReady, TerminalSubmissionResult},
     terrain::TerrainGenerator,
 };
 use input::AccumulatedInput;
@@ -35,6 +40,12 @@ use input::AccumulatedInput;
 const MISSION_TIMEOUT_SECS: f32 = 300.0;
 /// Retry interval after a synchronous terminal reducer submission error.
 const TERMINAL_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+/// Keeps the authoritative server observable just long enough for connected
+/// clients to render the committed outcome before the transport closes.
+const TERMINAL_PRESENTATION_DELAY: Duration = Duration::from_secs(3);
+/// An acknowledgement-ambiguous submission must fail closed rather than be
+/// retried blindly or strand a headless server forever.
+const TERMINAL_ACK_TIMEOUT: Duration = Duration::from_secs(10);
 /// Time a sealed, empty Party has to reconnect before the mission is abandoned.
 const PARTY_RECONNECT_GRACE: Duration = Duration::from_secs(10);
 
@@ -168,6 +179,10 @@ fn main() {
             pending_resolution: None,
             pending_receipt: None,
             committed: false,
+            terminal_in_flight: false,
+            terminal_ack_deadline: None,
+            terminal_transport_failed: false,
+            terminal_presentation: None,
         })
         .insert_resource(args)
         .add_systems(
@@ -176,7 +191,13 @@ fn main() {
                 (check_terminal_combat_outcome, check_mission_timeout)
                     .chain()
                     .after(combat::update_tactical_combat_state)
-                    .after(spawn_connected_players),
+                    .after(spawn_connected_players)
+                    .after(process_terminal_submission_results),
+                process_terminal_submission_results.after(stdb::update_spacetimedb),
+                fail_stalled_terminal_submission
+                    .after(process_terminal_submission_results)
+                    .before(check_terminal_combat_outcome),
+                finish_terminal_presentation.after(check_mission_timeout),
                 spawn_connected_players.after(stdb::update_spacetimedb),
                 (setup_server, setup_stdb_callbacks).run_if(resource_added::<SpacetimeDbReady>),
             ),
@@ -211,6 +232,30 @@ pub struct MissionState {
     pending_resolution: Option<TacticalMissionResolution>,
     pending_receipt: Option<TacticalConsequenceReceipt>,
     committed: bool,
+    terminal_in_flight: bool,
+    terminal_ack_deadline: Option<Duration>,
+    terminal_transport_failed: bool,
+    terminal_presentation: Option<TerminalPresentationState>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TerminalPresentationState {
+    outcome: TacticalOutcome,
+    remaining: Duration,
+}
+
+impl TerminalPresentationState {
+    fn begin(outcome: TacticalOutcome) -> Self {
+        Self {
+            outcome,
+            remaining: TERMINAL_PRESENTATION_DELAY,
+        }
+    }
+
+    fn advance(&mut self, delta: Duration) -> bool {
+        self.remaining = self.remaining.saturating_sub(delta);
+        self.remaining.is_zero()
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -264,26 +309,83 @@ fn enrollment_ready(expected: u32, seen: usize, has_loading_player: bool) -> boo
 }
 
 impl MissionState {
-    fn submit_terminal<E>(
+    fn begin_terminal_submission(
         &mut self,
         resolution: TacticalMissionResolution,
         receipt: TacticalConsequenceReceipt,
         now: Duration,
-        mut send: impl FnMut(TacticalMissionResolution, TacticalConsequenceReceipt) -> Result<(), E>,
-    ) -> Result<bool, E> {
-        if self.committed || now < self.terminal_retry_not_before {
-            return Ok(false);
+    ) -> Option<(TacticalMissionResolution, TacticalConsequenceReceipt)> {
+        if self.committed
+            || self.terminal_in_flight
+            || self.terminal_transport_failed
+            || now < self.terminal_retry_not_before
+        {
+            return None;
         }
         let resolution = *self.pending_resolution.get_or_insert(resolution);
         let receipt = self.pending_receipt.get_or_insert(receipt).clone();
-        if let Err(error) = send(resolution, receipt) {
-            self.terminal_retry_not_before = now.saturating_add(TERMINAL_RETRY_BACKOFF);
-            return Err(error);
+        self.terminal_in_flight = true;
+        self.terminal_ack_deadline = Some(now.saturating_add(TERMINAL_ACK_TIMEOUT));
+        Some((resolution, receipt))
+    }
+
+    fn terminal_submission_failed(&mut self, now: Duration) {
+        if self.committed {
+            return;
         }
-        self.committed = true;
-        self.pending_resolution = None;
-        self.pending_receipt = None;
-        Ok(true)
+        self.terminal_in_flight = false;
+        self.terminal_ack_deadline = None;
+        self.terminal_retry_not_before = now.saturating_add(TERMINAL_RETRY_BACKOFF);
+    }
+
+    fn apply_terminal_submission_result(
+        &mut self,
+        result: TerminalSubmissionResult,
+        now: Duration,
+    ) -> Option<TacticalOutcome> {
+        if self.committed || !self.terminal_in_flight {
+            return None;
+        }
+        self.terminal_in_flight = false;
+        self.terminal_ack_deadline = None;
+        match result {
+            TerminalSubmissionResult::Accepted => {
+                let resolution = self.pending_resolution.take()?;
+                self.pending_receipt = None;
+                self.committed = true;
+                let outcome = presentation_outcome(resolution);
+                self.terminal_presentation = Some(TerminalPresentationState::begin(outcome));
+                Some(outcome)
+            }
+            TerminalSubmissionResult::Rejected(_) => {
+                self.terminal_retry_not_before = now.saturating_add(TERMINAL_RETRY_BACKOFF);
+                None
+            }
+        }
+    }
+
+    fn fail_if_terminal_ack_stalled(&mut self, now: Duration) -> bool {
+        let stalled = self.terminal_in_flight
+            && self
+                .terminal_ack_deadline
+                .is_some_and(|deadline| now >= deadline);
+        if stalled {
+            self.terminal_in_flight = false;
+            self.terminal_ack_deadline = None;
+            self.terminal_transport_failed = true;
+        }
+        stalled
+    }
+}
+
+fn presentation_outcome(resolution: TacticalMissionResolution) -> TacticalOutcome {
+    match resolution {
+        TacticalMissionResolution::Defeated
+        | TacticalMissionResolution::DrivenOff
+        | TacticalMissionResolution::Captured => TacticalOutcome::Victory,
+        TacticalMissionResolution::Failed | TacticalMissionResolution::CaptureTargetKilled => {
+            TacticalOutcome::Defeat
+        }
     }
 }
 
@@ -667,30 +769,84 @@ fn commit_terminal_resolution(
     conn: Res<SpacetimeDb>,
     consequences: Res<TacticalConsequenceAccumulator>,
     mut state: ResMut<MissionState>,
-    mut exit: MessageWriter<AppExit>,
 ) -> Result {
     let receipt = tactical_consequence_receipt(&consequences);
-    let submitted = match state.submit_terminal(resolution, receipt, now, |resolution, receipt| {
-        conn.reducers().end_tactical_server(resolution, receipt)
-    }) {
-        Ok(submitted) => submitted,
-        Err(error) => {
+    let Some((resolution, receipt)) = state.begin_terminal_submission(resolution, receipt, now)
+    else {
+        return Ok(());
+    };
+    if let Err(error) = conn.submit_terminal(resolution, receipt) {
+        state.terminal_submission_failed(now);
+        warn!(
+            "Terminal result enqueue failed; retrying in {}s: {error}",
+            TERMINAL_RETRY_BACKOFF.as_secs()
+        );
+    } else {
+        info!(
+            ?resolution,
+            "Terminal result queued; awaiting reducer acceptance"
+        );
+    }
+    Ok(())
+}
+
+fn process_terminal_submission_results(
+    time: Res<Time>,
+    conn: Res<SpacetimeDb>,
+    mut state: ResMut<MissionState>,
+    mut cmd: Commands,
+) {
+    for result in conn.take_terminal_results() {
+        let rejection = match &result {
+            TerminalSubmissionResult::Rejected(error) => Some(error.clone()),
+            TerminalSubmissionResult::Accepted => None,
+        };
+        if let Some(outcome) = state.apply_terminal_submission_result(result, time.elapsed()) {
+            cmd.server_trigger(ToClients {
+                mode: SendMode::CLIENTS_ONLY,
+                message: TacticalOutcomeResponse { outcome },
+            });
+            info!(
+                ?outcome,
+                "Mission terminal result accepted; presenting outcome"
+            );
+        } else if let Some(error) = rejection {
             warn!(
-                "Terminal result submission failed; retrying in {}s: {error}",
+                "Terminal reducer rejected submission; retrying in {}s: {error}",
                 TERMINAL_RETRY_BACKOFF.as_secs()
             );
-            return Ok(());
         }
-    };
-    if !submitted {
-        return Ok(());
     }
-    info!(
-        ?resolution,
-        "Mission terminal result committed; shutting down"
-    );
-    exit.write(AppExit::Success);
-    Ok(())
+}
+
+fn fail_stalled_terminal_submission(
+    time: Res<Time>,
+    mut state: ResMut<MissionState>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    if state.fail_if_terminal_ack_stalled(time.elapsed()) {
+        error!(
+            timeout_seconds = TERMINAL_ACK_TIMEOUT.as_secs(),
+            "Terminal reducer acknowledgement timed out; exiting without presenting an outcome"
+        );
+        exit.write(AppExit::Error(NonZeroU8::new(1).expect("one is non-zero")));
+    }
+}
+
+fn finish_terminal_presentation(
+    time: Res<Time>,
+    mut state: ResMut<MissionState>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    let Some(mut presentation) = state.terminal_presentation.take() else {
+        return;
+    };
+    if presentation.advance(time.delta()) {
+        info!(?presentation.outcome, "Terminal presentation complete; shutting down");
+        exit.write(AppExit::Success);
+    } else {
+        state.terminal_presentation = Some(presentation);
+    }
 }
 
 fn receipt_body_part(body_part: BodyPart) -> TacticalReceiptBodyPart {
@@ -773,7 +929,6 @@ fn check_terminal_combat_outcome(
     conn: Res<SpacetimeDb>,
     consequences: Res<TacticalConsequenceAccumulator>,
     mut state: ResMut<MissionState>,
-    exit: MessageWriter<AppExit>,
     enemies: Query<(), (With<bot::MissionEnemy>, With<Player>)>,
     combatants: Query<(&TacticalCombatSide, &TacticalCombatState, &PlayerId), With<Player>>,
     loading_players: Query<(), With<LoadingPlayer>>,
@@ -784,14 +939,7 @@ fn check_terminal_combat_outcome(
     // A result whose first submission failed is already decided. Retry it
     // before observing recoveries, disconnects, or any newly terminal state.
     if let Some(resolution) = state.pending_resolution {
-        return commit_terminal_resolution(
-            resolution,
-            time.elapsed(),
-            conn,
-            consequences,
-            state,
-            exit,
-        );
+        return commit_terminal_resolution(resolution, time.elapsed(), conn, consequences, state);
     }
     let mut loaded_party = 0;
     let mut incapacitated_party = 0;
@@ -831,7 +979,6 @@ fn check_terminal_combat_outcome(
             conn,
             consequences,
             state,
-            exit,
         );
     }
     let snapshot = TerminalCombatSnapshot {
@@ -845,7 +992,7 @@ fn check_terminal_combat_outcome(
     let Some(resolution) = terminal_resolution(snapshot) else {
         return Ok(());
     };
-    commit_terminal_resolution(resolution, time.elapsed(), conn, consequences, state, exit)
+    commit_terminal_resolution(resolution, time.elapsed(), conn, consequences, state)
 }
 
 fn check_mission_timeout(
@@ -853,7 +1000,6 @@ fn check_mission_timeout(
     conn: Res<SpacetimeDb>,
     consequences: Res<TacticalConsequenceAccumulator>,
     mut state: ResMut<MissionState>,
-    exit: MessageWriter<AppExit>,
 ) -> Result {
     let is_timeout = match state.timeout {
         Some(ref mut timer) => {
@@ -874,7 +1020,6 @@ fn check_mission_timeout(
         conn,
         consequences,
         state,
-        exit,
     )
 }
 
@@ -1157,50 +1302,36 @@ mod tests {
     }
 
     #[test]
-    fn no_timeout_mission_can_claim_exactly_one_terminal_result() {
-        let mut state = MissionState {
-            timeout: None,
-            enemies_defeated: 2,
-            required_enemy_defeats: 2,
-            expected_party_members: 1,
-            seen_party_members: HashSet::from([7]),
-            enrollment_begun: true,
-            enrollment_sealed: true,
-            abandonment_elapsed: Duration::ZERO,
-            terminal_retry_not_before: Duration::ZERO,
-            pending_resolution: None,
-            pending_receipt: None,
-            committed: false,
-        };
-        let resolution = terminal_resolution(TerminalCombatSnapshot {
-            defeated_enemies: state.enemies_defeated,
-            ..snapshot()
-        })
-        .unwrap();
-
+    fn committed_resolution_maps_to_one_client_outcome() {
         assert_eq!(
-            state.submit_terminal(
-                resolution,
-                empty_tactical_consequence_receipt(),
-                Duration::ZERO,
-                |_, _| Ok::<_, ()>(()),
-            ),
-            Ok(true)
+            presentation_outcome(TacticalMissionResolution::Defeated),
+            TacticalOutcome::Victory
         );
-        assert_eq!(
-            state.submit_terminal(
-                resolution,
-                empty_tactical_consequence_receipt(),
-                Duration::ZERO,
-                |_, _| Ok::<_, ()>(()),
-            ),
-            Ok(false)
-        );
+        for resolution in [
+            TacticalMissionResolution::DrivenOff,
+            TacticalMissionResolution::Captured,
+        ] {
+            assert_eq!(presentation_outcome(resolution), TacticalOutcome::Victory);
+        }
+        for resolution in [
+            TacticalMissionResolution::Failed,
+            TacticalMissionResolution::CaptureTargetKilled,
+        ] {
+            assert_eq!(presentation_outcome(resolution), TacticalOutcome::Defeat);
+        }
     }
 
     #[test]
-    fn failed_submission_retries_frozen_result_after_predicate_clears() {
-        let mut state = MissionState {
+    fn terminal_presentation_delay_is_exact_and_bounded() {
+        let mut presentation = TerminalPresentationState::begin(TacticalOutcome::Victory);
+        assert!(!presentation.advance(TERMINAL_PRESENTATION_DELAY - Duration::from_millis(1)));
+        assert_eq!(presentation.remaining, Duration::from_millis(1));
+        assert!(presentation.advance(Duration::from_millis(1)));
+        assert_eq!(presentation.remaining, Duration::ZERO);
+    }
+
+    fn terminal_test_state() -> MissionState {
+        MissionState {
             timeout: None,
             enemies_defeated: 1,
             required_enemy_defeats: 1,
@@ -1213,85 +1344,176 @@ mod tests {
             pending_resolution: None,
             pending_receipt: None,
             committed: false,
-        };
-        let mut attempts = 0;
-        let mut reports = Vec::new();
-        let mut receipts = Vec::new();
+            terminal_in_flight: false,
+            terminal_ack_deadline: None,
+            terminal_transport_failed: false,
+            terminal_presentation: None,
+        }
+    }
+
+    #[test]
+    fn stalled_terminal_ack_fails_closed_without_presentation() {
+        let mut state = terminal_test_state();
+        assert!(
+            state
+                .begin_terminal_submission(
+                    TacticalMissionResolution::Defeated,
+                    empty_tactical_consequence_receipt(),
+                    Duration::ZERO,
+                )
+                .is_some()
+        );
+
+        assert!(
+            !state.fail_if_terminal_ack_stalled(TERMINAL_ACK_TIMEOUT - Duration::from_millis(1))
+        );
+        assert!(state.fail_if_terminal_ack_stalled(TERMINAL_ACK_TIMEOUT));
+        assert!(state.terminal_transport_failed);
+        assert!(!state.committed);
+        assert!(state.terminal_presentation.is_none());
+        assert!(
+            state
+                .begin_terminal_submission(
+                    TacticalMissionResolution::Defeated,
+                    empty_tactical_consequence_receipt(),
+                    Duration::MAX,
+                )
+                .is_none(),
+            "an ambiguously acknowledged request must not be retried"
+        );
+    }
+
+    #[test]
+    fn queued_terminal_submission_is_not_committed_or_presented() {
+        let mut state = terminal_test_state();
+        let queued = state.begin_terminal_submission(
+            TacticalMissionResolution::Defeated,
+            empty_tactical_consequence_receipt(),
+            Duration::ZERO,
+        );
+        assert!(queued.is_some());
+        assert!(state.terminal_in_flight);
+        assert!(!state.committed);
+        assert!(state.terminal_presentation.is_none());
+        assert!(
+            state
+                .begin_terminal_submission(
+                    TacticalMissionResolution::Failed,
+                    empty_tactical_consequence_receipt(),
+                    Duration::ZERO,
+                )
+                .is_none(),
+            "an in-flight request cannot be duplicated"
+        );
+    }
+
+    #[test]
+    fn rejection_retries_frozen_data_then_acceptance_presents_exactly_once() {
+        let mut state = terminal_test_state();
         let frozen_receipt = TacticalConsequenceReceipt {
             party: vec![TacticalCharacterConsequence {
                 character_id: 7,
-                injuries: vec![TacticalHitInjury {
-                    body_part: TacticalReceiptBodyPart::Chest,
-                    cut_damage: 0.2,
-                    blunt_damage: 0.0,
-                    max_single_hit_blunt_damage: 0.0,
-                }],
+                injuries: Vec::new(),
                 blood_loss_fraction: 0.1,
-                ammunition_used: 0,
+                ammunition_used: 2,
             }],
             equipment_contacts: Vec::new(),
         };
-        let mut sender = |resolution, receipt| {
-            attempts += 1;
-            reports.push(resolution);
-            receipts.push(receipt);
-            (attempts > 1).then_some(()).ok_or("offline")
-        };
-
-        assert_eq!(
-            state.submit_terminal(
+        let first = state
+            .begin_terminal_submission(
                 TacticalMissionResolution::Defeated,
                 frozen_receipt.clone(),
                 Duration::ZERO,
-                &mut sender
-            ),
-            Err("offline")
-        );
-        let current_resolution = terminal_resolution(TerminalCombatSnapshot {
-            defeated_enemies: 0,
-            ..snapshot()
-        });
-        assert_eq!(current_resolution, None, "the original predicate recovered");
-        let retry_resolution = state
-            .pending_resolution
-            .or(current_resolution)
-            .expect("failed submission remains pending");
+            )
+            .unwrap();
         assert_eq!(
-            state.submit_terminal(
-                retry_resolution,
+            first,
+            (TacticalMissionResolution::Defeated, frozen_receipt.clone())
+        );
+
+        assert_eq!(
+            state.apply_terminal_submission_result(
+                TerminalSubmissionResult::Rejected("reducer rejected".into()),
+                Duration::ZERO,
+            ),
+            None
+        );
+        assert!(!state.terminal_in_flight);
+        assert!(!state.committed);
+        assert!(state.terminal_presentation.is_none());
+        assert!(
+            state
+                .begin_terminal_submission(
+                    TacticalMissionResolution::Failed,
+                    empty_tactical_consequence_receipt(),
+                    Duration::from_millis(999),
+                )
+                .is_none()
+        );
+
+        let retry = state
+            .begin_terminal_submission(
+                TacticalMissionResolution::Failed,
                 empty_tactical_consequence_receipt(),
-                Duration::from_millis(999),
-                &mut sender,
-            ),
-            Ok(false)
+                TERMINAL_RETRY_BACKOFF,
+            )
+            .unwrap();
+        assert_eq!(
+            retry, first,
+            "retry must preserve the original terminal payload"
         );
         assert_eq!(
-            state.submit_terminal(
-                retry_resolution,
+            state.apply_terminal_submission_result(
+                TerminalSubmissionResult::Accepted,
+                TERMINAL_RETRY_BACKOFF,
+            ),
+            Some(TacticalOutcome::Victory)
+        );
+        assert!(state.committed);
+        assert!(state.terminal_presentation.is_some());
+        assert_eq!(
+            state.apply_terminal_submission_result(
+                TerminalSubmissionResult::Accepted,
+                TERMINAL_RETRY_BACKOFF,
+            ),
+            None,
+            "a duplicate callback cannot present twice"
+        );
+    }
+
+    #[test]
+    fn synchronous_enqueue_failure_releases_in_flight_for_bounded_retry() {
+        let mut state = terminal_test_state();
+        let first = state
+            .begin_terminal_submission(
+                TacticalMissionResolution::Failed,
                 empty_tactical_consequence_receipt(),
-                Duration::from_secs(1),
-                &mut sender,
-            ),
-            Ok(true)
+                Duration::ZERO,
+            )
+            .unwrap();
+        state.terminal_submission_failed(Duration::ZERO);
+        assert!(!state.terminal_in_flight);
+        assert!(!state.committed);
+        assert!(state.terminal_presentation.is_none());
+        assert!(
+            state
+                .begin_terminal_submission(
+                    TacticalMissionResolution::Defeated,
+                    empty_tactical_consequence_receipt(),
+                    Duration::from_millis(999),
+                )
+                .is_none()
         );
         assert_eq!(
-            state.submit_terminal(
-                TacticalMissionResolution::Defeated,
-                empty_tactical_consequence_receipt(),
-                Duration::from_secs(2),
-                &mut sender
-            ),
-            Ok(false)
+            state
+                .begin_terminal_submission(
+                    TacticalMissionResolution::Defeated,
+                    empty_tactical_consequence_receipt(),
+                    TERMINAL_RETRY_BACKOFF,
+                )
+                .unwrap(),
+            first
         );
-        assert_eq!(attempts, 2);
-        assert_eq!(
-            reports,
-            vec![
-                TacticalMissionResolution::Defeated,
-                TacticalMissionResolution::Defeated
-            ]
-        );
-        assert_eq!(receipts, vec![frozen_receipt.clone(), frozen_receipt]);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-server/src/stdb.rs
+++ b/crates/adventuresim-tactical-server/src/stdb.rs
@@ -48,6 +48,13 @@ impl SpacetimeDbReady {
 pub struct SpacetimeDb {
     conn: DbConnection,
     connected_players: Arc<Mutex<Vec<ConnectedPlayer>>>,
+    terminal_results: Arc<Mutex<Vec<TerminalSubmissionResult>>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum TerminalSubmissionResult {
+    Accepted,
+    Rejected(String),
 }
 
 impl SpacetimeDb {
@@ -84,6 +91,32 @@ impl SpacetimeDb {
     /// Take every `connected_players` row inserted since the last call.
     pub fn take_connected_players(&self) -> Vec<ConnectedPlayer> {
         std::mem::take(&mut *self.connected_players.lock().unwrap())
+    }
+
+    /// Queue a terminal reducer and mailbox its eventual nested callback
+    /// result. Queue success is not reducer acceptance.
+    pub fn submit_terminal(
+        &self,
+        resolution: TacticalMissionResolution,
+        receipt: TacticalConsequenceReceipt,
+    ) -> spacetimedb_sdk::Result<()> {
+        let terminal_results = self.terminal_results.clone();
+        self.conn
+            .reducers
+            .end_tactical_server_then(resolution, receipt, move |_, result| {
+                let result = match result {
+                    Ok(Ok(())) => TerminalSubmissionResult::Accepted,
+                    Ok(Err(error)) => TerminalSubmissionResult::Rejected(error),
+                    Err(error) => TerminalSubmissionResult::Rejected(format!(
+                        "internal reducer callback error: {error:?}"
+                    )),
+                };
+                terminal_results.lock().unwrap().push(result);
+            })
+    }
+
+    pub fn take_terminal_results(&self) -> Vec<TerminalSubmissionResult> {
+        std::mem::take(&mut *self.terminal_results.lock().unwrap())
     }
 }
 
@@ -151,6 +184,7 @@ fn connect_spacetimedb(mut commands: Commands, args: Res<Args>) -> Result {
     commands.insert_resource(SpacetimeDb {
         conn,
         connected_players: default(),
+        terminal_results: default(),
     });
 
     Ok(())

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -309,8 +309,12 @@ ten-second reconnection grace before `Failed`, including when every client
 disconnects before the seal. A timeout-disabled development server where nobody
 ever joins remains available. Terminal submission retries a frozen result after
 synchronous errors no more than once per second, before reevaluating combat
-predicates, and exits only after successful submission. A configured timeout
-remains a bounded `Failed` fallback.
+predicates. Queueing is not commitment: only an `end_tactical_server_then`
+callback confirming reducer acceptance latches the result and broadcasts the authoritative
+Victory/Defeat presentation event, keeps the transport alive for a bounded
+three-second display window, and then exits. The delay is strictly post-commit:
+it cannot defer strategic authority or create a second outcome. A configured
+timeout remains a bounded `Failed` fallback.
 
 The terminal call carries a bounded authenticated consequence receipt frozen
 with the resolution. It contains only Party character IDs, applied (clamped)

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -566,6 +566,34 @@ For a self-contained tactical database and request, prefer
 `just tactical-isolated`; it writes `.env.tactical` so a subsequent bare
 `just tactical` and `just client` target the same isolated instance.
 
+To demonstrate tactical combat presentation without touching the canonical
+development database, use three terminals from the repository root. First,
+create and seed the disposable mission profile (leave it running):
+
+```bash
+just tactical-isolated presentation-demo 23200 mission:presentation-demo hills 0 1
+```
+
+Then start the seeded mission server using the generated `.env.tactical`:
+
+```bash
+just tactical
+```
+
+Finally connect the seeded Party character:
+
+```bash
+just client
+```
+
+Fight the single enemy or allow the Party character to become incapacitated.
+The client shows live blood-loss/imbalance/incapacitation status, then an
+authoritative `VICTORY` or `DEFEAT` banner after the reducer callback confirms
+strategic acceptance.
+The server remains connected for the bounded three-second presentation window
+and exits automatically. Stop the isolated profile with Ctrl+C in its first
+terminal when finished.
+
 ## Troubleshooting
 
 - **SpacetimeDB not running:** `just status`, then `just spacetime-start`

--- a/wiki/tactical/combat.md
+++ b/wiki/tactical/combat.md
@@ -71,14 +71,16 @@ at one-second intervals before reevaluating combat, commits only after successfu
 submission, and does not depend on the optional mission timeout; a configured
 timeout is only a bounded failure fallback.
 
-This is still an iteration harness rather than complete enemy decision-making.
-It does not pathfind around terrain or other combatants, handle ranged weapons,
-or populate ranged ammunition/projectile consequences. Accepted melee attacks
-accumulate only clamped Party injury and blood consequences plus available
-weapon contact provenance in server memory. The frozen terminal receipt is
-strictly bounded and validated by strategic authority before injuries, blood,
-capability, filth, ammunition, equipment wear, and defeat morale commit
-transactionally; invalid receipts remain retryable.
+This remains an iteration harness without terrain/obstacle pathfinding, but
+offensive AI can pursue and attack with melee or ranged equipment. Accepted
+attacks accumulate clamped Party injury, blood, and ammunition consequences.
+The tactical consequence receipt introduced in stacked branch 4 also supplies
+durable equipment-wear provenance: presentation never infers contact from
+animations. Instead, the server records bounded contact stress against the
+actual attacker weapon, parry shield, or contacted armor inventory item. The
+frozen receipt is strictly bounded and validated by strategic authority before
+injuries, blood, capability, filth, ammunition, equipment wear, and defeat
+morale commit transactionally; invalid receipts remain retryable.
 
 ### Skill check algorithm
 Broadly speaking, the flow goes like this:


### PR DESCRIPTION
Stack layer 6 of #360.

Depends on #366.

This PR completes the tactical-combat parity stack with:
- live Active/Incapacitated, blood-loss, and imbalance presentation
- authoritative Victory/Defeat messages only after the end-tactical reducer callback confirms acceptance
- a bounded three-second outcome display before successful shutdown
- retry of explicit reducer rejection using the frozen receipt, while ambiguous/lost acknowledgements fail closed after ten seconds without presentation or unsafe retry
- updated tactical architecture, combat, and isolated-demo documentation
- regenerated client bindings aligned with the current module schema

Equipment wear itself is carried by the bounded consequence receipt added earlier in the stack; this layer presents the terminal result and documents the complete behavior.

Verification:
- cargo fmt --all -- --check
- cargo test --offline -p adventuresim-tactical-server (31 passed)
- cargo test --offline -p adventuresim-tactical-client (2 passed)
- cargo check --offline -p adventuresim-stdb-client
- just verify-db-client
- just test-dev-stack (53 passed)
- python scripts/update_project_map.py --check
- git diff --check

Two independent correctness/security review passes found no remaining medium- or high-severity issues. The isolated demo bootstrap preflight caught and fixed stale generated bindings; after that, the launcher did not reach readiness or emit diagnostics in this environment, so the exact three-terminal local workflow is documented in developing.md.