### PR TITLE
Refine strategic UI consistency and clarity

### DIFF
--- a/crates/strategic-web/src/routes/settlements/medical.rs
+++ b/crates/strategic-web/src/routes/settlements/medical.rs
@@ -88,7 +88,7 @@ pub(super) async fn surgery(
             return Html("<h1>Strategic data is unavailable</h1>".into());
         }
     };
-    location.active_building = building.valid().map(str::to_owned);
+    location.active_building = building.valid_for(&location).map(str::to_owned);
     let Some((active, _)) = get_active_character(&state, Some(actor_id)).await else {
         return Html("<h1>Choose a character first</h1>".into());
     };
@@ -301,10 +301,10 @@ pub(super) async fn perform_surgery(
 ) -> Redirect {
     let destination = format!("/locations/{kind}/{id}/party/{patient_id}/surgery/{limb}");
     let Some(actor_id) = session.character_id_u64() else {
-        return Redirect::to(&building.append_to(destination));
+        return Redirect::to(&building.append_to(&state, &kind, &id, destination).await);
     };
     if parse_surgery_limb(&limb).is_none() {
-        return Redirect::to(&building.append_to(destination));
+        return Redirect::to(&building.append_to(&state, &kind, &id, destination).await);
     }
     if let Err(error) = state
         .db
@@ -323,7 +323,7 @@ pub(super) async fn perform_surgery(
     {
         tracing::warn!(?error, "Manual surgery procedure failed");
     }
-    Redirect::to(&building.append_to(destination))
+    Redirect::to(&building.append_to(&state, &kind, &id, destination).await)
 }
 
 pub(super) async fn alchemy(

--- a/crates/strategic-web/src/routes/settlements/party/cooking.rs
+++ b/crates/strategic-web/src/routes/settlements/party/cooking.rs
@@ -65,9 +65,9 @@ pub(super) async fn cook_food(
         tracing::warn!(%error, character_id, "cooking failed");
         return (StatusCode::BAD_REQUEST, error.to_string()).into_response();
     }
-    Redirect::to(&building.append_to(format!(
+    Redirect::to(&building.append_to(&state, &kind, &id, format!(
         "/locations/{kind}/{id}/party/{character_id}?cook=true"
-    )))
+    )).await)
     .into_response()
 }
 

--- a/crates/strategic-web/src/routes/settlements/party/herbalism.rs
+++ b/crates/strategic-web/src/routes/settlements/party/herbalism.rs
@@ -35,8 +35,8 @@ pub(super) async fn prepare_herbal_remedy(
         tracing::warn!(%error, character_id, "herbal preparation failed");
         return (StatusCode::BAD_REQUEST, error.to_string()).into_response();
     }
-    Redirect::to(&building.append_to(format!(
+    Redirect::to(&building.append_to(&state, &kind, &id, format!(
         "/locations/{kind}/{id}/party/{character_id}?herbalism=true"
-    )))
+    )).await)
     .into_response()
 }

--- a/crates/strategic-web/src/routes/settlements/party/inventory_medical.rs
+++ b/crates/strategic-web/src/routes/settlements/party/inventory_medical.rs
@@ -396,7 +396,7 @@ pub(super) async fn deposit_party_inventory(
                 .await;
         }
     }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}/party-inventory")))
+    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party-inventory")).await)
 }
 
 pub(super) async fn withdraw_party_inventory(
@@ -417,7 +417,7 @@ pub(super) async fn withdraw_party_inventory(
                 .await;
         }
     }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}/party-inventory")))
+    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party-inventory")).await)
 }
 
 pub(super) fn transfer_entries(form: &PartyPoolTransferForm) -> Vec<(u64, u32)> {
@@ -457,7 +457,7 @@ pub(super) async fn liquidate_party_assets(
             )
             .await;
     }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}/party-inventory")))
+    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party-inventory")).await)
 }
 
 pub(super) async fn remove_party_member(
@@ -488,7 +488,7 @@ pub(super) async fn remove_party_member(
             tracing::error!("Failed to remove party member: {error:?}");
         }
     }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}")))
+    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}")).await)
 }
 
 pub(super) async fn party_stats(
@@ -530,7 +530,7 @@ pub(super) async fn render_party_stats(
             return Html("<h1>Strategic data is unavailable</h1>".to_string());
         }
     };
-    location.active_building = building.valid().map(str::to_owned);
+    location.active_building = building.valid_for(&location).map(str::to_owned);
     let Some((active_character, _)) =
         get_active_character(&state, session.character_id_u64()).await
     else {
@@ -817,7 +817,7 @@ pub(super) async fn stop_preparation(
     {
         tracing::warn!(%error, actor_id, patient_id, administration_id, "preparation stop rejected");
     }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}/party/{patient_id}")))
+    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party/{patient_id}")).await)
 }
 
 pub(super) async fn get_strategic_condition(

--- a/crates/strategic-web/src/routes/settlements/party/location_personal.rs
+++ b/crates/strategic-web/src/routes/settlements/party/location_personal.rs
@@ -22,6 +22,7 @@ pub(super) async fn resolve_location(state: &AppState, kind: &str, id: &str) -> 
                         settlement.name,
                         Some(settlement.category),
                         Some(settlement.religion_id),
+                        Some(settlement.economy),
                     )
                 })
             }),
@@ -32,9 +33,9 @@ pub(super) async fn resolve_location(state: &AppState, kind: &str, id: &str) -> 
                 sql_string_literal(id)
             ))
             .await
-            .map(|row| row.map(|site| (site.display_title, None, None))),
+            .map(|row| row.map(|site| (site.display_title, None, None, None))),
     };
-    let (name, category, religion_id) = match location {
+    let (name, category, religion_id, economy) = match location {
         Ok(Some(location)) => location,
         Ok(None) => return LocationLookup::NotFound,
         Err(error) => {
@@ -48,6 +49,7 @@ pub(super) async fn resolve_location(state: &AppState, kind: &str, id: &str) -> 
         name,
         religion_id,
         category,
+        economy,
         active_building: None,
     })
 }
@@ -102,7 +104,7 @@ pub(super) async fn render_party_personal(
             return Html("<h1>Strategic data is unavailable</h1>".to_string());
         }
     };
-    location.active_building = building.valid().map(str::to_owned);
+    location.active_building = building.valid_for(&location).map(str::to_owned);
     let Some((active_character, active_inventory)) =
         get_active_character(&state, session.character_id_u64()).await
     else {

--- a/crates/strategic-web/src/routes/settlements/party/social.rs
+++ b/crates/strategic-web/src/routes/settlements/party/social.rs
@@ -11,7 +11,7 @@ pub(super) async fn party_social(
             return Html("<h1>Strategic data is unavailable</h1>".into());
         }
     };
-    location.active_building = building.valid().map(str::to_owned);
+    location.active_building = building.valid_for(&location).map(str::to_owned);
     let Some((active, _)) = get_active_character(&state, session.character_id_u64()).await else {
         return Html("<h1>Choose a character first</h1>".into());
     };
@@ -320,7 +320,7 @@ pub(super) async fn set_automatic_social_chat(
     {
         tracing::warn!(%error, actor_id, target_id, "automatic social chat preference rejected");
     }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}/party/{target_id}/social")))
+    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party/{target_id}/social")).await)
         .into_response()
 }
 
@@ -371,9 +371,9 @@ pub(super) async fn perform_social_action(
             social_action_error_feedback(&error.to_string())
         }
     };
-    Redirect::to(&building.append_to(format!(
+    Redirect::to(&building.append_to(&state, &kind, &id, format!(
         "/locations/{kind}/{id}/party/{target_id}/social?social_feedback={feedback}"
-    )))
+    )).await)
     .into_response()
 }
 
@@ -419,9 +419,9 @@ pub(super) async fn chat_with_party_member(
             "chat_unavailable"
         }
     };
-    Redirect::to(&building.append_to(format!(
+    Redirect::to(&building.append_to(&state, &kind, &id, format!(
         "/locations/{kind}/{id}/party/{target_id}/social?social_feedback={feedback}"
-    )))
+    )).await)
     .into_response()
 }
 

--- a/crates/strategic-web/src/routes/settlements/party/training_activity.rs
+++ b/crates/strategic-web/src/routes/settlements/party/training_activity.rs
@@ -87,7 +87,7 @@ pub(super) async fn update_training_schedule(
         .await
     {
         Ok(()) => Redirect::to(
-            &building.append_to(format!("/locations/{kind}/{id}/party/{character_id}")),
+            &building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party/{character_id}")).await,
         )
         .into_response(),
         Err(error) => {
@@ -189,7 +189,7 @@ pub(super) async fn perform_immediate_activity(
                     .into_response();
             }
             Redirect::to(
-                &building.append_to(format!("/locations/{kind}/{id}/party/{character_id}")),
+                &building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party/{character_id}")).await,
             )
             .into_response()
         }
@@ -210,7 +210,7 @@ pub(super) async fn party_member(
             return Html("<h1>Strategic data is unavailable</h1>".to_string());
         }
     };
-    location.active_building = building.valid().map(str::to_owned);
+    location.active_building = building.valid_for(&location).map(str::to_owned);
 
     let Some((active_character, active_inventory)) =
         get_active_character(&state, session.character_id_u64()).await
@@ -345,7 +345,7 @@ pub(super) async fn party_pool_inventory(
             return Html("<h1>Strategic data is unavailable</h1>".into());
         }
     };
-    location.active_building = building.valid().map(str::to_owned);
+    location.active_building = building.valid_for(&location).map(str::to_owned);
     let Some((character, inventory)) =
         get_active_character(&state, session.character_id_u64()).await
     else {

--- a/crates/strategic-web/src/routes/settlements/party/transfers.rs
+++ b/crates/strategic-web/src/routes/settlements/party/transfers.rs
@@ -30,9 +30,9 @@ pub(super) async fn discard_inventory_items(
             }
         }
     }
-    Redirect::to(&building.append_to(format!(
+    Redirect::to(&building.append_to(&state, &kind, &id, format!(
         "/locations/{kind}/{id}/party/{character_id}/inventory"
-    )))
+    )).await)
 }
 
 pub(super) async fn finalize_party_offer(
@@ -76,9 +76,9 @@ pub(super) async fn finalize_party_offer(
             }
         }
     }
-    Redirect::to(&building.append_to(format!(
+    Redirect::to(&building.append_to(&state, &kind, &id, format!(
         "/locations/{kind}/{id}/party/{character_id}/inventory"
-    )))
+    )).await)
 }
 
 pub(super) async fn transfer_party_item(
@@ -94,7 +94,7 @@ pub(super) async fn transfer_party_item(
         return Redirect::to("/characters");
     };
     if form.from_character_id != active_character.id && recipient_id != active_character.id {
-        return Redirect::to(&building.append_to(format!("/locations/{kind}/{id}")));
+        return Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}")).await);
     }
     let to_character_id = if form.from_character_id == active_character.id {
         recipient_id
@@ -121,9 +121,9 @@ pub(super) async fn transfer_party_item(
     } else {
         form.from_character_id
     };
-    Redirect::to(&building.append_to(format!(
+    Redirect::to(&building.append_to(&state, &kind, &id, format!(
         "/locations/{kind}/{id}/party/{comparison_character_id}/inventory"
-    )))
+    )).await)
 }
 
 pub(super) async fn merchants(

--- a/crates/strategic-web/src/routes/settlements/religion.rs
+++ b/crates/strategic-web/src/routes/settlements/religion.rs
@@ -192,5 +192,5 @@ pub(super) async fn renounce_religion(
             tracing::warn!(%error, character_id, "failed to renounce character religion");
         }
     }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}/party/{character_id}")))
+    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party/{character_id}")).await)
 }

--- a/crates/strategic-web/src/routes/settlements/religion_party.rs
+++ b/crates/strategic-web/src/routes/settlements/religion_party.rs
@@ -21,5 +21,5 @@ pub(super) async fn resolve_religious_demand(
     {
         tracing::warn!(%error, character_id, demand_id, "failed to resolve religious demand");
     }
-    Redirect::to(&building.append_to(format!("/locations/{kind}/{id}/party/{character_id}")))
+    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party/{character_id}")).await)
 }

--- a/crates/strategic-web/src/routes/settlements/router.rs
+++ b/crates/strategic-web/src/routes/settlements/router.rs
@@ -25,19 +25,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 
-const BUILDINGS: &[&str] = &[
-    "public-square",
-    "residences",
-    "keep",
-    "map",
-    "merchants",
-    "weapons",
-    "armor",
-    "clothing",
-    "inn",
-    "religion",
-];
-
 #[derive(Clone, Debug, Default, Deserialize)]
 struct BuildingQuery {
     building: Option<String>,
@@ -55,14 +42,14 @@ impl BuildingQuery {
     fn herbalism(&self) -> bool {
         self.herbalism.unwrap_or(false)
     }
-    fn valid(&self) -> Option<&str> {
+    fn valid_for<'a>(&'a self, location: &LocationView) -> Option<&'a str> {
         self.building
             .as_deref()
-            .filter(|value| BUILDINGS.contains(value))
+            .and_then(|building| location.valid_building(building))
     }
 
-    fn append_to(&self, path: String) -> String {
-        self.valid().map_or_else(
+    fn append_to_location(&self, location: &LocationView, path: String) -> String {
+        self.valid_for(location).map_or_else(
             || path.clone(),
             |building| {
                 format!(
@@ -71,6 +58,19 @@ impl BuildingQuery {
                 )
             },
         )
+    }
+
+    async fn append_to(
+        &self,
+        state: &AppState,
+        kind: &str,
+        id: &str,
+        path: String,
+    ) -> String {
+        match resolve_location(state, kind, id).await {
+            LocationLookup::Found(location) => self.append_to_location(&location, path),
+            LocationLookup::NotFound | LocationLookup::Unavailable => path,
+        }
     }
 
     fn cooking(&self) -> bool {
@@ -84,17 +84,66 @@ mod building_query_tests {
 
     #[test]
     fn building_query_is_closed_and_preserved_on_redirects() {
+        let economy = adventuresim_world_schema::SettlementEconomyProfile::stage_placeholder();
+        let (_organization, chapter) = adventuresim_core::organization::catalog()
+            .organizations
+            .iter()
+            .find_map(|organization| {
+                organization.chapters.iter().find(|chapter| {
+                    adventuresim_core::organization::chapter_has_standalone_building(
+                        organization,
+                        chapter,
+                        &economy,
+                    )
+                }).map(|chapter| (organization, chapter))
+            })
+            .expect("standalone catalog chapter");
+        let location = crate::templates::settlement::LocationView {
+            kind: crate::templates::settlement::LocationKind::Settlement,
+            id: chapter.settlement_id.clone(),
+            name: "Place".into(),
+            religion_id: None,
+            category: Some(crate::spacetimedb::SettlementCategory::Village),
+            economy: Some(economy),
+            active_building: None,
+        };
         let valid = BuildingQuery {
             building: Some("inn".into()),
             ..Default::default()
         };
-        assert_eq!(valid.valid(), Some("inn"));
+        assert_eq!(valid.valid_for(&location), Some("inn"));
+        let unavailable = BuildingQuery { building: Some("books".into()), ..Default::default() };
+        assert_eq!(unavailable.valid_for(&location), None);
+        let organization_query = BuildingQuery {
+            building: Some(chapter.location_id.clone()),
+            ..Default::default()
+        };
+        assert_eq!(organization_query.valid_for(&location), Some(chapter.location_id.as_str()));
+        if let Some(foreign) = adventuresim_core::organization::catalog()
+            .organizations
+            .iter()
+            .flat_map(|organization| &organization.chapters)
+            .find(|foreign| {
+                foreign.settlement_id != location.id
+                    && adventuresim_core::organization::organization_chapter_at(
+                        &location.id,
+                        &foreign.location_id,
+                    )
+                    .is_none()
+            })
+        {
+            let foreign_query = BuildingQuery {
+                building: Some(foreign.location_id.clone()),
+                ..Default::default()
+            };
+            assert_eq!(foreign_query.valid_for(&location), None);
+        }
         assert_eq!(
-            valid.append_to("/locations/settlement/x/party/1".into()),
+            valid.append_to_location(&location, "/locations/settlement/x/party/1".into()),
             "/locations/settlement/x/party/1?building=inn"
         );
         assert_eq!(
-            valid.append_to("/locations/settlement/x/party/1?cook=true".into()),
+            valid.append_to_location(&location, "/locations/settlement/x/party/1?cook=true".into()),
             "/locations/settlement/x/party/1?cook=true&building=inn"
         );
         let non_service = BuildingQuery {
@@ -102,16 +151,16 @@ mod building_query_tests {
             ..Default::default()
         };
         assert_eq!(
-            non_service.append_to("/locations/settlement/x/party/1".into()),
+            non_service.append_to_location(&location, "/locations/settlement/x/party/1".into()),
             "/locations/settlement/x/party/1?building=public-square"
         );
         let invalid = BuildingQuery {
             building: Some("../religion".into()),
             ..Default::default()
         };
-        assert_eq!(invalid.valid(), None);
+        assert_eq!(invalid.valid_for(&location), None);
         assert_eq!(
-            invalid.append_to("/locations/settlement/x/party/1".into()),
+            invalid.append_to_location(&location, "/locations/settlement/x/party/1".into()),
             "/locations/settlement/x/party/1"
         );
     }

--- a/crates/strategic-web/src/templates/character.rs
+++ b/crates/strategic-web/src/templates/character.rs
@@ -178,14 +178,10 @@ mod tests {
     }
 }
 
-const PROTOTYPE_NOTICE: &str = "Early prototype: All text and images are placeholders. Features and saved progress may change or be reset during development.";
-
 pub fn character_candidates_bootstrap_page(version: u16) -> Markup {
     let content = html! {
         main class="center-content candidate-bootstrap" {
-            p class="prototype-disclaimer" role="note" { (PROTOTYPE_NOTICE) }
             h2 class="page-title" { "Choose a stage of life" }
-            p class="small-copy text-muted" { "Choose how established your adventurer is before meeting the candidates." }
             noscript { p role="alert" { "JavaScript is required to prepare a private candidate roster." } }
             div data-candidate-bootstrap data-generator-version=(version) {}
             nav class="candidate-age-options" aria-label="Starting age" {
@@ -259,10 +255,8 @@ pub fn character_candidates_page(
     let attributes_title = format!("{}'s attributes", candidate.character.name);
     let skills_title = format!("{}'s skills", candidate.character.name);
     let portraits = character_portrait_overlay("Candidate adventurers", None, &portraits);
-    let center_before = html! {
-            p class="prototype-disclaimer" role="note" { (PROTOTYPE_NOTICE) }
-            span data-candidate-roster data-age-tier=(age_tier.as_str()) hidden {}
-    };
+    let center_before =
+        html! { span data-candidate-roster data-age-tier=(age_tier.as_str()) hidden {} };
     let center_after = html! {
             @if show_inventory {
                 (candidate_inventory_view(spec))
@@ -782,7 +776,7 @@ fn candidate_personality(spec: &StartingCharacterSpec) -> CharacterPersonality {
 
 #[cfg(test)]
 mod creation_tests {
-    use super::{CandidatePresentation, PROTOTYPE_NOTICE, character_candidates_page};
+    use super::{CandidatePresentation, character_candidates_page};
     use adventuresim_core::organization::StartingProfession;
     use adventuresim_core::starting_character::{StartingAgeTier, StartingItem, roster};
 
@@ -804,7 +798,7 @@ mod creation_tests {
         )
         .into_string();
         assert_eq!(markup.matches("class=\"party-portrait\"").count(), 5);
-        assert!(markup.contains(PROTOTYPE_NOTICE));
+        assert!(!markup.contains("prototype-disclaimer"));
         assert!(!markup.contains("role=\"dialog\""));
         assert!(markup.contains("class=\"party-portrait-overlay\""));
         assert!(markup.contains("class=\"party-attributes-list\""));

--- a/crates/strategic-web/src/templates/components.rs
+++ b/crates/strategic-web/src/templates/components.rs
@@ -1,8 +1,58 @@
 //! Reusable Maud components
 
+use adventuresim_core::organization::OrganizationDefinition;
 use maud::{Markup, html};
 
 const GAME_ICON_ROOT: &str = "/static/icons/game";
+
+pub(crate) fn organization_colors(id: &str) -> (&'static str, &'static str) {
+    const PALETTES: &[(&str, &str)] = &[
+        ("#7f1d1d", "#f5d77b"),
+        ("#173f5f", "#d9edf7"),
+        ("#285943", "#f0cf65"),
+        ("#4c2a63", "#e6c9ff"),
+        ("#7a4b12", "#f6e7c1"),
+        ("#1e4d4f", "#f1b24a"),
+        ("#5a2333", "#f3d9a5"),
+        ("#243b67", "#d8c89b"),
+    ];
+    let hash = id.bytes().fold(0usize, |hash, byte| {
+        hash.wrapping_mul(31).wrapping_add(usize::from(byte))
+    });
+    PALETTES[hash % PALETTES.len()]
+}
+
+pub(crate) fn organization_charge(definition: &OrganizationDefinition) -> &'static str {
+    match definition.id.as_str() {
+        "order_saint_george" => return "mounted-knight",
+        "lodge_hart_king" => return "wood-axe",
+        "hunt_pale_lantern" => return "eye-target",
+        _ => {}
+    }
+    match definition.service_id.as_deref() {
+        Some("merchants") => "coins",
+        Some("weapons") => "anvil",
+        Some("armor") => "breastplate",
+        Some("clothing") => "clothes",
+        Some("herbalist") => "medical-pack",
+        Some("physician") => "caduceus",
+        Some("surgeon") => "scalpel",
+        Some("inn") => "meal",
+        _ if definition.id.contains("forester") => "wood-axe",
+        _ if definition.id.contains("saint_george")
+            || definition.id.contains("royal")
+            || definition.id.contains("knight") =>
+        {
+            "mounted-knight"
+        }
+        _ if definition.id.contains("witch") || definition.id.contains("watchful") => "eye-target",
+        _ if definition.id.contains("religion") || definition.id.contains("theolog") => {
+            "gothic-cross"
+        }
+        _ if definition.id.contains("scholar") || definition.id.contains("college") => "open-book",
+        _ => "shield",
+    }
+}
 
 /// A locally-vendored, theme-recolourable Game Icons mask.
 pub fn game_icon(label: &str, icon: &str) -> Markup {

--- a/crates/strategic-web/src/templates/inventory_browser.rs
+++ b/crates/strategic-web/src/templates/inventory_browser.rs
@@ -87,8 +87,8 @@ impl InventoryBrowser<'_> {
                         (sortable_icon_header("type", "inventory-column-type", "Item type", game_icon("Item type", "knapsack")))
                         (sortable_text_header("name", "Item", "inventory-column-item"))
                         @if self.show_quantities {
-                            (sortable_text_header("quantity", "#", "inventory-column-count"))
-                            (sortable_text_header("target", "#?", "inventory-column-target"))
+                            (sortable_icon_header("quantity", "inventory-column-count", "Quantity", game_icon("Quantity", "open-chest")))
+                            (sortable_icon_header("target", "inventory-column-target", "Target quantity", game_icon("Target quantity", "eye-target")))
                         }
                         @if self.show_equipped {
                             (sortable_icon_header("equipped", "inventory-column-equipped", "Equipped", game_icon("Equipped", "check-mark")))
@@ -140,6 +140,11 @@ mod tests {
         assert!(rendered.contains("data-inventory-browser=\"trade-left\""));
         assert!(rendered.contains("data-inventory-sort=\"quantity\""));
         assert!(rendered.contains("data-inventory-sort=\"target\""));
+        assert!(rendered.contains("aria-label=\"Sort by Quantity\""));
+        assert!(rendered.contains("open-chest.svg"));
+        assert!(rendered.contains("aria-label=\"Sort by Target quantity\""));
+        assert!(!rendered.contains(">#<"));
+        assert!(!rendered.contains(">#?<"));
         assert!(rendered.contains("accuracy,reach,penetration,damage,block"));
         assert!(rendered.contains("inventory-browser-table-frame"));
         assert!(rendered.contains("inventory-actions-header"));

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -3,7 +3,7 @@
 use crate::spacetimedb::SettlementCategory;
 use maud::{DOCTYPE, Markup, html};
 
-use super::religion_icon_path;
+use super::{organization_charge, organization_colors, religion_icon_path};
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ScriptProfile {
     Entry,
@@ -167,16 +167,16 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 link rel="stylesheet" href="/static/css/base.css?v=environment-14";
                 // Shared CSS
                 link rel="stylesheet" href="/static/css/reset.css";
-                link rel="stylesheet" href="/static/css/layout.css?v=developer-visibility-1";
+                link rel="stylesheet" href="/static/css/layout.css?v=organization-facades-1";
                 link rel="stylesheet" href="/static/css/components.css?v=lowercase-display-type-1";
-                link rel="stylesheet" href="/static/css/strategic.css?v=candidate-inventory-3-item-yaml-editor-1-claim-challenges-1-equipment-slots-7-weather-status-2-residences-1-continuity-1-puzzle-chat-2";
+                link rel="stylesheet" href="/static/css/strategic.css?v=visual-ui-audit-1";
                 link rel="stylesheet" href="/static/css/utilities.css?v=strategic-ui-overhaul-1";
 
                 // Datastar
                 script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar/bundles/datastar.js" {}
                 script src="/static/background-fetch.js?v=background-fetch-2" {}
                 script src="/static/developer-mode.js?v=development-clock-2" defer {}
-                script src="/static/tooltips.js?v=pinnable-lifecycle-3" defer {}
+                script src="/static/tooltips.js?v=delegated-mouseover-1" defer {}
                 script src="/static/character-action-dialog.js?v=character-actions-1" defer {}
                 @if scripts != ScriptProfile::Entry {
                     script src="/static/live-state.js?v=sse-4" defer {}
@@ -203,7 +203,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                     script src="/static/chat-resize.js?v=counterparty-portraits-1" defer {}
                     script src="/static/local-chat.js?v=local-chat-location-authority-1" defer {}
                     script src="/static/strategic-condition.js?v=strategic-condition-4" defer {}
-                    script src="/static/building-state.js?v=non-service-building-tabs-2" defer {}
+                    script src="/static/building-state.js?v=exact-place-facades-1" defer {}
                     script src="/static/travel-planner.js?v=travel-rails-1" defer {}
                     script src="/static/strategic-map.js?v=population-culling-3" defer {}
                     script src="/static/rest-duration.js?v=wake-time-4" defer {}
@@ -294,11 +294,7 @@ fn settlement_top_bar(
             nav class="top-bar-center settlement-services" aria-label="Settlement services"
                 data-settlement-id=(settlement_id) {
                 @for (path, service_id, label, icon) in services {
-                    @let available = match path {
-                        "" | "residences" => true,
-                        "keep" => settlement_has_keep(category),
-                        _ => economy.is_none_or(|profile| service_tab_available(profile, path)),
-                    };
+                    @let available = settlement_building_available(settlement_id, category, economy, service_id);
                     @if available {
                     @let href = if path == "map" {
                         format!("/locations/settlement/{}/map", settlement_id)
@@ -311,15 +307,17 @@ fn settlement_top_bar(
                     };
                     @let service_material = if service_id == "religion" || (service_id == "keep" && !matches!(category, SettlementCategory::Village)) { "stone" } else { material };
                     @let tint = building_tint(settlement_id, service_id, service_material);
+                    @let selected = active_service == path || (path.is_empty() && active_service == service_id);
                     a href=(href)
-                        class=(if active_service == path { "nav-tab active" } else { "nav-tab" })
+                        class=(if selected { "nav-tab active" } else { "nav-tab" })
                         style=(format!("--building-tint:{tint}"))
                         data-service-id=(service_id)
+                        data-building-id=(service_id)
                         data-building-material=(service_material)
                         data-service-label=(label)
                         aria-label=(label)
                         data-strategic-tooltip=(label)
-                        aria-current=(if active_service == path { "page" } else { "false" })
+                        aria-current=(if selected { "page" } else { "false" })
                     {
                         span class="service-tab-building" aria-hidden="true" {}
                         @if path == "weapons" {
@@ -340,11 +338,14 @@ fn settlement_top_bar(
                     @let standalone = economy.is_none_or(|profile| adventuresim_core::organization::chapter_has_standalone_building(organization, chapter, profile));
                     @if standalone {
                     @let kind = format!("{:?}", chapter.building_kind).to_ascii_lowercase();
+                    @let charge = organization_charge(organization);
+                    @let (field, accent) = organization_colors(&organization.id);
                     @let tint = building_tint(settlement_id, &chapter.location_id, material);
                     a href=(format!("/settlements/{}/places/{}", settlement_id, chapter.location_id))
                         class=(if active_service == chapter.location_id { "nav-tab active" } else { "nav-tab" })
                         style=(format!("--building-tint:{tint}"))
                         data-service-id="organization"
+                        data-building-id=(&chapter.location_id)
                         data-organization-building-kind=(kind)
                         data-building-material=(material)
                         data-service-label=(&chapter.building_name)
@@ -352,7 +353,9 @@ fn settlement_top_bar(
                         data-strategic-tooltip=(&chapter.building_name)
                         aria-current=(if active_service == chapter.location_id { "page" } else { "false" }) {
                         span class="service-tab-building" aria-hidden="true" {}
-                        span class="service-tab-icon service-tab-icon-organization" aria-hidden="true" {}
+                        span class="service-tab-icon service-tab-icon-organization"
+                            style=(format!("--service-tab-icon: url('/static/icons/game/{charge}.svg'); --organization-field: {field}; --organization-accent: {accent}"))
+                            aria-hidden="true" {}
                         span class="service-tab-label" aria-hidden="true" { (&chapter.building_name) }
                     }
                     }
@@ -453,6 +456,30 @@ fn settlement_has_keep(category: &SettlementCategory) -> bool {
         category,
         SettlementCategory::Town | SettlementCategory::City | SettlementCategory::Capital
     )
+}
+
+pub(crate) fn settlement_building_available(
+    settlement_id: &str,
+    category: &SettlementCategory,
+    economy: Option<&adventuresim_world_schema::SettlementEconomyProfile>,
+    building_id: &str,
+) -> bool {
+    match building_id {
+        "public-square" | "residences" | "map" => true,
+        "keep" => settlement_has_keep(category),
+        "merchants" | "weapons" | "armor" | "clothing" | "herbalist" | "books" | "inn"
+        | "religion" => economy.is_none_or(|profile| service_tab_available(profile, building_id)),
+        _ => adventuresim_core::organization::organization_chapter_at(settlement_id, building_id)
+            .is_some_and(|(organization, chapter)| {
+                economy.is_none_or(|profile| {
+                    adventuresim_core::organization::chapter_has_standalone_building(
+                        organization,
+                        chapter,
+                        profile,
+                    )
+                })
+            }),
+    }
 }
 
 fn service_tab_available(
@@ -897,6 +924,32 @@ mod tests {
     }
 
     #[test]
+    fn standalone_organization_facade_has_exact_identity_and_heraldry() {
+        let organization = adventuresim_core::organization::catalog()
+            .organizations
+            .iter()
+            .find(|organization| !organization.chapters.is_empty())
+            .expect("catalog organization with a chapter");
+        let chapter = &organization.chapters[0];
+        let markup = settlement_top_bar(
+            "Place",
+            &chapter.settlement_id,
+            &SettlementCategory::Town,
+            &chapter.location_id,
+            None,
+            None,
+            None,
+        )
+        .into_string();
+        assert!(markup.contains("data-service-id=\"organization\""));
+        assert!(markup.contains(&format!("data-building-id=\"{}\"", chapter.location_id)));
+        assert!(markup.contains(&format!(
+            "/static/icons/game/{}.svg",
+            super::organization_charge(organization)
+        )));
+    }
+
+    #[test]
     fn horizon_variants_are_stable_reachable_and_emitted() {
         assert_eq!(horizon_variant("lubeck"), horizon_variant("lubeck"));
         let variants = (0..128)
@@ -973,6 +1026,13 @@ mod tests {
         assert!(markup.contains("service-tab-icon-house"));
         assert!(!markup.contains("aria-label=\"Keep\""));
         assert!(markup.contains("aria-label=\"Church\""));
+        let inn = markup
+            .split("data-building-id=\"inn\"")
+            .nth(1)
+            .and_then(|tail| tail.split("</a>").next())
+            .expect("rendered Inn Place Facade");
+        assert!(inn.contains("aria-label=\"Inn\""));
+        assert!(inn.contains("data-strategic-tooltip=\"Inn\""));
         assert!(markup.contains("aria-current=\"page\""));
         assert!(markup.contains("--service-tab-icon: url("));
         assert!(markup.contains(religion_icon_path(Some("roman_catholic"))));
@@ -1001,6 +1061,17 @@ mod tests {
         assert!(css.contains("data-service-id=\"residences\"].active"));
         assert!(css.contains("data-service-id=\"keep\"].active"));
         assert!(css.contains(".nav-tab[data-service-id=\"books\"]"));
+        for kind in [
+            "guildhall",
+            "workshop",
+            "college",
+            "confraternity",
+            "commandery",
+            "lodge",
+        ] {
+            assert!(css.contains(&format!("data-organization-building-kind=\"{kind}\"")));
+        }
+        assert!(css.contains("var(--organization-accent, #fff)"));
 
         let town = settlement_top_bar(
             "Larger Place",
@@ -1016,7 +1087,9 @@ mod tests {
         assert!(town.contains("aria-label=\"Keep\""));
         assert!(town.contains("href=\"/settlements/t/places/keep\" class=\"nav-tab active\""));
         assert!(town.contains("service-tab-icon-castle"));
-        assert!(town.contains("data-service-id=\"keep\" data-building-material=\"stone\""));
+        assert!(town.contains(
+            "data-service-id=\"keep\" data-building-id=\"keep\" data-building-material=\"stone\""
+        ));
     }
 
     #[test]
@@ -1048,8 +1121,9 @@ mod tests {
         assert!(building.contains("searchParams.get(\"building\")"));
         assert!(building.contains("searchParams.set(\"building\", building)"));
         assert!(building.contains("pathname.includes(\"/party\")"));
-        assert!(building.contains("partyInspection && services.has(requested)"));
-        assert!(building.contains("!services.has(requested) || !partyInspection"));
+        assert!(building.contains("partyInspection && buildings.has(requested)"));
+        assert!(building.contains("!buildings.has(requested) || !partyInspection"));
+        assert!(building.contains("tab.dataset.buildingId === building"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/character_details.rs
+++ b/crates/strategic-web/src/templates/settlement/character_details.rs
@@ -25,7 +25,9 @@ use crate::spacetimedb::{
     InventoryItemAmount, ItemDefinition, LimbInjury, OrganizationMembership,
     OrganizationPresentation, Party, RetainedProjectile,
 };
-use crate::templates::{decorative_game_icon, religion_icon, sidebar_section};
+use crate::templates::{
+    decorative_game_icon, organization_charge, organization_colors, religion_icon, sidebar_section,
+};
 
 fn character_summary_rail(
     capability: Option<&CharacterCapability>,
@@ -773,55 +775,6 @@ fn empty_organization_crest() -> Markup {
         span class="organization-crest organization-crest-empty" aria-hidden="true" {
             span class="organization-crest-charge" {}
         }
-    }
-}
-
-fn organization_colors(id: &str) -> (&'static str, &'static str) {
-    const PALETTES: &[(&str, &str)] = &[
-        ("#7f1d1d", "#f5d77b"),
-        ("#173f5f", "#d9edf7"),
-        ("#285943", "#f0cf65"),
-        ("#4c2a63", "#e6c9ff"),
-        ("#7a4b12", "#f6e7c1"),
-        ("#1e4d4f", "#f1b24a"),
-        ("#5a2333", "#f3d9a5"),
-        ("#243b67", "#d8c89b"),
-    ];
-    let hash = id.bytes().fold(0usize, |hash, byte| {
-        hash.wrapping_mul(31).wrapping_add(usize::from(byte))
-    });
-    PALETTES[hash % PALETTES.len()]
-}
-
-fn organization_charge(definition: &OrganizationDefinition) -> &'static str {
-    match definition.id.as_str() {
-        "order_saint_george" => return "mounted-knight",
-        "lodge_hart_king" => return "wood-axe",
-        "hunt_pale_lantern" => return "eye-target",
-        _ => {}
-    }
-    match definition.service_id.as_deref() {
-        Some("merchants") => "coins",
-        Some("weapons") => "anvil",
-        Some("armor") => "breastplate",
-        Some("clothing") => "clothes",
-        Some("herbalist") => "medical-pack",
-        Some("physician") => "caduceus",
-        Some("surgeon") => "scalpel",
-        Some("inn") => "meal",
-        _ if definition.id.contains("forester") => "wood-axe",
-        _ if definition.id.contains("saint_george")
-            || definition.id.contains("royal")
-            || definition.id.contains("knight") =>
-        {
-            "mounted-knight"
-        }
-        _ if definition.id.contains("witch") || definition.id.contains("watchful") => "eye-target",
-        _ if definition.id.contains("religion") || definition.id.contains("theolog") => {
-            "gothic-cross"
-        }
-        _ if definition.id.contains("scholar") || definition.id.contains("college") => "open-book",
-        _ => "shield",
     }
 }
 

--- a/crates/strategic-web/src/templates/settlement/character_health.rs
+++ b/crates/strategic-web/src/templates/settlement/character_health.rs
@@ -1665,13 +1665,14 @@ fn attribute_row(name: &str, icon: &str, value: f32, health: f32, show_label: bo
         div class=(if show_label { "party-attribute-row" } else { "party-attribute-row party-attribute-icon-only" }) {
             (stat_icon(name, "attributes", icon, show_label))
             @if show_label { span class="party-attribute-name" { (name) } }
-            div class="attribute-rank-bar" title=(format!("{effective_value:.1}"))
+            div class="attribute-rank-bar"
+                data-strategic-tooltip=(format!("{name}: {effective_value:.1} out of 5"))
+                tabindex="0"
                 role="meter" aria-valuemin="0" aria-valuemax="5" aria-valuenow=(format!("{effective_value:.1}"))
                 aria-label=(format!("{name}: {effective_value:.1} out of 5")) {
                 span class="rank-current" style=(format!("width:{current_width:.1}%")) {}
                 span class="rank-damage" style=(format!("left:{current_width:.1}%;width:{damage_width:.1}%")) {}
             }
-            span class="attribute-rank-value" aria-hidden="true" { (format!("{effective_value:.1}")) }
         }
     }
 }
@@ -2290,6 +2291,9 @@ mod tests {
         assert!(link_end < attribute_row);
         assert!(markup.contains("aria-label=\"Open surgery menu for Head\""));
         assert!(markup.contains("aria-haspopup=\"dialog\" aria-expanded=\"false\""));
+        assert!(markup.contains("data-strategic-tooltip=\"Intelligence: 2.2 out of 5\""));
+        assert!(markup.contains("class=\"attribute-rank-bar\" data-strategic-tooltip="));
+        assert!(!markup.contains("attribute-rank-value"));
     }
 
     #[test]

--- a/crates/strategic-web/src/templates/settlement/context.rs
+++ b/crates/strategic-web/src/templates/settlement/context.rs
@@ -1,9 +1,13 @@
 use std::{fmt, str::FromStr};
 
+use adventuresim_world_schema::SettlementEconomyProfile;
 use maud::Markup;
 
 use crate::spacetimedb::SettlementCategory;
-use crate::templates::{quest_location_layout_with_session, settlement_layout_with_session};
+use crate::templates::{
+    quest_location_layout_with_session, settlement_building_available,
+    settlement_layout_with_session,
+};
 
 #[derive(Clone, Debug)]
 pub struct LocationView {
@@ -12,6 +16,7 @@ pub struct LocationView {
     pub name: String,
     pub religion_id: Option<String>,
     pub category: Option<SettlementCategory>,
+    pub economy: Option<SettlementEconomyProfile>,
     pub active_building: Option<String>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -47,6 +52,18 @@ impl FromStr for LocationKind {
 }
 
 impl LocationView {
+    pub fn valid_building<'a>(&self, building: &'a str) -> Option<&'a str> {
+        (self.kind == LocationKind::Settlement
+            && settlement_building_available(
+                &self.id,
+                self.category
+                    .as_ref()
+                    .unwrap_or(&SettlementCategory::Unknown),
+                self.economy.as_ref(),
+                building,
+            ))
+        .then_some(building)
+    }
     pub fn base_path(&self) -> String {
         format!("/locations/{}/{}", self.kind, self.id)
     }
@@ -78,7 +95,7 @@ impl LocationView {
                     .unwrap_or(&SettlementCategory::Unknown),
                 self.active_building.as_deref().unwrap_or(""),
                 self.religion_id.as_deref(),
-                None,
+                self.economy.as_ref(),
                 content,
                 logged_in_as,
             )
@@ -104,5 +121,23 @@ mod tests {
         assert_eq!("case-site".parse(), Ok(LocationKind::CaseSite));
         assert!("quest".parse::<LocationKind>().is_err());
         assert!("merchant".parse::<LocationKind>().is_err());
+    }
+
+    #[test]
+    fn settlement_location_layout_respects_its_economy_services() {
+        let location = LocationView {
+            kind: LocationKind::Settlement,
+            id: "small-place".into(),
+            name: "Small Place".into(),
+            religion_id: None,
+            category: Some(SettlementCategory::Village),
+            economy: Some(SettlementEconomyProfile::stage_placeholder()),
+            active_building: Some("inn".into()),
+        };
+        let markup = location
+            .render_layout("Party", maud::html! {}, None)
+            .into_string();
+        assert!(markup.contains("data-building-id=\"inn\""));
+        assert!(!markup.contains("data-building-id=\"merchants\""));
     }
 }

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -623,6 +623,7 @@ mod tests {
             name: "Lubeck".into(),
             religion_id: None,
             category: None,
+            economy: None,
             active_building: Some("inn".into()),
         };
         let social = SocialPresentation {
@@ -751,6 +752,7 @@ mod tests {
             name: "Lubeck".into(),
             religion_id: None,
             category: None,
+            economy: None,
             active_building: None,
         };
         let source = CharacterMoraleSource {

--- a/crates/strategic-web/src/templates/settlement/trade.rs
+++ b/crates/strategic-web/src/templates/settlement/trade.rs
@@ -26,8 +26,9 @@ use crate::spacetimedb::{
 };
 use crate::templates::inventory_browser::{InventoryBrowser, InventoryColumnSet};
 use crate::templates::{
-    empty_state, game_icon, item_display_name, item_icon_name, item_source_edit_url,
-    item_type_header, item_type_icon, settlement_layout_with_session, sidebar_section,
+    decorative_game_icon, empty_state, game_icon, item_display_name, item_icon_name,
+    item_source_edit_url, item_type_header, item_type_icon, settlement_layout_with_session,
+    sidebar_section,
 };
 
 /// The currently available merchant storefronts. They share trade mechanics,
@@ -1047,10 +1048,9 @@ pub fn live_merchant_shop_page(
                             td class="inventory-item-name" { (item_name_with_quality(&target.item_id, definition)) }
                             td class="inventory-count" { (quantity_target_control(0, target.quantity, &target.item_id, false)) }
                             td class="inventory-equipped" {
-                                button type="button" class="equipment-slot-control" disabled
-                                    aria-label="No equipment in this row" {
-                                    span class="equipment-slot-empty" aria-hidden="true" { "—" }
-                                }
+                                span class="equipment-unavailable" role="img" tabindex="0"
+                                    aria-label="No equipment in this row"
+                                    data-strategic-tooltip="No equipment is available in this row" {}
                             }
                             td class="inventory-durability" { "—" }
                             td class="inventory-weight" { (item_weight(definition)) }
@@ -1143,11 +1143,12 @@ pub fn party_pool_page(
         aside class="left-sidebar" {
             (sidebar_section("Party inventory", html! {
                 (encumbrance_inventory_rail(html! {
-                    div class="party-stake-summary" {
+                    div class="party-stake-summary" tabindex="0"
+                        data-strategic-tooltip="Withdrawals use your stake; personal coin covers an indivisible item's shortfall."
+                        aria-label=(format!("Your available stake: {stake} coin. Withdrawals use your stake; personal coin covers an indivisible item's shortfall.")) {
                         span { "Your available stake" }
                         strong { (stake) " coin" }
                     }
-                    p class="small-copy text-muted" { "Withdrawals use your stake. Personal coin automatically covers an indivisible item's shortfall." }
                     (trade_inventory_table("party-pool-left", InventoryColumnSet::All, true, false, false, html! {
                         @for item in pooled {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1180,7 +1181,6 @@ pub fn party_pool_page(
         aside class="right-sidebar" {
             (sidebar_section(&format!("{}'s inventory", character.name), html! {
                 (encumbrance_inventory_rail(html! {
-                    p class="small-copy text-muted" { "Add items at their objective coin value." }
                     (trade_inventory_table("party-pool-right", InventoryColumnSet::All, true, true, false, html! {
                         @for item in inventory {
                             @let definition = items.iter().find(|definition| definition.id == item.item_id);
@@ -1198,7 +1198,7 @@ pub fn party_pool_page(
                                         @if equipped {
                                             (disabled_transfer_button("left", "Equipped items cannot be deposited"))
                                         } @else {
-                                            button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="deposit" data-transfer-mode="one" data-count=(item.qty) data-current=(current) data-target=(target) data-label-one=(format!("Deposit one {item_name}")) data-label-target=(format!("Deposit {item_name} to target")) data-label-all=(format!("Deposit all {item_name}")) aria-label=(format!("Deposit one {item_name}")) title=(format!("Deposit one {item_name}")) { (transfer_glyph(1)) }
+                                            button type="button" class="trade-transfer trade-transfer-left" data-dynamic-transfer data-default-transfer-mode="one" data-pool-stage=(item.id) data-pool-direction="deposit" data-transfer-mode="one" data-count=(item.qty) data-current=(current) data-target=(target) data-label-one=(format!("Deposit one {item_name}")) data-label-target=(format!("Deposit {item_name} to target")) data-label-all=(format!("Deposit all {item_name}")) aria-label=(format!("Deposit one {item_name} at its objective coin value")) data-strategic-tooltip=(format!("Deposit one {item_name} at its objective coin value")) { (transfer_glyph(1)) }
                                         }
                                     }
                                 }
@@ -1267,20 +1267,16 @@ fn encumbrance_inventory_rail(
 
 fn encumbrance_meter(summary: EncumbranceSummary) -> Markup {
     let penalty_percent = summary.penalty_fraction() * 100.0;
-    let weight_text = format!("{:.1} / {:.1} kg", summary.burden_kg, summary.capacity_kg);
-    let penalty_text = format!("-{penalty_percent:.1}%");
     let accessible_text = format!(
         "Weight {:.1} / {:.1} kilograms; Penalty -{penalty_percent:.1}%",
         summary.burden_kg, summary.capacity_kg
     );
     html! {
         div class="encumbrance" {
-            div class="encumbrance-values" aria-hidden="true" {
-                span class="encumbrance-weight" { (weight_text) }
-                span class="encumbrance-penalty" { (penalty_text) }
-            }
             div class="encumbrance-visual" {
                 div class="encumbrance-meter"
+                    tabindex="0"
+                    data-strategic-tooltip=(&accessible_text)
                     role="meter"
                     aria-label="Encumbrance"
                     aria-valuemin="0"
@@ -1559,7 +1555,7 @@ fn equipment_occupant_json(
 fn equipped_input_badges(
     equip: Option<&CharacterEquipmentGraph>,
     inventory_item_id: u64,
-) -> Vec<(String, usize)> {
+) -> Vec<(String, usize, String)> {
     let Some(equip) = equip else {
         return Vec::new();
     };
@@ -1582,7 +1578,14 @@ fn equipped_input_badges(
                 .iter()
                 .position(|(_, item_id)| *item_id == inventory_item_id)
                 .unwrap_or_default();
-            Some((equipment_input_display(binding.input), depth))
+            let locations = binding
+                .locations
+                .iter()
+                .copied()
+                .map(equipment_location_display)
+                .collect::<Vec<_>>()
+                .join(" / ");
+            Some((equipment_input_display(binding.input), depth, locations))
         })
         .collect()
 }
@@ -1906,6 +1909,20 @@ fn equipment_control(
     if let Some(attachment) = &attachment_summary {
         equipped_context.push(attachment.clone());
     }
+    if !input_badges.is_empty() {
+        equipped_context.push(format!(
+            "Keyboard: {}",
+            input_badges
+                .iter()
+                .map(|(input, depth, locations)| {
+                    format!("{input} = {locations}, layer {}", depth + 1)
+                })
+                .collect::<Vec<_>>()
+                .join("; ")
+        ));
+    } else if equipped {
+        equipped_context.push("Equipped; no keyboard binding".into());
+    }
     let item_name = item_display_name(&inventory.item_id);
     let base_label = if medication && medication_is_self {
         format!("Administer {item_name}")
@@ -1948,10 +1965,9 @@ fn equipment_control(
                 aria-describedby=(format!("equipment-status-{}", inventory.id))
                 aria-label=(label)
                 title=(title);
-        } @else {
+        } @else if equippable {
             button type="button"
                 class="equipment-slot-control"
-                disabled[!equippable]
                 data-equipment-toggle
                 data-equipment-equipped=(equipped)
                 data-inventory-item-id=(inventory.id)
@@ -1959,29 +1975,33 @@ fn equipment_control(
                 data-wear-placements=(placement_labels)
                 data-equipment-input-map=(input_map_json)
                 data-equipment-placement-options=(placement_options_json)
-                aria-haspopup=[equippable.then_some("dialog")]
+                aria-haspopup="dialog"
                 aria-describedby=(format!("equipment-status-{}", inventory.id))
                 aria-label=(label)
-                title=(title) {
+                data-strategic-tooltip=(title) {
                 @if equipped {
                     @if input_badges.is_empty() {
-                        kbd class="equipment-slot-key" { "?" }
+                        span class="equipment-slot-unbound"
+                            aria-hidden="true" { (decorative_game_icon("check-mark")) }
                     } @else {
-                        @for (input, depth) in &input_badges {
+                        @for (input, depth, locations) in &input_badges {
                             @let lightness = 88usize.saturating_sub((*depth).min(5) * 9);
                             kbd class="equipment-slot-key"
                                 data-equipment-layer-depth=(depth)
+                                data-strategic-tooltip=(format!("{input}: {locations}, layer {}", depth + 1))
                                 style=(format!("--equipment-layer-lightness: {lightness}%")) {
                                 (input)
                             }
                         }
                     }
-                } @else if equippable {
-                    span class="equipment-slot-empty" aria-hidden="true" { "+" }
                 } @else {
-                    span class="equipment-slot-empty" aria-hidden="true" { "—" }
+                    span class="equipment-slot-empty" aria-hidden="true" { "+" }
                 }
             }
+        } @else {
+            span class="equipment-unavailable" role="img" tabindex="0"
+                aria-label="Not equippable"
+                data-strategic-tooltip="This item cannot be equipped" {}
         }
         span id=(format!("equipment-status-{}", inventory.id))
             class="equipment-toggle-status"
@@ -2433,7 +2453,7 @@ pub(super) fn trade_inventory_table_header(
     html! { thead { tr {
         (item_type_header())
         th scope="col" class="inventory-column-item" { "Item" }
-        th scope="col" class="inventory-column-count" { "#" }
+        th scope="col" class="inventory-column-count" title="Quantity" { (game_icon("Quantity", "open-chest")) }
         @if show_equipped { th scope="col" class="inventory-column-equipped" title="Equipped" { (game_icon("Equipped", "check-mark")) } }
         @if let Some(condition_header) = condition_header { th scope="col" class="inventory-column-durability" { (condition_header) } }
         th scope="col" class="inventory-column-weight" title="Weight" { (game_icon("Weight", "weight")) }
@@ -2578,20 +2598,16 @@ mod tests {
     #[test]
     fn encumbrance_meter_formats_exact_text_and_accessible_linear_position() {
         let markup = encumbrance_meter(EncumbranceSummary::new(85.36, 150.0)).into_string();
-        assert!(markup.contains(">85.4 / 150.0 kg<"));
-        assert!(markup.contains(">-56.9%<"));
-        assert!(!markup.contains(">Weight"));
-        assert!(!markup.contains(">Penalty"));
         assert!(markup.contains("Weight 85.4 / 150.0 kilograms; Penalty -56.9%"));
-        assert!(markup.contains("class=\"encumbrance-values\" aria-hidden=\"true\""));
-        assert!(markup.contains(
-            "<span class=\"encumbrance-weight\">85.4 / 150.0 kg</span><span class=\"encumbrance-penalty\">-56.9%</span>"
-        ));
+        assert!(!markup.contains("encumbrance-values"));
+        assert!(!markup.contains(">85.4 / 150.0 kg<"));
+        assert!(!markup.contains(">-56.9%<"));
         assert!(
             markup.contains(
-                "</div><div class=\"encumbrance-visual\"><div class=\"encumbrance-meter\""
+                "data-strategic-tooltip=\"Weight 85.4 / 150.0 kilograms; Penalty -56.9%\""
             )
         );
+        assert!(markup.contains("tabindex=\"0\""));
         assert!(markup.contains("role=\"meter\""));
         assert!(markup.contains("aria-valuenow=\"56.9\""));
         assert!(markup.contains("--encumbrance-position: 56.9067%"));
@@ -2600,8 +2616,8 @@ mod tests {
     #[test]
     fn overloaded_meter_keeps_burden_but_clamps_penalty_and_marker() {
         let markup = encumbrance_meter(EncumbranceSummary::new(185.4, 150.0)).into_string();
-        assert!(markup.contains(">185.4 / 150.0 kg<"));
-        assert!(markup.contains(">-100.0%<"));
+        assert!(markup.contains("Weight 185.4 / 150.0 kilograms; Penalty -100.0%"));
+        assert!(!markup.contains(">185.4 / 150.0 kg<"));
         assert!(markup.contains("--encumbrance-position: 100.0000%"));
     }
 
@@ -2646,19 +2662,16 @@ mod tests {
         assert!(css.contains("padding-left: 3.25rem"));
         assert!(css.contains("padding-right: 1.75rem"));
         assert!(css.contains("container-type: inline-size"));
-        assert!(css.contains("flex: 0 0 50%"));
-        assert!(css.contains("width: 50%"));
-        assert!(css.contains("font-size: clamp(0.55rem, 4cqi, 0.78rem)"));
+        assert!(css.contains("flex: 1 1 100%"));
+        assert!(css.contains("width: 100%"));
+        assert!(!markup.contains("encumbrance-values"));
         assert!(css.contains(".encumbrance-meter"));
         assert!(css.contains("width: 100%"));
         assert!(css.contains("@container (max-width: 12rem)"));
         assert!(css.contains("padding-inline: 0.2rem"));
-        assert!(css.contains("font-size: 0.5rem"));
         assert!(css.contains("@container (max-width: 10rem)"));
         assert!(css.contains("padding-inline: 0.1rem"));
-        assert!(css.contains("padding-right: 0.05rem"));
-        assert!(css.contains("padding-left: 0.05rem"));
-        assert!(css.contains("font-size: 0.43rem"));
+        assert!(!css.contains(".encumbrance-values"));
     }
 
     #[test]
@@ -2710,13 +2723,26 @@ mod tests {
         assert!(merchant.contains("data-hard-navigation"));
         assert!(merchant.contains("data-inventory-pane=\"player\""));
         assert!(merchant.contains("data-inventory-pane=\"party\""));
-        assert!(merchant.contains(">10.0 / 100.0 kg<"));
-        assert!(merchant.contains(">30.0 / 200.0 kg<"));
+        assert!(
+            merchant.contains(
+                "data-strategic-tooltip=\"Weight 10.0 / 100.0 kilograms; Penalty -10.0%\""
+            )
+        );
+        assert!(
+            merchant.contains(
+                "data-strategic-tooltip=\"Weight 30.0 / 200.0 kilograms; Penalty -15.0%\""
+            )
+        );
+        assert!(!merchant.contains(">10.0 / 100.0 kg<"));
+        assert!(!merchant.contains(">30.0 / 200.0 kg<"));
 
         let herbalist = render(MerchantShop::Herbalist);
-        assert!(herbalist.contains(">10.0 / 100.0 kg<"));
+        assert!(
+            herbalist.contains("aria-valuetext=\"Weight 10.0 / 100.0 kilograms; Penalty -10.0%\"")
+        );
+        assert!(!herbalist.contains(">10.0 / 100.0 kg<"));
         assert!(!herbalist.contains("data-inventory-pane=\"party\""));
-        assert!(!herbalist.contains(">30.0 / 200.0 kg<"));
+        assert!(!herbalist.contains("Weight 30.0 / 200.0 kilograms"));
 
         let inn = render(MerchantShop::Inn);
         assert!(inn.contains("Cooking supplies"));
@@ -3058,7 +3084,25 @@ mod tests {
         definition.equipment_placements.clear();
         let disabled =
             equipment_control(&inventory, Some(&definition), false, true, None).into_string();
-        assert!(disabled.contains(" disabled"));
+        assert!(disabled.contains("class=\"equipment-unavailable\""));
+        assert!(disabled.contains("aria-label=\"Not equippable\""));
+        assert!(!disabled.contains("equipment-slot-control"));
+
+        definition.equipment_placements.push(EquipmentPlacement {
+            id: "left_hand".into(),
+            occupancy: vec![EquipmentOccupancyRequirement {
+                location: EquipmentLocation::LeftHand,
+                channel: EquipmentChannel::Held,
+                order: 0,
+            }],
+            parents: Vec::new(),
+            protection: Vec::new(),
+        });
+        let unbound =
+            equipment_control(&inventory, Some(&definition), true, true, None).into_string();
+        assert!(unbound.contains("check-mark.svg"));
+        assert!(unbound.contains("Equipped; no keyboard binding"));
+        assert!(!unbound.contains(">?</kbd>"));
     }
 
     #[test]
@@ -3154,9 +3198,8 @@ mod tests {
         assert!(outer_control.contains(">G</kbd>"));
         assert!(outer_control.contains(">Y</kbd>"));
         assert!(outer_control.contains("--equipment-layer-lightness: 88%"));
-        assert!(outer_control.contains(
-            "aria-label=\"Unequip Cloak. Slots: Chest, Stomach. Protects Chest (80% coverage)\""
-        ));
+        assert!(outer_control.contains("aria-label=\"Unequip Cloak. Slots: Chest, Stomach. Protects Chest (80% coverage). Keyboard: G = Chest, layer 1; Y = Stomach, layer 1\""));
+        assert!(outer_control.contains("data-strategic-tooltip=\"G: Chest, layer 1\""));
         assert!(outer_control.contains("protects Chest (80% coverage)"));
 
         let inner_definition = crate::spacetimedb::ItemDefinition {
@@ -3249,8 +3292,9 @@ mod tests {
             equipment_control(&child, Some(&definition), true, true, Some(&graph)).into_string();
         assert!(rendered.contains(">F</kbd>"));
         assert!(rendered.contains(
-            "aria-label=\"Unequip Pouch. Slots: Front belt. Attached: Belt / front-loop\""
+            "aria-label=\"Unequip Pouch. Slots: Front belt. Attached: Belt / front-loop. Keyboard:"
         ));
+        assert!(rendered.contains("F = Front belt"));
         assert!(rendered.contains(
             "<span class=\"equipment-graph-summary\">Attached: Belt / front-loop</span>"
         ));

--- a/crates/strategic-web/src/templates/settlement/travel.rs
+++ b/crates/strategic-web/src/templates/settlement/travel.rs
@@ -385,10 +385,6 @@ pub(crate) fn map_destination_detail(
                         }
                     }
                 }))
-            } @else {
-                (sidebar_section("Destination", html! {
-                    p class="text-muted small-copy" { "Select a destination to inspect it and plan travel." }
-                }))
             }
         }
     }
@@ -1358,6 +1354,15 @@ mod tests {
         assert!(markup.contains("No direct route."));
         assert!(!markup.contains("Begin journey"));
         assert!(!markup.contains("data-travel-submit"));
+    }
+
+    #[test]
+    fn unselected_map_omits_the_destination_frame() {
+        let markup = map_destination_detail(
+            None, None, false, true, None, None, None, false, None, "/map",
+        )
+        .into_string();
+        assert!(!markup.contains("sidebar-header\">Destination"));
     }
 
     #[test]

--- a/crates/strategic-web/static/building-state.js
+++ b/crates/strategic-web/static/building-state.js
@@ -1,5 +1,4 @@
 (() => {
-  const services = new Set(["public-square", "residences", "keep", "map", "merchants", "weapons", "armor", "clothing", "herbalist", "inn", "religion"]);
   let observer;
   const mount = () => {
     observer?.disconnect();
@@ -8,16 +7,18 @@
     if (!nav) return;
     const current = new URL(location.href);
     const requested = current.searchParams.get("building");
-    const serverActive = nav.querySelector(".nav-tab.active")?.dataset.serviceId;
+    const tabs = [...nav.querySelectorAll("[data-building-id]")];
+    const buildings = new Set(tabs.map((tab) => tab.dataset.buildingId).filter(Boolean));
+    const serverActive = nav.querySelector(".nav-tab.active")?.dataset.buildingId;
     const partyInspection = current.pathname.startsWith("/locations/") && current.pathname.includes("/party");
-    const building = partyInspection && services.has(requested)
-      ? requested : (services.has(serverActive) ? serverActive : "map");
-    if (requested && (!services.has(requested) || !partyInspection)) {
+    const building = partyInspection && buildings.has(requested)
+      ? requested : (buildings.has(serverActive) ? serverActive : (buildings.has("map") ? "map" : tabs[0]?.dataset.buildingId));
+    if (requested && (!buildings.has(requested) || !partyInspection)) {
       current.searchParams.delete("building");
       history.replaceState(history.state, "", current);
     }
-    nav.querySelectorAll("[data-service-id]").forEach((tab) => {
-      const selected = tab.dataset.serviceId === building;
+    tabs.forEach((tab) => {
+      const selected = tab.dataset.buildingId === building;
       tab.classList.toggle("active", selected);
       tab.setAttribute("aria-current", selected ? "page" : "false");
       if (selected) document.documentElement.style.setProperty("--active-building-tint", tab.style.getPropertyValue("--building-tint"));

--- a/crates/strategic-web/static/css/layout.css
+++ b/crates/strategic-web/static/css/layout.css
@@ -877,6 +877,27 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="religion"] { --service-building-image: url("/static/styles/timber-framed/building/city/religion.png"); }
 .settlement-top-bar[data-building-tier="city"] .nav-tab[data-service-id="organization"] { --service-building-image: url("/static/styles/timber-framed/building/city/residences.png"); }
 
+/* Standalone chapters share the scene vocabulary, but their authored building
+   kind chooses the closest facade instead of presenting every institution as a house. */
+.settlement-top-bar[data-building-tier="village"] .nav-tab[data-organization-building-kind="guildhall"],
+.settlement-top-bar[data-building-tier="village"] .nav-tab[data-organization-building-kind="college"] { --service-building-image: url("/static/styles/timber-framed/building/village/merchants.png?v=facade-2"); }
+.settlement-top-bar[data-building-tier="village"] .nav-tab[data-organization-building-kind="workshop"] { --service-building-image: url("/static/styles/timber-framed/building/village/weapons.png"); }
+.settlement-top-bar[data-building-tier="village"] .nav-tab[data-organization-building-kind="confraternity"] { --service-building-image: url("/static/styles/timber-framed/building/village/religion.png?v=facade-2"); }
+.settlement-top-bar[data-building-tier="village"] .nav-tab[data-organization-building-kind="commandery"] { --service-building-image: url("/static/styles/timber-framed/building/village/keep.png"); }
+.settlement-top-bar[data-building-tier="village"] .nav-tab[data-organization-building-kind="lodge"] { --service-building-image: url("/static/styles/timber-framed/building/village/inn.png?v=facade-2"); }
+.settlement-top-bar[data-building-tier="town"] .nav-tab[data-organization-building-kind="guildhall"],
+.settlement-top-bar[data-building-tier="town"] .nav-tab[data-organization-building-kind="college"] { --service-building-image: url("/static/styles/timber-framed/building/town/merchants.png"); }
+.settlement-top-bar[data-building-tier="town"] .nav-tab[data-organization-building-kind="workshop"] { --service-building-image: url("/static/styles/timber-framed/building/town/weapons.png"); }
+.settlement-top-bar[data-building-tier="town"] .nav-tab[data-organization-building-kind="confraternity"] { --service-building-image: url("/static/styles/timber-framed/building/town/religion.png"); }
+.settlement-top-bar[data-building-tier="town"] .nav-tab[data-organization-building-kind="commandery"] { --service-building-image: url("/static/styles/timber-framed/building/town/keep.png"); }
+.settlement-top-bar[data-building-tier="town"] .nav-tab[data-organization-building-kind="lodge"] { --service-building-image: url("/static/styles/timber-framed/building/town/inn.png"); }
+.settlement-top-bar[data-building-tier="city"] .nav-tab[data-organization-building-kind="guildhall"],
+.settlement-top-bar[data-building-tier="city"] .nav-tab[data-organization-building-kind="college"] { --service-building-image: url("/static/styles/timber-framed/building/city/merchants.png"); }
+.settlement-top-bar[data-building-tier="city"] .nav-tab[data-organization-building-kind="workshop"] { --service-building-image: url("/static/styles/timber-framed/building/city/weapons.png"); }
+.settlement-top-bar[data-building-tier="city"] .nav-tab[data-organization-building-kind="confraternity"] { --service-building-image: url("/static/styles/timber-framed/building/city/religion.png"); }
+.settlement-top-bar[data-building-tier="city"] .nav-tab[data-organization-building-kind="commandery"] { --service-building-image: url("/static/styles/timber-framed/building/city/keep.png"); }
+.settlement-top-bar[data-building-tier="city"] .nav-tab[data-organization-building-kind="lodge"] { --service-building-image: url("/static/styles/timber-framed/building/city/inn.png"); }
+
 .service-notification-badge {
   position: absolute;
   z-index: 3;
@@ -983,6 +1004,20 @@ html[data-developer-mode] .location-stat-list > div[data-developer-only] { displ
 .settlement-top-bar[data-environment="settlement"] .nav-tab:hover .service-tab-icon,
 .settlement-top-bar[data-environment="settlement"] .nav-tab.active .service-tab-icon {
   background-color: transparent;
+}
+
+.settlement-top-bar[data-environment="settlement"] .service-tab-icon-organization,
+.settlement-top-bar[data-environment="settlement"] .nav-tab:hover .service-tab-icon-organization,
+.settlement-top-bar[data-environment="settlement"] .nav-tab.active .service-tab-icon-organization {
+  border: 1px solid var(--organization-accent, #fff);
+  border-radius: 50%;
+  background-color: var(--organization-field, transparent);
+  box-shadow: 0 0 2px var(--organization-field, transparent);
+}
+
+.settlement-top-bar[data-environment="settlement"] .service-tab-icon-organization::after {
+  inset: 0.16rem;
+  background-color: var(--organization-accent, #fff);
 }
 
 .quest-location-top-bar[data-environment="wilderness"] .nav-tab:hover .service-tab-icon,

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -941,33 +941,17 @@
   font-variant-numeric: tabular-nums;
 }
 
-.encumbrance-values,
 .encumbrance-visual {
   box-sizing: border-box;
-  flex: 0 0 50%;
-  width: 50%;
+  flex: 1 1 100%;
+  width: 100%;
   min-width: 0;
-}
-
-.encumbrance-values {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  padding-right: 0.35rem;
-  font-size: clamp(0.55rem, 4cqi, 0.78rem);
-  line-height: 1.25;
 }
 
 .encumbrance-visual {
   display: flex;
   align-items: center;
-  padding-left: 0.35rem;
-}
-
-.encumbrance-weight,
-.encumbrance-penalty {
-  max-width: 100%;
-  white-space: nowrap;
+  padding-left: 0;
 }
 
 @container (max-width: 12rem) {
@@ -975,14 +959,8 @@
     padding-inline: 0.2rem;
   }
 
-  .encumbrance-values {
-    padding-right: 0.1rem;
-    font-size: 0.5rem;
-    line-height: 1.15;
-  }
-
   .encumbrance-visual {
-    padding-left: 0.1rem;
+    padding-left: 0;
   }
 }
 
@@ -991,13 +969,8 @@
     padding-inline: 0.1rem;
   }
 
-  .encumbrance-values {
-    padding-right: 0.05rem;
-    font-size: 0.43rem;
-  }
-
   .encumbrance-visual {
-    padding-left: 0.05rem;
+    padding-left: 0;
   }
 }
 
@@ -4588,7 +4561,7 @@ button.identity-control:disabled {
 
 .party-attribute-row {
   display: grid;
-  grid-template-columns: 1.15rem minmax(0, 1fr) minmax(3rem, 2fr) 2rem;
+  grid-template-columns: 1.15rem minmax(0, 1fr) minmax(3rem, 2fr);
   align-items: center;
   gap: 0.35rem;
   min-width: 0;
@@ -4597,7 +4570,7 @@ button.identity-control:disabled {
 }
 
 .party-attribute-icon-only {
-  grid-template-columns: 1.15rem minmax(0, 1fr) 2rem;
+  grid-template-columns: 1.15rem minmax(0, 1fr);
 }
 
 .party-attribute-row .stat-icon {
@@ -4611,7 +4584,6 @@ button.identity-control:disabled {
   white-space: nowrap;
 }
 
-.attribute-rank-value,
 .skill-rank-value { color: var(--text-primary); font-size: var(--font-size-xs); font-variant-numeric: tabular-nums; text-align: right; }
 
 .limb-attribute-pair {
@@ -5178,7 +5150,6 @@ body.chat-resizing {
   white-space: normal;
 }
 
-.prototype-disclaimer { margin: 0 0 1rem; padding: .8rem 1rem; border: 2px solid #d7aa48; background: #342b19; color: #fff2c9; font-weight: 700; text-align: center; }
 .main-grid:has(> .candidate-bootstrap) {
   grid-template-columns: minmax(0, 1fr);
   overflow-y: auto;
@@ -6190,6 +6161,17 @@ body.chat-resizing {
 .equipment-slot-empty {
   color: #b9aa8d;
   font-weight: 700;
+}
+
+.equipment-slot-unbound .game-icon {
+  width: 0.9rem;
+  height: 0.9rem;
+}
+
+.equipment-unavailable {
+  display: block;
+  width: 100%;
+  min-height: 1.55rem;
 }
 
 .equipment-slot-modal {

--- a/crates/strategic-web/static/party-trade.js
+++ b/crates/strategic-web/static/party-trade.js
@@ -202,7 +202,7 @@ function ensureMerchantPlayerRow(itemId, sourceRow) {
   row.classList.remove("party-trade-changed");
   const equipped = document.createElement("td");
   equipped.className = "inventory-equipped";
-  equipped.innerHTML = '<button type="button" class="equipment-slot-control" disabled aria-label="Equipment availability updates after inventory refresh"><span class="equipment-slot-empty" aria-hidden="true">—</span></button>';
+  equipped.innerHTML = '<span class="equipment-unavailable" role="img" tabindex="0" aria-label="Equipment availability updates after inventory refresh" data-strategic-tooltip="Equipment availability updates after inventory refresh"></span>';
   (row.querySelector(".inventory-target") || count).after(equipped);
   row.querySelector(".inventory-gold").textContent = sourceRow.dataset.merchantSellPrice;
   row.dataset.generatedMerchantRow = "true";

--- a/crates/strategic-web/static/tooltips.js
+++ b/crates/strategic-web/static/tooltips.js
@@ -303,6 +303,13 @@
       if (event.pointerType === 'touch') return;
       show(tooltipTarget(event.target));
     });
+    documentRoot.addEventListener('mouseover', (event) => {
+      if (event.sourceCapabilities?.firesTouchEvents) return;
+      const target = tooltipTarget(event.target);
+      // Pointer-capable browsers normally emit pointerover first. In that case
+      // the shared target is already active and mouseover should be a no-op.
+      if (target && target !== activeTarget) show(target);
+    });
     documentRoot.addEventListener('pointerout', (event) => {
       if (pinnedTarget) return;
       if (!activeTarget || activeTarget.contains(event.relatedTarget)) return;

--- a/crates/strategic-web/tests/building-state.test.cjs
+++ b/crates/strategic-web/tests/building-state.test.cjs
@@ -2,12 +2,71 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const test = require("node:test");
+const vm = require("node:vm");
+const { parseHTML } = require("linkedom");
 
 const source = fs.readFileSync(path.join(__dirname, "..", "static", "building-state.js"), "utf8");
 
-test("building state preserves non-service settlement locations", () => {
-  assert.match(source, /"public-square", "residences", "keep", "map"/);
-  assert.doesNotMatch(source, /new Set\(\[""/);
-  assert.match(source, /if \(building\) url\.searchParams\.set\("building", building\)/);
-  assert.match(source, /else url\.searchParams\.delete\("building"\)/);
+function fixture(href) {
+  const { window, document } = parseHTML(`<html><body>
+    <main id="strategic-page">
+      <nav data-settlement-id="lubeck">
+        <a class="nav-tab" data-service-id="map" data-building-id="map"></a>
+        <a class="nav-tab active" data-service-id="organization"
+          data-building-id="organization-merchants-lubeck"></a>
+      </nav>
+      <a id="party-link" href="/locations/settlement/lubeck/party/7">Party</a>
+      <form id="party-form" action="/locations/settlement/lubeck/party/7/social"></form>
+    </main>
+  </body></html>`);
+  const location = { href, origin: "http://game.test" };
+  const replacements = [];
+  const history = {
+    state: null,
+    replaceState(_state, _title, url) {
+      replacements.push(url.toString());
+    },
+  };
+  vm.runInNewContext(source, {
+    document,
+    location,
+    history,
+    URL,
+    MutationObserver: window.MutationObserver,
+    Node: window.Node,
+  });
+  return { window, document, location, replacements };
+}
+
+test("exact organization state survives links, forms, remounts, and live insertion", async () => {
+  const view = fixture(
+    "http://game.test/locations/settlement/lubeck/party/7?building=organization-merchants-lubeck",
+  );
+  const organization = view.document.querySelector('[data-building-id="organization-merchants-lubeck"]');
+  assert.equal(organization.classList.contains("active"), true);
+  assert.equal(view.document.querySelectorAll(".nav-tab.active").length, 1);
+  assert.equal(view.document.querySelector("#party-link").getAttribute("href"),
+    "/locations/settlement/lubeck/party/7?building=organization-merchants-lubeck");
+  assert.equal(view.document.querySelector("#party-form").getAttribute("action"),
+    "/locations/settlement/lubeck/party/7/social?building=organization-merchants-lubeck");
+
+  view.document.dispatchEvent(new view.window.Event("strategic-page-mounted"));
+  assert.equal(organization.classList.contains("active"), true);
+  assert.equal(view.document.querySelectorAll(".nav-tab.active").length, 1);
+  const live = view.document.createElement("a");
+  live.href = "/locations/settlement/lubeck/party/9";
+  view.document.querySelector("#strategic-page").append(live);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(live.getAttribute("href"),
+    "/locations/settlement/lubeck/party/9?building=organization-merchants-lubeck");
+});
+
+test("an invalid requested identity is removed and cannot become active", () => {
+  const view = fixture(
+    "http://game.test/locations/settlement/lubeck/party/7?building=organization-foreign-town",
+  );
+  assert.equal(view.replacements.length, 1);
+  assert.equal(view.replacements[0], "http://game.test/locations/settlement/lubeck/party/7");
+  assert.equal(view.document.querySelector('[data-building-id="organization-foreign-town"]'), null);
+  assert.equal(view.document.querySelectorAll(".nav-tab.active").length, 1);
 });

--- a/crates/strategic-web/tests/tooltips.test.cjs
+++ b/crates/strategic-web/tests/tooltips.test.cjs
@@ -51,6 +51,24 @@ test('title tooltips enhance immediately while preserving an accessible descript
   assert.equal(system.tooltip.hidden, true);
 });
 
+test('a rendered Inn Place Facade opens the shared tooltip by mouse fallback and keyboard focus', () => {
+  const { window, document, system } = fixture(
+    '<a class="nav-tab" href="/settlements/lubeck/inn" data-service-id="inn" data-building-id="inn" aria-label="Inn" data-strategic-tooltip="Inn"></a>',
+  );
+  const inn = document.querySelector('[data-building-id="inn"]');
+
+  dispatch(window, inn, 'mouseover');
+  assert.equal(system.tooltip.id, 'strategic-tooltip');
+  assert.equal(system.tooltip.textContent, 'Inn');
+  assert.equal(system.tooltip.hidden, false);
+
+  system.hide(true);
+  dispatch(window, inn, 'focusin');
+  assert.equal(system.activeTarget, inn);
+  assert.equal(system.tooltip.textContent, 'Inn');
+  assert.equal(system.tooltip.hidden, false);
+});
+
 test('an otherwise unnamed icon retains the title as its accessible name', () => {
   const { window, document } = fixture('<span title="Armour condition"></span>');
   const icon = document.querySelector('span');

--- a/wiki/shared/encumbrance.md
+++ b/wiki/shared/encumbrance.md
@@ -22,10 +22,10 @@ weight from `character_condition`; invalid or missing legacy values use the
 70 kg schema default rather than silently treating every member as the same
 weight.
 
-Inventory rails split the summary into equal-width halves. The left half shows
-the exact burden and capacity to one decimal place with the exact penalty to
-one decimal percent directly below it. The right half is a stable-width
-green-to-yellow-to-red meter whose marker follows the same linear penalty.
+Inventory rails show a full-width green-to-yellow-to-red meter whose marker
+follows the linear penalty. Keyboard focus or pointer hover opens the shared
+tooltip with exact burden, capacity, and penalty values; the same detail is
+available through the meter's accessible value without persistent numeric copy.
 Merchant Player tabs use the personal summary; merchant
 Party tabs use the living-party aggregate. The party chest also shows this
 aggregate: all living party members' burdens and capacities are summed, with

--- a/wiki/shared/inventory.md
+++ b/wiki/shared/inventory.md
@@ -105,6 +105,12 @@ loot, and cooking:
 - keyboard-accessible item actions;
 - URL-backed search, sorting, and column preferences.
 
+Quantity and desired-target columns use accessible open-chest and target
+icons rather than punctuation. Equipped rows retain the compact QWERTY badges
+used by the tactical input map; their shared tooltip spells out each key's
+physical location and equipment layer. Non-equippable cells use accessible
+negative space instead of a visible placeholder glyph.
+
 Weaponsmith and armorer views can expose relevant combat statistics, while
 merchants whose goods do not use those fields retain a simpler table.
 

--- a/wiki/strategic/settlement.md
+++ b/wiki/strategic/settlement.md
@@ -49,9 +49,10 @@ with the selected quest's dry log; toggling it again or pressing Escape restores
 location rails.
 
 Public squares, residential areas, and, for towns and larger settlements, the keep appear
-as selectable building tabs alongside services in the settlement header. Until bespoke
-building art is available, non-service tabs reuse neutral building art and house/castle
-icons. These places use the same authoritative portrait, description, and chat surface;
+as selectable building tabs alongside services in the settlement header. Standalone
+organization chapters choose an existing facade by authored building kind and use their
+stable heraldic charge, while public places retain their house/castle vocabulary. These
+places use the same authoritative portrait, description, and chat surface;
 villages and hamlets cannot enter a keep that their population does not have.
 
 Resident presences and daily time windows are keyed by that character ID and
@@ -260,3 +261,8 @@ default operator and visitor, and do not add another Place Facade. If the
 mapped service is unavailable the chapter safely retains its standalone
 building. Physician and surgeon chapters, and organizations without a service,
 remain standalone. Organization-aware dialogue stays with the representative.
+Every rendered Place Facade exposes its exact building identity. Character and
+party inspection links preserve that identity only while it belongs to the
+current settlement's rendered set, including authored standalone organization
+chapters; unavailable services, non-standalone chapters, foreign chapter IDs,
+and unknown identities are discarded by both page state and redirects.


### PR DESCRIPTION
## Summary
- filter settlement Place Facades from the authoritative economy on party inspection pages
- preserve exact validated building and organization context through party links and redirects
- give organization chapters distinct existing facades, heraldry, and service identities
- replace explanatory UI copy and adjacent exact meter values with accessible instant tooltips
- clarify inventory quantity, target, equipment, and unavailable-state iconography
- add behavioral building-state and rendered-header tooltip regressions

## Verification
- `just fmt`
- `cargo test -p strategic-web` — 385 passed
- targeted strategic-web JavaScript tests — 19 passed
- `python scripts/update_project_map.py --check`
- isolated in-app browser demo on the strategic stack

## Existing repository-wide failures
- The full JavaScript suite includes unrelated stale tests that still read the removed `templates/settlement.rs` and other outdated source patterns.
- `just check` reaches an unrelated dialogue/content schema mismatch for `local_organization_representative`.