### PR TITLE
Refactor tactical combat around typed lifecycle states

### DIFF
--- a/crates/adventuresim-core/src/autoresolve.rs
+++ b/crates/adventuresim-core/src/autoresolve.rs
@@ -419,27 +419,22 @@ impl Combatant {
         }
     }
 
-    fn precision_damage_multiplier_cap_against(&self, defender: &Self) -> f32 {
-        let fallback = [BestiaryCategory::Human];
-        let categories = if defender.bestiary_categories.is_empty() {
-            &fallback
-        } else {
-            defender.bestiary_categories.as_slice()
-        };
-        let check = categories
-            .iter()
-            .map(|category| {
-                crate::capability::bestiary_knowledge_check(
-                    self.skills.bestiary_hours.effective(*category),
-                    self.attributes.instinct,
-                    self.attributes.intelligence,
-                    self.essentials.focus_level,
-                    self.body.body_part_health(BodyPart::Head),
-                )
-            })
-            .sum::<f32>()
-            / categories.len() as f32;
-        2.0 + check.clamp(0.0, 5.0)
+    fn view_with_equipment<'a>(
+        &'a self,
+        equipment: &'a CombatEquipment,
+    ) -> PlayerInfo<
+        &'a CombatAttributes,
+        &'a CombatBody,
+        &'a CombatEssentials,
+        &'a CombatEquipment,
+        &'a CombatSkills,
+    > {
+        PlayerInfo::empty()
+            .with_attributes(&self.attributes)
+            .with_body(&self.body)
+            .with_essentials(&self.essentials)
+            .with_equipment(equipment)
+            .with_skills(&self.skills)
     }
 
     pub fn incapacitation(&self) -> f32 {
@@ -1579,23 +1574,16 @@ fn melee_exchange(
     response: DefenderResponse,
 ) -> AttackResult {
     let attacker_equipment = attacker.equipment.for_melee();
-    resolve_melee_attack_by_parts(
-        &attacker.skills,
-        &attacker.attributes,
-        &attacker.body,
-        &attacker.essentials,
-        &attacker_equipment,
+    let attacker_view = attacker.view_with_equipment(&attacker_equipment);
+    let defender_view = defender.view_with_equipment(&defender.equipment);
+    attacker_view.resolve_melee_attack(
         attacker.equipment.holding_side,
+        &defender_view,
+        &defender.bestiary_categories,
+        response,
         precision,
-        attacker.precision_damage_multiplier_cap_against(defender),
         flanking,
         part,
-        response,
-        &defender.skills,
-        &defender.attributes,
-        &defender.body,
-        &defender.essentials,
-        &defender.equipment,
     )
 }
 
@@ -1608,22 +1596,15 @@ fn ranged_exchange(
     response: DefenderResponse,
 ) -> AttackResult {
     let attacker_equipment = attacker.equipment.for_ranged();
-    resolve_ranged_attack_by_parts(
-        &attacker.skills,
-        &attacker.attributes,
-        &attacker.body,
-        &attacker.essentials,
-        &attacker_equipment,
+    let attacker_view = attacker.view_with_equipment(&attacker_equipment);
+    let defender_view = defender.view_with_equipment(&defender.equipment);
+    attacker_view.resolve_ranged_attack(
+        &defender_view,
+        &defender.bestiary_categories,
+        response,
         precision,
-        attacker.precision_damage_multiplier_cap_against(defender),
         flanking,
         part,
-        response,
-        &defender.skills,
-        &defender.attributes,
-        &defender.body,
-        &defender.essentials,
-        &defender.equipment,
     )
 }
 
@@ -1914,10 +1895,14 @@ mod tests {
         attacker.skills.bestiary_hours.human = adventuresim_world_schema::BESTIARY_MASTERY_HOURS;
         let mut human = fighter(2, 1.0, false);
         human.bestiary_categories = vec![BestiaryCategory::Human];
-        let human_cap = attacker.precision_damage_multiplier_cap_against(&human);
+        let human_cap = attacker
+            .view_with_equipment(&attacker.equipment)
+            .precision_damage_multiplier_cap(&human.bestiary_categories);
 
         human.bestiary_categories = vec![BestiaryCategory::Human, BestiaryCategory::Draconid];
-        let combined_cap = attacker.precision_damage_multiplier_cap_against(&human);
+        let combined_cap = attacker
+            .view_with_equipment(&attacker.equipment)
+            .precision_damage_multiplier_cap(&human.bestiary_categories);
 
         assert!(human_cap > 2.0);
         assert!(combined_cap > 2.0);

--- a/crates/adventuresim-stdb-module/src/tactical.rs
+++ b/crates/adventuresim-stdb-module/src/tactical.rs
@@ -989,7 +989,8 @@ fn validate_tactical_receipt(
             .iter()
             .any(|row| row.channel == crate::item::EquipmentChannel::Held);
         let worn = occupancy.iter().any(|row| {
-            row.anchor_kind == crate::character::EquipmentAnchorKind::CharacterLocation && !held
+            row.anchor_kind == crate::character::EquipmentAnchorKind::CharacterLocation
+                && row.channel != crate::item::EquipmentChannel::Held
         });
         let definition = ctx
             .db

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -106,7 +106,7 @@ fn on_new_player_added_hook(
     event: On<Add, Player>,
     mut commands: Commands,
     camera: Single<Entity, With<Camera3d>>,
-    query: Query<(&Player, &PlayerId)>,
+    query: Query<(&Player, &CharacterId)>,
     args: Res<Args>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -262,17 +262,17 @@ fn update_attack_state_system(
             };
 
             if state.ranged {
-                cmd.client_trigger(RangedActionRequest::complete(
-                    Some(target),
-                    body_part,
-                    HIT_PRECISION,
-                ));
-            } else {
-                cmd.client_trigger(MeleeActionRequest::complete(
+                cmd.client_trigger(RangedActionRequest::CompleteHit {
                     target,
                     body_part,
-                    HIT_PRECISION,
-                ));
+                    reported_precision: HIT_PRECISION,
+                });
+            } else {
+                cmd.client_trigger(MeleeActionRequest::Complete {
+                    target,
+                    body_part,
+                    reported_precision: HIT_PRECISION,
+                });
             }
             cmd.trigger(HitPerformed {
                 entity: attacker,
@@ -282,11 +282,7 @@ fn update_attack_state_system(
             });
         } else {
             if state.ranged {
-                cmd.client_trigger(RangedActionRequest::complete(
-                    None,
-                    BodyPart::Chest,
-                    HIT_PRECISION,
-                ));
+                cmd.client_trigger(RangedActionRequest::CompleteMiss);
             }
             cmd.trigger(HitPerformed {
                 entity: attacker,
@@ -326,9 +322,9 @@ fn on_attack_fired_hook(
     cmd.entity(event.context)
         .insert(AttackState::new(PRE_HIT_DELAY, reach, ranged));
     if ranged {
-        cmd.client_trigger(RangedActionRequest::start());
+        cmd.client_trigger(RangedActionRequest::Start);
     } else {
-        cmd.client_trigger(MeleeActionRequest::start());
+        cmd.client_trigger(MeleeActionRequest::Start);
     }
 }
 

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -1,6 +1,6 @@
 use adventuresim_tactical_core::{
     inventory::{ItemQuery, ItemQueryItem},
-    player::{Player, PlayerId},
+    player::{CharacterId, Player},
     prelude::*,
 };
 use adventuresim_tactical_netcode::{
@@ -339,7 +339,7 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 fn combat_state_label(state: &TacticalCombatState) -> String {
-    if state.incapacitated {
+    if state.is_incapacitated() {
         format!(
             "INCAPACITATED | Blood loss {:.0}% | Imbalance {:.0}%",
             state.blood_loss_fraction * 100.0,
@@ -380,13 +380,13 @@ fn on_tactical_outcome_display(
 
 fn update_stats_ui(
     diagnostics: Res<DiagnosticsStore>,
-    player: Single<(Ref<Transform>, &PlayerId), With<ClientPlayer>>,
+    player: Single<(Ref<Transform>, &CharacterId), With<ClientPlayer>>,
     mut spans: ParamSet<(
         Single<&mut TextSpan, With<PositionSpan>>,
         Single<&mut TextSpan, With<FpsSpan>>,
     )>,
 ) {
-    let (transform, &PlayerId(_player_id)) = player.into_inner();
+    let (transform, &CharacterId(_player_id)) = player.into_inner();
 
     if transform.is_changed() {
         let translation = transform.translation;
@@ -404,7 +404,7 @@ fn update_stats_ui(
 }
 
 fn update_skills_ui(
-    player: Single<(&Skills, &PlayerId), (With<ClientPlayer>, Changed<Skills>)>,
+    player: Single<(&Skills, &CharacterId), (With<ClientPlayer>, Changed<Skills>)>,
     mut spans: Query<(&mut TextSpan, &SkillSpan)>,
 ) {
     let (skills, _player_id) = player.into_inner();
@@ -449,7 +449,7 @@ fn update_skills_ui(
 }
 
 fn update_limbs_ui(
-    player: Single<(&Limbs, &PlayerId), (With<ClientPlayer>, Changed<Limbs>)>,
+    player: Single<(&Limbs, &CharacterId), (With<ClientPlayer>, Changed<Limbs>)>,
     mut spans: ParamSet<(
         Single<&mut TextSpan, With<HeadSpan>>,
         Single<&mut TextSpan, With<ChestSpan>>,
@@ -593,7 +593,7 @@ fn update_attack_timer_ui(
 fn on_successful_attack_display(
     event: On<SuccessfulAttackResponse>,
     mut cmd: Commands,
-    q_player: Query<(&Player, &PlayerId)>,
+    q_player: Query<(&Player, &CharacterId)>,
     mut span: Single<(Entity, &mut AttackResultText, &mut Text)>,
 ) {
     let Some((player, id)) = event.hit.first().and_then(|e| q_player.get(*e).ok()) else {
@@ -663,7 +663,7 @@ fn update_attack_result_ui(
 fn on_new_player_added_hook(
     event: On<Add, Player>,
     mut commands: Commands,
-    query: Query<(&PlayerId, &Player)>,
+    query: Query<(&CharacterId, &Player)>,
     args: Res<Args>,
     players_list: Single<Entity, With<PlayersList>>,
 ) -> Result {
@@ -712,7 +712,7 @@ mod tests {
             "Active | Blood loss 25% | Imbalance 50%"
         );
         let incapacitated = TacticalCombatState {
-            incapacitated: true,
+            incapacitation: 1.0,
             ..active
         };
         assert!(combat_state_label(&incapacitated).starts_with("INCAPACITATED"));

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -22,8 +22,8 @@ pub mod prelude {
         InventoryItems, ItemOf, ItemProperties, ItemQuantity, ShieldItem, WeaponItem,
     };
     pub use crate::player::{
-        Attributes, BestiaryCategories, ControlledPlayer, Limbs, Player, PlayerId, Skills, Stats,
-        TacticalCombatState, TacticalPlayerView, TacticalPlayerViewer,
+        Attributes, BestiaryCategories, CharacterId, ControlledPlayer, Limbs, Player, Skills,
+        Stats, TacticalCombatState, TacticalPlayerView, TacticalPlayerViewer,
     };
     pub use crate::scene::{SceneId, SceneTerrain};
     pub use adventuresim_core::prelude::*;

--- a/crates/adventuresim-tactical-core/src/player.rs
+++ b/crates/adventuresim-tactical-core/src/player.rs
@@ -11,21 +11,21 @@ pub type ControlledPlayer = Actions<Player>;
 /// Component for a player entity, for both client-controlled
 /// active player and other players.
 #[derive(Component, Serialize, Deserialize, Default, Debug, Reflect, Clone, PartialEq, Eq)]
-#[require(PlayerId, Limbs, Skills, Attributes, Stats)]
+#[require(CharacterId, Limbs, Skills, Attributes, Stats)]
 #[component(immutable)]
 pub struct Player {
     pub name: String,
 }
 
-/// Player's client ID usable to distinguish the active player
-/// from other connected players.
+/// Strategic character identity projected into the transient tactical world.
+/// Network client identity remains a separate transport concern.
 #[derive(
-    Component, Serialize, Deserialize, Default, Debug, Reflect, Clone, Copy, PartialEq, Eq,
+    Component, Serialize, Deserialize, Default, Debug, Reflect, Clone, Copy, PartialEq, Eq, Hash,
 )]
 #[component(immutable)]
-pub struct PlayerId(pub u64);
+pub struct CharacterId(pub u64);
 
-impl PlayerId {
+impl CharacterId {
     /// Get associated color of this player.
     pub fn color(&self) -> Color {
         // SplitMix64-style mixing for good bit diffusion
@@ -91,7 +91,6 @@ pub struct TacticalCombatState {
     pub blood_loss_fraction: f32,
     pub imbalance: f32,
     pub incapacitation: f32,
-    pub incapacitated: bool,
 }
 
 impl Default for TacticalCombatState {
@@ -102,8 +101,26 @@ impl Default for TacticalCombatState {
             blood_loss_fraction: 0.0,
             imbalance: 0.0,
             incapacitation: 0.0,
-            incapacitated: false,
         }
+    }
+}
+
+impl TacticalCombatState {
+    /// Derives readiness from the one replicated incapacitation value.
+    ///
+    /// Readiness is intentionally not stored separately: clients, authority
+    /// checks, AI, and mission resolution therefore cannot observe divergent
+    /// boolean/component copies of the same state.
+    pub fn incapacitation_status(&self) -> IncapacitationStatus {
+        match self.incapacitation {
+            total if total >= 1.0 => IncapacitationStatus::Incapacitated,
+            total if total > 0.5 => IncapacitationStatus::Staggered,
+            _ => IncapacitationStatus::Ready,
+        }
+    }
+
+    pub fn is_incapacitated(&self) -> bool {
+        self.incapacitation_status() == IncapacitationStatus::Incapacitated
     }
 }
 

--- a/crates/adventuresim-tactical-netcode/src/client.rs
+++ b/crates/adventuresim-tactical-netcode/src/client.rs
@@ -56,7 +56,7 @@ fn on_client_added(
 
 fn announce_join(mut commands: Commands, client: Single<&AdventureSimulatorClient>) {
     commands.client_trigger(JoinRequest {
-        player_id: client.player_id,
+        character_id: CharacterId(client.player_id),
     });
 }
 

--- a/crates/adventuresim-tactical-netcode/src/lib.rs
+++ b/crates/adventuresim-tactical-netcode/src/lib.rs
@@ -18,8 +18,8 @@ pub mod prelude {
     #[cfg(feature = "client")]
     pub use crate::client::AdventureSimulatorClient;
     pub use crate::message::{
-        DefendRequest, JoinRequest, MeleeActionPhase, MeleeActionRequest, PlayerInputRequest,
-        RangedActionPhase, RangedActionRequest, TacticalOutcome, TacticalOutcomeResponse,
+        DefendRequest, JoinRequest, MeleeActionRequest, PlayerInputRequest, RangedActionRequest,
+        TacticalOutcome, TacticalOutcomeResponse,
     };
     #[cfg(feature = "server")]
     pub use crate::server::AdventureSimulatorServer;

--- a/crates/adventuresim-tactical-netcode/src/message.rs
+++ b/crates/adventuresim-tactical-netcode/src/message.rs
@@ -16,7 +16,7 @@ pub enum DefendRequest {
 /// The sender remains the authoritative network identity.
 #[derive(Debug, Clone, Copy, Event, Serialize, Deserialize)]
 pub struct JoinRequest {
-    pub player_id: u64,
+    pub character_id: CharacterId,
 }
 
 #[derive(Debug, Clone, Copy, Default, Event, Serialize, Deserialize)]
@@ -26,78 +26,31 @@ pub struct PlayerInputRequest {
     pub jump: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum MeleeActionPhase {
-    Start,
-    Complete,
-}
-
 /// Both melee phases share one mapped ordered stream, so a completion cannot
 /// overtake its server-observed start.
 #[derive(Debug, Clone, Copy, Event, Serialize, Deserialize, MapEntities)]
-pub struct MeleeActionRequest {
-    pub phase: MeleeActionPhase,
-    #[entities]
-    pub target: Option<Entity>,
-    pub body_part: BodyPart,
-    pub hit_precision: f32,
-}
-
-impl MeleeActionRequest {
-    pub fn start() -> Self {
-        Self {
-            phase: MeleeActionPhase::Start,
-            target: None,
-            body_part: BodyPart::Chest,
-            hit_precision: 0.0,
-        }
-    }
-
-    pub fn complete(target: Entity, body_part: BodyPart, hit_precision: f32) -> Self {
-        Self {
-            phase: MeleeActionPhase::Complete,
-            target: Some(target),
-            body_part,
-            hit_precision,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum RangedActionPhase {
+pub enum MeleeActionRequest {
     Start,
-    Complete,
+    Complete {
+        #[entities]
+        target: Entity,
+        body_part: BodyPart,
+        reported_precision: f32,
+    },
 }
 
 /// Both ranged phases share one mapped ordered stream. A completion may omit
 /// a target when the client-fired shot missed, but it still consumes ammo.
 #[derive(Debug, Clone, Copy, Event, Serialize, Deserialize, MapEntities)]
-pub struct RangedActionRequest {
-    pub phase: RangedActionPhase,
-    #[entities]
-    pub target: Option<Entity>,
-    pub body_part: BodyPart,
-    pub hit_precision: f32,
-}
-
-impl RangedActionRequest {
-    pub fn start() -> Self {
-        Self {
-            phase: RangedActionPhase::Start,
-            target: None,
-            body_part: BodyPart::Chest,
-            hit_precision: 0.0,
-        }
-    }
-
-    pub fn complete(target: Option<Entity>, body_part: BodyPart, hit_precision: f32) -> Self {
-        Self {
-            phase: RangedActionPhase::Complete,
-            target,
-            body_part,
-            hit_precision,
-        }
-    }
+pub enum RangedActionRequest {
+    Start,
+    CompleteMiss,
+    CompleteHit {
+        #[entities]
+        target: Entity,
+        body_part: BodyPart,
+        reported_precision: f32,
+    },
 }
 
 #[derive(Debug, Clone, Event, Serialize, Deserialize, MapEntities)]

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -21,7 +21,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
         app.insert_resource(Time::<Fixed>::from_hz(FIXED_TIMESTEP_HZ as f64))
             .add_plugins(RepliconPlugins)
             .replicate::<Player>()
-            .replicate::<PlayerId>()
+            .replicate::<CharacterId>()
             .replicate::<Limbs>()
             .replicate::<Skills>()
             .replicate::<Stats>()

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -1,88 +1,34 @@
+mod defense;
+mod offense;
+
+use adventuresim_core::item_references::ARROW_ID;
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::FromClient,
-    message::{DefendRequest, MeleeActionPhase, MeleeActionRequest},
+    message::{DefendRequest, MeleeActionRequest},
 };
 use bevy::prelude::*;
 use std::cmp::Ordering;
 
 use crate::{
-    MissionState,
     combat::{
-        Incapacitated, MeleeAttackIntent, MeleeAttackStartedIntent, PendingDefenderResponse,
-        RangedAttackIntent, RangedAttackStartedIntent, TacticalCombatSide,
-        TacticalCombatantDefeated,
+        CombatDuration, CombatInstant, CombatSet, MeleeAttackIntent, MeleeAttackStartedIntent,
+        PendingDefenderResponse, RangedAttackIntent, RangedAttackStartedIntent, ReportedPrecision,
+        TacticalCombatSide, TacticalCombatantDefeated,
     },
+    mission::MissionState,
 };
-
-/// Chance that a bot notices an incoming attack in time to parry it.
-const PARRY_CHANCE: f64 = 0.2;
-/// Chance that a bot notices an incoming attack in time to dodge it.
-const DODGE_CHANCE: f64 = 0.2;
-/// Flanking values at or below this are considered "facing each other" (see
-/// [`flanking_from_dir`]), which is the only case a bot can react at all.
-const FRONTAL_FLANKING_MAX: f32 = 0.01;
-/// Range (in seconds) a bot's reaction to a noticed attack is delayed by,
-/// simulating varying skill/reflexes between bots. A bot that rolls a long
-/// delay may end up committing its reaction only after the attack has
-/// already been resolved, i.e. reacting too late to matter.
-const REACTION_DELAY_SECS: std::ops::Range<f32> = 0.05..0.6;
-/// AI attacks are intentionally deterministic until animation-driven precision
-/// can be authored for server-controlled actors.
-const AI_HIT_PRECISION: f32 = 1.0;
-const AI_BODY_PART: BodyPart = BodyPart::Chest;
-const AI_WINDUP_SECS: f32 = 0.5;
-const AI_COOLDOWN_SECS: f32 = 1.0;
-const AI_RANGED_MIN_STANDOFF: f32 = 1.5;
-const AI_RANGED_MAX_STANDOFF: f32 = 12.0;
-const AI_RANGED_STANDOFF_SLOP: f32 = 0.5;
-const ARROW_ITEM_ID: &str = "arrow";
-
-fn ranged_weapon_needs_ammo_lookup(weapon_is_ranged: bool, weapon_reach: f32) -> bool {
-    weapon_is_ranged && weapon_reach.is_finite() && weapon_reach > 0.0
-}
+use defense::{
+    CountedEnemyDefeat, on_attack_started, on_tactical_combatant_defeated,
+    on_targeted_attack_started, on_targeted_ranged_attack_started, tick_bot_reactions,
+};
+pub use offense::OffensiveCombatAi;
+use offense::{compare_target, drive_offensive_combat_ai, ranged_weapon_needs_ammo_lookup};
 
 /// Marks a server-controlled bot filling in for a temporary (non-connected)
 /// mission character.
 #[derive(Component)]
 pub struct MissionEnemy;
-
-/// Enables server-owned offensive control, preferring ranged fire while a
-/// usable ranged weapon and arrows are available and otherwise using melee.
-#[derive(Component, Debug)]
-pub struct OffensiveMeleeAi {
-    target: Option<Entity>,
-    phase: OffensiveMeleePhase,
-}
-
-impl Default for OffensiveMeleeAi {
-    fn default() -> Self {
-        Self {
-            target: None,
-            phase: OffensiveMeleePhase::Pursuing,
-        }
-    }
-}
-
-#[derive(Debug)]
-enum OffensiveMeleePhase {
-    Pursuing,
-    MeleeWindup(Timer),
-    RangedWindup(Timer),
-    Cooldown(Timer),
-}
-
-#[derive(Component)]
-pub struct CountedEnemyDefeat;
-
-/// A bot's yet-to-commit reaction to a noticed attack. Ticks down for
-/// [`REACTION_DELAY_SECS`] before becoming a [`PendingDefenderResponse`],
-/// simulating the bot's reflexes.
-#[derive(Component)]
-struct PendingBotReaction {
-    timer: Timer,
-    choice: DefendRequest,
-}
 
 pub struct BotPlugin;
 
@@ -92,318 +38,10 @@ impl Plugin for BotPlugin {
             .add_observer(on_attack_started)
             .add_observer(on_targeted_attack_started)
             .add_observer(on_targeted_ranged_attack_started)
-            .add_systems(Update, (drive_offensive_melee_ai, tick_bot_reactions));
-    }
-}
-
-fn on_tactical_combatant_defeated(
-    defeated: On<TacticalCombatantDefeated>,
-    enemies: Query<(), (With<MissionEnemy>, Without<CountedEnemyDefeat>)>,
-    mut commands: Commands,
-    mut state: ResMut<MissionState>,
-) {
-    let entity = defeated.0;
-    if enemies.get(entity).is_err() {
-        return;
-    }
-    commands.entity(entity).insert(CountedEnemyDefeat);
-    state.enemies_defeated = state.enemies_defeated.saturating_add(1);
-}
-
-/// Predicts whether the nearest opposing AI facing a client attacker notices
-/// the untargeted client windup and decides to dodge or parry it.
-///
-/// A bot has no real reflexes: it only ever gets a chance to react when it is
-/// facing its attacker (`flanking <= FRONTAL_FLANKING_MAX`), and even then it
-/// correctly reads the attack only some of the time. A decision to react is
-/// committed only after a random delay (see [`REACTION_DELAY_SECS`]).
-fn on_attack_started(
-    event: On<FromClient<MeleeActionRequest>>,
-    mut cmd: Commands,
-    q_character: Query<(&CharacterLook, &Transform, &TacticalCombatSide)>,
-    q_bots: Query<
-        (Entity, &CharacterLook, &Transform, &TacticalCombatSide),
-        (With<OffensiveMeleeAi>, Without<Incapacitated>),
-    >,
-) {
-    if event.phase != MeleeActionPhase::Start {
-        return;
-    }
-    let Some(attacker) = event.client_id.entity() else {
-        return;
-    };
-    let Ok((attacker_look, attacker_transform, attacker_side)) = q_character.get(attacker) else {
-        return;
-    };
-    let nearest = q_bots
-        .iter()
-        .filter(|(_, _, _, side)| **side != *attacker_side)
-        .min_by(|(a, _, a_transform, _), (b, _, b_transform, _)| {
-            compare_target(attacker_transform, a_transform, *a, b_transform, *b)
-        });
-    let Some((bot, bot_look, _, _)) = nearest else {
-        return;
-    };
-    try_start_reaction(&mut cmd, bot, attacker_look, bot_look);
-}
-
-fn on_targeted_attack_started(
-    event: On<MeleeAttackStartedIntent>,
-    mut cmd: Commands,
-    q_character: Query<&CharacterLook>,
-    q_ai: Query<&CharacterLook, (With<OffensiveMeleeAi>, Without<Incapacitated>)>,
-) {
-    let Ok([attacker_look, defender_look]) = q_character.get_many([event.attacker, event.target])
-    else {
-        return;
-    };
-    if q_ai.get(event.target).is_ok() {
-        try_start_reaction(&mut cmd, event.target, attacker_look, defender_look);
-    }
-}
-
-fn on_targeted_ranged_attack_started(
-    event: On<RangedAttackStartedIntent>,
-    mut cmd: Commands,
-    q_character: Query<&CharacterLook>,
-    q_ai: Query<&CharacterLook, (With<OffensiveMeleeAi>, Without<Incapacitated>)>,
-) {
-    let Some(target) = event.target else {
-        return;
-    };
-    let Ok([attacker_look, defender_look]) = q_character.get_many([event.attacker, target]) else {
-        return;
-    };
-    if q_ai.get(target).is_ok() {
-        try_start_reaction(&mut cmd, target, attacker_look, defender_look);
-    }
-}
-
-fn try_start_reaction(
-    cmd: &mut Commands,
-    defender: Entity,
-    attacker_look: &CharacterLook,
-    defender_look: &CharacterLook,
-) {
-    let (a2, a1) = attacker_look.yaw.sin_cos();
-    let (d2, d1) = defender_look.yaw.sin_cos();
-    if flanking_from_dir((a1, a2), (d1, d2)) > FRONTAL_FLANKING_MAX {
-        return;
-    }
-    let Some(choice) = roll_defend_choice() else {
-        return;
-    };
-    cmd.entity(defender).insert(PendingBotReaction {
-        timer: Timer::from_seconds(rand::random_range(REACTION_DELAY_SECS), TimerMode::Once),
-        choice,
-    });
-}
-
-fn compare_target(
-    origin: &Transform,
-    a_transform: &Transform,
-    a: Entity,
-    b_transform: &Transform,
-    b: Entity,
-) -> Ordering {
-    let a_distance_squared = origin
-        .translation
-        .xz()
-        .distance_squared(a_transform.translation.xz());
-    let b_distance_squared = origin
-        .translation
-        .xz()
-        .distance_squared(b_transform.translation.xz());
-    a_distance_squared
-        .total_cmp(&b_distance_squared)
-        .then_with(|| a.to_bits().cmp(&b.to_bits()))
-}
-
-fn drive_offensive_melee_ai(
-    mut cmd: Commands,
-    time: Res<Time<()>>,
-    viewer: TacticalPlayerViewer,
-    candidates: Query<
-        (Entity, &Transform, &TacticalCombatSide),
-        (With<Player>, Without<Incapacitated>),
-    >,
-    mut ai: Query<
-        (
-            Entity,
-            &Transform,
-            &TacticalCombatSide,
-            &mut CharacterLook,
-            &mut input::AccumulatedInput,
-            &mut OffensiveMeleeAi,
-        ),
-        Without<Incapacitated>,
-    >,
-) {
-    for (entity, transform, side, mut look, mut input, mut controller) in &mut ai {
-        let target = candidates
-            .iter()
-            .filter(|(candidate, _, candidate_side)| {
-                *candidate != entity && **candidate_side != *side
-            })
-            .min_by(|(a, a_transform, _), (b, b_transform, _)| {
-                compare_target(transform, a_transform, *a, b_transform, *b)
-            })
-            .map(|(target, _, _)| target);
-
-        if target != controller.target {
-            controller.target = target;
-            controller.phase = OffensiveMeleePhase::Pursuing;
-        }
-        let Some(target) = target else {
-            input.last_movement = None;
-            continue;
-        };
-        let Ok((_, target_transform, _)) = candidates.get(target) else {
-            continue;
-        };
-
-        let offset = target_transform.translation.xz() - transform.translation.xz();
-        let distance = offset.length();
-        if distance > f32::EPSILON {
-            look.yaw = (-offset.x).atan2(-offset.y);
-        }
-        let (weapon_reach, weapon_is_melee, weapon_is_ranged) = viewer
-            .get(entity)
-            .map(|view| {
-                (
-                    view.weapon_reach(),
-                    view.weapon_is_melee(),
-                    view.weapon_is_ranged(),
-                )
-            })
-            .unwrap_or_default();
-        let has_ammo = ranged_weapon_needs_ammo_lookup(weapon_is_ranged, weapon_reach)
-            && viewer.inventory.get(entity).has_item_id(ARROW_ITEM_ID);
-        let use_ranged = weapon_is_ranged && weapon_reach > 0.0 && has_ammo;
-        let interaction_range = melee_interaction_range(weapon_reach);
-
-        let abort_windup = matches!(
-            &controller.phase,
-            OffensiveMeleePhase::MeleeWindup(_)
-                if !weapon_is_melee || weapon_reach <= 0.0 || distance > interaction_range
-        ) || matches!(
-            &controller.phase,
-            OffensiveMeleePhase::RangedWindup(_) if !use_ranged || distance > weapon_reach
-        );
-        if abort_windup {
-            controller.phase = OffensiveMeleePhase::Pursuing;
-        }
-
-        match &mut controller.phase {
-            OffensiveMeleePhase::Pursuing if use_ranged => {
-                let standoff = (weapon_reach * 0.5)
-                    .clamp(AI_RANGED_MIN_STANDOFF, AI_RANGED_MAX_STANDOFF)
-                    .min(weapon_reach);
-                if distance > weapon_reach || distance > standoff + AI_RANGED_STANDOFF_SLOP {
-                    input.last_movement = Some(Vec2::Y);
-                } else if distance + AI_RANGED_STANDOFF_SLOP < standoff {
-                    input.last_movement = Some(-Vec2::Y);
-                } else {
-                    input.last_movement = None;
-                    cmd.trigger(RangedAttackStartedIntent {
-                        attacker: entity,
-                        target: Some(target),
-                        windup_secs: AI_WINDUP_SECS,
-                    });
-                    controller.phase = OffensiveMeleePhase::RangedWindup(Timer::from_seconds(
-                        AI_WINDUP_SECS,
-                        TimerMode::Once,
-                    ));
-                }
-            }
-            OffensiveMeleePhase::Pursuing
-                if weapon_is_melee && weapon_reach > 0.0 && distance <= interaction_range =>
-            {
-                input.last_movement = None;
-                cmd.trigger(MeleeAttackStartedIntent {
-                    attacker: entity,
-                    target,
-                    windup_secs: AI_WINDUP_SECS,
-                });
-                controller.phase = OffensiveMeleePhase::MeleeWindup(Timer::from_seconds(
-                    AI_WINDUP_SECS,
-                    TimerMode::Once,
-                ));
-            }
-            OffensiveMeleePhase::Pursuing => {
-                input.last_movement = Some(Vec2::Y);
-            }
-            OffensiveMeleePhase::MeleeWindup(timer) => {
-                input.last_movement = None;
-                timer.tick(time.delta());
-                if timer.is_finished() {
-                    cmd.trigger(MeleeAttackIntent {
-                        attacker: entity,
-                        target,
-                        body_part: AI_BODY_PART,
-                        hit_precision: AI_HIT_PRECISION,
-                    });
-                    controller.phase = OffensiveMeleePhase::Cooldown(Timer::from_seconds(
-                        AI_COOLDOWN_SECS,
-                        TimerMode::Once,
-                    ));
-                }
-            }
-            OffensiveMeleePhase::RangedWindup(timer) => {
-                input.last_movement = None;
-                timer.tick(time.delta());
-                if timer.is_finished() {
-                    cmd.trigger(RangedAttackIntent {
-                        attacker: entity,
-                        target: Some(target),
-                        body_part: AI_BODY_PART,
-                        hit_precision: AI_HIT_PRECISION,
-                    });
-                    controller.phase = OffensiveMeleePhase::Cooldown(Timer::from_seconds(
-                        AI_COOLDOWN_SECS,
-                        TimerMode::Once,
-                    ));
-                }
-            }
-            OffensiveMeleePhase::Cooldown(timer) => {
-                input.last_movement = None;
-                timer.tick(time.delta());
-                if timer.is_finished() {
-                    controller.phase = OffensiveMeleePhase::Pursuing;
-                }
-            }
-        }
-    }
-}
-
-fn roll_defend_choice() -> Option<DefendRequest> {
-    let roll: f64 = rand::random();
-    if roll < PARRY_CHANCE {
-        Some(DefendRequest::Parry)
-    } else if roll < PARRY_CHANCE + DODGE_CHANCE {
-        Some(DefendRequest::Dodge)
-    } else {
-        None
-    }
-}
-
-fn tick_bot_reactions(
-    mut cmd: Commands,
-    time: Res<Time<()>>,
-    mut q_reacting: Query<(Entity, &mut PendingBotReaction), Without<Incapacitated>>,
-) {
-    for (bot, mut reaction) in &mut q_reacting {
-        reaction.timer.tick(time.delta());
-        if !reaction.timer.is_finished() {
-            continue;
-        }
-
-        cmd.entity(bot)
-            .remove::<PendingBotReaction>()
-            .insert(PendingDefenderResponse {
-                choice: reaction.choice,
-                set_at: time.elapsed_secs(),
-            });
+            .add_systems(
+                Update,
+                (drive_offensive_combat_ai, tick_bot_reactions).after(CombatSet::Condition),
+            );
     }
 }
 
@@ -468,7 +106,7 @@ mod tests {
                 side,
                 CharacterLook::default(),
                 input::AccumulatedInput::default(),
-                OffensiveMeleeAi::default(),
+                OffensiveCombatAi::default(),
                 TacticalCombatState::default(),
             ))
             .id();
@@ -505,7 +143,7 @@ mod tests {
                 side,
                 CharacterLook::default(),
                 input::AccumulatedInput::default(),
-                OffensiveMeleeAi::default(),
+                OffensiveCombatAi::default(),
                 TacticalCombatState::default(),
             ))
             .id();
@@ -528,7 +166,7 @@ mod tests {
             .spawn((
                 ItemOf(actor),
                 ItemProperties {
-                    id: ARROW_ITEM_ID.to_owned(),
+                    id: ARROW_ID.to_owned(),
                     weight: 0.05,
                 },
                 ItemQuantity(NonZeroU32::new(1).unwrap()),
@@ -556,7 +194,7 @@ mod tests {
             .init_resource::<RecordedRangedAttacks>()
             .add_observer(record_attack)
             .add_observer(record_ranged_attack)
-            .add_systems(Update, drive_offensive_melee_ai);
+            .add_systems(Update, drive_offensive_combat_ai);
         app
     }
 
@@ -612,25 +250,8 @@ mod tests {
     #[test]
     fn enemy_defeat_is_counted_only_once() {
         let mut app = App::new();
-        app.insert_resource(MissionState {
-            timeout: None,
-            enemies_defeated: 0,
-            required_enemy_defeats: 1,
-            expected_party_members: 1,
-            seen_party_members: Default::default(),
-            enrollment_begun: false,
-            enrollment_sealed: false,
-            abandonment_elapsed: Default::default(),
-            terminal_retry_not_before: Default::default(),
-            pending_resolution: None,
-            pending_receipt: None,
-            terminal_in_flight: false,
-            terminal_ack_deadline: None,
-            terminal_transport_failed: false,
-            terminal_presentation: None,
-            committed: false,
-        })
-        .add_observer(on_tactical_combatant_defeated);
+        app.insert_resource(MissionState::new(None, 1, NonZeroU32::new(1).unwrap()))
+            .add_observer(on_tactical_combatant_defeated);
         let enemy = app.world_mut().spawn(MissionEnemy).id();
 
         app.world_mut().trigger(TacticalCombatantDefeated(enemy));
@@ -638,7 +259,7 @@ mod tests {
         app.world_mut().trigger(TacticalCombatantDefeated(enemy));
         app.update();
 
-        assert_eq!(app.world().resource::<MissionState>().enemies_defeated, 1);
+        assert_eq!(app.world().resource::<MissionState>().enemies_defeated(), 1);
         assert!(app.world().entity(enemy).contains::<CountedEnemyDefeat>());
     }
 
@@ -762,9 +383,9 @@ mod tests {
         let selected = app
             .world()
             .entity(actor)
-            .get::<OffensiveMeleeAi>()
+            .get::<OffensiveCombatAi>()
             .unwrap()
-            .target;
+            .target();
         let expected = if first.to_bits() < second.to_bits() {
             first
         } else {
@@ -783,8 +404,8 @@ mod tests {
             .add_systems(
                 Update,
                 (
-                    drive_offensive_melee_ai,
                     crate::combat::update_tactical_combat_state,
+                    drive_offensive_combat_ai,
                 )
                     .chain(),
             );
@@ -832,7 +453,7 @@ mod tests {
                 app.world()
                     .entity(actor)
                     .get::<TacticalCombatState>()
-                    .is_some_and(|state| state.incapacitated)
+                    .is_some_and(TacticalCombatState::is_incapacitated)
             }) {
                 break;
             }
@@ -845,7 +466,7 @@ mod tests {
                     .entity(*actor)
                     .get::<TacticalCombatState>()
                     .unwrap()
-                    .incapacitated
+                    .is_incapacitated()
             })
             .collect();
         assert!(!incapacitated.is_empty());
@@ -866,25 +487,26 @@ mod tests {
             .entity(party)
             .get::<TacticalCombatState>()
             .unwrap()
-            .incapacitated;
+            .is_incapacitated();
         let enemy_defeated = app
             .world()
             .entity(enemy)
             .get::<TacticalCombatState>()
             .unwrap()
-            .incapacitated;
-        let resolution = crate::terminal_resolution(crate::TerminalCombatSnapshot {
-            required_enemies: 1,
-            loaded_enemies: 1,
-            defeated_enemies: u32::from(enemy_defeated),
-            loaded_party: 1,
-            incapacitated_party: u32::from(party_defeated),
-            enrollment_sealed: true,
-        });
+            .is_incapacitated();
+        let resolution =
+            crate::mission::terminal_resolution(crate::mission::TerminalCombatSnapshot {
+                required_enemies: 1,
+                loaded_enemies: 1,
+                defeated_enemies: u32::from(enemy_defeated),
+                loaded_party: 1,
+                incapacitated_party: u32::from(party_defeated),
+                enrollment_sealed: true,
+            });
         let expected = if party_defeated {
-            Some(crate::TacticalMissionResolution::Failed)
+            Some(adventuresim_stdb_client::TacticalMissionResolution::Failed)
         } else {
-            Some(crate::TacticalMissionResolution::Defeated)
+            Some(adventuresim_stdb_client::TacticalMissionResolution::Defeated)
         };
         assert_eq!(resolution, expected);
     }

--- a/crates/adventuresim-tactical-server/src/bot/defense.rs
+++ b/crates/adventuresim-tactical-server/src/bot/defense.rs
@@ -1,0 +1,165 @@
+use super::*;
+
+const PARRY_CHANCE: f64 = 0.2;
+const DODGE_CHANCE: f64 = 0.2;
+const FRONTAL_FLANKING_MAX: f32 = 0.01;
+const REACTION_DELAY_SECS: std::ops::Range<f32> = 0.05..0.6;
+
+#[derive(Component)]
+pub(super) struct CountedEnemyDefeat;
+
+#[derive(Component)]
+pub(super) struct PendingBotReaction {
+    timer: Timer,
+    choice: DefendRequest,
+}
+
+pub(super) fn on_tactical_combatant_defeated(
+    defeated: On<TacticalCombatantDefeated>,
+    enemies: Query<(), (With<MissionEnemy>, Without<CountedEnemyDefeat>)>,
+    mut commands: Commands,
+    mut state: ResMut<MissionState>,
+) {
+    let entity = defeated.0;
+    if enemies.get(entity).is_err() {
+        return;
+    }
+    commands.entity(entity).insert(CountedEnemyDefeat);
+    state.record_enemy_defeat();
+}
+
+/// Predicts whether the nearest opposing AI facing a client attacker notices
+/// the untargeted client windup and decides to dodge or parry it.
+///
+/// A bot has no real reflexes: it only ever gets a chance to react when it is
+/// facing its attacker (`flanking <= FRONTAL_FLANKING_MAX`), and even then it
+/// correctly reads the attack only some of the time. A decision to react is
+/// committed only after a random delay (see [`REACTION_DELAY_SECS`]).
+pub(super) fn on_attack_started(
+    event: On<FromClient<MeleeActionRequest>>,
+    mut cmd: Commands,
+    q_character: Query<(&CharacterLook, &Transform, &TacticalCombatSide)>,
+    q_bots: Query<
+        (
+            Entity,
+            &CharacterLook,
+            &Transform,
+            &TacticalCombatSide,
+            &TacticalCombatState,
+        ),
+        With<OffensiveCombatAi>,
+    >,
+) {
+    if !matches!(**event, MeleeActionRequest::Start) {
+        return;
+    }
+    let Some(attacker) = event.client_id.entity() else {
+        return;
+    };
+    let Ok((attacker_look, attacker_transform, attacker_side)) = q_character.get(attacker) else {
+        return;
+    };
+    let nearest = q_bots
+        .iter()
+        .filter(|(_, _, _, side, state)| **side != *attacker_side && !state.is_incapacitated())
+        .min_by(|(a, _, a_transform, _, _), (b, _, b_transform, _, _)| {
+            compare_target(attacker_transform, a_transform, *a, b_transform, *b)
+        });
+    let Some((bot, bot_look, _, _, _)) = nearest else {
+        return;
+    };
+    try_start_reaction(&mut cmd, bot, attacker_look, bot_look);
+}
+
+pub(super) fn on_targeted_attack_started(
+    event: On<MeleeAttackStartedIntent>,
+    mut cmd: Commands,
+    q_character: Query<&CharacterLook>,
+    q_ai: Query<(&CharacterLook, &TacticalCombatState), With<OffensiveCombatAi>>,
+) {
+    let Ok([attacker_look, defender_look]) = q_character.get_many([event.attacker, event.target])
+    else {
+        return;
+    };
+    if q_ai
+        .get(event.target)
+        .is_ok_and(|(_, state)| !state.is_incapacitated())
+    {
+        try_start_reaction(&mut cmd, event.target, attacker_look, defender_look);
+    }
+}
+
+pub(super) fn on_targeted_ranged_attack_started(
+    event: On<RangedAttackStartedIntent>,
+    mut cmd: Commands,
+    q_character: Query<&CharacterLook>,
+    q_ai: Query<(&CharacterLook, &TacticalCombatState), With<OffensiveCombatAi>>,
+) {
+    let Some(target) = event.target else {
+        return;
+    };
+    let Ok([attacker_look, defender_look]) = q_character.get_many([event.attacker, target]) else {
+        return;
+    };
+    if q_ai
+        .get(target)
+        .is_ok_and(|(_, state)| !state.is_incapacitated())
+    {
+        try_start_reaction(&mut cmd, target, attacker_look, defender_look);
+    }
+}
+
+pub(super) fn try_start_reaction(
+    cmd: &mut Commands,
+    defender: Entity,
+    attacker_look: &CharacterLook,
+    defender_look: &CharacterLook,
+) {
+    let (a2, a1) = attacker_look.yaw.sin_cos();
+    let (d2, d1) = defender_look.yaw.sin_cos();
+    if flanking_from_dir((a1, a2), (d1, d2)) > FRONTAL_FLANKING_MAX {
+        return;
+    }
+    let Some(choice) = roll_defend_choice() else {
+        return;
+    };
+    cmd.entity(defender).insert(PendingBotReaction {
+        timer: Timer::from_seconds(rand::random_range(REACTION_DELAY_SECS), TimerMode::Once),
+        choice,
+    });
+}
+
+pub(super) fn roll_defend_choice() -> Option<DefendRequest> {
+    let roll: f64 = rand::random();
+    if roll < PARRY_CHANCE {
+        Some(DefendRequest::Parry)
+    } else if roll < PARRY_CHANCE + DODGE_CHANCE {
+        Some(DefendRequest::Dodge)
+    } else {
+        None
+    }
+}
+
+pub(super) fn tick_bot_reactions(
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    mut q_reacting: Query<(Entity, &mut PendingBotReaction, &TacticalCombatState)>,
+) {
+    for (bot, mut reaction, state) in &mut q_reacting {
+        if state.is_incapacitated() {
+            cmd.entity(bot).remove::<PendingBotReaction>();
+            continue;
+        }
+        reaction.timer.tick(time.delta());
+        if !reaction.timer.is_finished() {
+            continue;
+        }
+
+        cmd.entity(bot)
+            .remove::<PendingBotReaction>()
+            .insert(PendingDefenderResponse {
+                choice: reaction.choice,
+                set_at: CombatInstant::from_elapsed(&time),
+            });
+    }
+}

--- a/crates/adventuresim-tactical-server/src/bot/offense.rs
+++ b/crates/adventuresim-tactical-server/src/bot/offense.rs
@@ -1,0 +1,235 @@
+use super::*;
+
+const AI_HIT_PRECISION: f32 = 1.0;
+const AI_BODY_PART: BodyPart = BodyPart::Chest;
+const AI_WINDUP_SECS: f32 = 0.5;
+const AI_COOLDOWN_SECS: f32 = 1.0;
+const AI_RANGED_MIN_STANDOFF: f32 = 1.5;
+const AI_RANGED_MAX_STANDOFF: f32 = 12.0;
+const AI_RANGED_STANDOFF_SLOP: f32 = 0.5;
+
+/// Enables server-owned offensive control, preferring ranged fire while a
+/// usable ranged weapon and arrows are available and otherwise using melee.
+#[derive(Component, Debug)]
+pub struct OffensiveCombatAi {
+    target: Option<Entity>,
+    phase: OffensiveCombatPhase,
+}
+
+impl Default for OffensiveCombatAi {
+    fn default() -> Self {
+        Self {
+            target: None,
+            phase: OffensiveCombatPhase::Pursuing,
+        }
+    }
+}
+
+#[cfg(test)]
+impl OffensiveCombatAi {
+    pub(super) fn target(&self) -> Option<Entity> {
+        self.target
+    }
+}
+
+#[derive(Debug)]
+enum OffensiveCombatPhase {
+    Pursuing,
+    MeleeWindup(Timer),
+    RangedWindup(Timer),
+    Cooldown(Timer),
+}
+
+pub(super) fn ranged_weapon_needs_ammo_lookup(weapon_is_ranged: bool, weapon_reach: f32) -> bool {
+    weapon_is_ranged && weapon_reach.is_finite() && weapon_reach > 0.0
+}
+
+pub(super) fn compare_target(
+    origin: &Transform,
+    a_transform: &Transform,
+    a: Entity,
+    b_transform: &Transform,
+    b: Entity,
+) -> Ordering {
+    let a_distance_squared = origin
+        .translation
+        .xz()
+        .distance_squared(a_transform.translation.xz());
+    let b_distance_squared = origin
+        .translation
+        .xz()
+        .distance_squared(b_transform.translation.xz());
+    a_distance_squared
+        .total_cmp(&b_distance_squared)
+        .then_with(|| a.to_bits().cmp(&b.to_bits()))
+}
+
+pub(super) fn drive_offensive_combat_ai(
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    viewer: TacticalPlayerViewer,
+    candidates: Query<
+        (
+            Entity,
+            &Transform,
+            &TacticalCombatSide,
+            &TacticalCombatState,
+        ),
+        With<Player>,
+    >,
+    mut ai: Query<(
+        Entity,
+        &Transform,
+        &TacticalCombatSide,
+        &mut CharacterLook,
+        &mut input::AccumulatedInput,
+        &mut OffensiveCombatAi,
+        &TacticalCombatState,
+    )>,
+) {
+    for (entity, transform, side, mut look, mut input, mut controller, state) in &mut ai {
+        if state.is_incapacitated() {
+            input.last_movement = None;
+            continue;
+        }
+        let target = candidates
+            .iter()
+            .filter(|(candidate, _, candidate_side, candidate_state)| {
+                *candidate != entity
+                    && **candidate_side != *side
+                    && !candidate_state.is_incapacitated()
+            })
+            .min_by(|(a, a_transform, _, _), (b, b_transform, _, _)| {
+                compare_target(transform, a_transform, *a, b_transform, *b)
+            })
+            .map(|(target, _, _, _)| target);
+
+        if target != controller.target {
+            controller.target = target;
+            controller.phase = OffensiveCombatPhase::Pursuing;
+        }
+        let Some(target) = target else {
+            input.last_movement = None;
+            continue;
+        };
+        let Ok((_, target_transform, _, _)) = candidates.get(target) else {
+            continue;
+        };
+
+        let offset = target_transform.translation.xz() - transform.translation.xz();
+        let distance = offset.length();
+        if distance > f32::EPSILON {
+            look.yaw = (-offset.x).atan2(-offset.y);
+        }
+        let (weapon_reach, weapon_is_melee, weapon_is_ranged) = viewer
+            .get(entity)
+            .map(|view| {
+                (
+                    view.weapon_reach(),
+                    view.weapon_is_melee(),
+                    view.weapon_is_ranged(),
+                )
+            })
+            .unwrap_or_default();
+        let has_ammo = ranged_weapon_needs_ammo_lookup(weapon_is_ranged, weapon_reach)
+            && viewer.inventory.get(entity).has_item_id(ARROW_ID);
+        let use_ranged = weapon_is_ranged && weapon_reach > 0.0 && has_ammo;
+        let interaction_range = melee_interaction_range(weapon_reach);
+
+        let abort_windup = matches!(
+            &controller.phase,
+            OffensiveCombatPhase::MeleeWindup(_)
+                if !weapon_is_melee || weapon_reach <= 0.0 || distance > interaction_range
+        ) || matches!(
+            &controller.phase,
+            OffensiveCombatPhase::RangedWindup(_) if !use_ranged || distance > weapon_reach
+        );
+        if abort_windup {
+            controller.phase = OffensiveCombatPhase::Pursuing;
+        }
+
+        match &mut controller.phase {
+            OffensiveCombatPhase::Pursuing if use_ranged => {
+                let standoff = (weapon_reach * 0.5)
+                    .clamp(AI_RANGED_MIN_STANDOFF, AI_RANGED_MAX_STANDOFF)
+                    .min(weapon_reach);
+                if distance > weapon_reach || distance > standoff + AI_RANGED_STANDOFF_SLOP {
+                    input.last_movement = Some(Vec2::Y);
+                } else if distance + AI_RANGED_STANDOFF_SLOP < standoff {
+                    input.last_movement = Some(-Vec2::Y);
+                } else {
+                    input.last_movement = None;
+                    cmd.trigger(RangedAttackStartedIntent {
+                        attacker: entity,
+                        target: Some(target),
+                        windup: CombatDuration::from_duration(std::time::Duration::from_millis(
+                            500,
+                        )),
+                    });
+                    controller.phase = OffensiveCombatPhase::RangedWindup(Timer::from_seconds(
+                        AI_WINDUP_SECS,
+                        TimerMode::Once,
+                    ));
+                }
+            }
+            OffensiveCombatPhase::Pursuing
+                if weapon_is_melee && weapon_reach > 0.0 && distance <= interaction_range =>
+            {
+                input.last_movement = None;
+                cmd.trigger(MeleeAttackStartedIntent {
+                    attacker: entity,
+                    target,
+                    windup: CombatDuration::from_duration(std::time::Duration::from_millis(500)),
+                });
+                controller.phase = OffensiveCombatPhase::MeleeWindup(Timer::from_seconds(
+                    AI_WINDUP_SECS,
+                    TimerMode::Once,
+                ));
+            }
+            OffensiveCombatPhase::Pursuing => {
+                input.last_movement = Some(Vec2::Y);
+            }
+            OffensiveCombatPhase::MeleeWindup(timer) => {
+                input.last_movement = None;
+                timer.tick(time.delta());
+                if timer.is_finished() {
+                    cmd.trigger(MeleeAttackIntent {
+                        attacker: entity,
+                        target,
+                        body_part: AI_BODY_PART,
+                        reported_precision: ReportedPrecision::new(AI_HIT_PRECISION)
+                            .expect("AI precision is finite"),
+                    });
+                    controller.phase = OffensiveCombatPhase::Cooldown(Timer::from_seconds(
+                        AI_COOLDOWN_SECS,
+                        TimerMode::Once,
+                    ));
+                }
+            }
+            OffensiveCombatPhase::RangedWindup(timer) => {
+                input.last_movement = None;
+                timer.tick(time.delta());
+                if timer.is_finished() {
+                    cmd.trigger(RangedAttackIntent {
+                        attacker: entity,
+                        target: Some(target),
+                        body_part: AI_BODY_PART,
+                        reported_precision: ReportedPrecision::new(AI_HIT_PRECISION)
+                            .expect("AI precision is finite"),
+                    });
+                    controller.phase = OffensiveCombatPhase::Cooldown(Timer::from_seconds(
+                        AI_COOLDOWN_SECS,
+                        TimerMode::Once,
+                    ));
+                }
+            }
+            OffensiveCombatPhase::Cooldown(timer) => {
+                input.last_movement = None;
+                timer.tick(time.delta());
+                if timer.is_finished() {
+                    controller.phase = OffensiveCombatPhase::Pursuing;
+                }
+            }
+        }
+    }
+}

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -1,13 +1,43 @@
+mod authority;
+mod condition;
+mod consequence;
+mod ingress;
+mod melee;
+mod protocol;
+mod ranged;
+
+use adventuresim_core::item_references::ARROW_ID;
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::{FromClient, SendMode, ServerTriggerExt, ToClients},
-    message::{
-        DefendRequest, MeleeActionPhase, MeleeActionRequest, RangedActionPhase,
-        RangedActionRequest, SuccessfulAttackResponse,
-    },
+    message::{DefendRequest, MeleeActionRequest, RangedActionRequest, SuccessfulAttackResponse},
 };
 use bevy::prelude::*;
-use std::{collections::HashMap, num::NonZeroU32};
+use std::{collections::HashMap, num::NonZeroU32, time::Duration};
+
+use crate::player_projection::PlayerProjectionSet;
+pub(crate) use authority::{
+    CombatDuration, CombatInstant, MeleeAttackAuthority, RangedAttackAuthority, ReportedPrecision,
+};
+use authority::{ValidatedRangedImpact, validate_melee_intent_cheap, validate_ranged_intent};
+pub(crate) use condition::update_tactical_combat_state;
+pub(crate) use consequence::apply_transient_attack_result;
+use consequence::{apply_melee_attack_result, record_party_ammunition_use};
+#[cfg(test)]
+use consequence::{
+    attacker_weapon_contact_matches, defender_equipment_contact_matches, record_party_injury,
+};
+use ingress::{
+    authoritative_line_of_sight, on_defender_response, on_melee_action_request,
+    on_melee_attack_started, on_ranged_action_request, on_ranged_attack_started,
+    resolve_defender_response,
+};
+use melee::resolve_melee_attack;
+pub(crate) use protocol::{
+    MeleeAttackIntent, MeleeAttackStartedIntent, PendingDefenderResponse, RangedAttackIntent,
+    RangedAttackStartedIntent, TacticalCombatSide, TacticalCombatantDefeated,
+};
+use ranged::resolve_ranged_attack;
 
 #[derive(Clone, Debug)]
 pub(crate) struct AppliedTacticalInjury {
@@ -26,7 +56,7 @@ pub(crate) struct AccumulatedPartyConsequence {
 
 #[derive(Clone, Debug)]
 pub(crate) struct AccumulatedEquipmentContact {
-    pub character_id: u64,
+    pub character_id: CharacterId,
     pub inventory_item_id: u64,
     pub contact_stress: f32,
     pub defender_equipment: bool,
@@ -34,151 +64,36 @@ pub(crate) struct AccumulatedEquipmentContact {
 
 #[derive(Resource, Clone, Debug, Default)]
 pub(crate) struct TacticalConsequenceAccumulator {
-    pub party: HashMap<u64, AccumulatedPartyConsequence>,
+    pub party: HashMap<CharacterId, AccumulatedPartyConsequence>,
     pub equipment_contacts: Vec<AccumulatedEquipmentContact>,
 }
 
 /// Maximum window (in seconds) after pressing dodge/parry that the response
 /// is still considered valid. A fresh press gives `input_reflex = 1.0`;
 /// a press older than this window is treated as no response.
-const MAX_REFLEX_WINDOW: f32 = 0.5;
-const CLIENT_MELEE_WINDUP_SECS: f32 = 0.3;
-const MELEE_COOLDOWN_SECS: f32 = 0.3;
+const MAX_REFLEX_WINDOW: Duration = Duration::from_millis(500);
+const CLIENT_MELEE_WINDUP: CombatDuration =
+    CombatDuration::from_duration(Duration::from_millis(300));
+const MELEE_COOLDOWN: CombatDuration = CombatDuration::from_duration(Duration::from_millis(300));
 /// Completion must arrive within this bounded ordered-network allowance after
 /// the windup becomes ready; old starts cannot authorize replayed completions.
-const MELEE_WINDUP_NETWORK_ALLOWANCE_SECS: f32 = 1.0;
+const MELEE_WINDUP_NETWORK_ALLOWANCE: CombatDuration =
+    CombatDuration::from_duration(Duration::from_secs(1));
 /// Allows bounded movement between the authoritative physics snapshot and an
 /// ordered attack request arriving at the server.
 const MELEE_RANGE_LATENCY_TOLERANCE: f32 = 0.25;
-const CLIENT_RANGED_WINDUP_SECS: f32 = 0.3;
-const RANGED_COOLDOWN_SECS: f32 = 0.6;
-const RANGED_NETWORK_ALLOWANCE_SECS: f32 = 1.0;
+const CLIENT_RANGED_WINDUP: CombatDuration =
+    CombatDuration::from_duration(Duration::from_millis(300));
+const RANGED_COOLDOWN: CombatDuration = CombatDuration::from_duration(Duration::from_millis(600));
+const RANGED_NETWORK_ALLOWANCE: CombatDuration =
+    CombatDuration::from_duration(Duration::from_secs(1));
 const RANGED_RANGE_LATENCY_TOLERANCE: f32 = 0.5;
 /// The server owns yaw but not full skeletal/secondary animation. Permit a
 /// small network/input cone while still rejecting targets behind the shooter.
 const RANGED_AIM_CONE_DEGREES: f32 = 20.0;
-const ARROW_ITEM_ID: &str = "arrow";
-
-/// Stores the defender's most recent dodge/parry choice along with the
-/// server timestamp when it was received. Consumed on each attack resolution.
-///
-/// Set either by [`on_defender_response`] for a real player's key press, or by
-/// [`crate::bot`]'s AI standing in for a bot's reaction.
-#[derive(Component)]
-pub struct PendingDefenderResponse {
-    pub choice: DefendRequest,
-    pub set_at: f32,
-}
-
-/// Transient allegiance used by the tactical server to identify opponents.
-///
-/// This is deliberately independent from player connectivity and bot control:
-/// tests and future mission types can put server-controlled combatants on
-/// either side.
-#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
-pub enum TacticalCombatSide {
-    Party,
-    Enemy,
-}
-
-#[derive(Debug)]
-struct ObservedMeleeWindup {
-    target: Option<Entity>,
-    ready_at: f32,
-    expires_at: f32,
-}
-
-#[derive(Component, Debug, Default)]
-pub(crate) struct MeleeAttackAuthority {
-    windup: Option<ObservedMeleeWindup>,
-    cooldown_until: f32,
-}
-
-#[derive(Debug)]
-struct ObservedRangedWindup {
-    ready_at: f32,
-    expires_at: f32,
-}
-
-#[derive(Component, Debug, Default)]
-pub(crate) struct RangedAttackAuthority {
-    windup: Option<ObservedRangedWindup>,
-    cooldown_until: f32,
-}
-
-fn consume_ranged_authority(authority: &mut RangedAttackAuthority, now: f32) -> bool {
-    let valid = authority.windup.as_ref().is_some_and(|windup| {
-        now >= windup.ready_at && now <= windup.expires_at && now >= authority.cooldown_until
-    });
-    if valid {
-        authority.windup = None;
-        authority.cooldown_until = now + RANGED_COOLDOWN_SECS;
-    }
-    valid
-}
 
 fn remaining_ammo_after_shot(quantity: NonZeroU32) -> Option<NonZeroU32> {
     NonZeroU32::new(quantity.get() - 1)
-}
-
-fn consume_melee_authority(authority: &mut MeleeAttackAuthority, target: Entity, now: f32) -> bool {
-    let valid = authority.windup.as_ref().is_some_and(|windup| {
-        windup.target.map_or(true, |observed| observed == target)
-            && now >= windup.ready_at
-            && now <= windup.expires_at
-            && now >= authority.cooldown_until
-    });
-    if valid {
-        authority.windup = None;
-        authority.cooldown_until = now + MELEE_COOLDOWN_SECS;
-    }
-    valid
-}
-
-/// Present while transient combat effects meet the incapacitation threshold.
-#[derive(Component, Debug)]
-pub struct Incapacitated;
-
-/// Emitted once per transition from active to incapacitated. Mission systems
-/// decide whether that transition constitutes a counted tactical defeat.
-#[derive(Event, Clone, Copy, Debug)]
-pub struct TacticalCombatantDefeated(pub Entity);
-
-/// A server-internal melee request. Both network clients and server-owned AI
-/// enter combat resolution through this seam.
-#[derive(Event, Clone, Copy, Debug)]
-pub struct MeleeAttackIntent {
-    pub attacker: Entity,
-    pub target: Entity,
-    pub body_part: BodyPart,
-    pub hit_precision: f32,
-}
-
-/// Announces a targeted windup so the intended defender alone can react.
-#[derive(Event, Clone, Copy, Debug)]
-pub struct MeleeAttackStartedIntent {
-    pub attacker: Entity,
-    pub target: Entity,
-    pub windup_secs: f32,
-}
-
-/// A server-internal fired shot. `target == None` is an authoritative miss
-/// that still consumes one projectile after the firing gate succeeds.
-#[derive(Event, Clone, Copy, Debug)]
-pub struct RangedAttackIntent {
-    pub attacker: Entity,
-    pub target: Option<Entity>,
-    pub body_part: BodyPart,
-    pub hit_precision: f32,
-}
-
-/// Announces a server-observed ranged windup. Clients and server-owned AI use
-/// this same seam before completing a shot.
-#[derive(Event, Clone, Copy, Debug)]
-pub struct RangedAttackStartedIntent {
-    pub attacker: Entity,
-    pub target: Option<Entity>,
-    pub windup_secs: f32,
 }
 
 #[derive(Event, Clone, Copy, Debug)]
@@ -199,12 +114,10 @@ enum RangedIntentRejection {
     MissingCombatState,
     FriendlyTarget,
     Incapacitated,
-    NonFinitePrecision,
     NotRanged,
     OutOfRange,
     OutsideAimCone,
     Windup,
-    Cooldown,
     BlockedLineOfSight,
 }
 
@@ -216,64 +129,17 @@ struct RangedIntentFacts {
     target_side: Option<TacticalCombatSide>,
     attacker_incapacitated: Option<bool>,
     target_incapacitated: Option<bool>,
-    hit_precision: f32,
+    reported_precision: ReportedPrecision,
     weapon_is_ranged: bool,
     weapon_range: f32,
     separation: Option<f32>,
     target_in_aim_cone: Option<bool>,
-    windup_ready: bool,
-    windup_unexpired: bool,
-    cooldown_ready: bool,
-}
-
-fn validate_ranged_intent(facts: RangedIntentFacts) -> Result<(), RangedIntentRejection> {
-    if facts.target == Some(facts.attacker) {
-        return Err(RangedIntentRejection::SelfTarget);
-    }
-    let Some(attacker_side) = facts.attacker_side else {
-        return Err(RangedIntentRejection::MissingSide);
-    };
-    let Some(attacker_incapacitated) = facts.attacker_incapacitated else {
-        return Err(RangedIntentRejection::MissingCombatState);
-    };
-    if attacker_incapacitated {
-        return Err(RangedIntentRejection::Incapacitated);
-    }
-    if !facts.hit_precision.is_finite() {
-        return Err(RangedIntentRejection::NonFinitePrecision);
-    }
-    if !facts.weapon_is_ranged || !facts.weapon_range.is_finite() || facts.weapon_range <= 0.0 {
-        return Err(RangedIntentRejection::NotRanged);
-    }
-    if let Some(_) = facts.target {
-        let Some(target_side) = facts.target_side else {
-            return Err(RangedIntentRejection::MissingSide);
-        };
-        let Some(target_incapacitated) = facts.target_incapacitated else {
-            return Err(RangedIntentRejection::MissingCombatState);
-        };
-        if attacker_side == target_side {
-            return Err(RangedIntentRejection::FriendlyTarget);
-        }
-        if target_incapacitated {
-            return Err(RangedIntentRejection::Incapacitated);
-        }
-        if !facts.separation.is_some_and(|distance| {
-            distance.is_finite() && distance <= facts.weapon_range + RANGED_RANGE_LATENCY_TOLERANCE
-        }) {
-            return Err(RangedIntentRejection::OutOfRange);
-        }
-        if facts.target_in_aim_cone != Some(true) {
-            return Err(RangedIntentRejection::OutsideAimCone);
-        }
-    }
-    if !facts.windup_ready || !facts.windup_unexpired {
-        return Err(RangedIntentRejection::Windup);
-    }
-    if !facts.cooldown_ready {
-        return Err(RangedIntentRejection::Cooldown);
-    }
-    Ok(())
+    authority_permits: bool,
+    body_part: BodyPart,
+    attacker_position: Vec3,
+    target_position: Option<Vec3>,
+    attacker_yaw: f32,
+    target_yaw: Option<f32>,
 }
 
 fn ranged_target_in_aim_cone(yaw: f32, attacker: Vec3, target: Vec3) -> bool {
@@ -292,11 +158,9 @@ enum MeleeIntentRejection {
     MissingCombatState,
     FriendlyTarget,
     Incapacitated,
-    NonFinitePrecision,
     Unarmed,
     OutOfRange,
     Windup,
-    Cooldown,
     BlockedLineOfSight,
 }
 
@@ -308,58 +172,15 @@ struct MeleeIntentFacts {
     target_side: Option<TacticalCombatSide>,
     attacker_incapacitated: Option<bool>,
     target_incapacitated: Option<bool>,
-    hit_precision: f32,
+    reported_precision: ReportedPrecision,
     weapon_reach: f32,
     separation: f32,
-    windup_target: Option<Option<Entity>>,
-    windup_ready: bool,
-    windup_unexpired: bool,
-    cooldown_ready: bool,
-}
-
-fn validate_melee_intent_cheap(facts: MeleeIntentFacts) -> Result<(), MeleeIntentRejection> {
-    if facts.attacker == facts.target {
-        return Err(MeleeIntentRejection::SelfTarget);
-    }
-    let (Some(attacker_side), Some(target_side)) = (facts.attacker_side, facts.target_side) else {
-        return Err(MeleeIntentRejection::MissingSide);
-    };
-    if attacker_side == target_side {
-        return Err(MeleeIntentRejection::FriendlyTarget);
-    }
-    let (Some(attacker_incapacitated), Some(target_incapacitated)) =
-        (facts.attacker_incapacitated, facts.target_incapacitated)
-    else {
-        return Err(MeleeIntentRejection::MissingCombatState);
-    };
-    if attacker_incapacitated || target_incapacitated {
-        return Err(MeleeIntentRejection::Incapacitated);
-    }
-    if !facts.hit_precision.is_finite() {
-        return Err(MeleeIntentRejection::NonFinitePrecision);
-    }
-    if !facts.weapon_reach.is_finite() || facts.weapon_reach <= 0.0 {
-        return Err(MeleeIntentRejection::Unarmed);
-    }
-    if !facts.separation.is_finite()
-        || facts.separation
-            > melee_interaction_range(facts.weapon_reach) + MELEE_RANGE_LATENCY_TOLERANCE
-    {
-        return Err(MeleeIntentRejection::OutOfRange);
-    }
-    let Some(windup_target) = facts.windup_target else {
-        return Err(MeleeIntentRejection::Windup);
-    };
-    if windup_target.is_some_and(|target| target != facts.target)
-        || !facts.windup_ready
-        || !facts.windup_unexpired
-    {
-        return Err(MeleeIntentRejection::Windup);
-    }
-    if !facts.cooldown_ready {
-        return Err(MeleeIntentRejection::Cooldown);
-    }
-    Ok(())
+    authority_permits: bool,
+    body_part: BodyPart,
+    attacker_position: Vec3,
+    target_position: Vec3,
+    attacker_yaw: f32,
+    target_yaw: f32,
 }
 
 fn validate_melee_line_of_sight(line_of_sight: bool) -> Result<(), MeleeIntentRejection> {
@@ -369,6 +190,11 @@ fn validate_melee_line_of_sight(line_of_sight: bool) -> Result<(), MeleeIntentRe
 }
 
 pub struct CombatPlugin;
+
+#[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum CombatSet {
+    Condition,
+}
 
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
@@ -381,830 +207,13 @@ impl Plugin for CombatPlugin {
             .add_observer(resolve_ranged_attack)
             .add_observer(apply_melee_attack_result)
             .add_observer(on_defender_response)
-            .add_systems(Update, update_tactical_combat_state);
-    }
-}
-
-fn on_defender_response(
-    event: On<FromClient<DefendRequest>>,
-    mut cmd: Commands,
-    time: Res<Time<()>>,
-    states: Query<&TacticalCombatState>,
-) {
-    let Some(entity) = event.client_id.entity() else {
-        warn!(
-            "Got defender response from an unknown client: {:?}",
-            event.client_id
-        );
-        return;
-    };
-
-    if states.get(entity).is_ok_and(|state| state.incapacitated) {
-        return;
-    }
-
-    cmd.entity(entity).insert(PendingDefenderResponse {
-        choice: **event,
-        set_at: time.elapsed_secs(),
-    });
-}
-
-fn on_melee_attack_started(
-    event: On<MeleeAttackStartedIntent>,
-    mut authorities: Query<&mut MeleeAttackAuthority>,
-    time: Res<Time<()>>,
-) {
-    let Ok(mut authority) = authorities.get_mut(event.attacker) else {
-        return;
-    };
-    authority.windup = Some(ObservedMeleeWindup {
-        target: Some(event.target),
-        ready_at: time.elapsed_secs() + event.windup_secs.max(0.0),
-        expires_at: time.elapsed_secs()
-            + event.windup_secs.max(0.0)
-            + MELEE_WINDUP_NETWORK_ALLOWANCE_SECS,
-    });
-}
-
-fn resolve_defender_response(
-    pending: Option<&PendingDefenderResponse>,
-    time: &Time<()>,
-    defender_view: &TacticalPlayerView,
-) -> DefenderResponse {
-    let Some(pending) = pending else {
-        return DefenderResponse::None;
-    };
-
-    let elapsed = time.elapsed_secs() - pending.set_at;
-    if elapsed > MAX_REFLEX_WINDOW {
-        return DefenderResponse::None;
-    }
-
-    let input_reflex = (1.0 - elapsed / MAX_REFLEX_WINDOW).clamp(0.0, 1.0);
-
-    match pending.choice {
-        DefendRequest::Dodge => DefenderResponse::Dodge { input_reflex },
-        DefendRequest::Parry => {
-            if defender_view.shield_block_bonus() > 0.0 {
-                DefenderResponse::Parry { input_reflex }
-            } else {
-                DefenderResponse::None
-            }
-        }
-    }
-}
-
-fn on_melee_action_request(
-    event: On<FromClient<MeleeActionRequest>>,
-    mut cmd: Commands,
-    time: Res<Time<()>>,
-    mut authorities: Query<&mut MeleeAttackAuthority>,
-) {
-    let Some(attacker) = event.client_id.entity() else {
-        debug!(
-            "Ignoring melee action from unknown client: {:?}",
-            event.client_id
-        );
-        return;
-    };
-    match event.phase {
-        MeleeActionPhase::Start => {
-            let Ok(mut authority) = authorities.get_mut(attacker) else {
-                return;
-            };
-            let ready_at = time.elapsed_secs() + CLIENT_MELEE_WINDUP_SECS;
-            authority.windup = Some(ObservedMeleeWindup {
-                target: None,
-                ready_at,
-                expires_at: ready_at + MELEE_WINDUP_NETWORK_ALLOWANCE_SECS,
-            });
-        }
-        MeleeActionPhase::Complete => {
-            let Some(target) = event.target else {
-                debug!("Ignoring malformed melee completion from {attacker:?}");
-                return;
-            };
-            // Finite precision is intentionally accepted as reported. Full
-            // animation and secondary physics remain client-owned.
-            cmd.trigger(MeleeAttackIntent {
-                attacker,
-                target,
-                body_part: event.body_part,
-                hit_precision: event.hit_precision,
-            });
-        }
-    }
-}
-
-fn on_ranged_action_request(event: On<FromClient<RangedActionRequest>>, mut cmd: Commands) {
-    let Some(attacker) = event.client_id.entity() else {
-        debug!(
-            "Ignoring ranged action from unknown client: {:?}",
-            event.client_id
-        );
-        return;
-    };
-    match event.phase {
-        RangedActionPhase::Start => {
-            cmd.trigger(RangedAttackStartedIntent {
-                attacker,
-                target: None,
-                windup_secs: CLIENT_RANGED_WINDUP_SECS,
-            });
-        }
-        RangedActionPhase::Complete => {
-            // Finite precision is deliberately trusted. Animation and
-            // secondary physics remain client-owned and non-deterministic.
-            cmd.trigger(RangedAttackIntent {
-                attacker,
-                target: event.target,
-                body_part: event.body_part,
-                hit_precision: event.hit_precision,
-            });
-        }
-    }
-}
-
-fn on_ranged_attack_started(
-    event: On<RangedAttackStartedIntent>,
-    mut authorities: Query<&mut RangedAttackAuthority>,
-    time: Res<Time<()>>,
-) {
-    let Ok(mut authority) = authorities.get_mut(event.attacker) else {
-        return;
-    };
-    let ready_at = time.elapsed_secs() + event.windup_secs.max(0.0);
-    authority.windup = Some(ObservedRangedWindup {
-        ready_at,
-        expires_at: ready_at + RANGED_NETWORK_ALLOWANCE_SECS,
-    });
-}
-
-fn authoritative_line_of_sight(
-    spatial: &SpatialQuery,
-    attacker: Entity,
-    target: Entity,
-    origin: Vec3,
-    target_position: Vec3,
-) -> bool {
-    let offset = target_position - origin;
-    let distance = offset.length();
-    let Ok(direction) = Dir3::new(offset) else {
-        return false;
-    };
-    let filter = SpatialQueryFilter::from_excluded_entities([attacker]);
-    spatial
-        .cast_ray(origin, direction, distance, true, &filter)
-        .is_some_and(|hit| hit.entity == target)
-}
-
-fn resolve_melee_attack(
-    event: On<MeleeAttackIntent>,
-    mut cmd: Commands,
-    viewer: TacticalPlayerViewer,
-    spatial: SpatialQuery,
-    q_character: Query<(&CharacterLook, &Transform)>,
-    q_sides: Query<&TacticalCombatSide>,
-    q_states: Query<&TacticalCombatState>,
-    mut q_authorities: Query<&mut MeleeAttackAuthority>,
-    q_bestiary_categories: Query<&BestiaryCategories>,
-    q_pending: Query<&PendingDefenderResponse>,
-    time: Res<Time<()>>,
-) {
-    let entity = event.attacker;
-
-    let Ok(attacker_view) = viewer.get(entity).inspect_err(|err| {
-        debug!("Rejected attacker view for {entity:?}: {err}");
-    }) else {
-        return;
-    };
-    let Ok(defender_view) = viewer.get(event.target).inspect_err(|err| {
-        debug!("Rejected defender view for {:?}: {err}", event.target);
-    }) else {
-        return;
-    };
-
-    let Ok([attacker_character, defender_character]) = q_character
-        .get_many([entity, event.target])
-        .inspect_err(|err| {
-            debug!("Rejected attacker/defender transform: {err}");
-        })
-    else {
-        return;
-    };
-    let (attacker_look, attacker_transform) = attacker_character;
-    let (defender_look, defender_transform) = defender_character;
-
-    let weapon_reach = attacker_view.weapon_reach();
-    let now = time.elapsed_secs();
-    let Ok(mut authority) = q_authorities.get_mut(entity) else {
-        return;
-    };
-    let windup = authority.windup.as_ref();
-    let facts = MeleeIntentFacts {
-        attacker: entity,
-        target: event.target,
-        attacker_side: q_sides.get(entity).ok().copied(),
-        target_side: q_sides.get(event.target).ok().copied(),
-        attacker_incapacitated: q_states.get(entity).ok().map(|state| state.incapacitated),
-        target_incapacitated: q_states
-            .get(event.target)
-            .ok()
-            .map(|state| state.incapacitated),
-        hit_precision: event.hit_precision,
-        weapon_reach,
-        separation: attacker_transform
-            .translation
-            .distance(defender_transform.translation),
-        windup_target: windup.map(|windup| windup.target),
-        windup_ready: windup.is_some_and(|windup| now >= windup.ready_at),
-        windup_unexpired: windup.is_some_and(|windup| now <= windup.expires_at),
-        cooldown_ready: now >= authority.cooldown_until,
-    };
-    if let Err(reason) = validate_melee_intent_cheap(facts) {
-        debug!(
-            "Rejected melee intent from {entity:?} to {:?}: {reason:?}",
-            event.target
-        );
-        return;
-    }
-    let line_of_sight = authoritative_line_of_sight(
-        &spatial,
-        entity,
-        event.target,
-        attacker_transform.translation,
-        defender_transform.translation,
-    );
-    if let Err(reason) = validate_melee_line_of_sight(line_of_sight) {
-        debug!(
-            "Rejected melee intent from {entity:?} to {:?}: {reason:?}",
-            event.target
-        );
-        return;
-    }
-    // Mutate the pre-existing authority component synchronously. A later
-    // completion in this same message flush observes the consumed windup and
-    // active cooldown instead of reusing deferred Commands state.
-    if !consume_melee_authority(&mut authority, event.target, now) {
-        debug!("Rejected already-consumed melee authorization for {entity:?}");
-        return;
-    }
-    let (a2, a1) = attacker_look.yaw.sin_cos();
-    let (d2, d1) = defender_look.yaw.sin_cos();
-    let flanking = flanking_from_dir((a1, a2), (d1, d2));
-
-    let Some(attacker_side) = attacker_view.weapon_holding_side() else {
-        debug!("Rejected attacker without a held weapon");
-        return;
-    };
-
-    let pending = q_pending.get(event.target).ok();
-    let defender_response = resolve_defender_response(pending, &time, &defender_view);
-
-    // Consume the pending response so it is not reused.
-    cmd.entity(event.target).remove::<PendingDefenderResponse>();
-
-    let fallback_categories = BestiaryCategories::default();
-    let defender_categories = q_bestiary_categories
-        .get(event.target)
-        .unwrap_or(&fallback_categories);
-
-    let result = attacker_view.resolve_melee_attack(
-        attacker_side,
-        &defender_view,
-        &defender_categories.0,
-        defender_response,
-        event.hit_precision,
-        flanking,
-        event.body_part,
-    );
-    let attacker_weapon_slot = match attacker_side {
-        BodySide::Left => EquipSlot::HoldingLeft,
-        BodySide::Right => EquipSlot::HoldingRight,
-        BodySide::Both => return,
-    };
-    let defender_parry_slot = matches!(defender_response, DefenderResponse::Parry { .. })
-        .then(|| defender_view.shield_holding_side())
-        .flatten()
-        .and_then(|side| match side {
-            BodySide::Left => Some(EquipSlot::HoldingLeft),
-            BodySide::Right => Some(EquipSlot::HoldingRight),
-            BodySide::Both => None,
-        });
-
-    cmd.trigger(ApplyMeleeAttackResult {
-        attacker: entity,
-        target: event.target,
-        body_part: event.body_part,
-        result,
-        attacker_weapon_slot,
-        defender_parry_slot,
-        attacker_weapon_contact: true,
-    });
-
-    match result {
-        AttackResult::ToAttacker { balance_damage, .. } => {
-            info!(
-                "{entity:?} failed to hit {:?} on {:?} and receiver {balance_damage:.1} balance damage",
-                event.target, event.body_part,
+            .configure_sets(Update, CombatSet::Condition)
+            .add_systems(
+                Update,
+                update_tactical_combat_state
+                    .in_set(CombatSet::Condition)
+                    .after(PlayerProjectionSet::Spawn),
             );
-        }
-        AttackResult::ToDefender {
-            cut_damage,
-            blunt_damage,
-            balance_damage,
-            ..
-        } => {
-            info!(
-                "{entity:?} hit {:?} on {:?} for {:.1} damage ({cut_damage:.1} cut + {blunt_damage:.1} blunt) and {balance_damage:.1} balance damage",
-                event.target,
-                event.body_part,
-                cut_damage + blunt_damage
-            );
-        }
-    }
-
-    cmd.server_trigger(ToClients {
-        mode: SendMode::CLIENTS_ONLY,
-        message: SuccessfulAttackResponse {
-            attacker: entity,
-            hit: vec![event.target],
-            body_part: event.body_part,
-            result,
-            flanking,
-            defender_response,
-        },
-    });
-}
-
-#[allow(clippy::too_many_arguments)]
-fn resolve_ranged_attack(
-    event: On<RangedAttackIntent>,
-    mut cmd: Commands,
-    viewer: TacticalPlayerViewer,
-    spatial: SpatialQuery,
-    q_character: Query<(&CharacterLook, &Transform)>,
-    q_sides: Query<&TacticalCombatSide>,
-    q_states: Query<&TacticalCombatState>,
-    mut q_authorities: Query<&mut RangedAttackAuthority>,
-    q_bestiary_categories: Query<&BestiaryCategories>,
-    q_pending: Query<&PendingDefenderResponse>,
-    q_ammo: Query<(Entity, &ItemOf, &ItemProperties, &ItemQuantity)>,
-    q_ids: Query<&PlayerId>,
-    mut consequences: ResMut<TacticalConsequenceAccumulator>,
-    time: Res<Time<()>>,
-) {
-    let attacker = event.attacker;
-    let Ok(attacker_view) = viewer.get(attacker) else {
-        return;
-    };
-    let Ok((attacker_look, attacker_transform)) = q_character.get(attacker) else {
-        return;
-    };
-    let target_character = event.target.and_then(|target| q_character.get(target).ok());
-    let now = time.elapsed_secs();
-    let Ok(mut authority) = q_authorities.get_mut(attacker) else {
-        return;
-    };
-    let windup = authority.windup.as_ref();
-    let facts = RangedIntentFacts {
-        attacker,
-        target: event.target,
-        attacker_side: q_sides.get(attacker).ok().copied(),
-        target_side: event
-            .target
-            .and_then(|target| q_sides.get(target).ok().copied()),
-        attacker_incapacitated: q_states.get(attacker).ok().map(|state| state.incapacitated),
-        target_incapacitated: event
-            .target
-            .and_then(|target| q_states.get(target).ok().map(|state| state.incapacitated)),
-        hit_precision: event.hit_precision,
-        weapon_is_ranged: attacker_view.weapon_is_ranged(),
-        weapon_range: attacker_view.weapon_reach(),
-        separation: target_character.map(|(_, transform)| {
-            attacker_transform
-                .translation
-                .distance(transform.translation)
-        }),
-        target_in_aim_cone: target_character.map(|(_, transform)| {
-            ranged_target_in_aim_cone(
-                attacker_look.yaw,
-                attacker_transform.translation,
-                transform.translation,
-            )
-        }),
-        windup_ready: windup.is_some_and(|windup| now >= windup.ready_at),
-        windup_unexpired: windup.is_some_and(|windup| now <= windup.expires_at),
-        cooldown_ready: now >= authority.cooldown_until,
-    };
-    if let Err(reason) = validate_ranged_intent(facts) {
-        if !matches!(
-            reason,
-            RangedIntentRejection::Windup | RangedIntentRejection::Cooldown
-        ) {
-            debug!("Rejected ranged intent from {attacker:?}: {reason:?}");
-        }
-        return;
-    }
-    if let (Some(target), Some((_, target_transform))) = (event.target, target_character) {
-        let line_of_sight = authoritative_line_of_sight(
-            &spatial,
-            attacker,
-            target,
-            attacker_transform.translation,
-            target_transform.translation,
-        );
-        if !line_of_sight {
-            debug!(
-                "Rejected ranged intent from {attacker:?}: {:?}",
-                RangedIntentRejection::BlockedLineOfSight
-            );
-            return;
-        }
-    }
-    if !consume_ranged_authority(&mut authority, now) {
-        return;
-    }
-
-    // Only an otherwise-authorized shot reaches the global inventory scan.
-    // A dry fire still consumes its windup/cooldown, bounding repeated scans.
-    let ammo = q_ammo.iter().find(|(_, owner, properties, quantity)| {
-        owner.0 == attacker && properties.id == ARROW_ITEM_ID && quantity.0.get() > 0
-    });
-    let Some((ammo_entity, _, _, quantity)) = ammo else {
-        return;
-    };
-    if let Some(remaining) = remaining_ammo_after_shot(quantity.0) {
-        cmd.entity(ammo_entity).insert(ItemQuantity(remaining));
-    } else {
-        cmd.entity(ammo_entity).despawn();
-    }
-    if q_sides
-        .get(attacker)
-        .is_ok_and(|side| *side == TacticalCombatSide::Party)
-        && let Ok(player_id) = q_ids.get(attacker)
-    {
-        record_party_ammunition_use(&mut consequences, player_id.0);
-    }
-
-    let Some(target) = event.target else {
-        return;
-    };
-    let Ok(defender_view) = viewer.get(target) else {
-        return;
-    };
-    let Some((defender_look, _)) = target_character else {
-        return;
-    };
-    let (a2, a1) = attacker_look.yaw.sin_cos();
-    let (d2, d1) = defender_look.yaw.sin_cos();
-    let flanking = flanking_from_dir((a1, a2), (d1, d2));
-    let defender_response =
-        resolve_defender_response(q_pending.get(target).ok(), &time, &defender_view);
-    cmd.entity(target).remove::<PendingDefenderResponse>();
-    let fallback_categories = BestiaryCategories::default();
-    let defender_categories = q_bestiary_categories
-        .get(target)
-        .unwrap_or(&fallback_categories);
-    let result = attacker_view.resolve_ranged_attack(
-        &defender_view,
-        &defender_categories.0,
-        defender_response,
-        event.hit_precision,
-        flanking,
-        event.body_part,
-    );
-    let defender_parry_slot = matches!(defender_response, DefenderResponse::Parry { .. })
-        .then(|| defender_view.shield_holding_side())
-        .flatten()
-        .and_then(|side| match side {
-            BodySide::Left => Some(EquipSlot::HoldingLeft),
-            BodySide::Right => Some(EquipSlot::HoldingRight),
-            BodySide::Both => None,
-        });
-    let attacker_weapon_slot = match attacker_view.weapon_holding_side() {
-        Some(BodySide::Left) => EquipSlot::HoldingLeft,
-        _ => EquipSlot::HoldingRight,
-    };
-    cmd.trigger(ApplyMeleeAttackResult {
-        attacker,
-        target,
-        body_part: event.body_part,
-        result,
-        attacker_weapon_slot,
-        defender_parry_slot,
-        attacker_weapon_contact: false,
-    });
-    cmd.server_trigger(ToClients {
-        mode: SendMode::CLIENTS_ONLY,
-        message: SuccessfulAttackResponse {
-            attacker,
-            hit: vec![target],
-            body_part: event.body_part,
-            result,
-            flanking,
-            defender_response,
-        },
-    });
-}
-
-fn apply_melee_attack_result(
-    event: On<ApplyMeleeAttackResult>,
-    mut combatants: Query<(&mut Limbs, &mut TacticalCombatState)>,
-    metadata: Query<(&TacticalCombatSide, &PlayerId)>,
-    mut consequences: ResMut<TacticalConsequenceAccumulator>,
-    items: Query<(
-        &ItemOf,
-        &EquipSlot,
-        &crate::TacticalInventoryItemId,
-        Option<&WeaponItem>,
-        Option<&ShieldItem>,
-        Option<&ArmorItem>,
-    )>,
-) {
-    let Ok([attacker, defender]) = combatants.get_many_mut([event.attacker, event.target]) else {
-        return;
-    };
-    let (_, mut attacker_state) = attacker;
-    let (mut defender_limbs, mut defender_state) = defender;
-    let applied = apply_transient_attack_result(
-        &mut attacker_state,
-        &mut defender_limbs,
-        &mut defender_state,
-        event.result,
-        event.body_part,
-    );
-    let attacker_metadata = metadata.get(event.attacker).ok();
-    let defender_metadata = metadata.get(event.target).ok();
-    if defender_metadata.is_some_and(|(side, _)| *side == TacticalCombatSide::Party)
-        && let Some((cut_damage, blunt_damage)) = applied
-    {
-        let defender_id = defender_metadata.unwrap().1;
-        record_party_injury(
-            &mut consequences,
-            defender_id.0,
-            event.body_part,
-            cut_damage,
-            blunt_damage,
-        );
-    }
-    if attacker_metadata.is_some_and(|(side, _)| *side == TacticalCombatSide::Party) {
-        let attacker_id = attacker_metadata.unwrap().1;
-        let contact_stress = match event.result {
-            AttackResult::ToAttacker { contact_force, .. }
-            | AttackResult::ToDefender { contact_force, .. } => contact_force.max(0.0),
-        };
-        if event.attacker_weapon_contact
-            && contact_stress > 0.0
-            && let Some((_, _, provenance, _, _, _)) = items.iter().find(|row| {
-                let (owner, slot, _, weapon, _, _) = row;
-                attacker_weapon_contact_matches(
-                    event.attacker,
-                    owner.0,
-                    **slot,
-                    event.attacker_weapon_slot,
-                    weapon.is_some(),
-                )
-            })
-        {
-            record_equipment_contact(
-                &mut consequences,
-                attacker_id.0,
-                provenance.0,
-                contact_stress,
-                false,
-            );
-        }
-    }
-    if defender_metadata.is_some_and(|(side, _)| *side == TacticalCombatSide::Party) {
-        let defender_id = defender_metadata.unwrap().1;
-        let (contact_stress, defender_slot, require_shield, require_armor) = match event.result {
-            AttackResult::ToDefender {
-                contact_force,
-                armor_contact,
-                ..
-            } if armor_contact => (
-                contact_force.max(0.0),
-                Some(EquipSlot::from_armor_body_part(event.body_part)),
-                false,
-                true,
-            ),
-            AttackResult::ToAttacker {
-                contact_force,
-                physical_contact: true,
-                ..
-            } if event.defender_parry_slot.is_some() => (
-                contact_force.max(0.0),
-                event.defender_parry_slot,
-                true,
-                false,
-            ),
-            _ => (0.0, None, false, false),
-        };
-        if contact_stress > 0.0
-            && let Some((_, _, provenance, _, _, _)) = items.iter().find(|row| {
-                let (owner, slot, _, _, shield, armor) = row;
-                defender_equipment_contact_matches(
-                    event.target,
-                    owner.0,
-                    **slot,
-                    defender_slot,
-                    shield.is_some(),
-                    armor.is_some(),
-                    require_shield,
-                    require_armor,
-                )
-            })
-        {
-            record_equipment_contact(
-                &mut consequences,
-                defender_id.0,
-                provenance.0,
-                contact_stress,
-                true,
-            );
-        }
-    }
-}
-
-fn record_party_injury(
-    consequences: &mut TacticalConsequenceAccumulator,
-    character_id: u64,
-    body_part: BodyPart,
-    cut_damage: f32,
-    blunt_damage: f32,
-) {
-    let consequence = consequences.party.entry(character_id).or_default();
-    if let Some(injury) = consequence
-        .injuries
-        .iter_mut()
-        .find(|injury| injury.body_part == body_part)
-    {
-        injury.cut_damage += cut_damage;
-        injury.blunt_damage += blunt_damage;
-        injury.max_single_hit_blunt_damage = injury.max_single_hit_blunt_damage.max(blunt_damage);
-    } else {
-        consequence.injuries.push(AppliedTacticalInjury {
-            body_part,
-            cut_damage,
-            blunt_damage,
-            max_single_hit_blunt_damage: blunt_damage,
-        });
-    }
-    consequence.blood_loss_fraction = (consequence.blood_loss_fraction
-        + (cut_damage + blunt_damage) * BLOOD_LOSS_PER_HEALTH_DAMAGE)
-        .clamp(0.0, 1.0);
-}
-
-fn record_party_ammunition_use(
-    consequences: &mut TacticalConsequenceAccumulator,
-    character_id: u64,
-) {
-    let consequence = consequences.party.entry(character_id).or_default();
-    consequence.ammunition_used = consequence
-        .ammunition_used
-        .saturating_add(1)
-        .min(adventuresim_core::mission::MAX_TACTICAL_AMMUNITION_USED);
-}
-
-fn attacker_weapon_contact_matches(
-    attacker: Entity,
-    owner: Entity,
-    slot: EquipSlot,
-    authoritative_slot: EquipSlot,
-    is_weapon: bool,
-) -> bool {
-    owner == attacker && slot == authoritative_slot && is_weapon
-}
-
-#[allow(clippy::too_many_arguments)]
-fn defender_equipment_contact_matches(
-    defender: Entity,
-    owner: Entity,
-    slot: EquipSlot,
-    required_slot: Option<EquipSlot>,
-    is_shield: bool,
-    is_armor: bool,
-    require_shield: bool,
-    require_armor: bool,
-) -> bool {
-    owner == defender
-        && required_slot.is_none_or(|expected| slot == expected)
-        && (!require_shield || is_shield)
-        && (!require_armor || is_armor)
-}
-
-fn record_equipment_contact(
-    consequences: &mut TacticalConsequenceAccumulator,
-    character_id: u64,
-    inventory_item_id: u64,
-    contact_stress: f32,
-    defender_equipment: bool,
-) {
-    if let Some(existing) = consequences
-        .equipment_contacts
-        .iter_mut()
-        .find(|contact| contact.inventory_item_id == inventory_item_id)
-    {
-        existing.contact_stress = (existing.contact_stress + contact_stress)
-            .min(adventuresim_core::mission::MAX_TACTICAL_CONTACT_STRESS);
-    } else if consequences.equipment_contacts.len()
-        < adventuresim_core::mission::MAX_TACTICAL_EQUIPMENT_CONTACTS
-    {
-        consequences
-            .equipment_contacts
-            .push(AccumulatedEquipmentContact {
-                character_id,
-                inventory_item_id,
-                contact_stress: contact_stress
-                    .min(adventuresim_core::mission::MAX_TACTICAL_CONTACT_STRESS),
-                defender_equipment,
-            });
-    }
-}
-
-pub(crate) fn apply_transient_attack_result(
-    attacker_state: &mut TacticalCombatState,
-    defender_limbs: &mut Limbs,
-    defender_state: &mut TacticalCombatState,
-    result: AttackResult,
-    body_part: BodyPart,
-) -> Option<(f32, f32)> {
-    match result {
-        AttackResult::ToAttacker { balance_damage, .. } => {
-            attacker_state.imbalance += balance_damage.max(0.0);
-            None
-        }
-        AttackResult::ToDefender {
-            cut_damage,
-            blunt_damage,
-            balance_damage,
-            ..
-        } => {
-            defender_state.imbalance += balance_damage.max(0.0);
-            let damage = health_damage_from_attack(result, body_part);
-            let applied = apply_clamped_limb_damage(defender_limbs.health_mut(body_part), damage);
-            defender_state.blood_loss_fraction = (defender_state.blood_loss_fraction
-                + applied * BLOOD_LOSS_PER_HEALTH_DAMAGE)
-                .clamp(0.0, 1.0);
-            let raw_total = (cut_damage + blunt_damage).max(0.0);
-            if applied > 0.0 && raw_total > 0.0 {
-                Some((
-                    applied * cut_damage.max(0.0) / raw_total,
-                    applied * blunt_damage.max(0.0) / raw_total,
-                ))
-            } else {
-                None
-            }
-        }
-    }
-}
-
-pub(crate) fn update_tactical_combat_state(
-    mut cmd: Commands,
-    time: Res<Time<()>>,
-    viewer: TacticalPlayerViewer,
-    limbs: Query<&Limbs>,
-    mut states: Query<(
-        Entity,
-        &mut TacticalCombatState,
-        Option<&mut input::AccumulatedInput>,
-    )>,
-) {
-    for (entity, mut state, mut input) in &mut states {
-        let was_incapacitated = state.incapacitated;
-        let Ok(view) = viewer.get(entity) else {
-            continue;
-        };
-        let balance = view.skill_check(Skill::Balance, LimbWeights::both_legs());
-        state.imbalance = recover_combat_imbalance(state.imbalance, balance, time.delta_secs());
-        let Ok(limbs) = limbs.get(entity) else {
-            continue;
-        };
-        let will = view.skill_check(Skill::Will, LimbWeights::all_equal());
-        state.incapacitation = combat_incapacitation(
-            state.starting_incapacitation,
-            state.starting_blood_fraction,
-            state.blood_loss_fraction,
-            limbs.total_damage(),
-            will,
-            state.imbalance,
-        );
-        state.incapacitated = state.incapacitation >= 1.0;
-        if state.incapacitated {
-            if let Some(input) = input.as_deref_mut() {
-                input.last_movement = None;
-                input.jumped = None;
-            }
-            if !was_incapacitated {
-                cmd.entity(entity)
-                    .remove::<PendingDefenderResponse>()
-                    .insert(Incapacitated);
-                cmd.trigger(TacticalCombatantDefeated(entity));
-            }
-        } else if was_incapacitated {
-            cmd.entity(entity).remove::<Incapacitated>();
-        }
     }
 }
 
@@ -1228,7 +237,11 @@ mod tests {
         for _ in 0..3 {
             cmd.trigger(FromClient {
                 client_id: ClientId::Client(batch.attacker),
-                message: MeleeActionRequest::complete(batch.target, BodyPart::Chest, 1.0),
+                message: MeleeActionRequest::Complete {
+                    target: batch.target,
+                    body_part: BodyPart::Chest,
+                    reported_precision: 1.0,
+                },
             });
         }
     }
@@ -1243,7 +256,34 @@ mod tests {
         let Ok(mut authority) = authorities.get_mut(event.attacker) else {
             return;
         };
-        if consume_melee_authority(&mut authority, event.target, time.elapsed_secs()) {
+        let Some(validated) = validate_melee_intent_cheap(MeleeIntentFacts {
+            attacker: event.attacker,
+            target: event.target,
+            attacker_side: Some(TacticalCombatSide::Party),
+            target_side: Some(TacticalCombatSide::Enemy),
+            attacker_incapacitated: Some(false),
+            target_incapacitated: Some(false),
+            reported_precision: event.reported_precision,
+            weapon_reach: 1.0,
+            separation: 1.0,
+            authority_permits: authority.permits(event.target, CombatInstant::from_elapsed(&time)),
+            body_part: event.body_part,
+            attacker_position: Vec3::ZERO,
+            target_position: Vec3::X,
+            attacker_yaw: 0.0,
+            target_yaw: 0.0,
+        })
+        .ok() else {
+            return;
+        };
+        if authority
+            .authorize_attack(
+                validated,
+                CombatInstant::from_elapsed(&time),
+                MELEE_COOLDOWN,
+            )
+            .is_some()
+        {
             accepted.0 += 1;
             if let Ok(mut limbs) = limbs.get_mut(event.target) {
                 limbs.chest -= 0.1;
@@ -1259,13 +299,15 @@ mod tests {
             target_side: Some(TacticalCombatSide::Enemy),
             attacker_incapacitated: Some(false),
             target_incapacitated: Some(false),
-            hit_precision: 1.0,
+            reported_precision: ReportedPrecision::new(1.0).unwrap(),
             weapon_reach: 0.8,
             separation: 2.0,
-            windup_target: Some(None),
-            windup_ready: true,
-            windup_unexpired: true,
-            cooldown_ready: true,
+            authority_permits: true,
+            body_part: BodyPart::Chest,
+            attacker_position: Vec3::ZERO,
+            target_position: Vec3::X,
+            attacker_yaw: 0.0,
+            target_yaw: 0.0,
         }
     }
 
@@ -1277,14 +319,17 @@ mod tests {
             target_side: Some(TacticalCombatSide::Enemy),
             attacker_incapacitated: Some(false),
             target_incapacitated: Some(false),
-            hit_precision: 1.0,
+            reported_precision: ReportedPrecision::new(1.0).unwrap(),
             weapon_is_ranged: true,
             weapon_range: 120.0,
             separation: Some(30.0),
             target_in_aim_cone: Some(true),
-            windup_ready: true,
-            windup_unexpired: true,
-            cooldown_ready: true,
+            authority_permits: true,
+            body_part: BodyPart::Chest,
+            attacker_position: Vec3::ZERO,
+            target_position: Some(Vec3::X),
+            attacker_yaw: 0.0,
+            target_yaw: Some(0.0),
         }
     }
 
@@ -1292,7 +337,7 @@ mod tests {
     fn authoritative_gate_rejects_invalid_relationship_state_and_geometry() {
         let mut world = World::new();
         let valid = valid_facts(&mut world);
-        assert_eq!(validate_melee_intent_cheap(valid), Ok(()));
+        assert!(validate_melee_intent_cheap(valid).is_ok());
         assert_eq!(validate_melee_line_of_sight(true), Ok(()));
         assert_eq!(
             validate_melee_line_of_sight(false),
@@ -1337,13 +382,6 @@ mod tests {
             ),
             (
                 MeleeIntentFacts {
-                    hit_precision: f32::NAN,
-                    ..valid
-                },
-                MeleeIntentRejection::NonFinitePrecision,
-            ),
-            (
-                MeleeIntentFacts {
                     separation: 4.0,
                     ..valid
                 },
@@ -1351,35 +389,14 @@ mod tests {
             ),
             (
                 MeleeIntentFacts {
-                    windup_ready: false,
+                    authority_permits: false,
                     ..valid
                 },
                 MeleeIntentRejection::Windup,
-            ),
-            (
-                MeleeIntentFacts {
-                    windup_target: Some(Some(valid.attacker)),
-                    ..valid
-                },
-                MeleeIntentRejection::Windup,
-            ),
-            (
-                MeleeIntentFacts {
-                    windup_unexpired: false,
-                    ..valid
-                },
-                MeleeIntentRejection::Windup,
-            ),
-            (
-                MeleeIntentFacts {
-                    cooldown_ready: false,
-                    ..valid
-                },
-                MeleeIntentRejection::Cooldown,
             ),
         ];
         for (facts, expected) in cases {
-            assert_eq!(validate_melee_intent_cheap(facts), Err(expected));
+            assert_eq!(validate_melee_intent_cheap(facts).unwrap_err(), expected);
         }
     }
 
@@ -1387,14 +404,13 @@ mod tests {
     fn ranged_gate_validates_authority_equipment_ammo_and_target() {
         let mut world = World::new();
         let valid = valid_ranged_facts(&mut world);
-        assert_eq!(validate_ranged_intent(valid), Ok(()));
-        assert_eq!(
+        assert!(validate_ranged_intent(valid).is_ok());
+        assert!(
             validate_ranged_intent(RangedIntentFacts {
-                hit_precision: 99.0,
+                reported_precision: ReportedPrecision::new(99.0).unwrap(),
                 ..valid
-            }),
-            Ok(()),
-            "finite client precision is intentionally trusted and core-clamped"
+            })
+            .is_ok()
         );
         let cases = [
             (
@@ -1420,13 +436,6 @@ mod tests {
             ),
             (
                 RangedIntentFacts {
-                    hit_precision: f32::NAN,
-                    ..valid
-                },
-                RangedIntentRejection::NonFinitePrecision,
-            ),
-            (
-                RangedIntentFacts {
                     weapon_is_ranged: false,
                     ..valid
                 },
@@ -1441,32 +450,25 @@ mod tests {
             ),
             (
                 RangedIntentFacts {
-                    windup_ready: false,
+                    authority_permits: false,
                     ..valid
                 },
                 RangedIntentRejection::Windup,
             ),
-            (
-                RangedIntentFacts {
-                    cooldown_ready: false,
-                    ..valid
-                },
-                RangedIntentRejection::Cooldown,
-            ),
         ];
         for (facts, expected) in cases {
-            assert_eq!(validate_ranged_intent(facts), Err(expected));
+            assert_eq!(validate_ranged_intent(facts).unwrap_err(), expected);
         }
 
-        assert_eq!(
+        assert!(
             validate_ranged_intent(RangedIntentFacts {
                 target: None,
                 target_side: None,
                 target_incapacitated: None,
                 separation: None,
                 ..valid
-            }),
-            Ok(()),
+            })
+            .is_ok(),
             "a fired miss still passes the firing gate and consumes ammo"
         );
     }
@@ -1479,32 +481,49 @@ mod tests {
 
         let mut world = World::new();
         let valid = valid_ranged_facts(&mut world);
-        assert_eq!(validate_ranged_intent(valid), Ok(()));
+        assert!(validate_ranged_intent(valid).is_ok());
         assert_eq!(
             validate_ranged_intent(RangedIntentFacts {
                 target_in_aim_cone: Some(false),
                 ..valid
-            }),
-            Err(RangedIntentRejection::OutsideAimCone)
+            })
+            .unwrap_err(),
+            RangedIntentRejection::OutsideAimCone
         );
     }
 
     #[test]
     fn ranged_rejections_happen_before_ammo_scan() {
-        let source = include_str!("combat.rs");
-        let resolver = source
-            .split("fn resolve_ranged_attack(")
-            .nth(1)
-            .and_then(|tail| tail.split("fn apply_melee_attack_result(").next())
-            .expect("ranged resolver body");
+        let resolver = include_str!("combat/ranged.rs");
         let validation = resolver
             .find("validate_ranged_intent(facts)")
             .expect("cheap validation");
         let authorization = resolver
-            .find("consume_ranged_authority")
+            .find("authority.authorize_shot")
             .expect("one-shot authorization");
         let ammo_scan = resolver.find("q_ammo.iter().find").expect("ammo scan");
         assert!(validation < authorization && authorization < ammo_scan);
+    }
+
+    #[test]
+    fn resolvers_only_use_authorized_payloads_after_consuming_authority() {
+        let melee = include_str!("combat/melee.rs");
+        let ranged = include_str!("combat/ranged.rs");
+
+        assert!(
+            !melee
+                .split("authorize_attack")
+                .nth(1)
+                .unwrap()
+                .contains("event.")
+        );
+        assert!(
+            !ranged
+                .split("authorize_shot")
+                .nth(1)
+                .unwrap()
+                .contains("event.")
+        );
     }
 
     #[test]
@@ -1516,10 +535,10 @@ mod tests {
         );
         let mut consequences = TacticalConsequenceAccumulator::default();
         for _ in 0..=adventuresim_core::mission::MAX_TACTICAL_AMMUNITION_USED {
-            record_party_ammunition_use(&mut consequences, 7);
+            record_party_ammunition_use(&mut consequences, CharacterId(7));
         }
         assert_eq!(
-            consequences.party[&7].ammunition_used,
+            consequences.party[&CharacterId(7)].ammunition_used,
             adventuresim_core::mission::MAX_TACTICAL_AMMUNITION_USED
         );
     }
@@ -1568,9 +587,15 @@ mod tests {
     fn repeated_hits_are_losslessly_aggregated_per_limb() {
         let mut consequences = TacticalConsequenceAccumulator::default();
         for _ in 0..100 {
-            record_party_injury(&mut consequences, 7, BodyPart::Chest, 0.003, 0.002);
+            record_party_injury(
+                &mut consequences,
+                CharacterId(7),
+                BodyPart::Chest,
+                0.003,
+                0.002,
+            );
         }
-        let consequence = &consequences.party[&7];
+        let consequence = &consequences.party[&CharacterId(7)];
         assert_eq!(consequence.injuries.len(), 1);
         assert!((consequence.injuries[0].cut_damage - 0.3).abs() < 0.0001);
         assert!((consequence.injuries[0].blunt_damage - 0.2).abs() < 0.0001);
@@ -1652,9 +677,8 @@ mod tests {
                 .entity(actor)
                 .get::<TacticalCombatState>()
                 .unwrap()
-                .incapacitated
+                .is_incapacitated()
         );
-        assert!(app.world().entity(actor).contains::<Incapacitated>());
         assert_eq!(
             app.world()
                 .entity(actor)
@@ -1673,9 +697,8 @@ mod tests {
                 .entity(actor)
                 .get::<TacticalCombatState>()
                 .unwrap()
-                .incapacitated
+                .is_incapacitated()
         );
-        assert!(!app.world().entity(actor).contains::<Incapacitated>());
     }
 
     #[test]
@@ -1689,11 +712,11 @@ mod tests {
         let target = app.world_mut().spawn(Limbs::default()).id();
         app.world_mut().trigger(FromClient {
             client_id: ClientId::Client(attacker),
-            message: MeleeActionRequest::start(),
+            message: MeleeActionRequest::Start,
         });
         app.world_mut()
             .resource_mut::<Time<()>>()
-            .advance_by(Duration::from_secs_f32(CLIENT_MELEE_WINDUP_SECS));
+            .advance_by(Duration::from_secs_f32(CLIENT_MELEE_WINDUP.as_secs_f32()));
         app.insert_resource(BatchedCompletions { attacker, target })
             .add_systems(Update, emit_batched_completions);
         app.update();

--- a/crates/adventuresim-tactical-server/src/combat/authority.rs
+++ b/crates/adventuresim-tactical-server/src/combat/authority.rs
@@ -1,0 +1,411 @@
+use std::{ops::Add, time::Duration};
+
+use adventuresim_tactical_core::prelude::{BodyPart, melee_interaction_range};
+use bevy::prelude::*;
+
+use super::{
+    MELEE_RANGE_LATENCY_TOLERANCE, MeleeIntentFacts, MeleeIntentRejection,
+    RANGED_RANGE_LATENCY_TOLERANCE, RangedIntentFacts, RangedIntentRejection, TacticalCombatSide,
+};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct CombatInstant(Duration);
+
+impl CombatInstant {
+    pub(crate) fn from_elapsed(time: &Time<()>) -> Self {
+        Self(time.elapsed())
+    }
+
+    pub(crate) fn elapsed_since(self, earlier: Self) -> Duration {
+        self.0.saturating_sub(earlier.0)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct CombatDuration(Duration);
+
+impl CombatDuration {
+    pub(crate) const fn from_duration(duration: Duration) -> Self {
+        Self(duration)
+    }
+
+    pub(crate) fn as_secs_f32(self) -> f32 {
+        self.0.as_secs_f32()
+    }
+}
+
+impl Add<CombatDuration> for CombatInstant {
+    type Output = Self;
+
+    fn add(self, rhs: CombatDuration) -> Self::Output {
+        Self(self.0.saturating_add(rhs.0))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct ReportedPrecision(f32);
+
+impl ReportedPrecision {
+    /// Accepts every finite client report exactly as supplied. Precision is a
+    /// deliberately trusted animation boundary and is not geometrically
+    /// reconstructed or range-clamped by the headless server.
+    pub(crate) fn new(value: f32) -> Option<Self> {
+        value.is_finite().then_some(Self(value))
+    }
+
+    pub(crate) fn get(self) -> f32 {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ValidatedMeleeAttack {
+    attacker: Entity,
+    target: Entity,
+    body_part: BodyPart,
+    reported_precision: ReportedPrecision,
+    attacker_position: Vec3,
+    target_position: Vec3,
+    attacker_yaw: f32,
+    target_yaw: f32,
+}
+
+impl ValidatedMeleeAttack {
+    pub(super) fn attacker(&self) -> Entity {
+        self.attacker
+    }
+    pub(super) fn target(&self) -> Entity {
+        self.target
+    }
+    pub(super) fn attacker_position(&self) -> Vec3 {
+        self.attacker_position
+    }
+    pub(super) fn target_position(&self) -> Vec3 {
+        self.target_position
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct AuthorizedMeleeAttack(ValidatedMeleeAttack);
+
+impl AuthorizedMeleeAttack {
+    pub(super) fn attacker(&self) -> Entity {
+        self.0.attacker
+    }
+    pub(super) fn target(&self) -> Entity {
+        self.0.target
+    }
+    pub(super) fn body_part(&self) -> BodyPart {
+        self.0.body_part
+    }
+    pub(super) fn reported_precision(&self) -> ReportedPrecision {
+        self.0.reported_precision
+    }
+    pub(super) fn attacker_yaw(&self) -> f32 {
+        self.0.attacker_yaw
+    }
+    pub(super) fn target_yaw(&self) -> f32 {
+        self.0.target_yaw
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum ValidatedRangedImpact {
+    Miss,
+    Hit {
+        target: Entity,
+        body_part: BodyPart,
+        target_position: Vec3,
+        target_yaw: f32,
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ValidatedRangedShot {
+    attacker: Entity,
+    attacker_side: TacticalCombatSide,
+    attacker_position: Vec3,
+    attacker_yaw: f32,
+    reported_precision: ReportedPrecision,
+    impact: ValidatedRangedImpact,
+}
+
+impl ValidatedRangedShot {
+    pub(super) fn attacker(&self) -> Entity {
+        self.attacker
+    }
+    pub(super) fn attacker_position(&self) -> Vec3 {
+        self.attacker_position
+    }
+    pub(super) fn impact(&self) -> ValidatedRangedImpact {
+        self.impact
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct AuthorizedRangedShot(ValidatedRangedShot);
+
+impl AuthorizedRangedShot {
+    pub(super) fn attacker(&self) -> Entity {
+        self.0.attacker
+    }
+    pub(super) fn attacker_side(&self) -> TacticalCombatSide {
+        self.0.attacker_side
+    }
+    pub(super) fn attacker_yaw(&self) -> f32 {
+        self.0.attacker_yaw
+    }
+    pub(super) fn reported_precision(&self) -> ReportedPrecision {
+        self.0.reported_precision
+    }
+    pub(super) fn impact(&self) -> ValidatedRangedImpact {
+        self.0.impact
+    }
+}
+
+#[derive(Debug)]
+struct ObservedMeleeWindup {
+    target: Option<Entity>,
+    ready_at: CombatInstant,
+    expires_at: CombatInstant,
+}
+
+#[derive(Component, Debug, Default)]
+pub(crate) struct MeleeAttackAuthority {
+    windup: Option<ObservedMeleeWindup>,
+    cooldown_until: CombatInstant,
+}
+
+impl MeleeAttackAuthority {
+    pub(crate) fn observe(
+        &mut self,
+        target: Option<Entity>,
+        now: CombatInstant,
+        windup: CombatDuration,
+        network_allowance: CombatDuration,
+    ) {
+        let ready_at = now + windup;
+        self.windup = Some(ObservedMeleeWindup {
+            target,
+            ready_at,
+            expires_at: ready_at + network_allowance,
+        });
+    }
+
+    fn authorize(&mut self, target: Entity, now: CombatInstant, cooldown: CombatDuration) -> bool {
+        let valid = self.windup.as_ref().is_some_and(|windup| {
+            windup.target.map_or(true, |observed| observed == target)
+                && now >= windup.ready_at
+                && now <= windup.expires_at
+                && now >= self.cooldown_until
+        });
+        if valid {
+            self.windup = None;
+            self.cooldown_until = now + cooldown;
+        }
+        valid
+    }
+
+    pub(super) fn authorize_attack(
+        &mut self,
+        attack: ValidatedMeleeAttack,
+        now: CombatInstant,
+        cooldown: CombatDuration,
+    ) -> Option<AuthorizedMeleeAttack> {
+        self.authorize(attack.target, now, cooldown)
+            .then_some(AuthorizedMeleeAttack(attack))
+    }
+
+    pub(crate) fn permits(&self, target: Entity, now: CombatInstant) -> bool {
+        self.windup.as_ref().is_some_and(|windup| {
+            windup.target.map_or(true, |observed| observed == target)
+                && now >= windup.ready_at
+                && now <= windup.expires_at
+                && now >= self.cooldown_until
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ObservedRangedWindup {
+    ready_at: CombatInstant,
+    expires_at: CombatInstant,
+}
+
+#[derive(Component, Debug, Default)]
+pub(crate) struct RangedAttackAuthority {
+    windup: Option<ObservedRangedWindup>,
+    cooldown_until: CombatInstant,
+}
+
+impl RangedAttackAuthority {
+    pub(crate) fn observe(
+        &mut self,
+        now: CombatInstant,
+        windup: CombatDuration,
+        network_allowance: CombatDuration,
+    ) {
+        let ready_at = now + windup;
+        self.windup = Some(ObservedRangedWindup {
+            ready_at,
+            expires_at: ready_at + network_allowance,
+        });
+    }
+
+    pub(crate) fn permits(&self, now: CombatInstant) -> bool {
+        self.windup.as_ref().is_some_and(|windup| {
+            now >= windup.ready_at && now <= windup.expires_at && now >= self.cooldown_until
+        })
+    }
+
+    fn authorize(&mut self, now: CombatInstant, cooldown: CombatDuration) -> bool {
+        let valid = self.permits(now);
+        if valid {
+            self.windup = None;
+            self.cooldown_until = now + cooldown;
+        }
+        valid
+    }
+
+    pub(super) fn authorize_shot(
+        &mut self,
+        shot: ValidatedRangedShot,
+        now: CombatInstant,
+        cooldown: CombatDuration,
+    ) -> Option<AuthorizedRangedShot> {
+        self.authorize(now, cooldown)
+            .then_some(AuthorizedRangedShot(shot))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECOND: CombatDuration = CombatDuration::from_duration(Duration::from_secs(1));
+
+    #[test]
+    fn precision_accepts_all_finite_reports_without_clamping() {
+        assert_eq!(ReportedPrecision::new(-1.0).unwrap().get(), -1.0);
+        assert_eq!(ReportedPrecision::new(99.0).unwrap().get(), 99.0);
+        assert!(ReportedPrecision::new(f32::NAN).is_none());
+        assert!(ReportedPrecision::new(f32::INFINITY).is_none());
+    }
+
+    #[test]
+    fn authority_boundaries_are_inclusive_and_duration_typed() {
+        let target = Entity::from_bits(7);
+        let start = CombatInstant(Duration::ZERO);
+        let mut authority = MeleeAttackAuthority::default();
+        authority.observe(Some(target), start, SECOND, SECOND);
+        assert!(!authority.permits(target, start));
+        assert!(authority.permits(target, start + SECOND));
+        assert!(authority.permits(target, start + SECOND + SECOND));
+    }
+}
+
+pub(super) fn validate_ranged_intent(
+    facts: RangedIntentFacts,
+) -> Result<ValidatedRangedShot, RangedIntentRejection> {
+    if facts.target == Some(facts.attacker) {
+        return Err(RangedIntentRejection::SelfTarget);
+    }
+    let Some(attacker_side) = facts.attacker_side else {
+        return Err(RangedIntentRejection::MissingSide);
+    };
+    let Some(attacker_incapacitated) = facts.attacker_incapacitated else {
+        return Err(RangedIntentRejection::MissingCombatState);
+    };
+    if attacker_incapacitated {
+        return Err(RangedIntentRejection::Incapacitated);
+    }
+    if !facts.weapon_is_ranged || !facts.weapon_range.is_finite() || facts.weapon_range <= 0.0 {
+        return Err(RangedIntentRejection::NotRanged);
+    }
+    if let Some(_) = facts.target {
+        let Some(target_side) = facts.target_side else {
+            return Err(RangedIntentRejection::MissingSide);
+        };
+        let Some(target_incapacitated) = facts.target_incapacitated else {
+            return Err(RangedIntentRejection::MissingCombatState);
+        };
+        if attacker_side == target_side {
+            return Err(RangedIntentRejection::FriendlyTarget);
+        }
+        if target_incapacitated {
+            return Err(RangedIntentRejection::Incapacitated);
+        }
+        if !facts.separation.is_some_and(|distance| {
+            distance.is_finite() && distance <= facts.weapon_range + RANGED_RANGE_LATENCY_TOLERANCE
+        }) {
+            return Err(RangedIntentRejection::OutOfRange);
+        }
+        if facts.target_in_aim_cone != Some(true) {
+            return Err(RangedIntentRejection::OutsideAimCone);
+        }
+    }
+    if !facts.authority_permits {
+        return Err(RangedIntentRejection::Windup);
+    }
+    let impact = match facts.target {
+        None => ValidatedRangedImpact::Miss,
+        Some(target) => ValidatedRangedImpact::Hit {
+            target,
+            body_part: facts.body_part,
+            target_position: facts.target_position.expect("validated target position"),
+            target_yaw: facts.target_yaw.expect("validated target yaw"),
+        },
+    };
+    Ok(ValidatedRangedShot {
+        attacker: facts.attacker,
+        attacker_side,
+        attacker_position: facts.attacker_position,
+        attacker_yaw: facts.attacker_yaw,
+        reported_precision: facts.reported_precision,
+        impact,
+    })
+}
+
+pub(super) fn validate_melee_intent_cheap(
+    facts: MeleeIntentFacts,
+) -> Result<ValidatedMeleeAttack, MeleeIntentRejection> {
+    if facts.attacker == facts.target {
+        return Err(MeleeIntentRejection::SelfTarget);
+    }
+    let (Some(attacker_side), Some(target_side)) = (facts.attacker_side, facts.target_side) else {
+        return Err(MeleeIntentRejection::MissingSide);
+    };
+    if attacker_side == target_side {
+        return Err(MeleeIntentRejection::FriendlyTarget);
+    }
+    let (Some(attacker_incapacitated), Some(target_incapacitated)) =
+        (facts.attacker_incapacitated, facts.target_incapacitated)
+    else {
+        return Err(MeleeIntentRejection::MissingCombatState);
+    };
+    if attacker_incapacitated || target_incapacitated {
+        return Err(MeleeIntentRejection::Incapacitated);
+    }
+    if !facts.weapon_reach.is_finite() || facts.weapon_reach <= 0.0 {
+        return Err(MeleeIntentRejection::Unarmed);
+    }
+    if !facts.separation.is_finite()
+        || facts.separation
+            > melee_interaction_range(facts.weapon_reach) + MELEE_RANGE_LATENCY_TOLERANCE
+    {
+        return Err(MeleeIntentRejection::OutOfRange);
+    }
+    if !facts.authority_permits {
+        return Err(MeleeIntentRejection::Windup);
+    }
+    Ok(ValidatedMeleeAttack {
+        attacker: facts.attacker,
+        target: facts.target,
+        body_part: facts.body_part,
+        reported_precision: facts.reported_precision,
+        attacker_position: facts.attacker_position,
+        target_position: facts.target_position,
+        attacker_yaw: facts.attacker_yaw,
+        target_yaw: facts.target_yaw,
+    })
+}

--- a/crates/adventuresim-tactical-server/src/combat/condition.rs
+++ b/crates/adventuresim-tactical-server/src/combat/condition.rs
@@ -1,0 +1,44 @@
+use super::*;
+
+pub(crate) fn update_tactical_combat_state(
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    viewer: TacticalPlayerViewer,
+    limbs: Query<&Limbs>,
+    mut states: Query<(
+        Entity,
+        &mut TacticalCombatState,
+        Option<&mut input::AccumulatedInput>,
+    )>,
+) {
+    for (entity, mut state, mut input) in &mut states {
+        let was_incapacitated = state.is_incapacitated();
+        let Ok(view) = viewer.get(entity) else {
+            continue;
+        };
+        let balance = view.skill_check(Skill::Balance, LimbWeights::both_legs());
+        state.imbalance = recover_combat_imbalance(state.imbalance, balance, time.delta_secs());
+        let Ok(limbs) = limbs.get(entity) else {
+            continue;
+        };
+        let will = view.skill_check(Skill::Will, LimbWeights::all_equal());
+        state.incapacitation = combat_incapacitation(
+            state.starting_incapacitation,
+            state.starting_blood_fraction,
+            state.blood_loss_fraction,
+            limbs.total_damage(),
+            will,
+            state.imbalance,
+        );
+        if state.is_incapacitated() {
+            if let Some(input) = input.as_deref_mut() {
+                input.last_movement = None;
+                input.jumped = None;
+            }
+            if !was_incapacitated {
+                cmd.entity(entity).remove::<PendingDefenderResponse>();
+                cmd.trigger(TacticalCombatantDefeated(entity));
+            }
+        }
+    }
+}

--- a/crates/adventuresim-tactical-server/src/combat/consequence.rs
+++ b/crates/adventuresim-tactical-server/src/combat/consequence.rs
@@ -1,0 +1,253 @@
+use super::*;
+
+pub(super) fn apply_melee_attack_result(
+    event: On<ApplyMeleeAttackResult>,
+    mut combatants: Query<(&mut Limbs, &mut TacticalCombatState)>,
+    metadata: Query<(&TacticalCombatSide, &CharacterId)>,
+    mut consequences: ResMut<TacticalConsequenceAccumulator>,
+    items: Query<(
+        &ItemOf,
+        &EquipSlot,
+        &crate::player_projection::TacticalInventoryItemId,
+        Option<&WeaponItem>,
+        Option<&ShieldItem>,
+        Option<&ArmorItem>,
+    )>,
+) {
+    let Ok([attacker, defender]) = combatants.get_many_mut([event.attacker, event.target]) else {
+        return;
+    };
+    let (_, mut attacker_state) = attacker;
+    let (mut defender_limbs, mut defender_state) = defender;
+    let applied = apply_transient_attack_result(
+        &mut attacker_state,
+        &mut defender_limbs,
+        &mut defender_state,
+        event.result,
+        event.body_part,
+    );
+    let attacker_metadata = metadata.get(event.attacker).ok();
+    let defender_metadata = metadata.get(event.target).ok();
+    if defender_metadata.is_some_and(|(side, _)| *side == TacticalCombatSide::Party)
+        && let Some((cut_damage, blunt_damage)) = applied
+    {
+        let defender_id = defender_metadata.unwrap().1;
+        record_party_injury(
+            &mut consequences,
+            *defender_id,
+            event.body_part,
+            cut_damage,
+            blunt_damage,
+        );
+    }
+    if attacker_metadata.is_some_and(|(side, _)| *side == TacticalCombatSide::Party) {
+        let attacker_id = attacker_metadata.unwrap().1;
+        let contact_stress = match event.result {
+            AttackResult::ToAttacker { contact_force, .. }
+            | AttackResult::ToDefender { contact_force, .. } => contact_force.max(0.0),
+        };
+        if event.attacker_weapon_contact
+            && contact_stress > 0.0
+            && let Some((_, _, provenance, _, _, _)) = items.iter().find(|row| {
+                let (owner, slot, _, weapon, _, _) = row;
+                attacker_weapon_contact_matches(
+                    event.attacker,
+                    owner.0,
+                    **slot,
+                    event.attacker_weapon_slot,
+                    weapon.is_some(),
+                )
+            })
+        {
+            record_equipment_contact(
+                &mut consequences,
+                *attacker_id,
+                provenance.0,
+                contact_stress,
+                false,
+            );
+        }
+    }
+    if defender_metadata.is_some_and(|(side, _)| *side == TacticalCombatSide::Party) {
+        let defender_id = defender_metadata.unwrap().1;
+        let (contact_stress, defender_slot, require_shield, require_armor) = match event.result {
+            AttackResult::ToDefender {
+                contact_force,
+                armor_contact,
+                ..
+            } if armor_contact => (
+                contact_force.max(0.0),
+                Some(EquipSlot::from_armor_body_part(event.body_part)),
+                false,
+                true,
+            ),
+            AttackResult::ToAttacker {
+                contact_force,
+                physical_contact: true,
+                ..
+            } if event.defender_parry_slot.is_some() => (
+                contact_force.max(0.0),
+                event.defender_parry_slot,
+                true,
+                false,
+            ),
+            _ => (0.0, None, false, false),
+        };
+        if contact_stress > 0.0
+            && let Some((_, _, provenance, _, _, _)) = items.iter().find(|row| {
+                let (owner, slot, _, _, shield, armor) = row;
+                defender_equipment_contact_matches(
+                    event.target,
+                    owner.0,
+                    **slot,
+                    defender_slot,
+                    shield.is_some(),
+                    armor.is_some(),
+                    require_shield,
+                    require_armor,
+                )
+            })
+        {
+            record_equipment_contact(
+                &mut consequences,
+                *defender_id,
+                provenance.0,
+                contact_stress,
+                true,
+            );
+        }
+    }
+}
+
+pub(super) fn record_party_injury(
+    consequences: &mut TacticalConsequenceAccumulator,
+    character_id: CharacterId,
+    body_part: BodyPart,
+    cut_damage: f32,
+    blunt_damage: f32,
+) {
+    let consequence = consequences.party.entry(character_id).or_default();
+    if let Some(injury) = consequence
+        .injuries
+        .iter_mut()
+        .find(|injury| injury.body_part == body_part)
+    {
+        injury.cut_damage += cut_damage;
+        injury.blunt_damage += blunt_damage;
+        injury.max_single_hit_blunt_damage = injury.max_single_hit_blunt_damage.max(blunt_damage);
+    } else {
+        consequence.injuries.push(AppliedTacticalInjury {
+            body_part,
+            cut_damage,
+            blunt_damage,
+            max_single_hit_blunt_damage: blunt_damage,
+        });
+    }
+    consequence.blood_loss_fraction = (consequence.blood_loss_fraction
+        + (cut_damage + blunt_damage) * BLOOD_LOSS_PER_HEALTH_DAMAGE)
+        .clamp(0.0, 1.0);
+}
+
+pub(super) fn record_party_ammunition_use(
+    consequences: &mut TacticalConsequenceAccumulator,
+    character_id: CharacterId,
+) {
+    let consequence = consequences.party.entry(character_id).or_default();
+    consequence.ammunition_used = consequence
+        .ammunition_used
+        .saturating_add(1)
+        .min(adventuresim_core::mission::MAX_TACTICAL_AMMUNITION_USED);
+}
+
+pub(super) fn attacker_weapon_contact_matches(
+    attacker: Entity,
+    owner: Entity,
+    slot: EquipSlot,
+    authoritative_slot: EquipSlot,
+    is_weapon: bool,
+) -> bool {
+    owner == attacker && slot == authoritative_slot && is_weapon
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn defender_equipment_contact_matches(
+    defender: Entity,
+    owner: Entity,
+    slot: EquipSlot,
+    required_slot: Option<EquipSlot>,
+    is_shield: bool,
+    is_armor: bool,
+    require_shield: bool,
+    require_armor: bool,
+) -> bool {
+    owner == defender
+        && required_slot.is_none_or(|expected| slot == expected)
+        && (!require_shield || is_shield)
+        && (!require_armor || is_armor)
+}
+
+fn record_equipment_contact(
+    consequences: &mut TacticalConsequenceAccumulator,
+    character_id: CharacterId,
+    inventory_item_id: u64,
+    contact_stress: f32,
+    defender_equipment: bool,
+) {
+    if let Some(existing) = consequences
+        .equipment_contacts
+        .iter_mut()
+        .find(|contact| contact.inventory_item_id == inventory_item_id)
+    {
+        existing.contact_stress = (existing.contact_stress + contact_stress)
+            .min(adventuresim_core::mission::MAX_TACTICAL_CONTACT_STRESS);
+    } else if consequences.equipment_contacts.len()
+        < adventuresim_core::mission::MAX_TACTICAL_EQUIPMENT_CONTACTS
+    {
+        consequences
+            .equipment_contacts
+            .push(AccumulatedEquipmentContact {
+                character_id,
+                inventory_item_id,
+                contact_stress: contact_stress
+                    .min(adventuresim_core::mission::MAX_TACTICAL_CONTACT_STRESS),
+                defender_equipment,
+            });
+    }
+}
+
+pub(crate) fn apply_transient_attack_result(
+    attacker_state: &mut TacticalCombatState,
+    defender_limbs: &mut Limbs,
+    defender_state: &mut TacticalCombatState,
+    result: AttackResult,
+    body_part: BodyPart,
+) -> Option<(f32, f32)> {
+    match result {
+        AttackResult::ToAttacker { balance_damage, .. } => {
+            attacker_state.imbalance += balance_damage.max(0.0);
+            None
+        }
+        AttackResult::ToDefender {
+            cut_damage,
+            blunt_damage,
+            balance_damage,
+            ..
+        } => {
+            defender_state.imbalance += balance_damage.max(0.0);
+            let damage = health_damage_from_attack(result, body_part);
+            let applied = apply_clamped_limb_damage(defender_limbs.health_mut(body_part), damage);
+            defender_state.blood_loss_fraction = (defender_state.blood_loss_fraction
+                + applied * BLOOD_LOSS_PER_HEALTH_DAMAGE)
+                .clamp(0.0, 1.0);
+            let raw_total = (cut_damage + blunt_damage).max(0.0);
+            if applied > 0.0 && raw_total > 0.0 {
+                Some((
+                    applied * cut_damage.max(0.0) / raw_total,
+                    applied * blunt_damage.max(0.0) / raw_total,
+                ))
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/crates/adventuresim-tactical-server/src/combat/ingress.rs
+++ b/crates/adventuresim-tactical-server/src/combat/ingress.rs
@@ -1,0 +1,200 @@
+use super::*;
+
+pub(super) fn on_defender_response(
+    event: On<FromClient<DefendRequest>>,
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    states: Query<&TacticalCombatState>,
+) {
+    let Some(entity) = event.client_id.entity() else {
+        warn!(
+            "Got defender response from an unknown client: {:?}",
+            event.client_id
+        );
+        return;
+    };
+
+    if states
+        .get(entity)
+        .is_ok_and(TacticalCombatState::is_incapacitated)
+    {
+        return;
+    }
+
+    cmd.entity(entity).insert(PendingDefenderResponse {
+        choice: **event,
+        set_at: CombatInstant::from_elapsed(&time),
+    });
+}
+
+pub(super) fn on_melee_attack_started(
+    event: On<MeleeAttackStartedIntent>,
+    mut authorities: Query<&mut MeleeAttackAuthority>,
+    time: Res<Time<()>>,
+) {
+    let Ok(mut authority) = authorities.get_mut(event.attacker) else {
+        return;
+    };
+    authority.observe(
+        Some(event.target),
+        CombatInstant::from_elapsed(&time),
+        event.windup,
+        MELEE_WINDUP_NETWORK_ALLOWANCE,
+    );
+}
+
+pub(super) fn resolve_defender_response(
+    pending: Option<&PendingDefenderResponse>,
+    time: &Time<()>,
+    defender_view: &TacticalPlayerView,
+) -> DefenderResponse {
+    let Some(pending) = pending else {
+        return DefenderResponse::None;
+    };
+
+    let elapsed = CombatInstant::from_elapsed(time).elapsed_since(pending.set_at);
+    if elapsed > MAX_REFLEX_WINDOW {
+        return DefenderResponse::None;
+    }
+
+    let input_reflex =
+        (1.0 - elapsed.as_secs_f32() / MAX_REFLEX_WINDOW.as_secs_f32()).clamp(0.0, 1.0);
+
+    match pending.choice {
+        DefendRequest::Dodge => DefenderResponse::Dodge { input_reflex },
+        DefendRequest::Parry => {
+            if defender_view.shield_block_bonus() > 0.0 {
+                DefenderResponse::Parry { input_reflex }
+            } else {
+                DefenderResponse::None
+            }
+        }
+    }
+}
+
+pub(super) fn on_melee_action_request(
+    event: On<FromClient<MeleeActionRequest>>,
+    mut cmd: Commands,
+    time: Res<Time<()>>,
+    mut authorities: Query<&mut MeleeAttackAuthority>,
+) {
+    let Some(attacker) = event.client_id.entity() else {
+        debug!(
+            "Ignoring melee action from unknown client: {:?}",
+            event.client_id
+        );
+        return;
+    };
+    match **event {
+        MeleeActionRequest::Start => {
+            let Ok(mut authority) = authorities.get_mut(attacker) else {
+                return;
+            };
+            authority.observe(
+                None,
+                CombatInstant::from_elapsed(&time),
+                CLIENT_MELEE_WINDUP,
+                MELEE_WINDUP_NETWORK_ALLOWANCE,
+            );
+        }
+        MeleeActionRequest::Complete {
+            target,
+            body_part,
+            reported_precision,
+        } => {
+            let Some(reported_precision) = ReportedPrecision::new(reported_precision) else {
+                debug!("Ignoring non-finite melee precision from {attacker:?}");
+                return;
+            };
+            // Finite precision is intentionally accepted as reported. Full
+            // animation and secondary physics remain client-owned.
+            cmd.trigger(MeleeAttackIntent {
+                attacker,
+                target,
+                body_part,
+                reported_precision,
+            });
+        }
+    }
+}
+
+pub(super) fn on_ranged_action_request(
+    event: On<FromClient<RangedActionRequest>>,
+    mut cmd: Commands,
+) {
+    let Some(attacker) = event.client_id.entity() else {
+        debug!(
+            "Ignoring ranged action from unknown client: {:?}",
+            event.client_id
+        );
+        return;
+    };
+    match **event {
+        RangedActionRequest::Start => {
+            cmd.trigger(RangedAttackStartedIntent {
+                attacker,
+                target: None,
+                windup: CLIENT_RANGED_WINDUP,
+            });
+        }
+        RangedActionRequest::CompleteMiss => {
+            cmd.trigger(RangedAttackIntent {
+                attacker,
+                target: None,
+                body_part: BodyPart::Chest,
+                reported_precision: ReportedPrecision::new(0.0).expect("zero is finite"),
+            });
+        }
+        RangedActionRequest::CompleteHit {
+            target,
+            body_part,
+            reported_precision,
+        } => {
+            let Some(reported_precision) = ReportedPrecision::new(reported_precision) else {
+                debug!("Ignoring non-finite ranged precision from {attacker:?}");
+                return;
+            };
+            // Finite precision is deliberately trusted. Animation and
+            // secondary physics remain client-owned and non-deterministic.
+            cmd.trigger(RangedAttackIntent {
+                attacker,
+                target: Some(target),
+                body_part,
+                reported_precision,
+            });
+        }
+    }
+}
+
+pub(super) fn on_ranged_attack_started(
+    event: On<RangedAttackStartedIntent>,
+    mut authorities: Query<&mut RangedAttackAuthority>,
+    time: Res<Time<()>>,
+) {
+    let Ok(mut authority) = authorities.get_mut(event.attacker) else {
+        return;
+    };
+    authority.observe(
+        CombatInstant::from_elapsed(&time),
+        event.windup,
+        RANGED_NETWORK_ALLOWANCE,
+    );
+}
+
+pub(super) fn authoritative_line_of_sight(
+    spatial: &SpatialQuery,
+    attacker: Entity,
+    target: Entity,
+    origin: Vec3,
+    target_position: Vec3,
+) -> bool {
+    let offset = target_position - origin;
+    let distance = offset.length();
+    let Ok(direction) = Dir3::new(offset) else {
+        return false;
+    };
+    let filter = SpatialQueryFilter::from_excluded_entities([attacker]);
+    spatial
+        .cast_ray(origin, direction, distance, true, &filter)
+        .is_some_and(|hit| hit.entity == target)
+}

--- a/crates/adventuresim-tactical-server/src/combat/melee.rs
+++ b/crates/adventuresim-tactical-server/src/combat/melee.rs
@@ -1,0 +1,190 @@
+use super::*;
+
+pub(super) fn resolve_melee_attack(
+    event: On<MeleeAttackIntent>,
+    mut cmd: Commands,
+    viewer: TacticalPlayerViewer,
+    spatial: SpatialQuery,
+    q_character: Query<(&CharacterLook, &Transform)>,
+    q_sides: Query<&TacticalCombatSide>,
+    q_states: Query<&TacticalCombatState>,
+    mut q_authorities: Query<&mut MeleeAttackAuthority>,
+    q_bestiary_categories: Query<&BestiaryCategories>,
+    q_pending: Query<&PendingDefenderResponse>,
+    time: Res<Time<()>>,
+) {
+    let entity = event.attacker;
+
+    let Ok(attacker_view) = viewer.get(entity).inspect_err(|err| {
+        debug!("Rejected attacker view for {entity:?}: {err}");
+    }) else {
+        return;
+    };
+    let Ok(defender_view) = viewer.get(event.target).inspect_err(|err| {
+        debug!("Rejected defender view for {:?}: {err}", event.target);
+    }) else {
+        return;
+    };
+
+    let Ok([attacker_character, defender_character]) = q_character
+        .get_many([entity, event.target])
+        .inspect_err(|err| {
+            debug!("Rejected attacker/defender transform: {err}");
+        })
+    else {
+        return;
+    };
+    let (attacker_look, attacker_transform) = attacker_character;
+    let (defender_look, defender_transform) = defender_character;
+
+    let weapon_reach = attacker_view.weapon_reach();
+    let now = CombatInstant::from_elapsed(&time);
+    let Ok(mut authority) = q_authorities.get_mut(entity) else {
+        return;
+    };
+    let facts = MeleeIntentFacts {
+        attacker: entity,
+        target: event.target,
+        attacker_side: q_sides.get(entity).ok().copied(),
+        target_side: q_sides.get(event.target).ok().copied(),
+        attacker_incapacitated: q_states
+            .get(entity)
+            .ok()
+            .map(TacticalCombatState::is_incapacitated),
+        target_incapacitated: q_states
+            .get(event.target)
+            .ok()
+            .map(TacticalCombatState::is_incapacitated),
+        reported_precision: event.reported_precision,
+        weapon_reach,
+        separation: attacker_transform
+            .translation
+            .distance(defender_transform.translation),
+        authority_permits: authority.permits(event.target, now),
+        body_part: event.body_part,
+        attacker_position: attacker_transform.translation,
+        target_position: defender_transform.translation,
+        attacker_yaw: attacker_look.yaw,
+        target_yaw: defender_look.yaw,
+    };
+    let validated = match validate_melee_intent_cheap(facts) {
+        Ok(validated) => validated,
+        Err(reason) => {
+            debug!(
+                "Rejected melee intent from {entity:?} to {:?}: {reason:?}",
+                event.target
+            );
+            return;
+        }
+    };
+    let line_of_sight = authoritative_line_of_sight(
+        &spatial,
+        validated.attacker(),
+        validated.target(),
+        validated.attacker_position(),
+        validated.target_position(),
+    );
+    if let Err(reason) = validate_melee_line_of_sight(line_of_sight) {
+        debug!(
+            "Rejected melee intent from {entity:?} to {:?}: {reason:?}",
+            event.target
+        );
+        return;
+    }
+    // Mutate the pre-existing authority component synchronously. A later
+    // completion in this same message flush observes the consumed windup and
+    // active cooldown instead of reusing deferred Commands state.
+    let Some(authorized) = authority.authorize_attack(validated, now, MELEE_COOLDOWN) else {
+        debug!("Rejected already-consumed melee authorization for {entity:?}");
+        return;
+    };
+    let attack = authorized;
+    let (a2, a1) = attack.attacker_yaw().sin_cos();
+    let (d2, d1) = attack.target_yaw().sin_cos();
+    let flanking = flanking_from_dir((a1, a2), (d1, d2));
+
+    let Some(attacker_side) = attacker_view.weapon_holding_side() else {
+        debug!("Rejected attacker without a held weapon");
+        return;
+    };
+
+    let pending = q_pending.get(attack.target()).ok();
+    let defender_response = resolve_defender_response(pending, &time, &defender_view);
+
+    // Consume the pending response so it is not reused.
+    cmd.entity(attack.target())
+        .remove::<PendingDefenderResponse>();
+
+    let fallback_categories = BestiaryCategories::default();
+    let defender_categories = q_bestiary_categories
+        .get(attack.target())
+        .unwrap_or(&fallback_categories);
+
+    let result = attacker_view.resolve_melee_attack(
+        attacker_side,
+        &defender_view,
+        &defender_categories.0,
+        defender_response,
+        attack.reported_precision().get(),
+        flanking,
+        attack.body_part(),
+    );
+    let attacker_weapon_slot = match attacker_side {
+        BodySide::Left => EquipSlot::HoldingLeft,
+        BodySide::Right => EquipSlot::HoldingRight,
+        BodySide::Both => return,
+    };
+    let defender_parry_slot = matches!(defender_response, DefenderResponse::Parry { .. })
+        .then(|| defender_view.shield_holding_side())
+        .flatten()
+        .and_then(|side| match side {
+            BodySide::Left => Some(EquipSlot::HoldingLeft),
+            BodySide::Right => Some(EquipSlot::HoldingRight),
+            BodySide::Both => None,
+        });
+
+    cmd.trigger(ApplyMeleeAttackResult {
+        attacker: attack.attacker(),
+        target: attack.target(),
+        body_part: attack.body_part(),
+        result,
+        attacker_weapon_slot,
+        defender_parry_slot,
+        attacker_weapon_contact: true,
+    });
+
+    match result {
+        AttackResult::ToAttacker { balance_damage, .. } => {
+            info!(
+                "{entity:?} failed to hit {:?} on {:?} and receiver {balance_damage:.1} balance damage",
+                attack.target(),
+                attack.body_part(),
+            );
+        }
+        AttackResult::ToDefender {
+            cut_damage,
+            blunt_damage,
+            balance_damage,
+            ..
+        } => {
+            info!(
+                "{entity:?} hit {:?} on {:?} for {:.1} damage ({cut_damage:.1} cut + {blunt_damage:.1} blunt) and {balance_damage:.1} balance damage",
+                attack.target(),
+                attack.body_part(),
+                cut_damage + blunt_damage
+            );
+        }
+    }
+
+    cmd.server_trigger(ToClients {
+        mode: SendMode::CLIENTS_ONLY,
+        message: SuccessfulAttackResponse {
+            attacker: attack.attacker(),
+            hit: vec![attack.target()],
+            body_part: attack.body_part(),
+            result,
+            flanking,
+            defender_response,
+        },
+    });
+}

--- a/crates/adventuresim-tactical-server/src/combat/protocol.rs
+++ b/crates/adventuresim-tactical-server/src/combat/protocol.rs
@@ -1,0 +1,56 @@
+use adventuresim_tactical_core::prelude::BodyPart;
+use adventuresim_tactical_netcode::message::DefendRequest;
+use bevy::prelude::*;
+
+use super::{CombatDuration, CombatInstant, ReportedPrecision};
+
+/// Stores the defender's most recent dodge/parry choice along with the
+/// server timestamp when it was received. Consumed on each attack resolution.
+#[derive(Component)]
+pub(crate) struct PendingDefenderResponse {
+    pub(crate) choice: DefendRequest,
+    pub(crate) set_at: CombatInstant,
+}
+
+/// Transient allegiance is independent from connectivity and bot control.
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TacticalCombatSide {
+    Party,
+    Enemy,
+}
+
+/// Emitted once per transition from active to incapacitated.
+#[derive(Event, Clone, Copy, Debug)]
+pub(crate) struct TacticalCombatantDefeated(pub(crate) Entity);
+
+/// Both network clients and server-owned AI enter melee through this seam.
+#[derive(Event, Clone, Copy, Debug)]
+pub(crate) struct MeleeAttackIntent {
+    pub(crate) attacker: Entity,
+    pub(crate) target: Entity,
+    pub(crate) body_part: BodyPart,
+    pub(crate) reported_precision: ReportedPrecision,
+}
+
+#[derive(Event, Clone, Copy, Debug)]
+pub(crate) struct MeleeAttackStartedIntent {
+    pub(crate) attacker: Entity,
+    pub(crate) target: Entity,
+    pub(crate) windup: CombatDuration,
+}
+
+/// `target == None` is an authoritative miss that still consumes a projectile.
+#[derive(Event, Clone, Copy, Debug)]
+pub(crate) struct RangedAttackIntent {
+    pub(crate) attacker: Entity,
+    pub(crate) target: Option<Entity>,
+    pub(crate) body_part: BodyPart,
+    pub(crate) reported_precision: ReportedPrecision,
+}
+
+#[derive(Event, Clone, Copy, Debug)]
+pub(crate) struct RangedAttackStartedIntent {
+    pub(crate) attacker: Entity,
+    pub(crate) target: Option<Entity>,
+    pub(crate) windup: CombatDuration,
+}

--- a/crates/adventuresim-tactical-server/src/combat/ranged.rs
+++ b/crates/adventuresim-tactical-server/src/combat/ranged.rs
@@ -1,0 +1,187 @@
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn resolve_ranged_attack(
+    event: On<RangedAttackIntent>,
+    mut cmd: Commands,
+    viewer: TacticalPlayerViewer,
+    spatial: SpatialQuery,
+    q_character: Query<(&CharacterLook, &Transform)>,
+    q_sides: Query<&TacticalCombatSide>,
+    q_states: Query<&TacticalCombatState>,
+    mut q_authorities: Query<&mut RangedAttackAuthority>,
+    q_bestiary_categories: Query<&BestiaryCategories>,
+    q_pending: Query<&PendingDefenderResponse>,
+    q_ammo: Query<(Entity, &ItemOf, &ItemProperties, &ItemQuantity)>,
+    q_ids: Query<&CharacterId>,
+    mut consequences: ResMut<TacticalConsequenceAccumulator>,
+    time: Res<Time<()>>,
+) {
+    let attacker = event.attacker;
+    let Ok(attacker_view) = viewer.get(attacker) else {
+        return;
+    };
+    let Ok((attacker_look, attacker_transform)) = q_character.get(attacker) else {
+        return;
+    };
+    let target_character = event.target.and_then(|target| q_character.get(target).ok());
+    let now = CombatInstant::from_elapsed(&time);
+    let Ok(mut authority) = q_authorities.get_mut(attacker) else {
+        return;
+    };
+    let facts = RangedIntentFacts {
+        attacker,
+        target: event.target,
+        attacker_side: q_sides.get(attacker).ok().copied(),
+        target_side: event
+            .target
+            .and_then(|target| q_sides.get(target).ok().copied()),
+        attacker_incapacitated: q_states
+            .get(attacker)
+            .ok()
+            .map(TacticalCombatState::is_incapacitated),
+        target_incapacitated: event.target.and_then(|target| {
+            q_states
+                .get(target)
+                .ok()
+                .map(TacticalCombatState::is_incapacitated)
+        }),
+        reported_precision: event.reported_precision,
+        weapon_is_ranged: attacker_view.weapon_is_ranged(),
+        weapon_range: attacker_view.weapon_reach(),
+        separation: target_character.map(|(_, transform)| {
+            attacker_transform
+                .translation
+                .distance(transform.translation)
+        }),
+        target_in_aim_cone: target_character.map(|(_, transform)| {
+            ranged_target_in_aim_cone(
+                attacker_look.yaw,
+                attacker_transform.translation,
+                transform.translation,
+            )
+        }),
+        authority_permits: authority.permits(now),
+        body_part: event.body_part,
+        attacker_position: attacker_transform.translation,
+        target_position: target_character.map(|(_, transform)| transform.translation),
+        attacker_yaw: attacker_look.yaw,
+        target_yaw: target_character.map(|(look, _)| look.yaw),
+    };
+    let validated = match validate_ranged_intent(facts) {
+        Ok(validated) => validated,
+        Err(reason) => {
+            if !matches!(reason, RangedIntentRejection::Windup) {
+                debug!("Rejected ranged intent from {attacker:?}: {reason:?}");
+            }
+            return;
+        }
+    };
+    if let ValidatedRangedImpact::Hit {
+        target,
+        target_position,
+        ..
+    } = validated.impact()
+    {
+        let line_of_sight = authoritative_line_of_sight(
+            &spatial,
+            validated.attacker(),
+            target,
+            validated.attacker_position(),
+            target_position,
+        );
+        if !line_of_sight {
+            debug!(
+                "Rejected ranged intent from {attacker:?}: {:?}",
+                RangedIntentRejection::BlockedLineOfSight
+            );
+            return;
+        }
+    }
+    let Some(authorized) = authority.authorize_shot(validated, now, RANGED_COOLDOWN) else {
+        return;
+    };
+    let shot = authorized;
+
+    // Only an otherwise-authorized shot reaches the global inventory scan.
+    // A dry fire still consumes its windup/cooldown, bounding repeated scans.
+    let ammo = q_ammo.iter().find(|(_, owner, properties, quantity)| {
+        owner.0 == shot.attacker() && properties.id == ARROW_ID && quantity.0.get() > 0
+    });
+    let Some((ammo_entity, _, _, quantity)) = ammo else {
+        return;
+    };
+    if let Some(remaining) = remaining_ammo_after_shot(quantity.0) {
+        cmd.entity(ammo_entity).insert(ItemQuantity(remaining));
+    } else {
+        cmd.entity(ammo_entity).despawn();
+    }
+    if shot.attacker_side() == TacticalCombatSide::Party
+        && let Ok(player_id) = q_ids.get(shot.attacker())
+    {
+        record_party_ammunition_use(&mut consequences, *player_id);
+    }
+
+    let ValidatedRangedImpact::Hit {
+        target,
+        body_part,
+        target_yaw,
+        ..
+    } = shot.impact()
+    else {
+        return;
+    };
+    let Ok(defender_view) = viewer.get(target) else {
+        return;
+    };
+    let (a2, a1) = shot.attacker_yaw().sin_cos();
+    let (d2, d1) = target_yaw.sin_cos();
+    let flanking = flanking_from_dir((a1, a2), (d1, d2));
+    let defender_response =
+        resolve_defender_response(q_pending.get(target).ok(), &time, &defender_view);
+    cmd.entity(target).remove::<PendingDefenderResponse>();
+    let fallback_categories = BestiaryCategories::default();
+    let defender_categories = q_bestiary_categories
+        .get(target)
+        .unwrap_or(&fallback_categories);
+    let result = attacker_view.resolve_ranged_attack(
+        &defender_view,
+        &defender_categories.0,
+        defender_response,
+        shot.reported_precision().get(),
+        flanking,
+        body_part,
+    );
+    let defender_parry_slot = matches!(defender_response, DefenderResponse::Parry { .. })
+        .then(|| defender_view.shield_holding_side())
+        .flatten()
+        .and_then(|side| match side {
+            BodySide::Left => Some(EquipSlot::HoldingLeft),
+            BodySide::Right => Some(EquipSlot::HoldingRight),
+            BodySide::Both => None,
+        });
+    let attacker_weapon_slot = match attacker_view.weapon_holding_side() {
+        Some(BodySide::Left) => EquipSlot::HoldingLeft,
+        _ => EquipSlot::HoldingRight,
+    };
+    cmd.trigger(ApplyMeleeAttackResult {
+        attacker: shot.attacker(),
+        target,
+        body_part,
+        result,
+        attacker_weapon_slot,
+        defender_parry_slot,
+        attacker_weapon_contact: false,
+    });
+    cmd.server_trigger(ToClients {
+        mode: SendMode::CLIENTS_ONLY,
+        message: SuccessfulAttackResponse {
+            attacker: shot.attacker(),
+            hit: vec![target],
+            body_part,
+            result,
+            flanking,
+            defender_response,
+        },
+    });
+}

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -1,156 +1,82 @@
-//! Tactical Server - Replicon + Aeronet websocket game server
+//! Tactical Server - Replicon + Aeronet websocket game server.
 
 mod bot;
 mod combat;
+mod mission;
+mod player_projection;
 mod stdb;
 mod terrain;
 
-use std::{
-    collections::HashSet,
-    net::SocketAddr,
-    num::{NonZeroU8, NonZeroU32},
-    time::Duration,
-};
+use std::{net::SocketAddr, num::NonZeroU32};
 
 use adventuresim_stdb_client::*;
-use adventuresim_tactical_core::{
-    inventory::ItemProperties, physics::AdventureSimulatorPhysicsPlugin, prelude::*,
-};
+use adventuresim_tactical_core::{physics::AdventureSimulatorPhysicsPlugin, prelude::*};
 use adventuresim_tactical_netcode::{
-    aeronet::io::connection::{DisconnectReason, Disconnected, LocalAddr},
-    bevy_replicon::prelude::*,
-    prelude::*,
+    aeronet::io::connection::LocalAddr,
+    bevy_replicon::prelude::{Replicated, ServerState},
+    prelude::{AdventureSimulatorNetPlugins, AdventureSimulatorServer},
 };
+use bevy::ecs::schedule::ApplyDeferred;
 use bevy::prelude::*;
-use bevy::time::Stopwatch;
 use clap::{ArgAction, Parser};
 
 use crate::{
-    bot::{MissionEnemy, OffensiveMeleeAi},
-    combat::{
-        MeleeAttackAuthority, RangedAttackAuthority, TacticalCombatSide,
-        TacticalConsequenceAccumulator,
+    combat::CombatSet,
+    mission::{
+        MissionState, check_mission_timeout, check_terminal_combat_outcome,
+        fail_stalled_terminal_submission, finish_terminal_presentation,
+        process_terminal_submission_results,
     },
-    stdb::{SpacetimeDb, SpacetimeDbReady, TerminalSubmissionResult},
+    player_projection::{
+        PlayerProjectionSet, on_client_disconnected, on_join_request, on_player_input,
+        spawn_connected_players,
+    },
+    stdb::{SpacetimeDb, SpacetimeDbReady},
     terrain::TerrainGenerator,
 };
-use input::AccumulatedInput;
 
-/// Default [`Args::timeout`] time.
 const MISSION_TIMEOUT_SECS: f32 = 300.0;
-/// Retry interval after a synchronous terminal reducer submission error.
-const TERMINAL_RETRY_BACKOFF: Duration = Duration::from_secs(1);
-/// Keeps the authoritative server observable just long enough for connected
-/// clients to render the committed outcome before the transport closes.
-const TERMINAL_PRESENTATION_DELAY: Duration = Duration::from_secs(3);
-/// An acknowledgement-ambiguous submission must fail closed rather than be
-/// retried blindly or strand a headless server forever.
-const TERMINAL_ACK_TIMEOUT: Duration = Duration::from_secs(10);
-/// Time a sealed, empty Party has to reconnect before the mission is abandoned.
-const PARTY_RECONNECT_GRACE: Duration = Duration::from_secs(10);
-
-/// Level map size.
 const TERRAIN_SIZE: usize = 100;
-
-/// Transient mission projection: durable Characters keep their strategic
-/// baseline while tactical combat receives mission difficulty/escalation.
-fn mission_enemy_scale(difficulty: i32, combat_scale_bps: u32, countermeasure_bps: u32) -> f32 {
-    let difficulty_scale = 1.0 + (difficulty.saturating_sub(1).max(0) as f32 * 0.05);
-    difficulty_scale * (combat_scale_bps as f32 / 10_000.0) * (countermeasure_bps as f32 / 10_000.0)
-}
-
-#[derive(Component)]
-struct MissionOpeningAwareness {
-    party_has_surprise: bool,
-}
-
-fn tactical_covered_parts(parts: &[EquipmentBodyPart]) -> [bool; 7] {
-    let mut covered = [false; 7];
-    for part in parts {
-        let index = match part {
-            EquipmentBodyPart::LeftArm => 0,
-            EquipmentBodyPart::RightArm => 1,
-            EquipmentBodyPart::LeftLeg => 2,
-            EquipmentBodyPart::RightLeg => 3,
-            EquipmentBodyPart::Chest => 4,
-            EquipmentBodyPart::Stomach => 5,
-            EquipmentBodyPart::Head => 6,
-        };
-        covered[index] = true;
-    }
-    covered
-}
 
 #[derive(Parser, Debug, Clone, Resource)]
 #[command(name = "adventuresim-tactical-server")]
 #[command(about = "Tactical mission server for Adventure Simulator")]
 struct Args {
-    /// Address to listen on
     #[arg(long, default_value = "127.0.0.1:6000")]
     addr: SocketAddr,
-
-    /// Unique mission instance ID
     #[arg(long)]
     mission_id: String,
-
-    /// One-use dispatcher claim, supplied only through the child environment.
     #[arg(long, env = "ADVENTURESIM_TACTICAL_CLAIM", hide_env_values = true)]
     tactical_claim: String,
-
-    /// Scene key (e.g., "hills", "desert")
     #[arg(long)]
     scene_key: String,
-
-    /// Scene allowed physical width (x-size).
     #[arg(long, default_value_t = TERRAIN_SIZE)]
     scene_width: usize,
-
-    /// Scene allowed physical depth (z-size).
     #[arg(long, default_value_t = TERRAIN_SIZE)]
     scene_depth: usize,
-
-    /// Authoritative number of quest enemies that must be defeated.
     #[arg(long)]
     required_enemy_kills: u32,
-
-    /// Living Party members bound by strategic authority for this mission.
     #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
     expected_party_members: u32,
-
-    /// Observer-safe combat scale copied from the trusted mission request.
-    /// The strategic reducer independently derives the authoritative value.
     #[arg(long)]
     enemy_combat_scale_bps: u32,
-
-    /// SpacetimeDB URI (e.g., http://localhost:3000)
     #[arg(long, default_value = "http://localhost:3000")]
     spacetimedb_url: String,
-
-    /// SpacetimeDB module name
     #[arg(long, default_value = "adventuresim-stdb-module")]
     spacetimedb_module: String,
-
-    /// Mission timeout in seconds (how long the server stays up waiting for players)
     #[arg(long, default_value_t = MISSION_TIMEOUT_SECS)]
     timeout: f32,
-
-    /// Disable the timeout entirely
-    #[arg(
-        long,
-        action = ArgAction::SetTrue,
-        conflicts_with = "timeout"
-    )]
+    #[arg(long, action = ArgAction::SetTrue, conflicts_with = "timeout")]
     no_timeout: bool,
 }
 
 fn main() {
     let args = Args::parse();
-
     App::new()
-        .add_plugins((DefaultPlugins.set(bevy::log::LogPlugin {
+        .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
             filter: "tactical_server=info,bevy_app=warn,bevy_ecs=warn".to_string(),
             ..default()
-        }),))
+        }))
         .add_plugins((
             AdventureSimulatorCorePlugins
                 .build()
@@ -164,33 +90,21 @@ fn main() {
             combat::CombatPlugin,
             bot::BotPlugin,
         ))
-        .insert_resource(MissionState {
-            timeout: (!args.no_timeout)
+        .insert_resource(MissionState::new(
+            (!args.no_timeout)
                 .then_some(args.timeout)
                 .map(|duration| Timer::from_seconds(duration, TimerMode::Once)),
-            enemies_defeated: 0,
-            required_enemy_defeats: args.required_enemy_kills,
-            expected_party_members: args.expected_party_members,
-            seen_party_members: HashSet::new(),
-            enrollment_begun: false,
-            enrollment_sealed: false,
-            abandonment_elapsed: Duration::ZERO,
-            terminal_retry_not_before: Duration::ZERO,
-            pending_resolution: None,
-            pending_receipt: None,
-            committed: false,
-            terminal_in_flight: false,
-            terminal_ack_deadline: None,
-            terminal_transport_failed: false,
-            terminal_presentation: None,
-        })
+            args.required_enemy_kills,
+            NonZeroU32::new(args.expected_party_members)
+                .expect("clap validates at least one expected party member"),
+        ))
         .insert_resource(args)
         .add_systems(
             Update,
             (
                 (check_terminal_combat_outcome, check_mission_timeout)
                     .chain()
-                    .after(combat::update_tactical_combat_state)
+                    .after(CombatSet::Condition)
                     .after(spawn_connected_players)
                     .after(process_terminal_submission_results),
                 process_terminal_submission_results.after(stdb::update_spacetimedb),
@@ -198,7 +112,10 @@ fn main() {
                     .after(process_terminal_submission_results)
                     .before(check_terminal_combat_outcome),
                 finish_terminal_presentation.after(check_mission_timeout),
-                spawn_connected_players.after(stdb::update_spacetimedb),
+                (spawn_connected_players, ApplyDeferred)
+                    .chain()
+                    .in_set(PlayerProjectionSet::Spawn)
+                    .after(stdb::update_spacetimedb),
                 (setup_server, setup_stdb_callbacks).run_if(resource_added::<SpacetimeDbReady>),
             ),
         )
@@ -207,186 +124,6 @@ fn main() {
         .add_observer(on_player_input)
         .add_observer(on_client_disconnected)
         .run();
-}
-
-#[derive(Component, Debug, Clone, Copy)]
-struct LoadingPlayer {
-    requested_player_id: u64,
-}
-
-/// Durable inventory provenance retained only on the authoritative server.
-#[derive(Component, Debug, Clone, Copy)]
-pub(crate) struct TacticalInventoryItemId(pub u64);
-
-#[derive(Resource)]
-pub struct MissionState {
-    timeout: Option<Timer>,
-    pub enemies_defeated: u32,
-    required_enemy_defeats: u32,
-    expected_party_members: u32,
-    seen_party_members: HashSet<u64>,
-    enrollment_begun: bool,
-    enrollment_sealed: bool,
-    abandonment_elapsed: Duration,
-    terminal_retry_not_before: Duration,
-    pending_resolution: Option<TacticalMissionResolution>,
-    pending_receipt: Option<TacticalConsequenceReceipt>,
-    committed: bool,
-    terminal_in_flight: bool,
-    terminal_ack_deadline: Option<Duration>,
-    terminal_transport_failed: bool,
-    terminal_presentation: Option<TerminalPresentationState>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct TerminalPresentationState {
-    outcome: TacticalOutcome,
-    remaining: Duration,
-}
-
-impl TerminalPresentationState {
-    fn begin(outcome: TacticalOutcome) -> Self {
-        Self {
-            outcome,
-            remaining: TERMINAL_PRESENTATION_DELAY,
-        }
-    }
-
-    fn advance(&mut self, delta: Duration) -> bool {
-        self.remaining = self.remaining.saturating_sub(delta);
-        self.remaining.is_zero()
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct TerminalCombatSnapshot {
-    pub required_enemies: u32,
-    pub loaded_enemies: u32,
-    pub defeated_enemies: u32,
-    pub loaded_party: u32,
-    pub incapacitated_party: u32,
-    pub enrollment_sealed: bool,
-}
-
-pub(crate) fn terminal_resolution(
-    snapshot: TerminalCombatSnapshot,
-) -> Option<TacticalMissionResolution> {
-    if snapshot.required_enemies == 0
-        || snapshot.loaded_enemies < snapshot.required_enemies
-        || !snapshot.enrollment_sealed
-        || snapshot.loaded_party == 0
-    {
-        return None;
-    }
-    let enemies_defeated = snapshot.defeated_enemies >= snapshot.required_enemies;
-    let party_defeated = snapshot.incapacitated_party >= snapshot.loaded_party;
-    match (enemies_defeated, party_defeated) {
-        // Simultaneous defeat fails closed, matching autoresolve's lack of an
-        // allied victory when both sides are unable to continue.
-        (_, true) => Some(TacticalMissionResolution::Failed),
-        (true, false) => Some(TacticalMissionResolution::Defeated),
-        (false, false) => None,
-    }
-}
-
-fn abandonment_due(
-    elapsed: &mut Duration,
-    enrollment_begun: bool,
-    loaded_party: u32,
-    has_loading_player: bool,
-    delta: Duration,
-) -> bool {
-    if enrollment_begun && loaded_party == 0 && !has_loading_player {
-        *elapsed = elapsed.saturating_add(delta);
-    } else {
-        *elapsed = Duration::ZERO;
-    }
-    *elapsed >= PARTY_RECONNECT_GRACE
-}
-
-fn enrollment_ready(expected: u32, seen: usize, has_loading_player: bool) -> bool {
-    expected > 0 && seen >= expected as usize && !has_loading_player
-}
-
-impl MissionState {
-    fn begin_terminal_submission(
-        &mut self,
-        resolution: TacticalMissionResolution,
-        receipt: TacticalConsequenceReceipt,
-        now: Duration,
-    ) -> Option<(TacticalMissionResolution, TacticalConsequenceReceipt)> {
-        if self.committed
-            || self.terminal_in_flight
-            || self.terminal_transport_failed
-            || now < self.terminal_retry_not_before
-        {
-            return None;
-        }
-        let resolution = *self.pending_resolution.get_or_insert(resolution);
-        let receipt = self.pending_receipt.get_or_insert(receipt).clone();
-        self.terminal_in_flight = true;
-        self.terminal_ack_deadline = Some(now.saturating_add(TERMINAL_ACK_TIMEOUT));
-        Some((resolution, receipt))
-    }
-
-    fn terminal_submission_failed(&mut self, now: Duration) {
-        if self.committed {
-            return;
-        }
-        self.terminal_in_flight = false;
-        self.terminal_ack_deadline = None;
-        self.terminal_retry_not_before = now.saturating_add(TERMINAL_RETRY_BACKOFF);
-    }
-
-    fn apply_terminal_submission_result(
-        &mut self,
-        result: TerminalSubmissionResult,
-        now: Duration,
-    ) -> Option<TacticalOutcome> {
-        if self.committed || !self.terminal_in_flight {
-            return None;
-        }
-        self.terminal_in_flight = false;
-        self.terminal_ack_deadline = None;
-        match result {
-            TerminalSubmissionResult::Accepted => {
-                let resolution = self.pending_resolution.take()?;
-                self.pending_receipt = None;
-                self.committed = true;
-                let outcome = presentation_outcome(resolution);
-                self.terminal_presentation = Some(TerminalPresentationState::begin(outcome));
-                Some(outcome)
-            }
-            TerminalSubmissionResult::Rejected(_) => {
-                self.terminal_retry_not_before = now.saturating_add(TERMINAL_RETRY_BACKOFF);
-                None
-            }
-        }
-    }
-
-    fn fail_if_terminal_ack_stalled(&mut self, now: Duration) -> bool {
-        let stalled = self.terminal_in_flight
-            && self
-                .terminal_ack_deadline
-                .is_some_and(|deadline| now >= deadline);
-        if stalled {
-            self.terminal_in_flight = false;
-            self.terminal_ack_deadline = None;
-            self.terminal_transport_failed = true;
-        }
-        stalled
-    }
-}
-
-fn presentation_outcome(resolution: TacticalMissionResolution) -> TacticalOutcome {
-    match resolution {
-        TacticalMissionResolution::Defeated
-        | TacticalMissionResolution::DrivenOff
-        | TacticalMissionResolution::Captured => TacticalOutcome::Victory,
-        TacticalMissionResolution::Failed | TacticalMissionResolution::CaptureTargetKilled => {
-            TacticalOutcome::Defeat
-        }
-    }
 }
 
 fn setup_server(mut commands: Commands, args: Res<Args>) {
@@ -399,9 +136,7 @@ fn setup_server(mut commands: Commands, args: Res<Args>) {
         "Enemy objective: count={}, scale={} bps",
         args.required_enemy_kills, args.enemy_combat_scale_bps
     );
-
     commands.spawn(AdventureSimulatorServer { addr: args.addr });
-
     if !args.no_timeout {
         info!("Will timeout in {} seconds", args.timeout);
     }
@@ -411,628 +146,14 @@ fn setup_stdb_callbacks(conn: Res<SpacetimeDb>) {
     conn.subscribe_connected_players();
 }
 
-fn spawn_connected_players(
-    conn: Res<SpacetimeDb>,
-    mut cmd: Commands,
-    q_loading: Query<(Entity, &LoadingPlayer)>,
-    q_scene: Query<&SceneTerrain>,
-) {
-    for player in conn.take_connected_players() {
-        spawn_connected_player(&player, &mut cmd, &q_loading, &q_scene);
-    }
-}
-
-fn spawn_connected_player(
-    player: &ConnectedPlayer,
-    cmd: &mut Commands,
-    q_loading: &Query<(Entity, &LoadingPlayer)>,
-    q_scene: &Query<&SceneTerrain>,
-) {
-    let entity = if player.mission_side == TacticalMissionSide::Enemy {
-        cmd.spawn((
-            MissionEnemy,
-            OffensiveMeleeAi::default(),
-            TacticalCombatSide::Enemy,
-        ))
-        .id()
-    } else {
-        let Some((entity, _)) = q_loading
-            .iter()
-            .find(|(_, id)| id.requested_player_id == player.character.id)
-        else {
-            warn!(
-                "Got new ConnectedPlayer from stdb, but there is no LoadingPlayer for it: {}#{}",
-                player.character.name, player.character.id
-            );
-            return;
-        };
-        entity
-    };
-
-    let mut skills = Skills {
-        polearm_hours: player.skills.polearm_hours,
-        axe_hours: player.skills.axe_hours,
-        bludgeon_hours: player.skills.bludgeon_hours,
-        sword_hours: player.skills.sword_hours,
-        knife_hours: player.skills.knife_hours,
-        dodge_hours: player.skills.dodge_hours,
-        block_hours: player.skills.block_hours,
-        bow_hours: player.skills.bow_hours,
-        crossbow_hours: player.skills.crossbow_hours,
-        firearm_hours: player.skills.firearm_hours,
-        throw_hours: player.skills.throw_hours,
-        will_hours: player.skills.will_hours,
-        insight_hours: player.skills.insight_hours,
-        charm_hours: player.skills.charm_hours,
-        command_hours: player.skills.command_hours,
-        deception_hours: player.skills.deception_hours,
-        physiology_hours: player.skills.physiology_hours,
-        religion_hours: {
-            let religion = &player.skills.religion_hours;
-            [
-                religion.roman_catholic,
-                religion.lutheran,
-                religion.reformed,
-                religion.anglican,
-                religion.eastern_orthodox,
-                religion.islamic,
-                religion.judaism,
-            ]
-            .into_iter()
-            .filter(|hours| hours.is_finite())
-            .map(|hours| hours.max(0.0))
-            .sum()
-        },
-        bestiary_beast_hours: player.skills.bestiary_hours.beast,
-        bestiary_undead_hours: player.skills.bestiary_hours.undead,
-        bestiary_human_hours: player.skills.bestiary_hours.human,
-        bestiary_werekin_hours: player.skills.bestiary_hours.werekin,
-        bestiary_elf_hours: player.skills.bestiary_hours.elf,
-        bestiary_dwarf_hours: player.skills.bestiary_hours.dwarf,
-        bestiary_fey_hours: player.skills.bestiary_hours.fey,
-        bestiary_spirit_hours: player.skills.bestiary_hours.spirit,
-        bestiary_greenskin_hours: player.skills.bestiary_hours.greenskin,
-        bestiary_insectoid_hours: player.skills.bestiary_hours.insectoid,
-        bestiary_draconid_hours: player.skills.bestiary_hours.draconid,
-        bestiary_construct_hours: player.skills.bestiary_hours.construct,
-        bestiary_wildmen_hours: player.skills.bestiary_hours.wildmen,
-        surgery_hours: player.skills.surgery_hours,
-        stealth_hours: player.skills.stealth_hours,
-        balance_hours: player.skills.balance_hours,
-        tailoring_hours: player.skills.tailoring_hours,
-        smithing_hours: player.skills.smithing_hours,
-    };
-    let mut limbs = Limbs {
-        body_weight_kg: player.body_weight_kg,
-        left_arm: player.limbs.left_arm_health,
-        right_arm: player.limbs.right_arm_health,
-        left_leg: player.limbs.left_leg_health,
-        right_leg: player.limbs.right_leg_health,
-        chest: player.limbs.chest_health,
-        stomach: player.limbs.stomach_health,
-        head: player.limbs.head_health,
-    };
-    let mut attributes = Attributes {
-        endurance: player.attrs.endurance,
-        immunity: player.attrs.immunity,
-        gut: player.attrs.gut,
-        intelligence: player.attrs.intelligence,
-        instinct: player.attrs.instinct,
-        eyesight: player.attrs.eyesight,
-        hearing: player.attrs.hearing,
-        left_arm_strength: player.attrs.left_arm_strength,
-        right_arm_strength: player.attrs.right_arm_strength,
-        left_leg_strength: player.attrs.left_leg_strength,
-        right_leg_strength: player.attrs.right_leg_strength,
-        left_arm_agility: player.attrs.left_arm_agility,
-        right_arm_agility: player.attrs.right_arm_agility,
-        left_leg_agility: player.attrs.left_leg_agility,
-        right_leg_agility: player.attrs.right_leg_agility,
-    };
-    if player.mission_side == TacticalMissionSide::Enemy {
-        let scale = mission_enemy_scale(
-            player.enemy_difficulty,
-            player.enemy_combat_scale_bps,
-            player.countermeasure_multiplier_bps,
-        );
-        for hours in [
-            &mut skills.polearm_hours,
-            &mut skills.axe_hours,
-            &mut skills.bludgeon_hours,
-            &mut skills.sword_hours,
-            &mut skills.knife_hours,
-            &mut skills.dodge_hours,
-            &mut skills.block_hours,
-            &mut skills.bow_hours,
-            &mut skills.crossbow_hours,
-            &mut skills.firearm_hours,
-            &mut skills.throw_hours,
-        ] {
-            *hours *= scale;
-        }
-        for attribute in [
-            &mut attributes.endurance,
-            &mut attributes.gut,
-            &mut attributes.instinct,
-            &mut attributes.eyesight,
-            &mut attributes.hearing,
-            &mut attributes.left_arm_strength,
-            &mut attributes.right_arm_strength,
-            &mut attributes.left_leg_strength,
-            &mut attributes.right_leg_strength,
-            &mut attributes.left_arm_agility,
-            &mut attributes.right_arm_agility,
-            &mut attributes.left_leg_agility,
-            &mut attributes.right_leg_agility,
-        ] {
-            *attribute *= scale;
-        }
-        for health in [
-            &mut limbs.left_arm,
-            &mut limbs.right_arm,
-            &mut limbs.left_leg,
-            &mut limbs.right_leg,
-            &mut limbs.chest,
-            &mut limbs.stomach,
-            &mut limbs.head,
-        ] {
-            *health *= scale;
-        }
-    }
-    let stats = Stats {
-        calories_used: player.stats.calories_used,
-        focus: player.stats.focus,
-    };
-
-    let player_collider = player_collider();
-    let spawn_position = Vec2::new(rand::random_range(-5.0..5.0), rand::random_range(-5.0..5.0));
-    let spawn_height = q_scene
-        .iter()
-        .next()
-        .and_then(|terrain| terrain.height_at(spawn_position))
-        .unwrap_or_default()
-        + player_spawn_offset(&player_collider);
-
-    let tag = if player.character.temporary {
-        "Bot"
-    } else {
-        "Player"
-    };
-    let name = format!("{tag}#{} {}", player.character.id, player.character.name);
-
-    let (starting_incapacitation, starting_blood_fraction) = derive_combat_starting_condition(
-        player.strategic_incapacitation,
-        player.strategic_pain,
-        player.strategic_blood_loss,
-        player.current_blood_ml,
-        player.maximum_blood_ml,
-    );
-
-    cmd.entity(entity)
-        .remove::<LoadingPlayer>()
-        .insert((
-            Name::new(name),
-            Replicated,
-            Player {
-                name: player.character.name.clone(),
-            },
-            PlayerId(player.character.id),
-            BestiaryCategories::default(),
-            skills,
-            limbs,
-            attributes,
-            stats,
-            MissionOpeningAwareness {
-                party_has_surprise: player.party_has_surprise,
-            },
-            TacticalCombatState {
-                starting_incapacitation,
-                starting_blood_fraction,
-                ..default()
-            },
-            MeleeAttackAuthority::default(),
-            RangedAttackAuthority::default(),
-            if player.mission_side == TacticalMissionSide::Enemy {
-                TacticalCombatSide::Enemy
-            } else {
-                TacticalCombatSide::Party
-            },
-            Transform::from_xyz(spawn_position.x, spawn_height, spawn_position.y),
-        ))
-        .insert((
-            player_collider.clone(),
-            CollisionMargin(0.01),
-            CharacterController::default(),
-            CharacterLook::default(),
-        ));
-
-    for item in &player.items {
-        let Some(quantity) = NonZeroU32::new(item.quantity) else {
-            warn!(
-                "Got item '{}' with zero quantity for Player#{}; skipped",
-                item.item.id, player.character.id
-            );
-            continue;
-        };
-
-        let mut item_cmd = cmd.spawn((
-            Replicated,
-            TacticalInventoryItemId(item.inventory_item_id),
-            ItemOf(entity),
-            ItemQuantity(quantity),
-            ItemProperties {
-                weight: item.item.weight,
-                id: item.item.id.clone(),
-            },
-        ));
-        item_cmd.insert(EquipmentTopology {
-            placement_id: item.selected_placement_id.clone(),
-            occupancies: item
-                .occupancies
-                .iter()
-                .map(|occupancy| EquipmentTopologyOccupancy {
-                    occupancy_id: occupancy.id.clone(),
-                    anchor_kind: format!("{:?}", occupancy.anchor_kind),
-                    location: occupancy.location.map(|location| format!("{location:?}")),
-                    parent_inventory_item_id: occupancy.parent_inventory_item_id,
-                    attachment_point_id: occupancy.attachment_point_id.clone(),
-                    channel: format!("{:?}", occupancy.channel),
-                    order: occupancy.order,
-                    requirement_index: occupancy.requirement_index,
-                    capacity_index: occupancy.capacity_index,
-                })
-                .collect(),
-        });
-
-        match item.item.kind {
-            ItemKind::Simple
-            | ItemKind::Container
-            | ItemKind::Currency
-            | ItemKind::Ingredient
-            | ItemKind::Medication
-            | ItemKind::Food => {}
-            ItemKind::Weapon => {
-                item_cmd.insert(WeaponItem {
-                    skill_weights: [
-                        item.item.weapon_skills.polearm,
-                        item.item.weapon_skills.axe,
-                        item.item.weapon_skills.bludgeon,
-                        item.item.weapon_skills.sword,
-                        item.item.weapon_skills.knife,
-                        item.item.weapon_skills.bow,
-                        item.item.weapon_skills.crossbow,
-                        item.item.weapon_skills.firearm,
-                        item.item.weapon_skills.throw_skill,
-                    ],
-                    accuracy: item.item.accuracy,
-                    penetration: item.item.penetration,
-                    reach: item.item.reach,
-                    balance: item.item.balance,
-                    precise: item.item.precise,
-                    melee: item.item.melee,
-                    ranged: item.item.ranged,
-                    blunt: item.item.blunt,
-                    slash: item.item.slash,
-                    pierce: item.item.pierce,
-                });
-            }
-            ItemKind::Armor | ItemKind::Clothing => {}
-            ItemKind::Shield => {
-                item_cmd.insert(ShieldItem {
-                    block: item.item.block,
-                });
-            }
-        }
-        if let Some(part) = item.protected_body_parts.first() {
-            let slot = match part {
-                EquipmentBodyPart::LeftArm => ArmorSlot::Arms(Some(ArmorSide::Left)),
-                EquipmentBodyPart::RightArm => ArmorSlot::Arms(Some(ArmorSide::Right)),
-                EquipmentBodyPart::LeftLeg => ArmorSlot::Legs(Some(ArmorSide::Left)),
-                EquipmentBodyPart::RightLeg => ArmorSlot::Legs(Some(ArmorSide::Right)),
-                EquipmentBodyPart::Head => ArmorSlot::Head,
-                EquipmentBodyPart::Chest => ArmorSlot::Chest,
-                EquipmentBodyPart::Stomach => ArmorSlot::Stomach,
-            };
-            item_cmd.insert(ArmorItem {
-                range_of_motion: item.item.range_of_motion,
-                coverage: item.item.coverage,
-                slot,
-                resistance: item.item.resistance,
-                padding: item.item.padding,
-                flexibility: item.item.flexibility,
-                covered_parts: tactical_covered_parts(&item.protected_body_parts),
-            });
-        }
-
-        if item.occupancies.iter().any(|occupancy| {
-            occupancy.channel == EquipmentChannel::Held
-                && occupancy.location == Some(EquipmentLocation::LeftHand)
-        }) {
-            item_cmd.insert(EquipSlot::HoldingLeft);
-        } else if item.occupancies.iter().any(|occupancy| {
-            occupancy.channel == EquipmentChannel::Held
-                && occupancy.location == Some(EquipmentLocation::RightHand)
-        }) {
-            item_cmd.insert(EquipSlot::HoldingRight);
-        }
-    }
-
-    info!(
-        temorary = player.character.temporary,
-        "Player {entity:?} is fully loaded"
-    );
-}
-
-fn commit_terminal_resolution(
-    resolution: TacticalMissionResolution,
-    now: Duration,
-    conn: Res<SpacetimeDb>,
-    consequences: Res<TacticalConsequenceAccumulator>,
-    mut state: ResMut<MissionState>,
-) -> Result {
-    let receipt = tactical_consequence_receipt(&consequences);
-    let Some((resolution, receipt)) = state.begin_terminal_submission(resolution, receipt, now)
-    else {
-        return Ok(());
-    };
-    if let Err(error) = conn.submit_terminal(resolution, receipt) {
-        state.terminal_submission_failed(now);
-        warn!(
-            "Terminal result enqueue failed; retrying in {}s: {error}",
-            TERMINAL_RETRY_BACKOFF.as_secs()
-        );
-    } else {
-        info!(
-            ?resolution,
-            "Terminal result queued; awaiting reducer acceptance"
-        );
-    }
-    Ok(())
-}
-
-fn process_terminal_submission_results(
-    time: Res<Time>,
-    conn: Res<SpacetimeDb>,
-    mut state: ResMut<MissionState>,
-    mut cmd: Commands,
-) {
-    for result in conn.take_terminal_results() {
-        let rejection = match &result {
-            TerminalSubmissionResult::Rejected(error) => Some(error.clone()),
-            TerminalSubmissionResult::Accepted => None,
-        };
-        if let Some(outcome) = state.apply_terminal_submission_result(result, time.elapsed()) {
-            cmd.server_trigger(ToClients {
-                mode: SendMode::CLIENTS_ONLY,
-                message: TacticalOutcomeResponse { outcome },
-            });
-            info!(
-                ?outcome,
-                "Mission terminal result accepted; presenting outcome"
-            );
-        } else if let Some(error) = rejection {
-            warn!(
-                "Terminal reducer rejected submission; retrying in {}s: {error}",
-                TERMINAL_RETRY_BACKOFF.as_secs()
-            );
-        }
-    }
-}
-
-fn fail_stalled_terminal_submission(
-    time: Res<Time>,
-    mut state: ResMut<MissionState>,
-    mut exit: MessageWriter<AppExit>,
-) {
-    if state.fail_if_terminal_ack_stalled(time.elapsed()) {
-        error!(
-            timeout_seconds = TERMINAL_ACK_TIMEOUT.as_secs(),
-            "Terminal reducer acknowledgement timed out; exiting without presenting an outcome"
-        );
-        exit.write(AppExit::Error(NonZeroU8::new(1).expect("one is non-zero")));
-    }
-}
-
-fn finish_terminal_presentation(
-    time: Res<Time>,
-    mut state: ResMut<MissionState>,
-    mut exit: MessageWriter<AppExit>,
-) {
-    let Some(mut presentation) = state.terminal_presentation.take() else {
-        return;
-    };
-    if presentation.advance(time.delta()) {
-        info!(?presentation.outcome, "Terminal presentation complete; shutting down");
-        exit.write(AppExit::Success);
-    } else {
-        state.terminal_presentation = Some(presentation);
-    }
-}
-
-fn receipt_body_part(body_part: BodyPart) -> TacticalReceiptBodyPart {
-    match body_part {
-        BodyPart::LeftArm => TacticalReceiptBodyPart::LeftArm,
-        BodyPart::RightArm => TacticalReceiptBodyPart::RightArm,
-        BodyPart::LeftLeg => TacticalReceiptBodyPart::LeftLeg,
-        BodyPart::RightLeg => TacticalReceiptBodyPart::RightLeg,
-        BodyPart::Chest => TacticalReceiptBodyPart::Chest,
-        BodyPart::Stomach => TacticalReceiptBodyPart::Stomach,
-        BodyPart::Head => TacticalReceiptBodyPart::Head,
-    }
-}
-
-fn tactical_consequence_receipt(
-    accumulated: &TacticalConsequenceAccumulator,
-) -> TacticalConsequenceReceipt {
-    let mut party: Vec<_> = accumulated
-        .party
-        .iter()
-        .map(|(character_id, consequence)| TacticalCharacterConsequence {
-            character_id: *character_id,
-            injuries: consequence
-                .injuries
-                .iter()
-                .map(|injury| TacticalHitInjury {
-                    body_part: receipt_body_part(injury.body_part),
-                    cut_damage: injury.cut_damage,
-                    blunt_damage: injury.blunt_damage,
-                    max_single_hit_blunt_damage: injury.max_single_hit_blunt_damage,
-                })
-                .collect(),
-            blood_loss_fraction: consequence.blood_loss_fraction,
-            ammunition_used: consequence.ammunition_used,
-        })
-        .collect();
-    for contact in &accumulated.equipment_contacts {
-        if !party
-            .iter()
-            .any(|consequence| consequence.character_id == contact.character_id)
-        {
-            party.push(TacticalCharacterConsequence {
-                character_id: contact.character_id,
-                injuries: Vec::new(),
-                blood_loss_fraction: 0.0,
-                ammunition_used: 0,
-            });
-        }
-    }
-    party.sort_by_key(|consequence| consequence.character_id);
-    party.truncate(adventuresim_core::mission::MAX_TACTICAL_RECEIPT_PARTICIPANTS);
-    TacticalConsequenceReceipt {
-        party,
-        equipment_contacts: accumulated
-            .equipment_contacts
-            .iter()
-            .map(|contact| TacticalEquipmentContact {
-                character_id: contact.character_id,
-                inventory_item_id: contact.inventory_item_id,
-                contact_stress: contact.contact_stress,
-                role: if contact.defender_equipment {
-                    TacticalEquipmentContactRole::DefenderEquipment
-                } else {
-                    TacticalEquipmentContactRole::AttackerWeapon
-                },
-            })
-            .collect(),
-    }
-}
-
-fn empty_tactical_consequence_receipt() -> TacticalConsequenceReceipt {
-    TacticalConsequenceReceipt {
-        party: Vec::new(),
-        equipment_contacts: Vec::new(),
-    }
-}
-
-fn check_terminal_combat_outcome(
-    time: Res<Time>,
-    conn: Res<SpacetimeDb>,
-    consequences: Res<TacticalConsequenceAccumulator>,
-    mut state: ResMut<MissionState>,
-    enemies: Query<(), (With<bot::MissionEnemy>, With<Player>)>,
-    combatants: Query<(&TacticalCombatSide, &TacticalCombatState, &PlayerId), With<Player>>,
-    loading_players: Query<(), With<LoadingPlayer>>,
-) -> Result {
-    if state.committed {
-        return Ok(());
-    }
-    // A result whose first submission failed is already decided. Retry it
-    // before observing recoveries, disconnects, or any newly terminal state.
-    if let Some(resolution) = state.pending_resolution {
-        return commit_terminal_resolution(resolution, time.elapsed(), conn, consequences, state);
-    }
-    let mut loaded_party = 0;
-    let mut incapacitated_party = 0;
-    for (side, combat_state, player_id) in &combatants {
-        if *side == TacticalCombatSide::Party {
-            loaded_party += 1;
-            incapacitated_party += u32::from(combat_state.incapacitated);
-            state.seen_party_members.insert(player_id.0);
-        }
-    }
-    let has_loading_player = !loading_players.is_empty();
-    state.enrollment_begun |= has_loading_player || !state.seen_party_members.is_empty();
-    if !state.enrollment_sealed
-        && enrollment_ready(
-            state.expected_party_members,
-            state.seen_party_members.len(),
-            has_loading_player,
-        )
-    {
-        state.enrollment_sealed = true;
-        info!(
-            expected = state.expected_party_members,
-            "Party enrollment sealed"
-        );
-    }
-    let enrollment_begun = state.enrollment_begun;
-    if abandonment_due(
-        &mut state.abandonment_elapsed,
-        enrollment_begun,
-        loaded_party,
-        has_loading_player,
-        time.delta(),
-    ) {
-        return commit_terminal_resolution(
-            TacticalMissionResolution::Failed,
-            time.elapsed(),
-            conn,
-            consequences,
-            state,
-        );
-    }
-    let snapshot = TerminalCombatSnapshot {
-        required_enemies: state.required_enemy_defeats,
-        loaded_enemies: enemies.iter().count() as u32,
-        defeated_enemies: state.enemies_defeated,
-        loaded_party,
-        incapacitated_party,
-        enrollment_sealed: state.enrollment_sealed && !has_loading_player,
-    };
-    let Some(resolution) = terminal_resolution(snapshot) else {
-        return Ok(());
-    };
-    commit_terminal_resolution(resolution, time.elapsed(), conn, consequences, state)
-}
-
-fn check_mission_timeout(
-    time: Res<Time>,
-    conn: Res<SpacetimeDb>,
-    consequences: Res<TacticalConsequenceAccumulator>,
-    mut state: ResMut<MissionState>,
-) -> Result {
-    let is_timeout = match state.timeout {
-        Some(ref mut timer) => {
-            timer.tick(time.delta());
-            timer.is_finished()
-        }
-        None => false,
-    };
-
-    if !is_timeout || state.committed {
-        return Ok(());
-    }
-
-    info!("Mission timeout, committing bounded failure fallback");
-    commit_terminal_resolution(
-        TacticalMissionResolution::Failed,
-        time.elapsed(),
-        conn,
-        consequences,
-        state,
-    )
-}
-
 fn on_server_started(
     args: Res<Args>,
     conn: Res<SpacetimeDb>,
-    ready: Res<SpacetimeDbReady>,
     mut commands: Commands,
     server_addr: Single<&LocalAddr, With<AdventureSimulatorServer>>,
 ) -> Result {
     info!("Server opened on {:?}", **server_addr);
     info!("Creating a game scene for {}", args.scene_key);
-
     let mut generator = TerrainGenerator::from_hash((&args.mission_id, &args.scene_key));
     let (scene_height, gen_period) = match args.scene_key.as_str() {
         "hills" => (30, 200.0),
@@ -1045,7 +166,6 @@ fn on_server_started(
     generator.period = gen_period;
     let terrain = generator.generate(args.scene_width, scene_height, args.scene_depth);
     let terrain_collider = terrain.collider();
-
     commands.spawn((
         Replicated,
         SceneId(args.scene_key.clone()),
@@ -1054,7 +174,6 @@ fn on_server_started(
         terrain_collider,
         Transform::default(),
     ));
-
     let scene_width = args.scene_width as f32;
     let scene_depth = args.scene_depth as f32;
     commands.spawn((
@@ -1063,550 +182,30 @@ fn on_server_started(
         children![
             (
                 Collider::half_space(Vec3::X),
-                Transform::from_xyz(-scene_width * 0.5, 0.0, 0.0),
+                Transform::from_xyz(-scene_width * 0.5, 0.0, 0.0)
             ),
             (
                 Collider::half_space(Vec3::NEG_X),
-                Transform::from_xyz(scene_width * 0.5, 0.0, 0.0),
+                Transform::from_xyz(scene_width * 0.5, 0.0, 0.0)
             ),
             (
                 Collider::half_space(Vec3::Z),
-                Transform::from_xyz(0.0, 0.0, -scene_depth * 0.5),
+                Transform::from_xyz(0.0, 0.0, -scene_depth * 0.5)
             ),
             (
                 Collider::half_space(Vec3::NEG_Z),
-                Transform::from_xyz(0.0, 0.0, scene_depth * 0.5),
+                Transform::from_xyz(0.0, 0.0, scene_depth * 0.5)
             )
         ],
     ));
-
     info!("Creating tactical server in stdb...");
-
     conn.reducers().create_tactical_server_for_request(
         args.mission_id.clone(),
         args.tactical_claim.clone(),
         args.addr.to_string(),
         default(),
     )?;
-
     // Strategic authority enrolls the mission's exact durable enemy roster as
     // part of server creation. ConnectedPlayer delivery spawns those rows.
-
     Ok(())
-}
-
-fn on_join_request(
-    join: On<FromClient<JoinRequest>>,
-    mut commands: Commands,
-    mut state: ResMut<MissionState>,
-    loading_players: Query<(), With<LoadingPlayer>>,
-    players: Query<(), With<Player>>,
-    conn: Res<SpacetimeDb>,
-    ready: Res<SpacetimeDbReady>,
-) -> Result {
-    let Some(client) = join.client_id.entity() else {
-        return Ok(());
-    };
-
-    if loading_players.contains(client) || players.contains(client) {
-        return Ok(());
-    }
-
-    // JoinRequest carries a character id chosen by the client. The strategic
-    // reducer therefore treats it only as a request to enroll an existing
-    // member of this mission's authoritative party; it never creates a row.
-    // Until the netcode authenticates character ownership, deployments must
-    // keep tactical clients within the trusted mission boundary.
-    conn.reducers()
-        .enter_mission(join.player_id, ready.identity())?;
-
-    state.enrollment_begun = true;
-    commands.entity(client).insert(LoadingPlayer {
-        requested_player_id: join.player_id,
-    });
-
-    info!(
-        "Character {} connected and entered mission, awaiting loading",
-        join.player_id
-    );
-
-    Ok(())
-}
-
-fn on_player_input(
-    input: On<FromClient<PlayerInputRequest>>,
-    mut players: Query<
-        (
-            &mut AccumulatedInput,
-            &mut CharacterLook,
-            &TacticalCombatState,
-        ),
-        With<Player>,
-    >,
-) {
-    let Some(entity) = input.client_id.entity() else {
-        return;
-    };
-
-    let Ok((mut accumulated_input, mut look, combat_state)) = players.get_mut(entity) else {
-        return;
-    };
-    if combat_state.incapacitated {
-        accumulated_input.last_movement = None;
-        accumulated_input.jumped = None;
-        return;
-    }
-
-    look.yaw = input.look.x;
-    look.pitch = input.look.y.clamp(-1.5, 1.5);
-
-    accumulated_input.last_movement = input.movement.map(|m| m.clamp_length_max(1.0));
-
-    if input.jump {
-        accumulated_input.jumped = Some(Stopwatch::new());
-    }
-}
-
-fn on_client_disconnected(
-    disconnected: On<Disconnected>,
-    query: Query<(Option<&PlayerId>, Option<&LoadingPlayer>)>,
-    conn: Res<SpacetimeDb>,
-) -> Result {
-    let entity = disconnected.event_target();
-    let Ok((player_id, loading)) = query.get(entity) else {
-        return Ok(());
-    };
-
-    let Some(character_id) = player_id
-        .map(|player_id| player_id.0)
-        .or_else(|| loading.map(|loading| loading.requested_player_id))
-    else {
-        return Ok(());
-    };
-
-    conn.reducers().leave_mission(character_id)?;
-
-    match &disconnected.reason {
-        DisconnectReason::ByUser(reason) => {
-            info!("Character {character_id} disconnected by server request: {reason}");
-        }
-        DisconnectReason::ByPeer(reason) => {
-            info!("Character {character_id} disconnected by peer: {reason}");
-        }
-        DisconnectReason::ByError(error) => {
-            warn!("Character {character_id} disconnected due to error: {error:#}");
-        }
-    }
-
-    Ok(())
-}
-
-fn player_collider() -> Collider {
-    Collider::cylinder(0.4, 1.9)
-}
-
-fn player_spawn_offset(collider: &Collider) -> f32 {
-    -collider.aabb(default(), Rotation::default()).min.y
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn same_durable_enemy_identity_projects_different_mission_strength() {
-        let baseline = mission_enemy_scale(1, 10_000, 10_000);
-        let escalated = mission_enemy_scale(4, 13_000, 10_000);
-        let countered = mission_enemy_scale(4, 13_000, 7_500);
-        assert_eq!(baseline, 1.0);
-        assert!(escalated > baseline);
-        assert!(countered < escalated);
-    }
-
-    fn snapshot() -> TerminalCombatSnapshot {
-        TerminalCombatSnapshot {
-            required_enemies: 2,
-            loaded_enemies: 2,
-            defeated_enemies: 0,
-            loaded_party: 2,
-            incapacitated_party: 0,
-            enrollment_sealed: true,
-        }
-    }
-
-    #[test]
-    fn terminal_resolution_waits_for_both_sides_to_load() {
-        assert_eq!(
-            terminal_resolution(TerminalCombatSnapshot {
-                loaded_enemies: 1,
-                ..snapshot()
-            }),
-            None
-        );
-        assert_eq!(
-            terminal_resolution(TerminalCombatSnapshot {
-                loaded_party: 0,
-                ..snapshot()
-            }),
-            None
-        );
-        assert_eq!(
-            terminal_resolution(TerminalCombatSnapshot {
-                enrollment_sealed: false,
-                ..snapshot()
-            }),
-            None
-        );
-        assert_eq!(
-            terminal_resolution(TerminalCombatSnapshot {
-                required_enemies: 0,
-                loaded_enemies: 0,
-                ..snapshot()
-            }),
-            None
-        );
-    }
-
-    #[test]
-    fn terminal_resolution_reports_immediate_victory() {
-        assert_eq!(
-            terminal_resolution(TerminalCombatSnapshot {
-                defeated_enemies: 2,
-                ..snapshot()
-            }),
-            Some(TacticalMissionResolution::Defeated)
-        );
-    }
-
-    #[test]
-    fn terminal_resolution_reports_immediate_party_defeat() {
-        assert_eq!(
-            terminal_resolution(TerminalCombatSnapshot {
-                incapacitated_party: 2,
-                ..snapshot()
-            }),
-            Some(TacticalMissionResolution::Failed)
-        );
-    }
-
-    #[test]
-    fn simultaneous_defeat_deterministically_fails() {
-        assert_eq!(
-            terminal_resolution(TerminalCombatSnapshot {
-                defeated_enemies: 2,
-                incapacitated_party: 2,
-                ..snapshot()
-            }),
-            Some(TacticalMissionResolution::Failed)
-        );
-    }
-
-    #[test]
-    fn committed_resolution_maps_to_one_client_outcome() {
-        assert_eq!(
-            presentation_outcome(TacticalMissionResolution::Defeated),
-            TacticalOutcome::Victory
-        );
-        for resolution in [
-            TacticalMissionResolution::DrivenOff,
-            TacticalMissionResolution::Captured,
-        ] {
-            assert_eq!(presentation_outcome(resolution), TacticalOutcome::Victory);
-        }
-        for resolution in [
-            TacticalMissionResolution::Failed,
-            TacticalMissionResolution::CaptureTargetKilled,
-        ] {
-            assert_eq!(presentation_outcome(resolution), TacticalOutcome::Defeat);
-        }
-    }
-
-    #[test]
-    fn terminal_presentation_delay_is_exact_and_bounded() {
-        let mut presentation = TerminalPresentationState::begin(TacticalOutcome::Victory);
-        assert!(!presentation.advance(TERMINAL_PRESENTATION_DELAY - Duration::from_millis(1)));
-        assert_eq!(presentation.remaining, Duration::from_millis(1));
-        assert!(presentation.advance(Duration::from_millis(1)));
-        assert_eq!(presentation.remaining, Duration::ZERO);
-    }
-
-    fn terminal_test_state() -> MissionState {
-        MissionState {
-            timeout: None,
-            enemies_defeated: 1,
-            required_enemy_defeats: 1,
-            expected_party_members: 1,
-            seen_party_members: HashSet::from([7]),
-            enrollment_begun: true,
-            enrollment_sealed: true,
-            abandonment_elapsed: Duration::ZERO,
-            terminal_retry_not_before: Duration::ZERO,
-            pending_resolution: None,
-            pending_receipt: None,
-            committed: false,
-            terminal_in_flight: false,
-            terminal_ack_deadline: None,
-            terminal_transport_failed: false,
-            terminal_presentation: None,
-        }
-    }
-
-    #[test]
-    fn stalled_terminal_ack_fails_closed_without_presentation() {
-        let mut state = terminal_test_state();
-        assert!(
-            state
-                .begin_terminal_submission(
-                    TacticalMissionResolution::Defeated,
-                    empty_tactical_consequence_receipt(),
-                    Duration::ZERO,
-                )
-                .is_some()
-        );
-
-        assert!(
-            !state.fail_if_terminal_ack_stalled(TERMINAL_ACK_TIMEOUT - Duration::from_millis(1))
-        );
-        assert!(state.fail_if_terminal_ack_stalled(TERMINAL_ACK_TIMEOUT));
-        assert!(state.terminal_transport_failed);
-        assert!(!state.committed);
-        assert!(state.terminal_presentation.is_none());
-        assert!(
-            state
-                .begin_terminal_submission(
-                    TacticalMissionResolution::Defeated,
-                    empty_tactical_consequence_receipt(),
-                    Duration::MAX,
-                )
-                .is_none(),
-            "an ambiguously acknowledged request must not be retried"
-        );
-    }
-
-    #[test]
-    fn queued_terminal_submission_is_not_committed_or_presented() {
-        let mut state = terminal_test_state();
-        let queued = state.begin_terminal_submission(
-            TacticalMissionResolution::Defeated,
-            empty_tactical_consequence_receipt(),
-            Duration::ZERO,
-        );
-        assert!(queued.is_some());
-        assert!(state.terminal_in_flight);
-        assert!(!state.committed);
-        assert!(state.terminal_presentation.is_none());
-        assert!(
-            state
-                .begin_terminal_submission(
-                    TacticalMissionResolution::Failed,
-                    empty_tactical_consequence_receipt(),
-                    Duration::ZERO,
-                )
-                .is_none(),
-            "an in-flight request cannot be duplicated"
-        );
-    }
-
-    #[test]
-    fn rejection_retries_frozen_data_then_acceptance_presents_exactly_once() {
-        let mut state = terminal_test_state();
-        let frozen_receipt = TacticalConsequenceReceipt {
-            party: vec![TacticalCharacterConsequence {
-                character_id: 7,
-                injuries: Vec::new(),
-                blood_loss_fraction: 0.1,
-                ammunition_used: 2,
-            }],
-            equipment_contacts: Vec::new(),
-        };
-        let first = state
-            .begin_terminal_submission(
-                TacticalMissionResolution::Defeated,
-                frozen_receipt.clone(),
-                Duration::ZERO,
-            )
-            .unwrap();
-        assert_eq!(
-            first,
-            (TacticalMissionResolution::Defeated, frozen_receipt.clone())
-        );
-
-        assert_eq!(
-            state.apply_terminal_submission_result(
-                TerminalSubmissionResult::Rejected("reducer rejected".into()),
-                Duration::ZERO,
-            ),
-            None
-        );
-        assert!(!state.terminal_in_flight);
-        assert!(!state.committed);
-        assert!(state.terminal_presentation.is_none());
-        assert!(
-            state
-                .begin_terminal_submission(
-                    TacticalMissionResolution::Failed,
-                    empty_tactical_consequence_receipt(),
-                    Duration::from_millis(999),
-                )
-                .is_none()
-        );
-
-        let retry = state
-            .begin_terminal_submission(
-                TacticalMissionResolution::Failed,
-                empty_tactical_consequence_receipt(),
-                TERMINAL_RETRY_BACKOFF,
-            )
-            .unwrap();
-        assert_eq!(
-            retry, first,
-            "retry must preserve the original terminal payload"
-        );
-        assert_eq!(
-            state.apply_terminal_submission_result(
-                TerminalSubmissionResult::Accepted,
-                TERMINAL_RETRY_BACKOFF,
-            ),
-            Some(TacticalOutcome::Victory)
-        );
-        assert!(state.committed);
-        assert!(state.terminal_presentation.is_some());
-        assert_eq!(
-            state.apply_terminal_submission_result(
-                TerminalSubmissionResult::Accepted,
-                TERMINAL_RETRY_BACKOFF,
-            ),
-            None,
-            "a duplicate callback cannot present twice"
-        );
-    }
-
-    #[test]
-    fn synchronous_enqueue_failure_releases_in_flight_for_bounded_retry() {
-        let mut state = terminal_test_state();
-        let first = state
-            .begin_terminal_submission(
-                TacticalMissionResolution::Failed,
-                empty_tactical_consequence_receipt(),
-                Duration::ZERO,
-            )
-            .unwrap();
-        state.terminal_submission_failed(Duration::ZERO);
-        assert!(!state.terminal_in_flight);
-        assert!(!state.committed);
-        assert!(state.terminal_presentation.is_none());
-        assert!(
-            state
-                .begin_terminal_submission(
-                    TacticalMissionResolution::Defeated,
-                    empty_tactical_consequence_receipt(),
-                    Duration::from_millis(999),
-                )
-                .is_none()
-        );
-        assert_eq!(
-            state
-                .begin_terminal_submission(
-                    TacticalMissionResolution::Defeated,
-                    empty_tactical_consequence_receipt(),
-                    TERMINAL_RETRY_BACKOFF,
-                )
-                .unwrap(),
-            first
-        );
-    }
-
-    #[test]
-    fn sealed_empty_party_fails_only_after_reconnection_grace() {
-        let mut elapsed = Duration::ZERO;
-        assert!(!abandonment_due(
-            &mut elapsed,
-            true,
-            0,
-            false,
-            Duration::from_secs(9)
-        ));
-        assert!(!abandonment_due(
-            &mut elapsed,
-            true,
-            0,
-            true,
-            Duration::from_secs(1)
-        ));
-        assert_eq!(elapsed, Duration::ZERO);
-        assert!(abandonment_due(
-            &mut elapsed,
-            true,
-            0,
-            false,
-            PARTY_RECONNECT_GRACE
-        ));
-    }
-
-    #[test]
-    fn pending_second_party_member_prevents_enrollment_seal() {
-        assert!(!enrollment_ready(2, 1, false));
-        assert!(!enrollment_ready(2, 2, true));
-        assert!(enrollment_ready(2, 2, false));
-    }
-
-    #[test]
-    fn partially_enrolled_party_abandons_after_every_client_disconnects() {
-        let expected = 2;
-        let seen = HashSet::from([7]);
-        assert!(!enrollment_ready(expected, seen.len(), true));
-
-        let enrollment_begun = !seen.is_empty();
-        let mut elapsed = Duration::ZERO;
-        // B is still represented by LoadingPlayer, so its disconnect resets
-        // rather than advances the grace period.
-        assert!(!abandonment_due(
-            &mut elapsed,
-            enrollment_begun,
-            1,
-            true,
-            Duration::from_secs(5)
-        ));
-        // B's LoadingPlayer and then A's loaded entity disappear. Enrollment
-        // was already begun, so the same bounded abandonment policy applies.
-        assert!(abandonment_due(
-            &mut elapsed,
-            enrollment_begun,
-            0,
-            false,
-            PARTY_RECONNECT_GRACE
-        ));
-    }
-
-    #[test]
-    fn never_joined_timeout_disabled_server_does_not_abandon() {
-        let mut elapsed = Duration::ZERO;
-        assert!(!abandonment_due(
-            &mut elapsed,
-            false,
-            0,
-            false,
-            PARTY_RECONNECT_GRACE.saturating_mul(2)
-        ));
-        assert_eq!(elapsed, Duration::ZERO);
-    }
-
-    #[test]
-    fn weapon_contact_owner_is_included_without_an_injury() {
-        let mut accumulated = TacticalConsequenceAccumulator::default();
-        accumulated
-            .equipment_contacts
-            .push(combat::AccumulatedEquipmentContact {
-                character_id: 7,
-                inventory_item_id: 99,
-                contact_stress: 12.0,
-                defender_equipment: false,
-            });
-
-        let receipt = tactical_consequence_receipt(&accumulated);
-        assert_eq!(receipt.party.len(), 1);
-        assert_eq!(receipt.party[0].character_id, 7);
-        assert!(receipt.party[0].injuries.is_empty());
-        assert_eq!(receipt.equipment_contacts.len(), 1);
-    }
 }

--- a/crates/adventuresim-tactical-server/src/mission/enrollment.rs
+++ b/crates/adventuresim-tactical-server/src/mission/enrollment.rs
@@ -1,0 +1,189 @@
+use std::{collections::HashSet, num::NonZeroU32, time::Duration};
+
+use adventuresim_tactical_core::prelude::CharacterId;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EnrollmentEffect {
+    None,
+    Sealed,
+    Abandoned,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AdmissionResult {
+    Admitted,
+    RejectedAfterSeal,
+}
+
+#[derive(Debug)]
+pub(crate) enum PartyEnrollment {
+    Awaiting {
+        expected: NonZeroU32,
+    },
+    Enrolling {
+        expected: NonZeroU32,
+        seen: HashSet<CharacterId>,
+        empty_for: Duration,
+    },
+    Sealed {
+        expected: NonZeroU32,
+        seen: HashSet<CharacterId>,
+        empty_for: Duration,
+    },
+}
+
+impl PartyEnrollment {
+    pub(crate) fn new(expected: NonZeroU32) -> Self {
+        Self::Awaiting { expected }
+    }
+
+    pub(crate) fn begin(&mut self) {
+        if let Self::Awaiting { expected } = *self {
+            *self = Self::Enrolling {
+                expected,
+                seen: HashSet::new(),
+                empty_for: Duration::ZERO,
+            };
+        }
+    }
+
+    pub(crate) fn observe_loaded(&mut self, character: CharacterId) -> AdmissionResult {
+        self.begin();
+        match self {
+            Self::Enrolling { seen, .. } => {
+                seen.insert(character);
+                AdmissionResult::Admitted
+            }
+            Self::Sealed { seen, .. } if seen.contains(&character) => AdmissionResult::Admitted,
+            Self::Sealed { .. } => AdmissionResult::RejectedAfterSeal,
+            Self::Awaiting { .. } => unreachable!("begin transitions awaiting enrollment"),
+        }
+    }
+
+    pub(crate) fn allows_join(&self, character: CharacterId) -> bool {
+        match self {
+            Self::Awaiting { .. } | Self::Enrolling { .. } => true,
+            Self::Sealed { seen, .. } => seen.contains(&character),
+        }
+    }
+
+    pub(crate) fn advance(
+        &mut self,
+        loaded_party: u32,
+        has_loading_player: bool,
+        delta: Duration,
+        reconnect_grace: Duration,
+    ) -> EnrollmentEffect {
+        let mut effect = EnrollmentEffect::None;
+        if let Self::Enrolling {
+            expected,
+            seen,
+            empty_for,
+        } = self
+            && seen.len() >= expected.get() as usize
+            && !has_loading_player
+        {
+            let expected = *expected;
+            let seen = std::mem::take(seen);
+            let empty_for = *empty_for;
+            *self = Self::Sealed {
+                expected,
+                seen,
+                empty_for,
+            };
+            effect = EnrollmentEffect::Sealed;
+        }
+
+        let empty_for = match self {
+            Self::Awaiting { .. } => return effect,
+            Self::Enrolling { empty_for, .. } | Self::Sealed { empty_for, .. } => empty_for,
+        };
+        if loaded_party == 0 && !has_loading_player {
+            *empty_for = empty_for.saturating_add(delta);
+        } else {
+            *empty_for = Duration::ZERO;
+        }
+        if *empty_for >= reconnect_grace {
+            EnrollmentEffect::Abandoned
+        } else {
+            effect
+        }
+    }
+
+    pub(crate) fn ready_for_outcome(&self, has_loading_player: bool) -> bool {
+        matches!(self, Self::Sealed { .. }) && !has_loading_player
+    }
+
+    pub(crate) fn expected(&self) -> NonZeroU32 {
+        match self {
+            Self::Awaiting { expected }
+            | Self::Enrolling { expected, .. }
+            | Self::Sealed { expected, .. } => *expected,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GRACE: Duration = Duration::from_secs(10);
+
+    #[test]
+    fn enrollment_seals_only_after_expected_roster_finishes_loading() {
+        let mut enrollment = PartyEnrollment::new(NonZeroU32::new(2).unwrap());
+        enrollment.begin();
+        enrollment.observe_loaded(CharacterId(1));
+        assert_eq!(
+            enrollment.advance(1, false, Duration::ZERO, GRACE),
+            EnrollmentEffect::None
+        );
+        enrollment.observe_loaded(CharacterId(2));
+        assert_eq!(
+            enrollment.advance(2, true, Duration::ZERO, GRACE),
+            EnrollmentEffect::None
+        );
+        assert_eq!(
+            enrollment.advance(2, false, Duration::ZERO, GRACE),
+            EnrollmentEffect::Sealed
+        );
+        assert!(enrollment.ready_for_outcome(false));
+    }
+
+    #[test]
+    fn begun_partial_enrollment_uses_bounded_abandonment_grace() {
+        let mut enrollment = PartyEnrollment::new(NonZeroU32::new(2).unwrap());
+        enrollment.observe_loaded(CharacterId(1));
+        assert_eq!(
+            enrollment.advance(0, false, GRACE - Duration::from_millis(1), GRACE),
+            EnrollmentEffect::None
+        );
+        assert_eq!(
+            enrollment.advance(0, false, Duration::from_millis(1), GRACE),
+            EnrollmentEffect::Abandoned
+        );
+    }
+
+    #[test]
+    fn sealed_roster_allows_known_reconnect_and_rejects_unseen_member() {
+        let mut enrollment = PartyEnrollment::new(NonZeroU32::new(1).unwrap());
+        assert_eq!(
+            enrollment.observe_loaded(CharacterId(1)),
+            AdmissionResult::Admitted
+        );
+        assert_eq!(
+            enrollment.advance(1, false, Duration::ZERO, GRACE),
+            EnrollmentEffect::Sealed
+        );
+        assert!(enrollment.allows_join(CharacterId(1)));
+        assert!(!enrollment.allows_join(CharacterId(2)));
+        assert_eq!(
+            enrollment.observe_loaded(CharacterId(1)),
+            AdmissionResult::Admitted
+        );
+        assert_eq!(
+            enrollment.observe_loaded(CharacterId(2)),
+            AdmissionResult::RejectedAfterSeal
+        );
+    }
+}

--- a/crates/adventuresim-tactical-server/src/mission/mod.rs
+++ b/crates/adventuresim-tactical-server/src/mission/mod.rs
@@ -1,0 +1,234 @@
+mod enrollment;
+mod receipt;
+mod systems;
+mod terminal;
+
+use std::{num::NonZeroU32, time::Duration};
+
+use adventuresim_tactical_core::prelude::CharacterId;
+use bevy::prelude::*;
+
+use enrollment::PartyEnrollment;
+pub(crate) use enrollment::{AdmissionResult, EnrollmentEffect};
+pub(crate) use systems::{
+    check_mission_timeout, check_terminal_combat_outcome, fail_stalled_terminal_submission,
+    finish_terminal_presentation, process_terminal_submission_results,
+};
+pub(crate) use terminal::FrozenTerminal;
+use terminal::TerminalState;
+
+#[derive(Resource, Debug)]
+pub(crate) struct MissionState {
+    timeout: Option<Timer>,
+    enemies_defeated: u32,
+    required_enemy_defeats: u32,
+    enrollment: PartyEnrollment,
+    terminal: TerminalState,
+}
+
+impl MissionState {
+    pub(crate) fn new(
+        timeout: Option<Timer>,
+        required_enemy_defeats: u32,
+        expected_party_members: NonZeroU32,
+    ) -> Self {
+        Self {
+            timeout,
+            enemies_defeated: 0,
+            required_enemy_defeats,
+            enrollment: PartyEnrollment::new(expected_party_members),
+            terminal: TerminalState::default(),
+        }
+    }
+
+    pub(crate) fn record_enemy_defeat(&mut self) {
+        self.enemies_defeated = self.enemies_defeated.saturating_add(1);
+    }
+
+    pub(crate) fn enemies_defeated(&self) -> u32 {
+        self.enemies_defeated
+    }
+
+    pub(crate) fn required_enemy_defeats(&self) -> u32 {
+        self.required_enemy_defeats
+    }
+
+    pub(crate) fn begin_enrollment(&mut self) {
+        self.enrollment.begin();
+    }
+
+    pub(crate) fn observe_loaded_party_member(
+        &mut self,
+        character: CharacterId,
+    ) -> AdmissionResult {
+        self.enrollment.observe_loaded(character)
+    }
+
+    pub(crate) fn allows_party_join(&self, character: CharacterId) -> bool {
+        self.enrollment.allows_join(character)
+    }
+
+    pub(crate) fn advance_enrollment(
+        &mut self,
+        loaded_party: u32,
+        has_loading_player: bool,
+        delta: Duration,
+        reconnect_grace: Duration,
+    ) -> EnrollmentEffect {
+        self.enrollment
+            .advance(loaded_party, has_loading_player, delta, reconnect_grace)
+    }
+
+    pub(crate) fn enrollment_ready(&self, has_loading_player: bool) -> bool {
+        self.enrollment.ready_for_outcome(has_loading_player)
+    }
+
+    pub(crate) fn expected_party_members(&self) -> NonZeroU32 {
+        self.enrollment.expected()
+    }
+
+    pub(crate) fn terminal_is_running(&self) -> bool {
+        self.terminal.is_running()
+    }
+
+    pub(crate) fn begin_terminal_submission(
+        &mut self,
+        frozen: FrozenTerminal,
+        now: Duration,
+        ack_timeout: Duration,
+    ) -> Option<FrozenTerminal> {
+        self.terminal.begin(frozen, now, ack_timeout)
+    }
+
+    pub(crate) fn terminal_retry_due(
+        &mut self,
+        now: Duration,
+        ack_timeout: Duration,
+    ) -> Option<FrozenTerminal> {
+        self.terminal.retry_due(now, ack_timeout)
+    }
+
+    pub(crate) fn terminal_enqueue_failed(&mut self, now: Duration, retry_backoff: Duration) {
+        self.terminal.enqueue_failed(now, retry_backoff);
+    }
+
+    pub(crate) fn apply_terminal_submission_result(
+        &mut self,
+        result: crate::stdb::TerminalSubmissionResult,
+        now: Duration,
+        retry_backoff: Duration,
+        presentation_delay: Duration,
+    ) -> Option<adventuresim_tactical_netcode::message::TacticalOutcome> {
+        self.terminal
+            .apply_submission_result(result, now, retry_backoff, presentation_delay)
+    }
+
+    pub(crate) fn fail_if_terminal_ack_stalled(&mut self, now: Duration) -> bool {
+        self.terminal.fail_if_ack_stalled(now)
+    }
+
+    pub(crate) fn advance_terminal_presentation(
+        &mut self,
+        delta: Duration,
+    ) -> Option<adventuresim_tactical_netcode::message::TacticalOutcome> {
+        self.terminal.advance_presentation(delta)
+    }
+
+    pub(crate) fn tick_timeout(&mut self, delta: Duration) -> bool {
+        let Some(timeout) = &mut self.timeout else {
+            return false;
+        };
+        timeout.tick(delta);
+        timeout.is_finished()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct TerminalCombatSnapshot {
+    pub required_enemies: u32,
+    pub loaded_enemies: u32,
+    pub defeated_enemies: u32,
+    pub loaded_party: u32,
+    pub incapacitated_party: u32,
+    pub enrollment_sealed: bool,
+}
+
+pub(crate) fn terminal_resolution(
+    snapshot: TerminalCombatSnapshot,
+) -> Option<adventuresim_stdb_client::TacticalMissionResolution> {
+    use adventuresim_stdb_client::TacticalMissionResolution;
+
+    if snapshot.required_enemies == 0
+        || snapshot.loaded_enemies < snapshot.required_enemies
+        || !snapshot.enrollment_sealed
+        || snapshot.loaded_party == 0
+    {
+        return None;
+    }
+    let enemies_defeated = snapshot.defeated_enemies >= snapshot.required_enemies;
+    let party_defeated = snapshot.incapacitated_party >= snapshot.loaded_party;
+    match (enemies_defeated, party_defeated) {
+        (_, true) => Some(TacticalMissionResolution::Failed),
+        (true, false) => Some(TacticalMissionResolution::Defeated),
+        (false, false) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use adventuresim_stdb_client::TacticalMissionResolution;
+
+    use super::*;
+
+    fn snapshot() -> TerminalCombatSnapshot {
+        TerminalCombatSnapshot {
+            required_enemies: 2,
+            loaded_enemies: 2,
+            defeated_enemies: 0,
+            loaded_party: 2,
+            incapacitated_party: 0,
+            enrollment_sealed: true,
+        }
+    }
+
+    #[test]
+    fn terminal_resolution_waits_for_complete_enrollment_and_enemy_projection() {
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                loaded_enemies: 1,
+                ..snapshot()
+            }),
+            None
+        );
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                enrollment_sealed: false,
+                ..snapshot()
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn simultaneous_defeat_deterministically_fails() {
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                defeated_enemies: 2,
+                incapacitated_party: 2,
+                ..snapshot()
+            }),
+            Some(TacticalMissionResolution::Failed)
+        );
+    }
+
+    #[test]
+    fn victory_requires_enemy_defeat_with_an_active_party_member() {
+        assert_eq!(
+            terminal_resolution(TerminalCombatSnapshot {
+                defeated_enemies: 2,
+                ..snapshot()
+            }),
+            Some(TacticalMissionResolution::Defeated)
+        );
+    }
+}

--- a/crates/adventuresim-tactical-server/src/mission/receipt.rs
+++ b/crates/adventuresim-tactical-server/src/mission/receipt.rs
@@ -1,0 +1,102 @@
+use adventuresim_stdb_client::{
+    TacticalCharacterConsequence, TacticalConsequenceReceipt, TacticalEquipmentContact,
+    TacticalEquipmentContactRole, TacticalHitInjury, TacticalReceiptBodyPart,
+};
+use adventuresim_tactical_core::prelude::BodyPart;
+
+use crate::combat::TacticalConsequenceAccumulator;
+
+fn receipt_body_part(body_part: BodyPart) -> TacticalReceiptBodyPart {
+    match body_part {
+        BodyPart::LeftArm => TacticalReceiptBodyPart::LeftArm,
+        BodyPart::RightArm => TacticalReceiptBodyPart::RightArm,
+        BodyPart::LeftLeg => TacticalReceiptBodyPart::LeftLeg,
+        BodyPart::RightLeg => TacticalReceiptBodyPart::RightLeg,
+        BodyPart::Chest => TacticalReceiptBodyPart::Chest,
+        BodyPart::Stomach => TacticalReceiptBodyPart::Stomach,
+        BodyPart::Head => TacticalReceiptBodyPart::Head,
+    }
+}
+
+pub(super) fn tactical_consequence_receipt(
+    accumulated: &TacticalConsequenceAccumulator,
+) -> TacticalConsequenceReceipt {
+    let mut party: Vec<_> = accumulated
+        .party
+        .iter()
+        .map(|(character_id, consequence)| TacticalCharacterConsequence {
+            character_id: character_id.0,
+            injuries: consequence
+                .injuries
+                .iter()
+                .map(|injury| TacticalHitInjury {
+                    body_part: receipt_body_part(injury.body_part),
+                    cut_damage: injury.cut_damage,
+                    blunt_damage: injury.blunt_damage,
+                    max_single_hit_blunt_damage: injury.max_single_hit_blunt_damage,
+                })
+                .collect(),
+            blood_loss_fraction: consequence.blood_loss_fraction,
+            ammunition_used: consequence.ammunition_used,
+        })
+        .collect();
+    for contact in &accumulated.equipment_contacts {
+        if !party
+            .iter()
+            .any(|consequence| consequence.character_id == contact.character_id.0)
+        {
+            party.push(TacticalCharacterConsequence {
+                character_id: contact.character_id.0,
+                injuries: Vec::new(),
+                blood_loss_fraction: 0.0,
+                ammunition_used: 0,
+            });
+        }
+    }
+    party.sort_by_key(|consequence| consequence.character_id);
+    party.truncate(adventuresim_core::mission::MAX_TACTICAL_RECEIPT_PARTICIPANTS);
+    TacticalConsequenceReceipt {
+        party,
+        equipment_contacts: accumulated
+            .equipment_contacts
+            .iter()
+            .map(|contact| TacticalEquipmentContact {
+                character_id: contact.character_id.0,
+                inventory_item_id: contact.inventory_item_id,
+                contact_stress: contact.contact_stress,
+                role: if contact.defender_equipment {
+                    TacticalEquipmentContactRole::DefenderEquipment
+                } else {
+                    TacticalEquipmentContactRole::AttackerWeapon
+                },
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use adventuresim_tactical_core::prelude::CharacterId;
+
+    use super::*;
+    use crate::combat::AccumulatedEquipmentContact;
+
+    #[test]
+    fn weapon_contact_owner_is_included_without_an_injury() {
+        let mut accumulated = TacticalConsequenceAccumulator::default();
+        accumulated
+            .equipment_contacts
+            .push(AccumulatedEquipmentContact {
+                character_id: CharacterId(7),
+                inventory_item_id: 99,
+                contact_stress: 12.0,
+                defender_equipment: false,
+            });
+
+        let receipt = tactical_consequence_receipt(&accumulated);
+        assert_eq!(receipt.party.len(), 1);
+        assert_eq!(receipt.party[0].character_id, 7);
+        assert!(receipt.party[0].injuries.is_empty());
+        assert_eq!(receipt.equipment_contacts.len(), 1);
+    }
+}

--- a/crates/adventuresim-tactical-server/src/mission/systems.rs
+++ b/crates/adventuresim-tactical-server/src/mission/systems.rs
@@ -1,0 +1,217 @@
+use std::{num::NonZeroU8, time::Duration};
+
+use adventuresim_stdb_client::TacticalMissionResolution;
+use adventuresim_tactical_core::prelude::{CharacterId, Player, TacticalCombatState};
+use adventuresim_tactical_netcode::{
+    bevy_replicon::prelude::{SendMode, ServerTriggerExt, ToClients},
+    message::TacticalOutcomeResponse,
+};
+use bevy::prelude::*;
+
+use super::{
+    AdmissionResult, EnrollmentEffect, FrozenTerminal, MissionState, TerminalCombatSnapshot,
+    terminal_resolution,
+};
+use crate::{
+    bot::MissionEnemy,
+    combat::{TacticalCombatSide, TacticalConsequenceAccumulator},
+    player_projection::LoadingPlayer,
+    stdb::{SpacetimeDb, TerminalSubmissionResult},
+};
+
+const TERMINAL_RETRY_BACKOFF: Duration = Duration::from_secs(1);
+const TERMINAL_PRESENTATION_DELAY: Duration = Duration::from_secs(3);
+const TERMINAL_ACK_TIMEOUT: Duration = Duration::from_secs(10);
+const PARTY_RECONNECT_GRACE: Duration = Duration::from_secs(10);
+
+fn commit_terminal_resolution(
+    resolution: TacticalMissionResolution,
+    now: Duration,
+    conn: Res<SpacetimeDb>,
+    consequences: Res<TacticalConsequenceAccumulator>,
+    mut state: ResMut<MissionState>,
+) -> Result {
+    let frozen = FrozenTerminal {
+        resolution,
+        receipt: super::receipt::tactical_consequence_receipt(&consequences),
+    };
+    let Some(frozen) = state.begin_terminal_submission(frozen, now, TERMINAL_ACK_TIMEOUT) else {
+        return Ok(());
+    };
+    submit_frozen_terminal(frozen, now, conn, state)
+}
+
+fn submit_frozen_terminal(
+    frozen: FrozenTerminal,
+    now: Duration,
+    conn: Res<SpacetimeDb>,
+    mut state: ResMut<MissionState>,
+) -> Result {
+    if let Err(error) = conn.submit_terminal(frozen.resolution, frozen.receipt) {
+        state.terminal_enqueue_failed(now, TERMINAL_RETRY_BACKOFF);
+        warn!(
+            "Terminal result enqueue failed; retrying in {}s: {error}",
+            TERMINAL_RETRY_BACKOFF.as_secs()
+        );
+    } else {
+        info!(resolution = ?frozen.resolution, "Terminal result queued; awaiting reducer acceptance");
+    }
+    Ok(())
+}
+
+pub(crate) fn process_terminal_submission_results(
+    time: Res<Time>,
+    conn: Res<SpacetimeDb>,
+    mut state: ResMut<MissionState>,
+    mut cmd: Commands,
+) {
+    for result in conn.take_terminal_results() {
+        let rejection = match &result {
+            TerminalSubmissionResult::Rejected(error) => Some(error.clone()),
+            TerminalSubmissionResult::Accepted => None,
+        };
+        if let Some(outcome) = state.apply_terminal_submission_result(
+            result,
+            time.elapsed(),
+            TERMINAL_RETRY_BACKOFF,
+            TERMINAL_PRESENTATION_DELAY,
+        ) {
+            cmd.server_trigger(ToClients {
+                mode: SendMode::CLIENTS_ONLY,
+                message: TacticalOutcomeResponse { outcome },
+            });
+            info!(
+                ?outcome,
+                "Mission terminal result accepted; presenting outcome"
+            );
+        } else if let Some(error) = rejection {
+            warn!(
+                "Terminal reducer rejected submission; retrying in {}s: {error}",
+                TERMINAL_RETRY_BACKOFF.as_secs()
+            );
+        }
+    }
+}
+
+pub(crate) fn fail_stalled_terminal_submission(
+    time: Res<Time>,
+    mut state: ResMut<MissionState>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    if state.fail_if_terminal_ack_stalled(time.elapsed()) {
+        error!(
+            timeout_seconds = TERMINAL_ACK_TIMEOUT.as_secs(),
+            "Terminal reducer acknowledgement timed out; exiting without presenting an outcome"
+        );
+        exit.write(AppExit::Error(NonZeroU8::new(1).expect("one is non-zero")));
+    }
+}
+
+pub(crate) fn finish_terminal_presentation(
+    time: Res<Time>,
+    mut state: ResMut<MissionState>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    if let Some(outcome) = state.advance_terminal_presentation(time.delta()) {
+        info!(?outcome, "Terminal presentation complete; shutting down");
+        exit.write(AppExit::Success);
+    }
+}
+
+pub(crate) fn check_terminal_combat_outcome(
+    mut commands: Commands,
+    time: Res<Time>,
+    conn: Res<SpacetimeDb>,
+    consequences: Res<TacticalConsequenceAccumulator>,
+    mut state: ResMut<MissionState>,
+    enemies: Query<(), (With<MissionEnemy>, With<Player>)>,
+    combatants: Query<
+        (
+            Entity,
+            &TacticalCombatSide,
+            &TacticalCombatState,
+            &CharacterId,
+        ),
+        With<Player>,
+    >,
+    loading_players: Query<(), With<LoadingPlayer>>,
+) -> Result {
+    if let Some(frozen) = state.terminal_retry_due(time.elapsed(), TERMINAL_ACK_TIMEOUT) {
+        return submit_frozen_terminal(frozen, time.elapsed(), conn, state);
+    }
+    if !state.terminal_is_running() {
+        return Ok(());
+    }
+    let mut loaded_party = 0;
+    let mut incapacitated_party = 0;
+    for (entity, side, combat_state, player_id) in &combatants {
+        if *side == TacticalCombatSide::Party {
+            if state.observe_loaded_party_member(*player_id) == AdmissionResult::RejectedAfterSeal {
+                error!(
+                    character_id = player_id.0,
+                    "Rejecting unseen Party character projected after enrollment sealed"
+                );
+                commands.entity(entity).despawn();
+                continue;
+            }
+            loaded_party += 1;
+            incapacitated_party += u32::from(combat_state.is_incapacitated());
+        }
+    }
+    let has_loading_player = !loading_players.is_empty();
+    if has_loading_player {
+        state.begin_enrollment();
+    }
+    match state.advance_enrollment(
+        loaded_party,
+        has_loading_player,
+        time.delta(),
+        PARTY_RECONNECT_GRACE,
+    ) {
+        EnrollmentEffect::Sealed => info!(
+            expected = state.expected_party_members().get(),
+            "Party enrollment sealed"
+        ),
+        EnrollmentEffect::Abandoned => {
+            return commit_terminal_resolution(
+                TacticalMissionResolution::Failed,
+                time.elapsed(),
+                conn,
+                consequences,
+                state,
+            );
+        }
+        EnrollmentEffect::None => {}
+    }
+    let snapshot = TerminalCombatSnapshot {
+        required_enemies: state.required_enemy_defeats(),
+        loaded_enemies: enemies.iter().count() as u32,
+        defeated_enemies: state.enemies_defeated(),
+        loaded_party,
+        incapacitated_party,
+        enrollment_sealed: state.enrollment_ready(has_loading_player),
+    };
+    let Some(resolution) = terminal_resolution(snapshot) else {
+        return Ok(());
+    };
+    commit_terminal_resolution(resolution, time.elapsed(), conn, consequences, state)
+}
+
+pub(crate) fn check_mission_timeout(
+    time: Res<Time>,
+    conn: Res<SpacetimeDb>,
+    consequences: Res<TacticalConsequenceAccumulator>,
+    mut state: ResMut<MissionState>,
+) -> Result {
+    if !state.tick_timeout(time.delta()) || !state.terminal_is_running() {
+        return Ok(());
+    }
+    info!("Mission timeout, committing bounded failure fallback");
+    commit_terminal_resolution(
+        TacticalMissionResolution::Failed,
+        time.elapsed(),
+        conn,
+        consequences,
+        state,
+    )
+}

--- a/crates/adventuresim-tactical-server/src/mission/terminal.rs
+++ b/crates/adventuresim-tactical-server/src/mission/terminal.rs
@@ -1,0 +1,308 @@
+use std::time::Duration;
+
+use adventuresim_stdb_client::{TacticalConsequenceReceipt, TacticalMissionResolution};
+use adventuresim_tactical_netcode::message::TacticalOutcome;
+
+use crate::stdb::TerminalSubmissionResult;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct FrozenTerminal {
+    pub(crate) resolution: TacticalMissionResolution,
+    pub(crate) receipt: TacticalConsequenceReceipt,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum TerminalLifecycle {
+    Running,
+    RetryScheduled {
+        frozen: FrozenTerminal,
+        not_before: Duration,
+    },
+    Submitting {
+        frozen: FrozenTerminal,
+        ack_deadline: Duration,
+    },
+    TransportFailed,
+    Presenting {
+        outcome: TacticalOutcome,
+        remaining: Duration,
+    },
+    Finished {
+        outcome: TacticalOutcome,
+    },
+}
+
+impl Default for TerminalLifecycle {
+    fn default() -> Self {
+        Self::Running
+    }
+}
+
+impl TerminalLifecycle {
+    pub(crate) fn is_running(&self) -> bool {
+        matches!(self, Self::Running)
+    }
+
+    pub(crate) fn begin(
+        &mut self,
+        frozen: FrozenTerminal,
+        now: Duration,
+        ack_timeout: Duration,
+    ) -> Option<FrozenTerminal> {
+        if !self.is_running() {
+            return None;
+        }
+        let submission = frozen.clone();
+        *self = Self::Submitting {
+            frozen,
+            ack_deadline: now.saturating_add(ack_timeout),
+        };
+        Some(submission)
+    }
+
+    pub(crate) fn retry_due(
+        &mut self,
+        now: Duration,
+        ack_timeout: Duration,
+    ) -> Option<FrozenTerminal> {
+        let Self::RetryScheduled { frozen, not_before } = self else {
+            return None;
+        };
+        if now < *not_before {
+            return None;
+        }
+        let frozen = frozen.clone();
+        let submission = frozen.clone();
+        *self = Self::Submitting {
+            frozen,
+            ack_deadline: now.saturating_add(ack_timeout),
+        };
+        Some(submission)
+    }
+
+    pub(crate) fn enqueue_failed(&mut self, now: Duration, retry_backoff: Duration) {
+        let Self::Submitting { frozen, .. } = self else {
+            return;
+        };
+        let frozen = frozen.clone();
+        *self = Self::RetryScheduled {
+            frozen,
+            not_before: now.saturating_add(retry_backoff),
+        };
+    }
+
+    pub(crate) fn apply_submission_result(
+        &mut self,
+        result: TerminalSubmissionResult,
+        now: Duration,
+        retry_backoff: Duration,
+        presentation_delay: Duration,
+    ) -> Option<TacticalOutcome> {
+        let Self::Submitting { frozen, .. } = self else {
+            return None;
+        };
+        match result {
+            TerminalSubmissionResult::Accepted => {
+                let outcome = presentation_outcome(frozen.resolution);
+                *self = Self::Presenting {
+                    outcome,
+                    remaining: presentation_delay,
+                };
+                Some(outcome)
+            }
+            TerminalSubmissionResult::Rejected(_) => {
+                let frozen = frozen.clone();
+                *self = Self::RetryScheduled {
+                    frozen,
+                    not_before: now.saturating_add(retry_backoff),
+                };
+                None
+            }
+        }
+    }
+
+    pub(crate) fn fail_if_ack_stalled(&mut self, now: Duration) -> bool {
+        let stalled = matches!(
+            self,
+            Self::Submitting { ack_deadline, .. } if now >= *ack_deadline
+        );
+        if stalled {
+            *self = Self::TransportFailed;
+        }
+        stalled
+    }
+
+    pub(crate) fn advance_presentation(&mut self, delta: Duration) -> Option<TacticalOutcome> {
+        let Self::Presenting { outcome, remaining } = self else {
+            return None;
+        };
+        *remaining = remaining.saturating_sub(delta);
+        if !remaining.is_zero() {
+            return None;
+        }
+        let outcome = *outcome;
+        *self = Self::Finished { outcome };
+        Some(outcome)
+    }
+}
+
+/// Crate-visible terminal facade. The lifecycle variants remain private so
+/// presentation and commitment cannot be fabricated by another server module.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub(crate) struct TerminalState(TerminalLifecycle);
+
+impl TerminalState {
+    pub(crate) fn is_running(&self) -> bool {
+        self.0.is_running()
+    }
+
+    pub(crate) fn begin(
+        &mut self,
+        frozen: FrozenTerminal,
+        now: Duration,
+        ack_timeout: Duration,
+    ) -> Option<FrozenTerminal> {
+        self.0.begin(frozen, now, ack_timeout)
+    }
+
+    pub(crate) fn retry_due(
+        &mut self,
+        now: Duration,
+        ack_timeout: Duration,
+    ) -> Option<FrozenTerminal> {
+        self.0.retry_due(now, ack_timeout)
+    }
+
+    pub(crate) fn enqueue_failed(&mut self, now: Duration, retry_backoff: Duration) {
+        self.0.enqueue_failed(now, retry_backoff);
+    }
+
+    pub(crate) fn apply_submission_result(
+        &mut self,
+        result: TerminalSubmissionResult,
+        now: Duration,
+        retry_backoff: Duration,
+        presentation_delay: Duration,
+    ) -> Option<TacticalOutcome> {
+        self.0
+            .apply_submission_result(result, now, retry_backoff, presentation_delay)
+    }
+
+    pub(crate) fn fail_if_ack_stalled(&mut self, now: Duration) -> bool {
+        self.0.fail_if_ack_stalled(now)
+    }
+
+    pub(crate) fn advance_presentation(&mut self, delta: Duration) -> Option<TacticalOutcome> {
+        self.0.advance_presentation(delta)
+    }
+}
+
+pub(crate) fn presentation_outcome(resolution: TacticalMissionResolution) -> TacticalOutcome {
+    match resolution {
+        TacticalMissionResolution::Defeated
+        | TacticalMissionResolution::DrivenOff
+        | TacticalMissionResolution::Captured => TacticalOutcome::Victory,
+        TacticalMissionResolution::Failed | TacticalMissionResolution::CaptureTargetKilled => {
+            TacticalOutcome::Defeat
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACK: Duration = Duration::from_secs(10);
+    const RETRY: Duration = Duration::from_secs(1);
+    const PRESENT: Duration = Duration::from_secs(3);
+
+    fn frozen(resolution: TacticalMissionResolution) -> FrozenTerminal {
+        FrozenTerminal {
+            resolution,
+            receipt: TacticalConsequenceReceipt {
+                party: Vec::new(),
+                equipment_contacts: Vec::new(),
+            },
+        }
+    }
+
+    #[test]
+    fn rejection_retries_the_same_inseparable_frozen_payload() {
+        let original = frozen(TacticalMissionResolution::Defeated);
+        let mut state = TerminalLifecycle::Running;
+        assert_eq!(
+            state.begin(original.clone(), Duration::ZERO, ACK),
+            Some(original.clone())
+        );
+        state.apply_submission_result(
+            TerminalSubmissionResult::Rejected("no".into()),
+            Duration::ZERO,
+            RETRY,
+            PRESENT,
+        );
+        assert!(
+            state
+                .retry_due(RETRY - Duration::from_millis(1), ACK)
+                .is_none()
+        );
+        assert_eq!(state.retry_due(RETRY, ACK), Some(original));
+    }
+
+    #[test]
+    fn accepted_submission_is_the_only_path_to_one_presentation() {
+        let mut state = TerminalLifecycle::Running;
+        state.begin(
+            frozen(TacticalMissionResolution::Defeated),
+            Duration::ZERO,
+            ACK,
+        );
+        assert_eq!(
+            state.apply_submission_result(
+                TerminalSubmissionResult::Accepted,
+                Duration::ZERO,
+                RETRY,
+                PRESENT,
+            ),
+            Some(TacticalOutcome::Victory)
+        );
+        assert!(
+            state
+                .advance_presentation(PRESENT - Duration::from_millis(1))
+                .is_none()
+        );
+        assert_eq!(
+            state.advance_presentation(Duration::from_millis(1)),
+            Some(TacticalOutcome::Victory)
+        );
+        assert!(state.advance_presentation(PRESENT).is_none());
+    }
+
+    #[test]
+    fn synchronous_enqueue_failure_observes_the_retry_boundary() {
+        let original = frozen(TacticalMissionResolution::Failed);
+        let mut state = TerminalLifecycle::Running;
+        state.begin(original.clone(), Duration::ZERO, ACK);
+        state.enqueue_failed(Duration::ZERO, RETRY);
+
+        assert!(
+            state
+                .retry_due(RETRY - Duration::from_millis(1), ACK)
+                .is_none()
+        );
+        assert_eq!(state.retry_due(RETRY, ACK), Some(original));
+    }
+
+    #[test]
+    fn ambiguous_ack_fails_closed_without_presentation_or_retry() {
+        let mut state = TerminalLifecycle::Running;
+        state.begin(
+            frozen(TacticalMissionResolution::Failed),
+            Duration::ZERO,
+            ACK,
+        );
+        assert!(!state.fail_if_ack_stalled(ACK - Duration::from_millis(1)));
+        assert!(state.fail_if_ack_stalled(ACK));
+        assert!(matches!(state, TerminalLifecycle::TransportFailed));
+        assert!(state.retry_due(Duration::MAX, ACK).is_none());
+    }
+}

--- a/crates/adventuresim-tactical-server/src/player_projection.rs
+++ b/crates/adventuresim-tactical-server/src/player_projection.rs
@@ -1,0 +1,530 @@
+use std::num::NonZeroU32;
+
+use adventuresim_stdb_client::*;
+use adventuresim_tactical_core::{inventory::ItemProperties, prelude::*};
+use adventuresim_tactical_netcode::{
+    aeronet::io::connection::{DisconnectReason, Disconnected},
+    bevy_replicon::prelude::{FromClient, Replicated},
+    prelude::{JoinRequest, PlayerInputRequest},
+};
+use bevy::prelude::*;
+use bevy::time::Stopwatch;
+
+use crate::{
+    bot::{MissionEnemy, OffensiveCombatAi},
+    combat::{MeleeAttackAuthority, RangedAttackAuthority, TacticalCombatSide},
+    mission::MissionState,
+    stdb::{SpacetimeDb, SpacetimeDbReady},
+};
+use input::AccumulatedInput;
+
+/// Player projection completes before condition derivation, so a newly loaded
+/// strategically incapacitated character cannot act for one simulation tick
+/// with default tactical readiness.
+#[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum PlayerProjectionSet {
+    Spawn,
+}
+
+#[derive(Component, Debug, Clone, Copy)]
+pub(crate) struct LoadingPlayer {
+    pub(crate) requested_character: CharacterId,
+}
+
+/// Durable inventory provenance retained only on the authoritative server.
+#[derive(Component, Debug, Clone, Copy)]
+pub(crate) struct TacticalInventoryItemId(pub u64);
+
+/// Transient mission projection: durable Characters keep their strategic
+/// baseline while tactical combat receives mission difficulty/escalation.
+fn mission_enemy_scale(difficulty: i32, combat_scale_bps: u32, countermeasure_bps: u32) -> f32 {
+    let difficulty_scale = 1.0 + (difficulty.saturating_sub(1).max(0) as f32 * 0.05);
+    difficulty_scale * (combat_scale_bps as f32 / 10_000.0) * (countermeasure_bps as f32 / 10_000.0)
+}
+
+#[derive(Component)]
+#[allow(dead_code)]
+struct MissionOpeningAwareness {
+    party_has_surprise: bool,
+}
+
+fn tactical_covered_parts(parts: &[EquipmentBodyPart]) -> [bool; 7] {
+    let mut covered = [false; 7];
+    for part in parts {
+        let index = match part {
+            EquipmentBodyPart::LeftArm => 0,
+            EquipmentBodyPart::RightArm => 1,
+            EquipmentBodyPart::LeftLeg => 2,
+            EquipmentBodyPart::RightLeg => 3,
+            EquipmentBodyPart::Chest => 4,
+            EquipmentBodyPart::Stomach => 5,
+            EquipmentBodyPart::Head => 6,
+        };
+        covered[index] = true;
+    }
+    covered
+}
+
+pub(crate) fn spawn_connected_players(
+    conn: Res<SpacetimeDb>,
+    mut cmd: Commands,
+    q_loading: Query<(Entity, &LoadingPlayer)>,
+    q_scene: Query<&SceneTerrain>,
+) {
+    for player in conn.take_connected_players() {
+        spawn_connected_player(&player, &mut cmd, &q_loading, &q_scene);
+    }
+}
+
+fn spawn_connected_player(
+    player: &ConnectedPlayer,
+    cmd: &mut Commands,
+    q_loading: &Query<(Entity, &LoadingPlayer)>,
+    q_scene: &Query<&SceneTerrain>,
+) {
+    let entity = if player.mission_side == TacticalMissionSide::Enemy {
+        cmd.spawn((
+            MissionEnemy,
+            OffensiveCombatAi::default(),
+            TacticalCombatSide::Enemy,
+        ))
+        .id()
+    } else {
+        let Some((entity, _)) = q_loading
+            .iter()
+            .find(|(_, id)| id.requested_character.0 == player.character.id)
+        else {
+            warn!(
+                "Got new ConnectedPlayer from stdb, but there is no LoadingPlayer for it: {}#{}",
+                player.character.name, player.character.id
+            );
+            return;
+        };
+        entity
+    };
+
+    let mut skills = Skills {
+        polearm_hours: player.skills.polearm_hours,
+        axe_hours: player.skills.axe_hours,
+        bludgeon_hours: player.skills.bludgeon_hours,
+        sword_hours: player.skills.sword_hours,
+        knife_hours: player.skills.knife_hours,
+        dodge_hours: player.skills.dodge_hours,
+        block_hours: player.skills.block_hours,
+        bow_hours: player.skills.bow_hours,
+        crossbow_hours: player.skills.crossbow_hours,
+        firearm_hours: player.skills.firearm_hours,
+        throw_hours: player.skills.throw_hours,
+        will_hours: player.skills.will_hours,
+        insight_hours: player.skills.insight_hours,
+        charm_hours: player.skills.charm_hours,
+        command_hours: player.skills.command_hours,
+        deception_hours: player.skills.deception_hours,
+        physiology_hours: player.skills.physiology_hours,
+        religion_hours: {
+            let religion = &player.skills.religion_hours;
+            [
+                religion.roman_catholic,
+                religion.lutheran,
+                religion.reformed,
+                religion.anglican,
+                religion.eastern_orthodox,
+                religion.islamic,
+                religion.judaism,
+            ]
+            .into_iter()
+            .filter(|hours| hours.is_finite())
+            .map(|hours| hours.max(0.0))
+            .sum()
+        },
+        bestiary_beast_hours: player.skills.bestiary_hours.beast,
+        bestiary_undead_hours: player.skills.bestiary_hours.undead,
+        bestiary_human_hours: player.skills.bestiary_hours.human,
+        bestiary_werekin_hours: player.skills.bestiary_hours.werekin,
+        bestiary_elf_hours: player.skills.bestiary_hours.elf,
+        bestiary_dwarf_hours: player.skills.bestiary_hours.dwarf,
+        bestiary_fey_hours: player.skills.bestiary_hours.fey,
+        bestiary_spirit_hours: player.skills.bestiary_hours.spirit,
+        bestiary_greenskin_hours: player.skills.bestiary_hours.greenskin,
+        bestiary_insectoid_hours: player.skills.bestiary_hours.insectoid,
+        bestiary_draconid_hours: player.skills.bestiary_hours.draconid,
+        bestiary_construct_hours: player.skills.bestiary_hours.construct,
+        bestiary_wildmen_hours: player.skills.bestiary_hours.wildmen,
+        surgery_hours: player.skills.surgery_hours,
+        stealth_hours: player.skills.stealth_hours,
+        balance_hours: player.skills.balance_hours,
+        tailoring_hours: player.skills.tailoring_hours,
+        smithing_hours: player.skills.smithing_hours,
+    };
+    let mut limbs = Limbs {
+        body_weight_kg: player.body_weight_kg,
+        left_arm: player.limbs.left_arm_health,
+        right_arm: player.limbs.right_arm_health,
+        left_leg: player.limbs.left_leg_health,
+        right_leg: player.limbs.right_leg_health,
+        chest: player.limbs.chest_health,
+        stomach: player.limbs.stomach_health,
+        head: player.limbs.head_health,
+    };
+    let mut attributes = Attributes {
+        endurance: player.attrs.endurance,
+        immunity: player.attrs.immunity,
+        gut: player.attrs.gut,
+        intelligence: player.attrs.intelligence,
+        instinct: player.attrs.instinct,
+        eyesight: player.attrs.eyesight,
+        hearing: player.attrs.hearing,
+        left_arm_strength: player.attrs.left_arm_strength,
+        right_arm_strength: player.attrs.right_arm_strength,
+        left_leg_strength: player.attrs.left_leg_strength,
+        right_leg_strength: player.attrs.right_leg_strength,
+        left_arm_agility: player.attrs.left_arm_agility,
+        right_arm_agility: player.attrs.right_arm_agility,
+        left_leg_agility: player.attrs.left_leg_agility,
+        right_leg_agility: player.attrs.right_leg_agility,
+    };
+    if player.mission_side == TacticalMissionSide::Enemy {
+        let scale = mission_enemy_scale(
+            player.enemy_difficulty,
+            player.enemy_combat_scale_bps,
+            player.countermeasure_multiplier_bps,
+        );
+        for hours in [
+            &mut skills.polearm_hours,
+            &mut skills.axe_hours,
+            &mut skills.bludgeon_hours,
+            &mut skills.sword_hours,
+            &mut skills.knife_hours,
+            &mut skills.dodge_hours,
+            &mut skills.block_hours,
+            &mut skills.bow_hours,
+            &mut skills.crossbow_hours,
+            &mut skills.firearm_hours,
+            &mut skills.throw_hours,
+        ] {
+            *hours *= scale;
+        }
+        for attribute in [
+            &mut attributes.endurance,
+            &mut attributes.gut,
+            &mut attributes.instinct,
+            &mut attributes.eyesight,
+            &mut attributes.hearing,
+            &mut attributes.left_arm_strength,
+            &mut attributes.right_arm_strength,
+            &mut attributes.left_leg_strength,
+            &mut attributes.right_leg_strength,
+            &mut attributes.left_arm_agility,
+            &mut attributes.right_arm_agility,
+            &mut attributes.left_leg_agility,
+            &mut attributes.right_leg_agility,
+        ] {
+            *attribute *= scale;
+        }
+        for health in [
+            &mut limbs.left_arm,
+            &mut limbs.right_arm,
+            &mut limbs.left_leg,
+            &mut limbs.right_leg,
+            &mut limbs.chest,
+            &mut limbs.stomach,
+            &mut limbs.head,
+        ] {
+            *health *= scale;
+        }
+    }
+    let stats = Stats {
+        calories_used: player.stats.calories_used,
+        focus: player.stats.focus,
+    };
+
+    let player_collider = player_collider();
+    let spawn_position = Vec2::new(rand::random_range(-5.0..5.0), rand::random_range(-5.0..5.0));
+    let spawn_height = q_scene
+        .iter()
+        .next()
+        .and_then(|terrain| terrain.height_at(spawn_position))
+        .unwrap_or_default()
+        + player_spawn_offset(&player_collider);
+
+    let tag = if player.character.temporary {
+        "Bot"
+    } else {
+        "Player"
+    };
+    let name = format!("{tag}#{} {}", player.character.id, player.character.name);
+    let (starting_incapacitation, starting_blood_fraction) = derive_combat_starting_condition(
+        player.strategic_incapacitation,
+        player.strategic_pain,
+        player.strategic_blood_loss,
+        player.current_blood_ml,
+        player.maximum_blood_ml,
+    );
+
+    cmd.entity(entity).insert(MissionOpeningAwareness {
+        party_has_surprise: player.party_has_surprise,
+    });
+    cmd.entity(entity).remove::<LoadingPlayer>().insert((
+        Name::new(name),
+        Replicated,
+        Player {
+            name: player.character.name.clone(),
+        },
+        CharacterId(player.character.id),
+        BestiaryCategories::default(),
+        skills,
+        limbs,
+        attributes,
+        stats,
+        TacticalCombatState {
+            starting_incapacitation,
+            starting_blood_fraction,
+            ..default()
+        },
+        MeleeAttackAuthority::default(),
+        RangedAttackAuthority::default(),
+        if player.mission_side == TacticalMissionSide::Enemy {
+            TacticalCombatSide::Enemy
+        } else {
+            TacticalCombatSide::Party
+        },
+        Transform::from_xyz(spawn_position.x, spawn_height, spawn_position.y),
+        (
+            player_collider.clone(),
+            CollisionMargin(0.01),
+            CharacterController::default(),
+            CharacterLook::default(),
+        ),
+    ));
+
+    for item in &player.items {
+        let Some(quantity) = NonZeroU32::new(item.quantity) else {
+            warn!(
+                "Got item '{}' with zero quantity for Player#{}; skipped",
+                item.item.id, player.character.id
+            );
+            continue;
+        };
+        let mut item_cmd = cmd.spawn((
+            Replicated,
+            TacticalInventoryItemId(item.inventory_item_id),
+            ItemOf(entity),
+            ItemQuantity(quantity),
+            ItemProperties {
+                weight: item.item.weight,
+                id: item.item.id.clone(),
+            },
+        ));
+        item_cmd.insert(EquipmentTopology {
+            placement_id: item.selected_placement_id.clone(),
+            occupancies: item
+                .occupancies
+                .iter()
+                .map(|occupancy| EquipmentTopologyOccupancy {
+                    occupancy_id: occupancy.id.clone(),
+                    anchor_kind: format!("{:?}", occupancy.anchor_kind),
+                    location: occupancy.location.map(|location| format!("{location:?}")),
+                    parent_inventory_item_id: occupancy.parent_inventory_item_id,
+                    attachment_point_id: occupancy.attachment_point_id.clone(),
+                    channel: format!("{:?}", occupancy.channel),
+                    order: occupancy.order,
+                    requirement_index: occupancy.requirement_index,
+                    capacity_index: occupancy.capacity_index,
+                })
+                .collect(),
+        });
+        match item.item.kind {
+            ItemKind::Simple
+            | ItemKind::Container
+            | ItemKind::Currency
+            | ItemKind::Ingredient
+            | ItemKind::Medication
+            | ItemKind::Food => {}
+            ItemKind::Weapon => {
+                item_cmd.insert(WeaponItem {
+                    skill_weights: [
+                        item.item.weapon_skills.polearm,
+                        item.item.weapon_skills.axe,
+                        item.item.weapon_skills.bludgeon,
+                        item.item.weapon_skills.sword,
+                        item.item.weapon_skills.knife,
+                        item.item.weapon_skills.bow,
+                        item.item.weapon_skills.crossbow,
+                        item.item.weapon_skills.firearm,
+                        item.item.weapon_skills.throw_skill,
+                    ],
+                    accuracy: item.item.accuracy,
+                    penetration: item.item.penetration,
+                    reach: item.item.reach,
+                    balance: item.item.balance,
+                    precise: item.item.precise,
+                    melee: item.item.melee,
+                    ranged: item.item.ranged,
+                    blunt: item.item.blunt,
+                    slash: item.item.slash,
+                    pierce: item.item.pierce,
+                });
+            }
+            ItemKind::Armor | ItemKind::Clothing => {}
+            ItemKind::Shield => {
+                item_cmd.insert(ShieldItem {
+                    block: item.item.block,
+                });
+            }
+        }
+        if let Some(part) = item.protected_body_parts.first() {
+            let slot = match part {
+                EquipmentBodyPart::LeftArm => ArmorSlot::Arms(Some(ArmorSide::Left)),
+                EquipmentBodyPart::RightArm => ArmorSlot::Arms(Some(ArmorSide::Right)),
+                EquipmentBodyPart::LeftLeg => ArmorSlot::Legs(Some(ArmorSide::Left)),
+                EquipmentBodyPart::RightLeg => ArmorSlot::Legs(Some(ArmorSide::Right)),
+                EquipmentBodyPart::Head => ArmorSlot::Head,
+                EquipmentBodyPart::Chest => ArmorSlot::Chest,
+                EquipmentBodyPart::Stomach => ArmorSlot::Stomach,
+            };
+            item_cmd.insert(ArmorItem {
+                range_of_motion: item.item.range_of_motion,
+                coverage: item.item.coverage,
+                slot,
+                resistance: item.item.resistance,
+                padding: item.item.padding,
+                flexibility: item.item.flexibility,
+                covered_parts: tactical_covered_parts(&item.protected_body_parts),
+            });
+        }
+
+        if item.occupancies.iter().any(|occupancy| {
+            occupancy.channel == EquipmentChannel::Held
+                && occupancy.location == Some(EquipmentLocation::LeftHand)
+        }) {
+            item_cmd.insert(EquipSlot::HoldingLeft);
+        } else if item.occupancies.iter().any(|occupancy| {
+            occupancy.channel == EquipmentChannel::Held
+                && occupancy.location == Some(EquipmentLocation::RightHand)
+        }) {
+            item_cmd.insert(EquipSlot::HoldingRight);
+        }
+    }
+    info!(
+        temorary = player.character.temporary,
+        "Player {entity:?} is fully loaded"
+    );
+}
+
+pub(crate) fn on_join_request(
+    join: On<FromClient<JoinRequest>>,
+    mut commands: Commands,
+    mut state: ResMut<MissionState>,
+    loading_players: Query<(), With<LoadingPlayer>>,
+    players: Query<(), With<Player>>,
+    conn: Res<SpacetimeDb>,
+    ready: Res<SpacetimeDbReady>,
+) -> Result {
+    let Some(client) = join.client_id.entity() else {
+        return Ok(());
+    };
+    if loading_players.contains(client) || players.contains(client) {
+        return Ok(());
+    }
+    if !state.allows_party_join(join.character_id) {
+        warn!(
+            character_id = join.character_id.0,
+            "Rejected unseen Party join after enrollment sealed"
+        );
+        return Ok(());
+    }
+    conn.reducers()
+        .enter_mission(join.character_id.0, ready.identity())?;
+    state.begin_enrollment();
+    commands.entity(client).insert(LoadingPlayer {
+        requested_character: join.character_id,
+    });
+    info!(
+        "Character {} connected and entered mission, awaiting loading",
+        join.character_id.0
+    );
+    Ok(())
+}
+
+pub(crate) fn on_player_input(
+    input: On<FromClient<PlayerInputRequest>>,
+    mut players: Query<
+        (
+            &mut AccumulatedInput,
+            &mut CharacterLook,
+            &TacticalCombatState,
+        ),
+        With<Player>,
+    >,
+) {
+    let Some(entity) = input.client_id.entity() else {
+        return;
+    };
+    let Ok((mut accumulated_input, mut look, combat_state)) = players.get_mut(entity) else {
+        return;
+    };
+    if combat_state.is_incapacitated() {
+        accumulated_input.last_movement = None;
+        accumulated_input.jumped = None;
+        return;
+    }
+    look.yaw = input.look.x;
+    look.pitch = input.look.y.clamp(-1.5, 1.5);
+    accumulated_input.last_movement = input.movement.map(|m| m.clamp_length_max(1.0));
+    if input.jump {
+        accumulated_input.jumped = Some(Stopwatch::new());
+    }
+}
+
+pub(crate) fn on_client_disconnected(
+    disconnected: On<Disconnected>,
+    query: Query<(Option<&CharacterId>, Option<&LoadingPlayer>)>,
+    conn: Res<SpacetimeDb>,
+) -> Result {
+    let entity = disconnected.event_target();
+    let Ok((player_id, loading)) = query.get(entity) else {
+        return Ok(());
+    };
+    let Some(character_id) = player_id
+        .map(|id| id.0)
+        .or_else(|| loading.map(|id| id.requested_character.0))
+    else {
+        return Ok(());
+    };
+    conn.reducers().leave_mission(character_id)?;
+    match &disconnected.reason {
+        DisconnectReason::ByUser(reason) => {
+            info!("Character {character_id} disconnected by server request: {reason}")
+        }
+        DisconnectReason::ByPeer(reason) => {
+            info!("Character {character_id} disconnected by peer: {reason}")
+        }
+        DisconnectReason::ByError(error) => {
+            warn!("Character {character_id} disconnected due to error: {error:#}")
+        }
+    }
+    Ok(())
+}
+
+fn player_collider() -> Collider {
+    Collider::cylinder(0.4, 1.9)
+}
+
+fn player_spawn_offset(collider: &Collider) -> f32 {
+    -collider.aabb(default(), Rotation::default()).min.y
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mission_enemy_scale;
+
+    #[test]
+    fn same_durable_enemy_identity_projects_different_mission_strength() {
+        let baseline = mission_enemy_scale(1, 10_000, 10_000);
+        let escalated = mission_enemy_scale(4, 13_000, 10_000);
+        let countered = mission_enemy_scale(4, 13_000, 7_500);
+        assert_eq!(baseline, 1.0);
+        assert!(escalated > baseline);
+        assert!(countered < escalated);
+    }
+}

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -286,6 +286,11 @@ protocol. The tactical server validates melee allegiance, state, range, a fresh
 observed windup and cooldown, then authoritative physics line of sight before resolving an
 attack. Finite client-reported precision remains trusted because reconstructing
 animation and secondary physics is intentionally outside the headless server.
+The ordered wire messages are payload enums rather than phase-tagged field
+bags: starts cannot carry completion data, melee completions always name a
+target, and ranged completion distinguishes a miss from a targeted hit. Raw
+finite precision becomes `ReportedPrecision` without clamping or geometric
+reconstruction, and duration-backed authority types gate mutation.
 Accepted results mutate replicated limb health plus transient blood loss and
 imbalance. Shared autoresolve rules derive pain, blood-loss, and imbalance
 incapacitation and recover balance over time. Tactical enrollment projects
@@ -294,6 +299,9 @@ contributions; the same shared derivation as autoresolve excludes pain and blood
 from starting incapacitation before recomputing them live. Actors currently
 over the threshold stop moving, attacking, defending, and participating in
 offensive AI target selection; imbalance-only incapacitation can recover.
+The numeric incapacitation value is the sole stored readiness authority;
+active, staggered, and incapacitated status are mechanically derived from it
+rather than synchronized through a second boolean or ECS marker.
 
 These per-tick effects remain in memory only. A mission enemy's first transition
 into incapacitation counts as its defeat; recovery and later incapacitation do
@@ -315,6 +323,10 @@ Victory/Defeat presentation event, keeps the transport alive for a bounded
 three-second display window, and then exits. The delay is strictly post-commit:
 it cannot defer strategic authority or create a second outcome. A configured
 timeout remains a bounded `Failed` fallback.
+Enrollment and terminal progress are private lifecycle enums. A resolution and
+its bounded receipt form one frozen value whose retry time, acknowledgement
+deadline, transport failure, committed presentation, and finished state exist
+only in their applicable variants.
 
 The terminal call carries a bounded authenticated consequence receipt frozen
 with the resolution. It contains only Party character IDs, applied (clamped)

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -554,6 +554,11 @@ Each tactical server:
 4. Calls `end_tactical_server` with its terminal resolution
 5. Exits after strategic authority validates and commits the durable outcome
 
+Party enrollment and terminal submission are explicit lifecycle enums. The
+frozen resolution and bounded receipt stay together through bounded retry,
+acknowledgement, presentation, and shutdown; an ambiguous acknowledgement
+timeout fails closed without presenting an uncommitted result.
+
 ## Testing a Single Server
 
 For testing without the spawner:

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1772)
+## Files (1789)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1238,8 +1238,25 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-server-dispatcher/src/main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-server/Cargo.toml` — Cargo package/workspace manifest.
 - `crates/adventuresim-tactical-server/src/bot.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-server/src/bot/defense.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/bot/offense.rs` — Rust source module.
 - `crates/adventuresim-tactical-server/src/combat.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-server/src/combat/authority.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/combat/condition.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/combat/consequence.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/combat/ingress.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/combat/melee.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/combat/protocol.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/combat/ranged.rs` — Rust source module.
 - `crates/adventuresim-tactical-server/src/main.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-server/src/main.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-server/src/main.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-server/src/mission/enrollment.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/mission/mod.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/mission/receipt.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/mission/systems.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/mission/terminal.rs` — Rust source module.
+- `crates/adventuresim-tactical-server/src/player_projection.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-server/src/stdb.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-server/src/terrain.rs` — Rust source module for this component.
 - `crates/adventuresim-terrain/Cargo.toml` — Cargo package/workspace manifest.

--- a/wiki/tactical/combat.md
+++ b/wiki/tactical/combat.md
@@ -23,6 +23,12 @@ action protocol, so completion cannot overtake start on a separate event
 stream. An observed windup expires one second after it becomes ready, bounding
 delayed or replayed completions.
 
+The variants carry only valid data: `Start` has no completion sentinels, melee
+`Complete` always carries a target, body part, and reported precision, while
+ranged completion is either `CompleteMiss` or `CompleteHit`. Finite precision
+is converted to a trusted boundary type and timing to duration-backed authority
+types before combat mutation.
+
 ### Current offensive AI
 
 Each AI melee combatant has an explicit Party or Enemy allegiance and chooses
@@ -55,6 +61,9 @@ An actor over the threshold stops moving, attacking, defending, and being
 selected by offensive AI; an imbalance-only incapacitation can recover and
 return the actor to combat. Limb and live combat-state replication provide
 basic client feedback, but all of this remains transient server memory.
+Every consumer derives readiness from the one numeric incapacitation value;
+there is no parallel boolean or server marker for AI and authority to observe
+differently.
 
 An enemy's first transition into incapacitation counts as its defeat, even if
 temporary imbalance later lets it recover. The server immediately ends the


### PR DESCRIPTION
Closes #370.

Stacked on #367 / codex/tactical-combat-presentation.

## Summary

Refactors tactical combat so lifecycle, readiness, protocol, and authority invariants are encoded in types rather than synchronized field bags.

- derives readiness from one replicated incapacitation value and removes the parallel boolean/ECS marker
- models party enrollment and terminal submission as private typed lifecycles with inseparable frozen resolution/receipt data
- makes sealed enrollment admit known reconnects only
- replaces phase-plus-sentinel attack requests with ordered enum payloads
- validates finite client-reported precision without reconstructing or clamping the report server-side
- uses Duration-backed combat clocks and typed CharacterId boundaries
- seals validated and authorized attack capability construction so mutation requires feasibility checks plus windup/cooldown consumption
- routes tactical and autoresolve combat through the same PlayerInfo contract and removes duplicated bestiary precision-cap logic
- reuses canonical arrow identity
- decomposes the tactical server into player projection, mission lifecycle/receipt/systems, combat authority/ingress/melee/ranged/condition/consequence, and AI offense/defense modules

The transient tactical/durable strategic persistence boundary is unchanged. No SpacetimeDB schema or generated binding changes are required.

## Verification

- cargo test --offline -p adventuresim-tactical-server — 30 passed
- cargo test --offline -p adventuresim-core -p adventuresim-tactical-core -p adventuresim-tactical-netcode -p adventuresim-tactical-client — 520 core tests, 2 client tests, all doctests and crate builds passed
- just verify-db-client — bindings current
- just test-dev-stack — 53 passed
- cargo fmt --all -- --check
- python scripts/update_project_map.py --check
- git diff --check

Two independent correctness and security/maintainability reviews were completed. All medium findings were remediated, and targeted re-reviews found no remaining medium/high issues.

## Compatibility and demo

The tactical attack wire layout changes from phase-tagged structs to enum payloads. Tactical clients and servers must be rebuilt/restarted together; no prelaunch compatibility shim is included. This is an architecture-only change with no new user-visible demo surface.