### PR TITLE
Wire up tactical melee damage, bot death, and client fade-out

### DIFF
--- a/crates/adventuresim-core/src/autoresolve.rs
+++ b/crates/adventuresim-core/src/autoresolve.rs
@@ -5,7 +5,9 @@ use adventuresim_world_schema::{BestiaryCategory, BestiaryHours};
 
 const MAX_COMBAT_ROUNDS: usize = 256;
 const MAX_RANGED_ATTACKS_PER_PHASE: usize = 64;
-const BLOOD_LOSS_PER_HEALTH_DAMAGE: f32 = 0.5;
+/// Blood volume lost per point of applied 0-1 body-part health damage. Shared
+/// with tactical combat so both layers derive blood loss the same way.
+pub const BLOOD_LOSS_PER_HEALTH_DAMAGE: f32 = 0.5;
 const FORMATION_SPACING_METERS: f32 = 2.0;
 const COMBAT_ROUND_SECONDS: f32 = 1.0;
 const REFERENCE_MELEE_ATTACK_SECONDS: f32 = 1.0;

--- a/crates/adventuresim-tactical-client/assets/ui.css
+++ b/crates/adventuresim-tactical-client/assets/ui.css
@@ -123,11 +123,35 @@ text,span {
   &>#limbs>:nth-child(1) {
     color: var(--success);
   }
+  &>#incapacitation>:nth-child(1) {
+    color: rgb(240, 98, 146);
+  }
+  &>#incapacitation>#incap-meter {
+    width: 100%;
+    height: 14px;
+    background: #0006;
+    border-radius: 7px;
+  }
   &>#equipped-items>:nth-child(1) {
     color: rgb(200, 200, 50);
   }
   &>#inventory-items>:nth-child(1) {
     color: rgb(130, 130, 120);
+  }
+}
+
+#incap-meter {
+  &>.incap-pain {
+    height: 100%;
+    background: rgb(240, 98, 146);
+  }
+  &>.incap-blood {
+    height: 100%;
+    background: var(--error);
+  }
+  &>.incap-imbalance {
+    height: 100%;
+    background: #fffc;
   }
 }
 

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -49,6 +49,10 @@ const HITBOX_LAYER: LayerMask = LayerMask(1 << 1);
 const PRE_HIT_DELAY: f32 = 0.3;
 const HIT_PRECISION: f32 = 1.0;
 const HANDS_REACH: f32 = 1.5;
+/// Seconds a dead bot's detached visual takes to fade to transparent. Purely
+/// a client-side presentation detail: the server despawns the authoritative
+/// entity immediately on death and has no notion of this delay.
+const ENEMY_DEATH_FADE_SECONDS: f32 = 2.0;
 
 pub struct PlayerPlugin;
 
@@ -63,6 +67,8 @@ impl Plugin for PlayerPlugin {
                 (
                     update_character_look_rotation.run_if(any_with_component::<CharacterLook>),
                     update_attack_state_system.run_if(any_with_component::<AttackState>),
+                    start_fade_on_incapacitation,
+                    tick_fade_out.run_if(any_with_component::<FadingOut>),
                 ),
             );
     }
@@ -81,6 +87,18 @@ pub struct HitPerformed {
 
 #[derive(Component, Clone, Copy)]
 pub struct LimbHitbox(pub BodyPart);
+
+/// A standalone, client-only entity holding a dead player/bot's detached body
+/// meshes, fading them to transparent over [`ENEMY_DEATH_FADE_SECONDS`] before
+/// despawning itself. Spawned by [`start_fade_on_incapacitation`] the moment
+/// [`CombatState`] is seen to be `Incapacitated`, since by that point the
+/// server may despawn (and replication may remove) the real player entity at
+/// any time — this entity has no server counterpart and outlives it on
+/// purpose so the fade has something to animate.
+#[derive(Component)]
+struct FadingOut {
+    timer: Timer,
+}
 
 #[derive(Component, Default)]
 pub struct AttackState {
@@ -223,6 +241,81 @@ fn on_new_player_added_hook(
     }
 
     Ok(())
+}
+
+/// Detaches another player/bot's body meshes onto a standalone [`FadingOut`]
+/// corpse entity the first time their replicated [`CombatState`] is seen to
+/// be `Incapacitated`. The server despawns the real entity immediately on
+/// death with no fade delay of its own (see the tactical server's
+/// `bot::on_authoritative_enemy_death`), so the meshes have to be moved off
+/// of it before that despawn — which recursively despawns children — can take
+/// them with it. Excludes the locally controlled player, which never spawns
+/// any body meshes to fade (see [`on_new_player_added_hook`]).
+fn start_fade_on_incapacitation(
+    mut commands: Commands,
+    q: Query<(&CombatState, &Transform, &Children), (Changed<CombatState>, Without<ClientPlayer>)>,
+    q_mesh: Query<(), With<MeshMaterial3d<StandardMaterial>>>,
+) {
+    for (state, transform, children) in &q {
+        if state.status() != IncapacitationStatus::Incapacitated {
+            continue;
+        }
+
+        let meshes: Vec<Entity> = children
+            .iter()
+            .filter(|&child| q_mesh.contains(child))
+            .collect();
+        if meshes.is_empty() {
+            // Already detached by an earlier `CombatState` change (e.g. the
+            // continuing imbalance-recovery ticks), or nothing to fade.
+            continue;
+        }
+
+        let corpse = commands
+            .spawn((
+                *transform,
+                Visibility::default(),
+                FadingOut {
+                    timer: Timer::from_seconds(ENEMY_DEATH_FADE_SECONDS, TimerMode::Once),
+                },
+            ))
+            .id();
+        for mesh in meshes {
+            commands.entity(mesh).insert(ChildOf(corpse));
+        }
+    }
+}
+
+/// Fades a [`FadingOut`] corpse's detached meshes toward transparent and
+/// despawns the corpse once the timer finishes — nothing server-side ever
+/// removes it, since it has no networked counterpart. Each material handle is
+/// unique per body part per player (see [`on_new_player_added_hook`]), so
+/// mutating alpha here can't bleed into any other entity's appearance.
+fn tick_fade_out(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut q_fading: Query<(Entity, &mut FadingOut, &Children)>,
+    q_material: Query<&MeshMaterial3d<StandardMaterial>>,
+) {
+    for (corpse, mut fading, children) in &mut q_fading {
+        fading.timer.tick(time.delta());
+        let alpha = (1.0 - fading.timer.fraction()).clamp(0.0, 1.0);
+
+        for child in children.iter() {
+            let Ok(material_handle) = q_material.get(child) else {
+                continue;
+            };
+            if let Some(material) = materials.get_mut(&material_handle.0) {
+                material.alpha_mode = AlphaMode::Blend;
+                material.base_color = material.base_color.with_alpha(alpha);
+            }
+        }
+
+        if fading.timer.is_finished() {
+            commands.entity(corpse).despawn();
+        }
+    }
 }
 
 fn update_attack_state_system(

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -35,6 +35,7 @@ impl Plugin for UiPlugin {
                     update_connection_ui,
                     update_skills_ui.run_if(any_with_component::<ClientPlayer>),
                     update_limbs_ui.run_if(any_with_component::<ClientPlayer>),
+                    update_incapacitation_ui.run_if(any_with_component::<ClientPlayer>),
                     update_items_ui.run_if(any_with_component::<ClientPlayer>),
                     update_attack_timer_ui.run_if(any_with_component::<ClientPlayer>),
                 ),
@@ -83,6 +84,23 @@ struct StomachSpan;
 
 #[derive(Component)]
 struct HeadSpan;
+
+/// Which incapacitation factor a meter-bar fill node visualizes.
+#[derive(Clone, Copy)]
+enum IncapacitationFactor {
+    Pain,
+    BloodLoss,
+    Imbalance,
+}
+
+#[derive(Component)]
+struct IncapacitationBarFill(IncapacitationFactor);
+
+#[derive(Component)]
+struct IncapacitationTotalSpan;
+
+#[derive(Component)]
+struct IncapacitationStatusSpan;
 
 #[derive(Component)]
 struct AttackTimerSpan;
@@ -260,6 +278,48 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ]
                     ),
                     (
+                        Name::new("incapacitation"),
+                        Node::default(),
+                        children![
+                            Text::new("Incapacitation"),
+                            (
+                                Name::new("incap-meter"),
+                                Node::default(),
+                                children![
+                                    (
+                                        IncapacitationBarFill(IncapacitationFactor::Pain),
+                                        ClassList::new("incap-pain"),
+                                        Node::default()
+                                    ),
+                                    (
+                                        IncapacitationBarFill(IncapacitationFactor::BloodLoss),
+                                        ClassList::new("incap-blood"),
+                                        Node::default()
+                                    ),
+                                    (
+                                        IncapacitationBarFill(IncapacitationFactor::Imbalance),
+                                        ClassList::new("incap-imbalance"),
+                                        Node::default()
+                                    ),
+                                ]
+                            ),
+                            (
+                                Name::new("incap-total"),
+                                Text::new("Total: "),
+                                children![(IncapacitationTotalSpan, TextSpan::default())]
+                            ),
+                            (
+                                Name::new("incap-status"),
+                                Text::new("Status: "),
+                                children![(
+                                    IncapacitationStatusSpan,
+                                    ClassList::default(),
+                                    TextSpan::default()
+                                )]
+                            ),
+                        ]
+                    ),
+                    (
                         Name::new("equipped-items"),
                         Node::default(),
                         children![
@@ -410,6 +470,44 @@ fn update_limbs_ui(
     spans.p4().0 = format!("{:.0}%", limbs.right_arm * 100.0);
     spans.p5().0 = format!("{:.0}%", limbs.left_leg * 100.0);
     spans.p6().0 = format!("{:.0}%", limbs.right_leg * 100.0);
+}
+
+/// Mirrors the "wheel" incapacitation meter from `wiki/tactical/combat.md` as
+/// a segmented bar (pain/blood loss/imbalance) plus a total/status readout,
+/// since the current HUD has no radial-gauge rendering path.
+fn update_incapacitation_ui(
+    player: Single<(&CombatState, &PlayerId), (With<ClientPlayer>, Changed<CombatState>)>,
+    mut bars: Query<(&IncapacitationBarFill, &mut Node)>,
+    mut spans: ParamSet<(
+        Single<&mut TextSpan, With<IncapacitationTotalSpan>>,
+        Single<(&mut TextSpan, &mut ClassList), With<IncapacitationStatusSpan>>,
+    )>,
+) {
+    let (state, _player_id) = player.into_inner();
+
+    for (fill, mut node) in &mut bars {
+        let value = match fill.0 {
+            IncapacitationFactor::Pain => state.pain,
+            IncapacitationFactor::BloodLoss => state.blood_loss,
+            IncapacitationFactor::Imbalance => state.imbalance,
+        };
+        node.width = Val::Percent((value * 100.0).clamp(0.0, 100.0));
+    }
+
+    spans.p0().0 = format!("{:.0}%", state.incapacitation() * 100.0);
+
+    let (status_text, status_class) = match state.status() {
+        IncapacitationStatus::Ready => ("Ready", "success"),
+        IncapacitationStatus::Staggered => ("Staggered", "primary"),
+        IncapacitationStatus::Incapacitated => ("Incapacitated", "error"),
+    };
+    let mut status_span = spans.p1();
+    if status_span.0.0 != status_text {
+        status_span.0.0 = status_text.to_string();
+    }
+    if !status_span.1.contains(status_class) {
+        *status_span.1 = ClassList::new(status_class);
+    }
 }
 
 fn item_display_name(item: &ItemQueryItem) -> String {

--- a/crates/adventuresim-tactical-core/src/inventory.rs
+++ b/crates/adventuresim-tactical-core/src/inventory.rs
@@ -71,6 +71,9 @@ pub struct WeaponItem {
     pub reach: f32,
     pub balance: f32,
     pub precise: bool,
+    pub blunt: bool,
+    pub slash: bool,
+    pub pierce: bool,
 }
 
 #[derive(Component, Reflect, Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
@@ -302,6 +305,24 @@ impl PlayerEquipment for InventoryView<'_, '_, '_> {
             .and_then(|item| item.weapon)
             .map(|weapon| weapon.balance)
             .unwrap_or_default()
+    }
+
+    fn weapon_does_blunt(&self) -> bool {
+        self.equipped_weapon()
+            .and_then(|item| item.weapon)
+            .is_some_and(|weapon| weapon.blunt)
+    }
+
+    fn weapon_does_slash(&self) -> bool {
+        self.equipped_weapon()
+            .and_then(|item| item.weapon)
+            .is_some_and(|weapon| weapon.slash)
+    }
+
+    fn weapon_does_pierce(&self) -> bool {
+        self.equipped_weapon()
+            .and_then(|item| item.weapon)
+            .is_some_and(|weapon| weapon.pierce)
     }
 
     fn armor_range_of_motion(&self, part: BodyPart) -> f32 {

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -22,8 +22,8 @@ pub mod prelude {
         InventoryItems, ItemOf, ItemProperties, ItemQuantity, ShieldItem, WeaponItem,
     };
     pub use crate::player::{
-        Attributes, BestiaryCategories, ControlledPlayer, Limbs, Player, PlayerId, Skills, Stats,
-        TacticalPlayerView, TacticalPlayerViewer,
+        Attributes, BestiaryCategories, CombatState, ControlledPlayer, Limbs, Player, PlayerId,
+        Skills, Stats, TacticalPlayerView, TacticalPlayerViewer,
     };
     pub use crate::scene::{SceneId, SceneTerrain};
     pub use adventuresim_core::prelude::*;

--- a/crates/adventuresim-tactical-core/src/player.rs
+++ b/crates/adventuresim-tactical-core/src/player.rs
@@ -11,7 +11,7 @@ pub type ControlledPlayer = Actions<Player>;
 /// Component for a player entity, for both client-controlled
 /// active player and other players.
 #[derive(Component, Serialize, Deserialize, Default, Debug, Reflect, Clone, PartialEq, Eq)]
-#[require(PlayerId, Limbs, Skills, Attributes, Stats)]
+#[require(PlayerId, Limbs, Skills, Attributes, Stats, CombatState)]
 #[component(immutable)]
 pub struct Player {
     pub name: String,
@@ -129,6 +129,87 @@ impl PlayerBody for Limbs {
     fn primary_side(&self) -> BodySide {
         // TODO: this should be stored in DB ?
         BodySide::Right
+    }
+}
+
+impl Limbs {
+    /// Applies up to `damage` (0-1 scale) to `part`'s health, clamped to what
+    /// remains, and returns how much was actually applied. Mirrors
+    /// `CombatBody::apply_damage` in `adventuresim_core::autoresolve`.
+    pub fn apply_damage(&mut self, part: BodyPart, damage: f32) -> f32 {
+        let health = match part {
+            BodyPart::LeftArm => &mut self.left_arm,
+            BodyPart::RightArm => &mut self.right_arm,
+            BodyPart::LeftLeg => &mut self.left_leg,
+            BodyPart::RightLeg => &mut self.right_leg,
+            BodyPart::Chest => &mut self.chest,
+            BodyPart::Stomach => &mut self.stomach,
+            BodyPart::Head => &mut self.head,
+        };
+        let applied = damage.max(0.0).min(health.max(0.0));
+        *health = (*health - applied).max(0.0);
+        applied
+    }
+
+    /// Aggregate health deficit across all body parts, used as the `pain`
+    /// input in [`CombatState::recompute`].
+    pub fn total_damage(&self) -> f32 {
+        [
+            self.left_arm,
+            self.right_arm,
+            self.left_leg,
+            self.right_leg,
+            self.chest,
+            self.stomach,
+            self.head,
+        ]
+        .into_iter()
+        .map(|health| (1.0 - health).max(0.0))
+        .sum()
+    }
+}
+
+/// Short-lived tactical combat state: the imbalance and blood-loss inputs to
+/// [`combat.md`'s incapacitation model](../../../../wiki/tactical/combat.md),
+/// tracked in real time instead of the abstract per-round battle resolved by
+/// `adventuresim_core::autoresolve`. Unlike [`Limbs`] wounds, this state is
+/// tactical-only and is not meant to be persisted strategically (see
+/// `adventuresim_core::morale`).
+#[derive(Component, Serialize, Deserialize, Default, Debug, Reflect, Clone, Copy, PartialEq)]
+pub struct CombatState {
+    /// Momentary stagger from unabsorbed attack force. Recovers continuously
+    /// (see the tactical server's `recover_imbalance` system).
+    pub imbalance: f32,
+    /// Fraction of blood volume lost so far this session.
+    pub blood_loss_fraction: f32,
+    /// Cached `pain_incapacitation` output, refreshed whenever damage lands.
+    pub pain: f32,
+    /// Cached `blood_loss_incapacitation` output, refreshed whenever damage lands.
+    pub blood_loss: f32,
+}
+
+impl CombatState {
+    /// Refreshes the cached `pain`/`blood_loss` incapacitation terms from the
+    /// current aggregate body damage and a Will skill check.
+    pub fn recompute(&mut self, total_damage: f32, will_check: f32) {
+        self.pain = pain_incapacitation(total_damage, will_check);
+        let remaining_blood = (1.0 - self.blood_loss_fraction).clamp(0.0, 1.0);
+        self.blood_loss = blood_loss_incapacitation(remaining_blood, 1.0);
+    }
+
+    /// Total incapacitation, matching `Combatant::incapacitation` in
+    /// `adventuresim_core::autoresolve` (without a strategic carryover term,
+    /// since there is none at the tactical layer).
+    pub fn incapacitation(&self) -> f32 {
+        self.pain + self.blood_loss + self.imbalance
+    }
+
+    pub fn status(&self) -> IncapacitationStatus {
+        match self.incapacitation() {
+            total if total >= 1.0 => IncapacitationStatus::Incapacitated,
+            total if total > 0.5 => IncapacitationStatus::Staggered,
+            _ => IncapacitationStatus::Ready,
+        }
     }
 }
 

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -23,6 +23,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .replicate::<Player>()
             .replicate::<PlayerId>()
             .replicate::<Limbs>()
+            .replicate::<CombatState>()
             .replicate::<Skills>()
             .replicate::<Stats>()
             .replicate::<Attributes>()

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -8,9 +8,9 @@ use bevy::prelude::*;
 use crate::{MissionState, combat::PendingDefenderResponse};
 
 /// Chance that a bot notices an incoming attack in time to parry it.
-const PARRY_CHANCE: f64 = 0.2;
+const PARRY_CHANCE: f64 = 0.4;
 /// Chance that a bot notices an incoming attack in time to dodge it.
-const DODGE_CHANCE: f64 = 0.2;
+const DODGE_CHANCE: f64 = 0.4;
 /// Flanking values at or below this are considered "facing each other" (see
 /// [`flanking_from_dir`]), which is the only case a bot can react at all.
 const FRONTAL_FLANKING_MAX: f32 = 0.01;
@@ -19,6 +19,10 @@ const FRONTAL_FLANKING_MAX: f32 = 0.01;
 /// delay may end up committing its reaction only after the attack has
 /// already been resolved, i.e. reacting too late to matter.
 const REACTION_DELAY_SECS: std::ops::Range<f32> = 0.05..0.6;
+/// Real-time grace period between a bot dying and its ECS despawn. See
+/// [`PendingRemoval`] for why this exists; it has nothing to do with the
+/// client's (much longer, purely cosmetic) fade-out duration.
+const DESPAWN_REPLICATION_GRACE_SECONDS: f32 = 0.3;
 
 /// Marks a server-controlled bot filling in for a temporary (non-connected)
 /// mission character.
@@ -28,11 +32,31 @@ pub struct MissionEnemy;
 #[derive(Component)]
 pub struct CountedEnemyDeath;
 
-/// Emitted only by the server's authoritative combat/death pipeline. Combat
-/// damage is not implemented yet, so no client-controlled path can emit it and
-/// incomplete missions fail closed at timeout.
+/// Emitted by the tactical server's combat resolution when a combatant's
+/// `CombatState` crosses into `IncapacitationStatus::Incapacitated`. Only
+/// `MissionEnemy` entities are actually removed by its handler; incomplete
+/// missions still fail closed at timeout if nothing dies.
 #[derive(Event)]
 pub struct AuthoritativeEnemyDeath(pub Entity);
+
+/// Marks a dead bot for removal after [`DESPAWN_REPLICATION_GRACE_SECONDS`]
+/// of real time, rather than despawning it the instant it dies.
+///
+/// This has nothing to do with the client's cosmetic fade (that lives
+/// entirely in the tactical client's `player::start_fade_on_incapacitation`
+/// and is invisible to the server, and lasts far longer). It exists because
+/// bevy_replicon sends this bot's killing-blow `SuccessfulAttackResponse` and
+/// its eventual despawn as separate messages, and an event referencing an
+/// already-despawned entity fails to deserialize client-side ("unable to map
+/// entities ... from the server"). Rather than relying on exact same-frame
+/// scheduling order against bevy_replicon's internal tick/send machinery (an
+/// assumption two earlier attempts got wrong in practice), this just waits
+/// long enough in wall-clock time that several replication sends have
+/// unambiguously happened first, however that machinery is actually timed.
+#[derive(Component)]
+struct PendingRemoval {
+    timer: Timer,
+}
 
 /// A bot's yet-to-commit reaction to a noticed attack. Ticks down for
 /// [`REACTION_DELAY_SECS`] before becoming a [`PendingDefenderResponse`],
@@ -49,10 +73,14 @@ impl Plugin for BotPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(on_authoritative_enemy_death)
             .add_observer(on_attack_started)
-            .add_systems(Update, tick_bot_reactions);
+            .add_systems(Update, (tick_bot_reactions, despawn_pending_removals));
     }
 }
 
+/// Marks a dead bot [`PendingRemoval`] rather than despawning it inline (see
+/// that type's docs for why). This is still "the server deletes it" from a
+/// gameplay standpoint — no health/incapacitation state lingers, just a brief
+/// technical grace period before the ECS despawn.
 fn on_authoritative_enemy_death(
     death: On<AuthoritativeEnemyDeath>,
     enemies: Query<(), (With<MissionEnemy>, Without<CountedEnemyDeath>)>,
@@ -63,8 +91,27 @@ fn on_authoritative_enemy_death(
     if enemies.get(entity).is_err() {
         return;
     }
-    commands.entity(entity).insert(CountedEnemyDeath);
+    commands.entity(entity).insert((
+        CountedEnemyDeath,
+        PendingRemoval {
+            timer: Timer::from_seconds(DESPAWN_REPLICATION_GRACE_SECONDS, TimerMode::Once),
+        },
+    ));
     state.enemies_killed = state.enemies_killed.saturating_add(1);
+}
+
+/// Despawns bots marked [`PendingRemoval`] once their grace timer elapses.
+fn despawn_pending_removals(
+    mut commands: Commands,
+    time: Res<Time<()>>,
+    mut q: Query<(Entity, &mut PendingRemoval)>,
+) {
+    for (entity, mut pending) in &mut q {
+        pending.timer.tick(time.delta());
+        if pending.timer.is_finished() {
+            commands.entity(entity).despawn();
+        }
+    }
 }
 
 pub fn mission_objective_satisfied(required: u32, killed: u32) -> bool {

--- a/crates/adventuresim-tactical-server/src/combat.rs
+++ b/crates/adventuresim-tactical-server/src/combat.rs
@@ -6,6 +6,8 @@ use adventuresim_tactical_netcode::{
 };
 use bevy::prelude::*;
 
+use crate::bot::AuthoritativeEnemyDeath;
+
 /// Maximum window (in seconds) after pressing dodge/parry that the response
 /// is still considered valid. A fresh press gives `input_reflex = 1.0`;
 /// a press older than this window is treated as no response.
@@ -27,7 +29,89 @@ pub struct CombatPlugin;
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
         app.add_observer(on_attack_action_triggered)
-            .add_observer(on_defender_response);
+            .add_observer(on_defender_response)
+            .add_observer(on_apply_melee_damage)
+            .add_systems(Update, recover_imbalance);
+    }
+}
+
+/// Rate, per point of Balance skill check, that imbalance recovers per
+/// second. Mirrors `Combatant::recover_balance` in
+/// `adventuresim_core::autoresolve`, which drains `0.03 * balance` once per
+/// one-second main round; here it is a continuous per-second rate instead.
+const IMBALANCE_RECOVERY_PER_BALANCE_PER_SECOND: f32 = 0.03;
+
+/// Carries the already-resolved attack result and skill check needed to
+/// apply it, so [`on_apply_melee_damage`] can mutate [`Limbs`]/[`CombatState`]
+/// without re-borrowing the read-only [`TacticalPlayerViewer`] mutably in the
+/// same system (it internally holds a `Query<&Limbs, ..>`).
+#[derive(Event, Clone, Copy)]
+struct ApplyMeleeDamage {
+    /// The single entity this result affects: the attacker on a miss
+    /// (unbalance penalty), the defender on a hit.
+    entity: Entity,
+    result: AttackResult,
+    body_part: BodyPart,
+    will_check: f32,
+}
+
+/// Applies a resolved melee attack's damage/imbalance to the affected
+/// entity's [`Limbs`] and [`CombatState`], following the same math as
+/// `apply_attack_result` in `adventuresim_core::autoresolve`.
+fn on_apply_melee_damage(
+    event: On<ApplyMeleeDamage>,
+    mut q: Query<(&mut Limbs, &mut CombatState)>,
+    mut commands: Commands,
+) {
+    let Ok((mut limbs, mut state)) = q.get_mut(event.entity) else {
+        return;
+    };
+
+    match event.result {
+        AttackResult::ToAttacker { balance_damage, .. } => {
+            state.imbalance += balance_damage.max(0.0);
+        }
+        AttackResult::ToDefender { balance_damage, .. } => {
+            let damage = health_damage_from_attack(event.result, event.body_part);
+            let applied = limbs.apply_damage(event.body_part, damage);
+            state.imbalance += balance_damage.max(0.0);
+            state.blood_loss_fraction += applied * BLOOD_LOSS_PER_HEALTH_DAMAGE;
+        }
+    }
+
+    state.recompute(limbs.total_damage(), event.will_check);
+
+    // `AuthoritativeEnemyDeath`'s handler only acts on `MissionEnemy` entities
+    // (and only once, via its own `Without<CountedEnemyDeath>` guard), so it's
+    // harmless to trigger this for any entity that becomes incapacitated.
+    if state.status() == IncapacitationStatus::Incapacitated {
+        commands.trigger(AuthoritativeEnemyDeath(event.entity));
+    }
+}
+
+/// Continuously drains imbalance back toward zero, at a rate proportional to
+/// each player's Balance skill check.
+fn recover_imbalance(
+    viewer: TacticalPlayerViewer,
+    mut q_combat_state: Query<(Entity, &mut CombatState)>,
+    time: Res<Time<()>>,
+) {
+    let dt = time.delta_secs();
+    if dt <= 0.0 {
+        return;
+    }
+
+    for (entity, mut state) in &mut q_combat_state {
+        if state.imbalance <= 0.0 {
+            continue;
+        }
+        let Ok(view) = viewer.get(entity) else {
+            continue;
+        };
+        let balance = view.skill_check(Skill::Balance, LimbWeights::both_legs());
+        state.imbalance = (state.imbalance
+            - IMBALANCE_RECOVERY_PER_BALANCE_PER_SECOND * balance.max(0.25) * dt)
+            .max(0.0);
     }
 }
 
@@ -144,13 +228,16 @@ fn on_attack_action_triggered(
         event.body_part,
     );
 
-    // TODO: apply damage
-    match result {
+    let (apply_to, will_check) = match result {
         AttackResult::ToAttacker { balance_damage, .. } => {
             info!(
                 "{entity:?} failed to hit {:?} on {:?} and receiver {balance_damage:.1} balance damage",
                 event.target, event.body_part,
             );
+            (
+                entity,
+                attacker_view.skill_check(Skill::Will, LimbWeights::all_equal()),
+            )
         }
         AttackResult::ToDefender {
             cut_damage,
@@ -164,8 +251,18 @@ fn on_attack_action_triggered(
                 event.body_part,
                 cut_damage + blunt_damage
             );
+            (
+                event.target,
+                defender_view.skill_check(Skill::Will, LimbWeights::all_equal()),
+            )
         }
-    }
+    };
+    cmd.trigger(ApplyMeleeDamage {
+        entity: apply_to,
+        result,
+        body_part: event.body_part,
+        will_check,
+    });
 
     cmd.server_trigger(ToClients {
         mode: SendMode::CLIENTS_ONLY,

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -400,6 +400,9 @@ fn spawn_connected_player(
                     reach: item.item.reach,
                     balance: item.item.balance,
                     precise: item.item.precise,
+                    blunt: item.item.blunt,
+                    slash: item.item.slash,
+                    pierce: item.item.pierce,
                 });
             }
             ItemKind::Armor | ItemKind::Clothing => {}

--- a/justfile
+++ b/justfile
@@ -260,6 +260,13 @@ load-viabundus-world server=spacetime_url database=spacetime_module: spacetime-v
 build-tactical: verify-db-client
     @cargo build --package adventuresim-tactical-server --package adventuresim-tactical-server-dispatcher
 
+# Same build as build-tactical, without first re-verifying bindings freshness
+# (a CI-hygiene check against the schema, not something a mission needs at
+# runtime). Used only by tactical-isolated so repeated combat-testing restarts
+# don't pay for a redundant module build/introspection every time.
+_build-tactical-unverified:
+    @cargo build --package adventuresim-tactical-server --package adventuresim-tactical-server-dispatcher
+
 # Build the WASM client
 build-wasm: verify-db-client
     @{{ python_bin }} scripts/build_wasm.py
@@ -294,7 +301,7 @@ client id=env_var_or_default("TACTICAL_CHARACTER_ID", "0") port=env_var_or_defau
 # No strategic layer, no WASM build - just the DB plus a mission. Writes
 # .env.tactical so a bare `just tactical` / `just client` (no arguments) in
 # other terminals targets it automatically.
-tactical-isolated profile="tactical-dev" base_port="23200" mission_id="mission:test-mission" scene_key="hills" character_id="0" bots="3": preflight verify-db-client build-tactical
+tactical-isolated profile="tactical-dev" base_port="23200" mission_id="mission:test-mission" scene_key="hills" character_id="0" bots="3": preflight _build-tactical-unverified
     @{{ python_bin }} scripts/dev_stack.py run-profile --mode tactical {{ quote(profile) }} {{ quote(base_port) }} --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --character-id {{ quote(character_id) }} --enemy-count {{ quote(bots) }}
 
 # Generate self-signed WebTransport certificates


### PR DESCRIPTION
## Summary
- Apply melee damage in real-time tactical combat (previously only logged), via a new `CombatState` component mirroring autoresolve's imbalance/blood-loss/pain incapacitation model, replicated to clients with a new HUD panel
- Fix tactical `WeaponItem` missing `blunt`/`slash`/`pierce` flags — the actual reason attacks did zero damage regardless of weapon
- Despawn bots on death (after a short grace period, to avoid racing the killing blow's own network event against bevy_replicon's entity mapping)
- Purely client-side fade-out on bot death, fully decoupled from server despawn timing
- Bump bot dodge/parry reaction chance from 20%/20% to 40%/40%
- Speed up `just tactical-isolated` by skipping the redundant bindings-freshness check