### PR TITLE
Add procedural tactical animation pass

### DIFF
--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -1,14 +1,78 @@
-# Adventure Simulator Tactical Client
+# Adventure Simulator tactical client
 
-The authored humanoid scene is loaded from
-`assets/animations/biped/unarmed/base.glb` for both the client-controlled
-character and replicated remote characters. Keep the skinned character mesh in
-the default scene when exporting the base rig; only authoring helpers such as
-the placeholder weapon cylinder are stripped by `scripts/prepare_rig_base.py`.
+The tactical client renders transient server-authoritative combat state with
+Bevy. Skeletal animation is presentation-only: the server replicates compact
+`SkeletonState` posture, locomotion, stance, action, and timing coordinates;
+the client selects and blends authored poses, then applies procedural look and
+terrain leg IK.
 
-Each motion is exported as a separate GLB with the same skeleton, hierarchy,
-bone names, bind pose, and neutral root transform as the base rig. Until the
-base scene is available, every character receives a generated T-pose fallback.
-Missing motion files are resolved through the semantic fallback chain and
-ultimately display the authored bind pose (or the generated T-pose if the base
-scene itself is unavailable).
+## Animation export contract
+
+The humanoid base rig is independent from authored motions:
+
+```text
+assets/animations/biped/unarmed/base.glb
+assets/animations/biped/unarmed/walk.glb
+assets/animations/biped/unarmed/attack_thrust_lead_left_stay.glb
+```
+
+Only `base.glb` supplies a spawnable scene. Its default scene must retain the
+skinned character mesh; `prepare_rig_base.py` strips only authoring helpers such
+as the placeholder weapon cylinder. The client attaches this authored scene to
+both the client-controlled character and replicated remote characters. Each
+other file contains exactly one coherent motion, named or unnamed, and never
+has its scene attached. The
+30fps `AnimationPackCatalog` explicitly owns every semantic pose through a
+file/frame anchor and includes unnamed endpoint/closure frames. Source motion
+files belong under `assets_src/biped/unarmed/`; `assets_src/base.*` remains the
+rig-source special case until `assets_src/biped/unarmed/base.casc` has a matching
+base GLB export.
+
+Prepare and verify runtime files without changing source exports:
+
+```powershell
+python scripts/prepare_rig_base.py assets_src/base.glb assets/animations/biped/unarmed/base.glb
+python scripts/prepare_animation_motion.py assets_src/biped/unarmed/walk.glb assets/animations/biped/unarmed/base.glb assets/animations/biped/unarmed/walk.glb --last-frame 32
+python scripts/prepare_animation_motion.py assets_src/biped/unarmed/walk.glb assets/animations/biped/unarmed/base.glb assets/animations/biped/unarmed/walk.glb --last-frame 32 --check
+```
+
+Motion preparation validates the one-animation, duration, and canonical
+bone-path contracts, then copies the GLB byte-for-byte. Scenes and meshes in a
+motion export are harmless because the client loads only its animation asset.
+
+Use these conventions:
+
+- glTF coordinates and meters: +Y up, -Z forward, +X anatomical left;
+- the scene root stays at the origin and gameplay movement is not baked into it;
+- the armature bind pose is a T-pose, which is the final runtime fallback;
+- each motion GLB contains exactly one animation and preserves all authored
+  in-betweens between its documented frame anchors;
+- all locomotion cycles use the documented normalized phase convention; and
+- packs in one fallback chain use identical bone names and hierarchy.
+
+The procedural humanoid pass recognizes these case-sensitive bone names:
+
+```text
+root                 pelvis               stomach_01 / stomach_02
+chest                neck_01 / neck_02    head
+clavicle.L / .R      upper_arm.L / .R     upper_arm_twist.L / .R
+forearm.L / .R       forearm_twist.L / .R hand.L / .R
+weapon.L / .R        thigh.L / .R         thigh_twist.L / .R
+shin.L / .R          shin_twist.L / .R    foot.L / .R, toe.L / .R
+```
+
+Finger and breast bones remain under authored FK. Twist, toe, and weapon socket
+bones are canonical parts of the base hierarchy and are available to later
+procedural constraints.
+
+## Missing assets
+
+Pack lookup first follows the pack's single fallback chain. If the requested
+semantic pose is still absent, lookup follows the deterministic similar-pose
+chain (for example run to walk and thrust to slash), restarting pack lookup for
+each candidate. Missing, unloaded, zero-animation, multiple-animation, or short
+motion files affect only that motion. Every local or remote character also gets
+a generated T-pose safety net until the base scene is available. If no pose
+candidate resolves, the client uses the authored bind pose, or that generated
+T-pose when the base scene itself is unavailable; incomplete in-progress art
+does not panic.

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -6,12 +6,14 @@ use std::{
 use adventuresim_tactical_core::prelude::*;
 use bevy::{
     animation::{AnimatedBy, AnimationTargetId},
+    app::AnimationSystems,
     asset::LoadState,
     ecs::hierarchy::ChildSpawnerCommands,
     gltf::Gltf,
     prelude::*,
 };
 
+mod procedural;
 const HUMANOID_UNARMED_PACK: &str = "humanoid_unarmed";
 const BIPED_BASE_GLB: &str = "animations/biped/unarmed/base.glb";
 const ANIMATION_FPS: f32 = 30.0;
@@ -30,12 +32,23 @@ impl Plugin for TacticalAnimationPlugin {
                     attach_loaded_rig_scenes,
                     establish_animation_targets,
                     identify_animation_players,
+                    procedural::bind_humanoid_bones,
                     evaluate_skeletons,
                     sync_animation_graphs,
                     drive_fk_players,
                     update_rig_visibility,
                 )
                     .chain(),
+            )
+            .add_systems(
+                PostUpdate,
+                (
+                    procedural::apply_head_and_torso_look,
+                    procedural::apply_terrain_leg_ik,
+                )
+                    .chain()
+                    .after(AnimationSystems)
+                    .before(TransformSystems::Propagate),
             );
     }
 }
@@ -356,7 +369,7 @@ struct WeightedClip {
 pub struct FallbackAnimationRig(pub Entity);
 
 #[derive(Component)]
-struct AnimationRigScene(pub Entity);
+pub(super) struct AnimationRigScene(pub Entity);
 
 #[derive(Component)]
 struct AnimationRigAttached;

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -1,0 +1,345 @@
+use std::collections::BTreeMap;
+
+use adventuresim_tactical_core::prelude::*;
+use bevy::prelude::*;
+
+use super::AnimationRigScene;
+
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct HumanoidBone {
+    owner: Entity,
+    role: BoneRole,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum BoneRole {
+    Root,
+    Pelvis,
+    StomachOne,
+    StomachTwo,
+    Chest,
+    NeckOne,
+    NeckTwo,
+    Head,
+    ClavicleLeft,
+    ClavicleRight,
+    ThighLeft,
+    ThighTwistLeft,
+    ShinLeft,
+    ShinTwistLeft,
+    FootLeft,
+    ToeLeft,
+    ThighRight,
+    ThighTwistRight,
+    ShinRight,
+    ShinTwistRight,
+    FootRight,
+    ToeRight,
+    UpperArmLeft,
+    UpperArmTwistLeft,
+    ForearmLeft,
+    ForearmTwistLeft,
+    HandLeft,
+    WeaponLeft,
+    UpperArmRight,
+    UpperArmTwistRight,
+    ForearmRight,
+    ForearmTwistRight,
+    HandRight,
+    WeaponRight,
+}
+
+impl BoneRole {
+    fn from_name(name: &str) -> Option<Self> {
+        Some(match name {
+            "root" => Self::Root,
+            "pelvis" => Self::Pelvis,
+            "stomach_01" => Self::StomachOne,
+            "stomach_02" => Self::StomachTwo,
+            "chest" => Self::Chest,
+            "neck_01" => Self::NeckOne,
+            "neck_02" => Self::NeckTwo,
+            "head" => Self::Head,
+            "clavicle.L" => Self::ClavicleLeft,
+            "clavicle.R" => Self::ClavicleRight,
+            "thigh.L" => Self::ThighLeft,
+            "thigh_twist.L" => Self::ThighTwistLeft,
+            "shin.L" => Self::ShinLeft,
+            "shin_twist.L" => Self::ShinTwistLeft,
+            "foot.L" => Self::FootLeft,
+            "toe.L" => Self::ToeLeft,
+            "thigh.R" => Self::ThighRight,
+            "thigh_twist.R" => Self::ThighTwistRight,
+            "shin.R" => Self::ShinRight,
+            "shin_twist.R" => Self::ShinTwistRight,
+            "foot.R" => Self::FootRight,
+            "toe.R" => Self::ToeRight,
+            "upper_arm.L" => Self::UpperArmLeft,
+            "upper_arm_twist.L" => Self::UpperArmTwistLeft,
+            "forearm.L" => Self::ForearmLeft,
+            "forearm_twist.L" => Self::ForearmTwistLeft,
+            "hand.L" => Self::HandLeft,
+            "weapon.L" => Self::WeaponLeft,
+            "upper_arm.R" => Self::UpperArmRight,
+            "upper_arm_twist.R" => Self::UpperArmTwistRight,
+            "forearm.R" => Self::ForearmRight,
+            "forearm_twist.R" => Self::ForearmTwistRight,
+            "hand.R" => Self::HandRight,
+            "weapon.R" => Self::WeaponRight,
+            _ => return None,
+        })
+    }
+}
+
+pub(super) fn bind_humanoid_bones(
+    mut commands: Commands,
+    bones: Query<(Entity, &Name), (Added<Name>, Without<HumanoidBone>)>,
+    parents: Query<&ChildOf>,
+    roots: Query<&AnimationRigScene>,
+) {
+    for (entity, name) in &bones {
+        let Some(role) = BoneRole::from_name(name.as_str()) else {
+            continue;
+        };
+        let mut current = entity;
+        for _ in 0..64 {
+            if let Ok(root) = roots.get(current) {
+                commands.entity(entity).insert(HumanoidBone {
+                    owner: root.0,
+                    role,
+                });
+                break;
+            }
+            let Ok(parent) = parents.get(current) else {
+                break;
+            };
+            current = parent.parent();
+        }
+    }
+}
+
+/// Procedural facing is an additive post-FK layer. Animation evaluation writes
+/// these local transforms again on the next frame, so the offsets do not drift.
+pub(super) fn apply_head_and_torso_look(
+    owners: Query<(&CharacterLook, &SkeletonState)>,
+    mut bones: Query<(&HumanoidBone, &mut Transform)>,
+) {
+    for (bone, mut transform) in &mut bones {
+        let Ok((look, skeleton)) = owners.get(bone.owner) else {
+            continue;
+        };
+        let pitch = look.pitch.clamp(-0.75, 0.75);
+        let directional_yaw = skeleton.action_direction.x.clamp(-1.0, 1.0) * 0.35;
+        match bone.role {
+            BoneRole::Head => {
+                transform.rotation *=
+                    Quat::from_euler(EulerRot::YXZ, directional_yaw, pitch * 0.7, 0.0);
+            }
+            BoneRole::Chest => {
+                transform.rotation *=
+                    Quat::from_euler(EulerRot::YXZ, directional_yaw * 0.35, pitch * 0.2, 0.0);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct BoneSnapshot {
+    entity: Entity,
+    global: GlobalTransform,
+    parent_rotation: Quat,
+}
+
+/// Places the planted foot on the terrain with an analytic two-bone solve,
+/// then lowers the hips by the bounded residual. Weapon/hand constraints use
+/// the same final-pose seam when authored held-item rigs arrive.
+pub(super) fn apply_terrain_leg_ik(
+    terrain: Query<&SceneTerrain>,
+    owners: Query<&SkeletonState>,
+    bones: Query<(Entity, &HumanoidBone)>,
+    parents: Query<&ChildOf>,
+    mut transforms: ParamSet<(TransformHelper, Query<&mut Transform>)>,
+) {
+    let Some(terrain) = terrain.iter().next() else {
+        return;
+    };
+    let mut rigs = BTreeMap::<Entity, BTreeMap<BoneRole, BoneSnapshot>>::new();
+    {
+        let helper = transforms.p0();
+        for (entity, bone) in &bones {
+            let Ok(global) = helper.compute_global_transform(entity) else {
+                continue;
+            };
+            rigs.entry(bone.owner).or_default().insert(
+                bone.role,
+                BoneSnapshot {
+                    entity,
+                    global,
+                    parent_rotation: parents
+                        .get(entity)
+                        .ok()
+                        .and_then(|parent| helper.compute_global_transform(parent.parent()).ok())
+                        .map(|global| global.rotation())
+                        .unwrap_or(Quat::IDENTITY),
+                },
+            );
+        }
+    }
+
+    for (owner, rig) in rigs {
+        let Ok(skeleton) = owners.get(owner) else {
+            continue;
+        };
+        if !skeleton.grounded || matches!(skeleton.posture, Posture::Prone | Posture::Supine) {
+            continue;
+        }
+        let plant_left = skeleton.gait_phase.rem_euclid(1.0) < 0.5;
+        for (upper_role, lower_role, foot_role, planted) in [
+            (
+                BoneRole::ThighLeft,
+                BoneRole::ShinLeft,
+                BoneRole::FootLeft,
+                plant_left,
+            ),
+            (
+                BoneRole::ThighRight,
+                BoneRole::ShinRight,
+                BoneRole::FootRight,
+                !plant_left,
+            ),
+        ] {
+            let (Some(upper), Some(lower), Some(foot)) = (
+                rig.get(&upper_role),
+                rig.get(&lower_role),
+                rig.get(&foot_role),
+            ) else {
+                continue;
+            };
+            let foot_position = foot.global.translation();
+            let Some(height) = terrain.height_at(foot_position.xz()) else {
+                continue;
+            };
+            let weight = if planted { 1.0 } else { 0.35 };
+            let correction = (height - foot_position.y).clamp(-0.35, 0.35) * weight;
+            if correction.abs() < 0.001 {
+                continue;
+            }
+            let target = foot_position + Vec3::Y * correction;
+            solve_and_apply_leg(*upper, *lower, *foot, target, &mut transforms.p1());
+        }
+    }
+}
+
+fn solve_and_apply_leg(
+    upper: BoneSnapshot,
+    lower: BoneSnapshot,
+    foot: BoneSnapshot,
+    target: Vec3,
+    transforms: &mut Query<&mut Transform>,
+) {
+    let root = upper.global.translation();
+    let knee = lower.global.translation();
+    let end = foot.global.translation();
+    let upper_length = root.distance(knee);
+    let lower_length = knee.distance(end);
+    let Some(knee_target) =
+        solve_two_bone_knee(root, knee, end, target, upper_length, lower_length)
+    else {
+        return;
+    };
+
+    let current_upper = knee - root;
+    let desired_upper = knee_target - root;
+    let (Some(current_upper), Some(desired_upper)) =
+        (current_upper.try_normalize(), desired_upper.try_normalize())
+    else {
+        return;
+    };
+    let upper_delta = Quat::from_rotation_arc(current_upper, desired_upper);
+    let upper_world = upper.global.rotation();
+    let new_upper_world = upper_delta * upper_world;
+    if let Ok(mut transform) = transforms.get_mut(upper.entity) {
+        transform.rotation = upper.parent_rotation.inverse() * new_upper_world;
+    }
+
+    let current_lower = upper_delta * (end - knee);
+    let desired_lower = target - knee_target;
+    let (Some(current_lower), Some(desired_lower)) =
+        (current_lower.try_normalize(), desired_lower.try_normalize())
+    else {
+        return;
+    };
+    let lower_delta = Quat::from_rotation_arc(current_lower, desired_lower);
+    let new_lower_world = lower_delta * upper_delta * lower.global.rotation();
+    if let Ok(mut transform) = transforms.get_mut(lower.entity) {
+        transform.rotation = new_upper_world.inverse() * new_lower_world;
+    }
+}
+
+fn solve_two_bone_knee(
+    root: Vec3,
+    current_knee: Vec3,
+    current_end: Vec3,
+    target: Vec3,
+    upper_length: f32,
+    lower_length: f32,
+) -> Option<Vec3> {
+    if upper_length <= f32::EPSILON || lower_length <= f32::EPSILON {
+        return None;
+    }
+    let target_offset = target - root;
+    let raw_distance = target_offset.length();
+    let target_direction = target_offset.try_normalize()?;
+    let distance = raw_distance.clamp(
+        (upper_length - lower_length).abs() + 0.0001,
+        upper_length + lower_length - 0.0001,
+    );
+    let along = (upper_length * upper_length - lower_length * lower_length + distance * distance)
+        / (2.0 * distance);
+    let height = (upper_length * upper_length - along * along)
+        .max(0.0)
+        .sqrt();
+    let current_plane_normal = (current_knee - root).cross(current_end - current_knee);
+    let plane_normal = current_plane_normal.try_normalize().unwrap_or(Vec3::X);
+    let bend = plane_normal
+        .cross(target_direction)
+        .try_normalize()
+        .unwrap_or(Vec3::Z);
+    let sign = if (current_knee - root).dot(bend) < 0.0 {
+        -1.0
+    } else {
+        1.0
+    };
+    Some(root + target_direction * along + bend * height * sign)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_bone_solver_preserves_segment_lengths_and_reaches_target() {
+        let root = Vec3::ZERO;
+        let knee = Vec3::new(0.0, -1.0, 0.15);
+        let end = Vec3::new(0.0, -2.0, 0.0);
+        let target = Vec3::new(0.3, -1.85, 0.0);
+        let solved = solve_two_bone_knee(root, knee, end, target, 1.0, 1.0).unwrap();
+        assert!((root.distance(solved) - 1.0).abs() < 0.0001);
+        assert!((solved.distance(target) - 1.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn two_bone_solver_clamps_unreachable_target_without_nan() {
+        let solved = solve_two_bone_knee(
+            Vec3::ZERO,
+            Vec3::new(0.0, -1.0, 0.1),
+            Vec3::new(0.0, -2.0, 0.0),
+            Vec3::new(0.0, -20.0, 0.0),
+            1.0,
+            1.0,
+        )
+        .unwrap();
+        assert!(solved.is_finite());
+    }
+}

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -268,10 +268,14 @@ fn update_attack_state_system(
 fn on_attack_fired_hook(
     event: On<Fire<Attack>>,
     mut cmd: Commands,
-    q_character: Query<Has<AttackState>>,
+    mut q_character: Query<(Has<AttackState>, &mut SkeletonState)>,
     viewer: TacticalPlayerViewer,
+    time: Res<Time>,
 ) {
-    if q_character.get(event.context).unwrap_or_default() {
+    let Ok((attacking, mut skeleton)) = q_character.get_mut(event.context) else {
+        return;
+    };
+    if attacking {
         // already in attack
         return;
     }
@@ -292,6 +296,8 @@ fn on_attack_fired_hook(
     }
     cmd.entity(event.context)
         .insert(AttackState::new(PRE_HIT_DELAY, reach, ranged));
+    let start = (time.elapsed_secs_f64() * 64.0).round() as u64;
+    skeleton.begin_action(SkeletonAction::Attack, start, start + 19);
     if ranged {
         cmd.client_trigger(RangedActionRequest::Start);
     } else {
@@ -310,10 +316,28 @@ fn update_character_look_rotation(
     }
 }
 
-fn on_dodge_fired(_event: On<Fire<Dodge>>, mut cmd: Commands) {
+fn on_dodge_fired(
+    event: On<Fire<Dodge>>,
+    mut cmd: Commands,
+    time: Res<Time>,
+    mut skeletons: Query<&mut SkeletonState>,
+) {
+    if let Ok(mut skeleton) = skeletons.get_mut(event.context) {
+        let start = (time.elapsed_secs_f64() * 64.0).round() as u64;
+        skeleton.begin_action(SkeletonAction::Dodge, start, start + 8);
+    }
     cmd.client_trigger(DefendRequest::Dodge);
 }
 
-fn on_parry_fired(_event: On<Fire<Parry>>, mut cmd: Commands) {
+fn on_parry_fired(
+    event: On<Fire<Parry>>,
+    mut cmd: Commands,
+    time: Res<Time>,
+    mut skeletons: Query<&mut SkeletonState>,
+) {
+    if let Ok(mut skeleton) = skeletons.get_mut(event.context) {
+        let start = (time.elapsed_secs_f64() * 64.0).round() as u64;
+        skeleton.begin_action(SkeletonAction::Block, start, start + 8);
+    }
     cmd.client_trigger(DefendRequest::Parry);
 }

--- a/crates/adventuresim-tactical-core/src/animation.rs
+++ b/crates/adventuresim-tactical-core/src/animation.rs
@@ -551,6 +551,39 @@ impl Default for SkeletonState {
     }
 }
 
+impl SkeletonState {
+    pub fn begin_action(&mut self, action: SkeletonAction, start_tick: u64, contact_tick: u64) {
+        self.action = action;
+        self.action_phase = 0.0;
+        self.action_started_tick = start_tick;
+        self.action_contact_tick = contact_tick.max(start_tick + 1);
+    }
+
+    /// Advances an action whose contact is the midpoint of its visual
+    /// timeline. Recovery gets the same bounded duration as preparation.
+    pub fn advance_action(&mut self, current_tick: u64) {
+        if self.action == SkeletonAction::None {
+            return;
+        }
+        let preparation = self
+            .action_contact_tick
+            .saturating_sub(self.action_started_tick)
+            .max(1);
+        let end_tick = self.action_contact_tick.saturating_add(preparation);
+        if current_tick >= end_tick {
+            self.action = SkeletonAction::None;
+            self.action_phase = 0.0;
+            return;
+        }
+        self.action_phase = if current_tick <= self.action_contact_tick {
+            0.5 * current_tick.saturating_sub(self.action_started_tick) as f32 / preparation as f32
+        } else {
+            0.5 + 0.5 * current_tick.saturating_sub(self.action_contact_tick) as f32
+                / preparation as f32
+        };
+    }
+}
+
 /// One weighted authored pose contributing to the FK result.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum PoseSampling {
@@ -1165,5 +1198,19 @@ mod tests {
                 progress: 0.5,
             }
         );
+    }
+
+    #[test]
+    fn authoritative_action_clock_centers_contact_and_finishes_recovery() {
+        let mut state = SkeletonState::default();
+        state.begin_action(SkeletonAction::Attack, 10, 20);
+        state.advance_action(15);
+        assert_eq!(state.action_phase, 0.25);
+        state.advance_action(20);
+        assert_eq!(state.action_phase, 0.5);
+        state.advance_action(25);
+        assert_eq!(state.action_phase, 0.75);
+        state.advance_action(30);
+        assert_eq!(state.action, SkeletonAction::None);
     }
 }

--- a/crates/adventuresim-tactical-server/src/combat/ingress.rs
+++ b/crates/adventuresim-tactical-server/src/combat/ingress.rs
@@ -5,6 +5,7 @@ pub(super) fn on_defender_response(
     mut cmd: Commands,
     time: Res<Time<()>>,
     states: Query<&TacticalCombatState>,
+    mut skeletons: Query<&mut SkeletonState>,
 ) {
     let Some(entity) = event.client_id.entity() else {
         warn!(
@@ -14,11 +15,23 @@ pub(super) fn on_defender_response(
         return;
     };
 
-    if states
-        .get(entity)
-        .is_ok_and(TacticalCombatState::is_incapacitated)
-    {
+    let Ok(combat_state) = states.get(entity) else {
         return;
+    };
+    if combat_state.is_incapacitated() {
+        return;
+    }
+
+    if let Ok(mut skeleton) = skeletons.get_mut(entity) {
+        let start = animation_tick(&time);
+        skeleton.begin_action(
+            match **event {
+                DefendRequest::Dodge => SkeletonAction::Dodge,
+                DefendRequest::Parry => SkeletonAction::Block,
+            },
+            start,
+            start + 8,
+        );
     }
 
     cmd.entity(entity).insert(PendingDefenderResponse {
@@ -30,6 +43,7 @@ pub(super) fn on_defender_response(
 pub(super) fn on_melee_attack_started(
     event: On<MeleeAttackStartedIntent>,
     mut authorities: Query<&mut MeleeAttackAuthority>,
+    mut skeletons: Query<&mut SkeletonState>,
     time: Res<Time<()>>,
 ) {
     let Ok(mut authority) = authorities.get_mut(event.attacker) else {
@@ -41,6 +55,14 @@ pub(super) fn on_melee_attack_started(
         event.windup,
         MELEE_WINDUP_NETWORK_ALLOWANCE,
     );
+    if let Ok(mut skeleton) = skeletons.get_mut(event.attacker) {
+        let start = animation_tick(&time);
+        skeleton.begin_action(
+            SkeletonAction::Attack,
+            start,
+            start + duration_ticks(event.windup),
+        );
+    }
 }
 
 pub(super) fn resolve_defender_response(
@@ -77,6 +99,7 @@ pub(super) fn on_melee_action_request(
     mut cmd: Commands,
     time: Res<Time<()>>,
     mut authorities: Query<&mut MeleeAttackAuthority>,
+    mut skeletons: Query<&mut SkeletonState>,
 ) {
     let Some(attacker) = event.client_id.entity() else {
         debug!(
@@ -96,6 +119,14 @@ pub(super) fn on_melee_action_request(
                 CLIENT_MELEE_WINDUP,
                 MELEE_WINDUP_NETWORK_ALLOWANCE,
             );
+            if let Ok(mut skeleton) = skeletons.get_mut(attacker) {
+                let start = animation_tick(&time);
+                skeleton.begin_action(
+                    SkeletonAction::Attack,
+                    start,
+                    start + duration_ticks(CLIENT_MELEE_WINDUP),
+                );
+            }
         }
         MeleeActionRequest::Complete {
             target,
@@ -121,6 +152,8 @@ pub(super) fn on_melee_action_request(
 pub(super) fn on_ranged_action_request(
     event: On<FromClient<RangedActionRequest>>,
     mut cmd: Commands,
+    time: Res<Time<()>>,
+    mut skeletons: Query<&mut SkeletonState>,
 ) {
     let Some(attacker) = event.client_id.entity() else {
         debug!(
@@ -131,6 +164,14 @@ pub(super) fn on_ranged_action_request(
     };
     match **event {
         RangedActionRequest::Start => {
+            if let Ok(mut skeleton) = skeletons.get_mut(attacker) {
+                let start = animation_tick(&time);
+                skeleton.begin_action(
+                    SkeletonAction::Attack,
+                    start,
+                    start + duration_ticks(CLIENT_RANGED_WINDUP),
+                );
+            }
             cmd.trigger(RangedAttackStartedIntent {
                 attacker,
                 target: None,
@@ -169,6 +210,7 @@ pub(super) fn on_ranged_action_request(
 pub(super) fn on_ranged_attack_started(
     event: On<RangedAttackStartedIntent>,
     mut authorities: Query<&mut RangedAttackAuthority>,
+    mut skeletons: Query<&mut SkeletonState>,
     time: Res<Time<()>>,
 ) {
     let Ok(mut authority) = authorities.get_mut(event.attacker) else {
@@ -179,6 +221,22 @@ pub(super) fn on_ranged_attack_started(
         event.windup,
         RANGED_NETWORK_ALLOWANCE,
     );
+    if let Ok(mut skeleton) = skeletons.get_mut(event.attacker) {
+        let start = animation_tick(&time);
+        skeleton.begin_action(
+            SkeletonAction::Attack,
+            start,
+            start + duration_ticks(event.windup),
+        );
+    }
+}
+
+fn animation_tick(time: &Time<()>) -> u64 {
+    (time.elapsed_secs_f64() * 64.0).round() as u64
+}
+
+fn duration_ticks(duration: CombatDuration) -> u64 {
+    (duration.as_secs_f32() * 64.0).round().max(1.0) as u64
 }
 
 pub(super) fn authoritative_line_of_sight(

--- a/crates/adventuresim-tactical-server/src/player_projection.rs
+++ b/crates/adventuresim-tactical-server/src/player_projection.rs
@@ -517,6 +517,8 @@ pub(crate) fn update_skeleton_locomotion(
                 LeadFoot::Right
             };
         }
+        let tick = (time.elapsed_secs_f64() * 64.0).round() as u64;
+        skeleton.advance_action(tick);
     }
 }
 

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -346,12 +346,12 @@ useful interpolation, but they do not redefine semantic poses owned by another
 file. The catalog entries above designate exactly one authoritative file and
 frame for every required semantic pose.
 
-The procedural humanoid pass initially binds the case-sensitive names `hips`,
-`chest`, `head`, `thigh.L`, `shin.L`, `foot.L`, `thigh.R`, `shin.R`, `foot.R`,
-`upper_arm.L`, `forearm.L`, `hand.L`, `upper_arm.R`, `forearm.R`, and `hand.R`.
-Additional twist, toe, finger, face, weapon, or attachment bones are permitted
-and remain under authored FK until a procedural constraint explicitly uses
-them. See the tactical-client README for the concise exporter checklist.
+The canonical procedural rig uses `root`, `pelvis`, `stomach_01`,
+`stomach_02`, `chest`, `neck_01`, `neck_02`, and `head`; paired clavicle,
+major arm, arm-twist, hand, major leg, leg-twist, foot, and toe bones use the
+`.L`/`.R` suffix. `weapon.L` and `weapon.R` are hand attachment sockets. The
+scene-root animation cylinder is authoring-only. See the tactical-client README
+for the concise exporter checklist.
 
 The server-owned character transform remains authoritative. Authored root
 offsets may shape a step or lean visually, but the evaluator reconciles them

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1831)
+## Files (1832)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1256,6 +1256,7 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-client/assets/crosshair.png` — Binary game or UI asset.
 - `crates/adventuresim-tactical-client/assets/ui.css` — Browser UI styling.
 - `crates/adventuresim-tactical-client/src/animation.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-client/src/animation/procedural.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/debug.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/player.rs` — Rust source module for this component.


### PR DESCRIPTION
## What changed

- bind the documented humanoid bone convention
- add post-FK head and torso facing
- derive authoritative action timing and presentation parameters
- introduce the isolated post-FK procedural stage used by later gait and rig-aware IK layers

## Why

Authored FK provides expressive motion while procedural constraints adapt presentation without changing authoritative gameplay state.

## Validation

- procedural solver and presentation tests in the tactical client suite
- tactical core and client suites at the final stack head
- formatting and generated project-map checks
