### PR TITLE
Layer mirrored gait and impact animation

### DIFF
--- a/assets/animations/biped/README.md
+++ b/assets/animations/biped/README.md
@@ -1,0 +1,34 @@
+# Biped runtime animation assets
+
+```text
+biped/
+  unarmed/
+    base.glb
+    idle_relaxed.glb
+    walk.glb
+    run.glb
+    attack_thrust_lead_left_stay.glb
+    ...
+```
+
+`base.glb` is the only spawnable scene and is generated from
+`assets_src/base.glb` by `scripts/prepare_rig_base.py`. Every other file is an
+exact validated copy of its export under `assets_src/biped/unarmed/`, prepared
+by `scripts/prepare_animation_motion.py`, and contains exactly one complete
+coherent motion at 30fps. Animation names are ignored;
+the code-owned catalog in the tactical client maps semantic anchors to exact
+file/frame pairs documented in `wiki/client/animation.md`.
+
+The ergonomic on-disk pack directory is `unarmed`; the runtime semantic pack ID
+remains `humanoid_unarmed`. Future specialized pack directories sit beside it
+under `biped/<pack-directory>/` and may inherit compatible motions from their
+single fallback pack.
+
+Motion GLBs retain their exported scenes and meshes because the runtime loads
+only their animation asset. The preparation step does not rewrite them: after
+validating the one-animation, duration, and canonical target-path contracts it
+copies source bytes exactly, and `--check` verifies the committed result.
+
+Missing motion files are expected while art is in progress. They participate
+in pack and similar-pose fallback independently and ultimately leave the
+authored base rig in its T-pose rather than crashing or hiding the actor.

--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -47,7 +47,9 @@ Use these conventions:
 - the armature bind pose is a T-pose, which is the final runtime fallback;
 - each motion GLB contains exactly one animation and preserves all authored
   in-betweens between its documented frame anchors;
-- all locomotion cycles use the documented normalized phase convention; and
+- locomotion exports provide the canonical contact and passing/flight poses;
+  the runtime interpolates them, mirrors only the lower body for the
+  opposite-foot half, and closes the normalized gait cycle; and
 - packs in one fallback chain use identical bone names and hierarchy.
 
 The procedural humanoid pass recognizes these case-sensitive bone names:

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -818,7 +818,7 @@ fn resolve_anchor<'a>(
     };
     let pack = catalog.packs.get(pack_id)?;
     let anchor = pack.poses.get(&resolved_pose)?;
-    let source = pack.motions.get(&anchor.motion)?;
+    pack.motions.get(&anchor.motion)?;
     let clip = runtime
         .clips
         .get(&(pack_id.to_owned(), anchor.motion.clone()))?;

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use adventuresim_tactical_core::prelude::*;
+use adventuresim_tactical_netcode::message::SuccessfulAttackResponse;
 use bevy::{
     animation::{AnimatedBy, AnimationTargetId},
     app::AnimationSystems,
@@ -25,6 +26,7 @@ impl Plugin for TacticalAnimationPlugin {
         app.init_resource::<AnimationPackCatalog>()
             .init_resource::<AnimationRuntime>()
             .add_systems(Startup, request_animation_packs)
+            .add_observer(on_successful_attack)
             .add_systems(
                 Update,
                 (
@@ -34,6 +36,7 @@ impl Plugin for TacticalAnimationPlugin {
                     identify_animation_players,
                     procedural::bind_humanoid_bones,
                     evaluate_skeletons,
+                    tick_impact_reactions,
                     sync_animation_graphs,
                     drive_fk_players,
                     update_rig_visibility,
@@ -44,6 +47,8 @@ impl Plugin for TacticalAnimationPlugin {
                 PostUpdate,
                 (
                     procedural::apply_head_and_torso_look,
+                    procedural::apply_lower_body_mirroring,
+                    procedural::apply_impact_reaction,
                     procedural::apply_terrain_leg_ik,
                 )
                     .chain()
@@ -344,9 +349,10 @@ struct AnimationRuntime {
 }
 
 #[derive(Component, Debug)]
-struct AnimationPlayback {
+pub(super) struct AnimationPlayback {
     clips: Vec<WeightedClip>,
     use_bind_pose_t: bool,
+    pub(super) lower_body_mirror: f32,
 }
 
 impl Default for AnimationPlayback {
@@ -354,6 +360,7 @@ impl Default for AnimationPlayback {
         Self {
             clips: Vec::new(),
             use_bind_pose_t: true,
+            lower_body_mirror: 0.0,
         }
     }
 }
@@ -382,6 +389,13 @@ struct AnimationPlayerOwner(pub Entity);
 
 #[derive(Component, Default)]
 struct AnimationGraphRevision(u64);
+
+#[derive(Component, Debug, Clone, Copy)]
+pub(super) struct ImpactReaction {
+    pub(super) remaining: f32,
+    pub(super) duration: f32,
+    pub(super) strength: f32,
+}
 
 fn request_animation_packs(
     catalog: Res<AnimationPackCatalog>,
@@ -726,7 +740,10 @@ fn evaluate_skeletons(
             &evaluation.action
         };
         let mut weighted = Vec::<WeightedClip>::new();
+        let mut mirror_weight = 0.0;
+        let mut resolved_weight = 0.0;
         for sample in samples {
+            let before = weighted.iter().map(|clip| clip.weight).sum::<f32>();
             append_resolved_sample(
                 &mut weighted,
                 &runtime,
@@ -734,15 +751,49 @@ fn evaluate_skeletons(
                 &skeleton.animation_pack,
                 *sample,
             );
+            let added = (weighted.iter().map(|clip| clip.weight).sum::<f32>() - before).max(0.0);
+            resolved_weight += added;
+            if sample.mirror_lower_body {
+                mirror_weight += added;
+            }
         }
         let next = AnimationPlayback {
             use_bind_pose_t: weighted.is_empty(),
             clips: weighted,
+            lower_body_mirror: if resolved_weight > f32::EPSILON {
+                (mirror_weight / resolved_weight).clamp(0.0, 1.0)
+            } else {
+                0.0
+            },
         };
         if let Some(mut playback) = playback {
             *playback = next;
         } else {
             commands.entity(entity).insert(next);
+        }
+    }
+}
+
+fn on_successful_attack(event: On<SuccessfulAttackResponse>, mut commands: Commands) {
+    let strength = (event.total_damage() / 100.0).clamp(0.15, 1.0);
+    for entity in &event.hit {
+        commands.entity(*entity).insert(ImpactReaction {
+            remaining: 0.22,
+            duration: 0.22,
+            strength,
+        });
+    }
+}
+
+fn tick_impact_reactions(
+    mut commands: Commands,
+    time: Res<Time>,
+    mut reactions: Query<(Entity, &mut ImpactReaction)>,
+) {
+    for (entity, mut reaction) in &mut reactions {
+        reaction.remaining -= time.delta_secs();
+        if reaction.remaining <= 0.0 {
+            commands.entity(entity).remove::<ImpactReaction>();
         }
     }
 }

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -15,6 +15,9 @@ use bevy::{
 };
 
 mod procedural;
+
+#[allow(unused_imports)]
+pub(crate) use procedural::{BoneRole, HumanoidBone};
 const HUMANOID_UNARMED_PACK: &str = "humanoid_unarmed";
 const BIPED_BASE_GLB: &str = "animations/biped/unarmed/base.glb";
 const ANIMATION_FPS: f32 = 30.0;
@@ -329,6 +332,7 @@ impl AnimationPackCatalog {
 #[derive(Debug, Clone)]
 struct LoadedClip {
     node: AnimationNodeIndex,
+    duration_seconds: f32,
 }
 
 #[derive(Resource, Default)]
@@ -353,6 +357,13 @@ pub(super) struct AnimationPlayback {
     clips: Vec<WeightedClip>,
     use_bind_pose_t: bool,
     pub(super) lower_body_mirror: f32,
+}
+
+impl AnimationPlayback {
+    #[allow(dead_code)] // Used by the standalone animation-viewer binary.
+    pub(super) fn authored_pose_is_ready(&self) -> bool {
+        !self.use_bind_pose_t && !self.clips.is_empty()
+    }
 }
 
 impl Default for AnimationPlayback {
@@ -549,7 +560,19 @@ fn collect_loaded_packs(
     runtime.clips = ordered
         .into_iter()
         .zip(nodes)
-        .map(|((key, _handle), node)| (key, LoadedClip { node }))
+        .map(|((key, handle), node)| {
+            let duration_seconds = clips
+                .get(&handle)
+                .map(AnimationClip::duration)
+                .unwrap_or_default();
+            (
+                key,
+                LoadedClip {
+                    node,
+                    duration_seconds,
+                },
+            )
+        })
         .collect();
     runtime.graph = Some(graphs.add(graph));
     runtime.revision = runtime.revision.wrapping_add(1);
@@ -869,6 +892,12 @@ fn append_resolved_sample(
             frame_seconds(start.anchor.frame),
             sample.weight,
         ),
+        PoseSampling::Cycle { progress } => append_weighted(
+            weighted,
+            &start,
+            start.clip.duration_seconds * progress.rem_euclid(1.0),
+            sample.weight,
+        ),
         PoseSampling::Span { end, progress } => {
             let end_pose = end;
             let progress = progress.clamp(0.0, 1.0);
@@ -1166,11 +1195,17 @@ mod tests {
         };
         for pose in poses {
             let anchor = &catalog.packs[HUMANOID_UNARMED_PACK].poses[&pose];
+            let duration_seconds = catalog.packs[HUMANOID_UNARMED_PACK].motions[&anchor.motion]
+                .last_frame as f32
+                / ANIMATION_FPS;
             let next_node = AnimationNodeIndex::new(runtime.clips.len());
             runtime
                 .clips
                 .entry((HUMANOID_UNARMED_PACK.to_owned(), anchor.motion.clone()))
-                .or_insert(LoadedClip { node: next_node });
+                .or_insert(LoadedClip {
+                    node: next_node,
+                    duration_seconds,
+                });
         }
         runtime
     }
@@ -1198,6 +1233,27 @@ mod tests {
         );
         assert_eq!(weighted.len(), 1);
         assert!((weighted[0].time_seconds - 4.0 / 30.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn complete_cycle_uses_the_motion_frame_range() {
+        let catalog = AnimationPackCatalog::default();
+        let runtime = runtime_with_available([SemanticPose::WalkContact]);
+        let mut weighted = Vec::new();
+        append_resolved_sample(
+            &mut weighted,
+            &runtime,
+            &catalog,
+            HUMANOID_UNARMED_PACK,
+            PoseSample {
+                pose: SemanticPose::WalkContact,
+                sampling: PoseSampling::Cycle { progress: 0.5 },
+                weight: 1.0,
+                mirror_lower_body: 0.0,
+            },
+        );
+        assert_eq!(weighted.len(), 1);
+        assert!((weighted[0].time_seconds - 16.0 / ANIMATION_FPS).abs() < 0.0001);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -753,9 +753,7 @@ fn evaluate_skeletons(
             );
             let added = (weighted.iter().map(|clip| clip.weight).sum::<f32>() - before).max(0.0);
             resolved_weight += added;
-            if sample.mirror_lower_body {
-                mirror_weight += added;
-            }
+            mirror_weight += added * sample.mirror_lower_body.clamp(0.0, 1.0);
         }
         let next = AnimationPlayback {
             use_bind_pose_t: weighted.is_empty(),
@@ -802,7 +800,6 @@ fn tick_impact_reactions(
 struct ResolvedAnchor<'a> {
     clip: &'a LoadedClip,
     anchor: &'a PoseAnchor,
-    source: &'a MotionSource,
     pack_id: &'a str,
 }
 
@@ -828,7 +825,6 @@ fn resolve_anchor<'a>(
     Some(ResolvedAnchor {
         clip,
         anchor,
-        source,
         pack_id,
     })
 }
@@ -871,12 +867,6 @@ fn append_resolved_sample(
             weighted,
             &start,
             frame_seconds(start.anchor.frame),
-            sample.weight,
-        ),
-        PoseSampling::Cycle { phase } => append_weighted(
-            weighted,
-            &start,
-            frame_seconds(start.source.last_frame) * phase.rem_euclid(1.0),
             sample.weight,
         ),
         PoseSampling::Span { end, progress } => {
@@ -1203,7 +1193,7 @@ mod tests {
                     progress: 0.5,
                 },
                 weight: 1.0,
-                mirror_lower_body: false,
+                mirror_lower_body: 0.0,
             },
         );
         assert_eq!(weighted.len(), 1);
@@ -1230,7 +1220,7 @@ mod tests {
                     progress: 0.5,
                 },
                 weight: 1.0,
-                mirror_lower_body: false,
+                mirror_lower_body: 0.0,
             },
         );
         assert_eq!(weighted.len(), 1);
@@ -1333,13 +1323,13 @@ mod tests {
             HUMANOID_UNARMED_PACK,
             PoseSample {
                 pose: SemanticPose::RunContact,
-                sampling: PoseSampling::Cycle { phase: 0.25 },
+                sampling: PoseSampling::Anchor,
                 weight: 1.0,
-                mirror_lower_body: false,
+                mirror_lower_body: 0.0,
             },
         );
         assert_eq!(weighted.len(), 1);
-        assert!((weighted[0].time_seconds - 8.0 / 30.0).abs() < 0.0001);
+        assert!(weighted[0].time_seconds.abs() < 0.0001);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -6,13 +6,13 @@ use bevy::{math::Affine3A, prelude::*};
 use super::{AnimationPlayback, AnimationRigScene, ImpactReaction};
 
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(super) struct HumanoidBone {
-    owner: Entity,
-    role: BoneRole,
+pub(crate) struct HumanoidBone {
+    pub(crate) owner: Entity,
+    pub(crate) role: BoneRole,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-enum BoneRole {
+pub(crate) enum BoneRole {
     Root,
     Pelvis,
     StomachOne,

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use adventuresim_tactical_core::prelude::*;
 use bevy::prelude::*;
 
-use super::AnimationRigScene;
+use super::{AnimationPlayback, AnimationRigScene, ImpactReaction};
 
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(super) struct HumanoidBone {
@@ -144,6 +144,86 @@ pub(super) fn apply_head_and_torso_look(
     }
 }
 
+/// Constructs the opposite gait half-cycle without mirroring handed upper-body
+/// carriage. The evaluator can continuously blend into or out of the mirror.
+pub(super) fn apply_lower_body_mirroring(
+    playbacks: Query<&AnimationPlayback>,
+    mut bones: ParamSet<(
+        Query<(Entity, &HumanoidBone, &Transform)>,
+        Query<&mut Transform>,
+    )>,
+) {
+    let mut rigs = BTreeMap::<Entity, BTreeMap<BoneRole, (Entity, Transform)>>::new();
+    {
+        let snapshots = bones.p0();
+        for (entity, bone, transform) in &snapshots {
+            rigs.entry(bone.owner)
+                .or_default()
+                .insert(bone.role, (entity, *transform));
+        }
+    }
+    for (owner, rig) in rigs {
+        let Ok(playback) = playbacks.get(owner) else {
+            continue;
+        };
+        let weight = playback.lower_body_mirror;
+        if weight <= f32::EPSILON {
+            continue;
+        }
+        for (left_role, right_role) in [
+            (BoneRole::ThighLeft, BoneRole::ThighRight),
+            (BoneRole::ShinLeft, BoneRole::ShinRight),
+            (BoneRole::FootLeft, BoneRole::FootRight),
+        ] {
+            let (Some((left_entity, left)), Some((right_entity, right))) =
+                (rig.get(&left_role), rig.get(&right_role))
+            else {
+                continue;
+            };
+            let mirrored_right = mirrored_across_anatomical_center(*right);
+            let mirrored_left = mirrored_across_anatomical_center(*left);
+            let mut transforms = bones.p1();
+            if let Ok(mut transform) = transforms.get_mut(*left_entity) {
+                transform.translation = left.translation.lerp(mirrored_right.translation, weight);
+                transform.rotation = left.rotation.slerp(mirrored_right.rotation, weight);
+            }
+            if let Ok(mut transform) = transforms.get_mut(*right_entity) {
+                transform.translation = right.translation.lerp(mirrored_left.translation, weight);
+                transform.rotation = right.rotation.slerp(mirrored_left.rotation, weight);
+            }
+        }
+    }
+}
+
+fn mirrored_across_anatomical_center(mut transform: Transform) -> Transform {
+    transform.translation.x = -transform.translation.x;
+    let rotation = transform.rotation;
+    transform.rotation = Quat::from_xyzw(rotation.x, -rotation.y, -rotation.z, rotation.w);
+    transform
+}
+
+pub(super) fn apply_impact_reaction(
+    reactions: Query<&ImpactReaction>,
+    mut bones: Query<(&HumanoidBone, &mut Transform)>,
+) {
+    for (bone, mut transform) in &mut bones {
+        let Ok(reaction) = reactions.get(bone.owner) else {
+            continue;
+        };
+        if !matches!(bone.role, BoneRole::Chest | BoneRole::Head) {
+            continue;
+        }
+        let progress = 1.0 - (reaction.remaining / reaction.duration).clamp(0.0, 1.0);
+        let pulse = (progress * std::f32::consts::PI).sin() * reaction.strength;
+        let scale = if bone.role == BoneRole::Head {
+            0.12
+        } else {
+            0.2
+        };
+        transform.rotation *= Quat::from_rotation_x(-pulse * scale);
+    }
+}
+
 #[derive(Clone, Copy)]
 struct BoneSnapshot {
     entity: Entity,
@@ -195,7 +275,7 @@ pub(super) fn apply_terrain_leg_ik(
             continue;
         }
         let plant_left = skeleton.gait_phase.rem_euclid(1.0) < 0.5;
-        for (upper_role, lower_role, foot_role, planted) in [
+        let legs = [
             (
                 BoneRole::ThighLeft,
                 BoneRole::ShinLeft,
@@ -208,7 +288,25 @@ pub(super) fn apply_terrain_leg_ik(
                 BoneRole::FootRight,
                 !plant_left,
             ),
-        ] {
+        ];
+        let mut hip_shift = 0.0_f32;
+        for (_, _, foot_role, _) in legs {
+            let Some(foot) = rig.get(&foot_role) else {
+                continue;
+            };
+            let position = foot.global.translation();
+            if let Some(height) = terrain.height_at(position.xz()) {
+                hip_shift = hip_shift.min((height - position.y).clamp(-0.2, 0.0));
+            }
+        }
+        if hip_shift < -0.001
+            && let Some(pelvis) = rig.get(&BoneRole::Pelvis)
+            && let Ok(mut transform) = transforms.p1().get_mut(pelvis.entity)
+        {
+            transform.translation.y += hip_shift;
+        }
+        let root_offset = Vec3::Y * hip_shift;
+        for (upper_role, lower_role, foot_role, planted) in legs {
             let (Some(upper), Some(lower), Some(foot)) = (
                 rig.get(&upper_role),
                 rig.get(&lower_role),
@@ -226,7 +324,14 @@ pub(super) fn apply_terrain_leg_ik(
                 continue;
             }
             let target = foot_position + Vec3::Y * correction;
-            solve_and_apply_leg(*upper, *lower, *foot, target, &mut transforms.p1());
+            solve_and_apply_leg(
+                *upper,
+                *lower,
+                *foot,
+                target,
+                root_offset,
+                &mut transforms.p1(),
+            );
         }
     }
 }
@@ -236,11 +341,12 @@ fn solve_and_apply_leg(
     lower: BoneSnapshot,
     foot: BoneSnapshot,
     target: Vec3,
+    root_offset: Vec3,
     transforms: &mut Query<&mut Transform>,
 ) {
-    let root = upper.global.translation();
-    let knee = lower.global.translation();
-    let end = foot.global.translation();
+    let root = upper.global.translation() + root_offset;
+    let knee = lower.global.translation() + root_offset;
+    let end = foot.global.translation() + root_offset;
     let upper_length = root.distance(knee);
     let lower_length = knee.distance(end);
     let Some(knee_target) =
@@ -341,5 +447,18 @@ mod tests {
         )
         .unwrap();
         assert!(solved.is_finite());
+    }
+
+    #[test]
+    fn lower_body_mirror_is_an_involution() {
+        let original = Transform::from_xyz(0.3, -0.8, 0.2).with_rotation(Quat::from_euler(
+            EulerRot::XYZ,
+            0.2,
+            -0.3,
+            0.4,
+        ));
+        let twice = mirrored_across_anatomical_center(mirrored_across_anatomical_center(original));
+        assert!(twice.translation.abs_diff_eq(original.translation, 0.0001));
+        assert!(twice.rotation.abs_diff_eq(original.rotation, 0.0001));
     }
 }

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use adventuresim_tactical_core::prelude::*;
-use bevy::prelude::*;
+use bevy::{math::Affine3A, prelude::*};
 
 use super::{AnimationPlayback, AnimationRigScene, ImpactReaction};
 
@@ -148,18 +148,47 @@ pub(super) fn apply_head_and_torso_look(
 /// carriage. The evaluator can continuously blend into or out of the mirror.
 pub(super) fn apply_lower_body_mirroring(
     playbacks: Query<&AnimationPlayback>,
-    mut bones: ParamSet<(
+    parents: Query<&ChildOf>,
+    mut transforms: ParamSet<(
         Query<(Entity, &HumanoidBone, &Transform)>,
+        TransformHelper,
         Query<&mut Transform>,
     )>,
 ) {
-    let mut rigs = BTreeMap::<Entity, BTreeMap<BoneRole, (Entity, Transform)>>::new();
+    let locals = {
+        let bones = transforms.p0();
+        bones
+            .iter()
+            .map(|(entity, bone, transform)| (entity, *bone, *transform))
+            .collect::<Vec<_>>()
+    };
+    let mut rigs = BTreeMap::<Entity, BTreeMap<BoneRole, MirrorBone>>::new();
+    let mut owner_globals = BTreeMap::<Entity, GlobalTransform>::new();
     {
-        let snapshots = bones.p0();
-        for (entity, bone, transform) in &snapshots {
-            rigs.entry(bone.owner)
-                .or_default()
-                .insert(bone.role, (entity, *transform));
+        let helper = transforms.p1();
+        for (entity, bone, local) in locals {
+            let Ok(global) = helper.compute_global_transform(entity) else {
+                continue;
+            };
+            let parent = parents.get(entity).ok().map(ChildOf::parent);
+            let parent_global = parent
+                .and_then(|parent| helper.compute_global_transform(parent).ok())
+                .unwrap_or(GlobalTransform::IDENTITY);
+            if !owner_globals.contains_key(&bone.owner)
+                && let Ok(owner_global) = helper.compute_global_transform(bone.owner)
+            {
+                owner_globals.insert(bone.owner, owner_global);
+            }
+            rigs.entry(bone.owner).or_default().insert(
+                bone.role,
+                MirrorBone {
+                    entity,
+                    local,
+                    global,
+                    parent,
+                    parent_global,
+                },
+            );
         }
     }
     for (owner, rig) in rigs {
@@ -170,29 +199,72 @@ pub(super) fn apply_lower_body_mirroring(
         if weight <= f32::EPSILON {
             continue;
         }
+        let Some(owner_global) = owner_globals.get(&owner) else {
+            continue;
+        };
+        let mut desired_globals = BTreeMap::<Entity, Affine3A>::new();
         for (left_role, right_role) in [
             (BoneRole::ThighLeft, BoneRole::ThighRight),
+            (BoneRole::ThighTwistLeft, BoneRole::ThighTwistRight),
             (BoneRole::ShinLeft, BoneRole::ShinRight),
+            (BoneRole::ShinTwistLeft, BoneRole::ShinTwistRight),
             (BoneRole::FootLeft, BoneRole::FootRight),
+            (BoneRole::ToeLeft, BoneRole::ToeRight),
         ] {
-            let (Some((left_entity, left)), Some((right_entity, right))) =
-                (rig.get(&left_role), rig.get(&right_role))
-            else {
+            let (Some(left), Some(right)) = (rig.get(&left_role), rig.get(&right_role)) else {
                 continue;
             };
-            let mirrored_right = mirrored_across_anatomical_center(*right);
-            let mirrored_left = mirrored_across_anatomical_center(*left);
-            let mut transforms = bones.p1();
-            if let Ok(mut transform) = transforms.get_mut(*left_entity) {
-                transform.translation = left.translation.lerp(mirrored_right.translation, weight);
-                transform.rotation = left.rotation.slerp(mirrored_right.rotation, weight);
+            desired_globals.insert(
+                left.entity,
+                mirrored_global_affine(right.global, *owner_global),
+            );
+            desired_globals.insert(
+                right.entity,
+                mirrored_global_affine(left.global, *owner_global),
+            );
+        }
+        let mut bones = transforms.p2();
+        for bone in rig.values() {
+            let Some(&desired_global) = desired_globals.get(&bone.entity) else {
+                continue;
+            };
+            let desired_parent = bone
+                .parent
+                .and_then(|parent| desired_globals.get(&parent).copied())
+                .unwrap_or_else(|| bone.parent_global.affine());
+            let (scale, rotation, translation) =
+                (desired_parent.inverse() * desired_global).to_scale_rotation_translation();
+            if !translation.is_finite() || !rotation.is_finite() || !scale.is_finite() {
+                continue;
             }
-            if let Ok(mut transform) = transforms.get_mut(*right_entity) {
-                transform.translation = right.translation.lerp(mirrored_left.translation, weight);
-                transform.rotation = right.rotation.slerp(mirrored_left.rotation, weight);
+            if let Ok(mut transform) = bones.get_mut(bone.entity) {
+                transform.translation = bone.local.translation.lerp(translation, weight);
+                transform.rotation = bone.local.rotation.slerp(rotation, weight);
+                transform.scale = bone.local.scale.lerp(scale, weight);
             }
         }
     }
+}
+
+#[derive(Clone, Copy)]
+struct MirrorBone {
+    entity: Entity,
+    local: Transform,
+    global: GlobalTransform,
+    parent: Option<Entity>,
+    parent_global: GlobalTransform,
+}
+
+fn mirrored_global_affine(source: GlobalTransform, owner: GlobalTransform) -> Affine3A {
+    let owner_affine = owner.affine();
+    let relative = owner_affine.inverse() * source.affine();
+    let (scale, rotation, translation) = relative.to_scale_rotation_translation();
+    let mirrored = mirrored_across_anatomical_center(Transform {
+        translation,
+        rotation,
+        scale,
+    });
+    owner_affine * mirrored.compute_affine()
 }
 
 fn mirrored_across_anatomical_center(mut transform: Transform) -> Transform {
@@ -460,5 +532,26 @@ mod tests {
         let twice = mirrored_across_anatomical_center(mirrored_across_anatomical_center(original));
         assert!(twice.translation.abs_diff_eq(original.translation, 0.0001));
         assert!(twice.rotation.abs_diff_eq(original.rotation, 0.0001));
+    }
+
+    #[test]
+    fn global_mirror_uses_character_space_under_owner_rotation() {
+        let owner = GlobalTransform::from(
+            Transform::from_xyz(4.0, 2.0, -3.0).with_rotation(Quat::from_rotation_y(1.1)),
+        );
+        let relative = Transform::from_xyz(0.4, -0.7, 0.2).with_rotation(Quat::from_euler(
+            EulerRot::XYZ,
+            0.2,
+            -0.3,
+            0.4,
+        ));
+        let source = owner.mul_transform(relative);
+        let mirrored = owner.affine().inverse() * mirrored_global_affine(source, owner);
+        let (scale, rotation, translation) = mirrored.to_scale_rotation_translation();
+        let expected = mirrored_across_anatomical_center(relative);
+
+        assert!(translation.abs_diff_eq(expected.translation, 0.0001));
+        assert!(rotation.abs_diff_eq(expected.rotation, 0.0001));
+        assert!(scale.abs_diff_eq(expected.scale, 0.0001));
     }
 }

--- a/crates/adventuresim-tactical-core/src/animation.rs
+++ b/crates/adventuresim-tactical-core/src/animation.rs
@@ -589,6 +589,9 @@ impl SkeletonState {
 pub enum PoseSampling {
     /// Sample the pose's authoritative catalog frame.
     Anchor,
+    /// Sample the complete cyclic motion containing this pose. The client
+    /// maps normalized gait phase across the motion's catalog frame range.
+    Cycle { progress: f32 },
     /// Sample between two semantic anchors. The client uses one exact clip
     /// time when both anchors belong to the same motion and blends otherwise.
     Span { end: SemanticPose, progress: f32 },
@@ -600,7 +603,7 @@ pub struct PoseSample {
     pub sampling: PoseSampling,
     pub weight: f32,
     /// Continuous weight for exchanging and reflecting the authored left/right
-    /// leg transforms. Sparse gaits use this to synthesize their opposite half.
+    /// leg transforms when a resolved source lacks an authored opposite half.
     pub mirror_lower_body: f32,
 }
 
@@ -742,21 +745,14 @@ fn weighted_pair(a: SemanticPose, b: SemanticPose, b_weight: f32) -> Vec<PoseSam
     samples
 }
 
-fn gait_pair(phase: f32, contact: SemanticPose, passing: SemanticPose) -> Vec<PoseSample> {
-    let quarter_phase = phase.rem_euclid(1.0) * 4.0;
-    let quarter = (quarter_phase.floor() as u8).min(3);
-    let progress = quarter_phase.fract();
-    let (pose, end, mirror_lower_body) = match quarter {
-        0 => (contact, passing, 0.0),
-        1 => (passing, contact, progress),
-        2 => (contact, passing, 1.0),
-        _ => (passing, contact, 1.0 - progress),
-    };
+fn gait_pair(phase: f32, contact: SemanticPose, _passing: SemanticPose) -> Vec<PoseSample> {
     vec![PoseSample {
-        pose,
-        sampling: PoseSampling::Span { end, progress },
+        pose: contact,
+        sampling: PoseSampling::Cycle {
+            progress: phase.rem_euclid(1.0),
+        },
         weight: 1.0,
-        mirror_lower_body,
+        mirror_lower_body: 0.0,
     }]
 }
 
@@ -1055,44 +1051,36 @@ mod tests {
         let evaluation = AnimationEvaluation::from_skeleton(&state);
         assert_eq!(evaluation.base.len(), 2);
         assert!(evaluation.base.iter().any(|sample| {
-            sample.pose == SemanticPose::WalkPassing
-                && sample.sampling
-                    == (PoseSampling::Span {
-                        end: SemanticPose::WalkContact,
-                        progress: 0.0,
-                    })
+            sample.pose == SemanticPose::WalkContact
+                && sample.sampling == (PoseSampling::Cycle { progress: 0.25 })
                 && sample.weight == 0.5
         }));
         assert!(evaluation.base.iter().any(|sample| {
-            sample.pose == SemanticPose::RunFlight
-                && sample.sampling
-                    == (PoseSampling::Span {
-                        end: SemanticPose::RunContact,
-                        progress: 0.0,
-                    })
+            sample.pose == SemanticPose::RunContact
+                && sample.sampling == (PoseSampling::Cycle { progress: 0.25 })
                 && sample.weight == 0.5
         }));
     }
 
     #[test]
-    fn sparse_gait_mirrors_and_closes_the_authored_half_cycle() {
+    fn gait_samples_the_complete_authored_cycle() {
         let samples = [0.0, 0.25, 0.5, 0.75]
             .map(|phase| gait_pair(phase, SemanticPose::WalkContact, SemanticPose::WalkPassing)[0]);
-        assert_eq!(samples[0].pose, SemanticPose::WalkContact);
-        assert_eq!(samples[1].pose, SemanticPose::WalkPassing);
-        assert_eq!(samples[2].pose, SemanticPose::WalkContact);
-        assert_eq!(samples[3].pose, SemanticPose::WalkPassing);
-        assert_eq!(
-            samples.map(|sample| sample.mirror_lower_body),
-            [0.0, 0.0, 1.0, 1.0]
+        assert!(
+            samples
+                .iter()
+                .all(|sample| sample.pose == SemanticPose::WalkContact)
         );
-
-        let entering_mirror =
-            gait_pair(0.375, SemanticPose::WalkContact, SemanticPose::WalkPassing)[0];
-        let leaving_mirror =
-            gait_pair(0.875, SemanticPose::WalkContact, SemanticPose::WalkPassing)[0];
-        assert_eq!(entering_mirror.mirror_lower_body, 0.5);
-        assert_eq!(leaving_mirror.mirror_lower_body, 0.5);
+        assert_eq!(
+            samples.map(|sample| sample.sampling),
+            [
+                PoseSampling::Cycle { progress: 0.0 },
+                PoseSampling::Cycle { progress: 0.25 },
+                PoseSampling::Cycle { progress: 0.5 },
+                PoseSampling::Cycle { progress: 0.75 },
+            ]
+        );
+        assert!(samples.iter().all(|sample| sample.mirror_lower_body == 0.0));
     }
 
     #[test]

--- a/crates/adventuresim-tactical-core/src/animation.rs
+++ b/crates/adventuresim-tactical-core/src/animation.rs
@@ -592,8 +592,6 @@ pub enum PoseSampling {
     /// Sample between two semantic anchors. The client uses one exact clip
     /// time when both anchors belong to the same motion and blends otherwise.
     Span { end: SemanticPose, progress: f32 },
-    /// Sample a complete authored cycle from its first anchor through closure.
-    Cycle { phase: f32 },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -601,7 +599,9 @@ pub struct PoseSample {
     pub pose: SemanticPose,
     pub sampling: PoseSampling,
     pub weight: f32,
-    pub mirror_lower_body: bool,
+    /// Continuous weight for exchanging and reflecting the authored left/right
+    /// leg transforms. Sparse gaits use this to synthesize their opposite half.
+    pub mirror_lower_body: f32,
 }
 
 /// Client-side blend coordinates derived from authoritative state.
@@ -674,7 +674,7 @@ fn gait_or_idle(
             pose: idle,
             sampling: PoseSampling::Anchor,
             weight: 1.0,
-            mirror_lower_body: false,
+            mirror_lower_body: 0.0,
         }]
     } else {
         gait_pair(phase, contact, passing)
@@ -728,7 +728,7 @@ fn weighted_pair(a: SemanticPose, b: SemanticPose, b_weight: f32) -> Vec<PoseSam
             pose: a,
             sampling: PoseSampling::Anchor,
             weight: 1.0 - b_weight,
-            mirror_lower_body: false,
+            mirror_lower_body: 0.0,
         });
     }
     if b_weight > 0.0 {
@@ -736,21 +736,27 @@ fn weighted_pair(a: SemanticPose, b: SemanticPose, b_weight: f32) -> Vec<PoseSam
             pose: b,
             sampling: PoseSampling::Anchor,
             weight: b_weight,
-            mirror_lower_body: false,
+            mirror_lower_body: 0.0,
         });
     }
     samples
 }
 
 fn gait_pair(phase: f32, contact: SemanticPose, passing: SemanticPose) -> Vec<PoseSample> {
-    let _ = passing;
+    let quarter_phase = phase.rem_euclid(1.0) * 4.0;
+    let quarter = (quarter_phase.floor() as u8).min(3);
+    let progress = quarter_phase.fract();
+    let (pose, end, mirror_lower_body) = match quarter {
+        0 => (contact, passing, 0.0),
+        1 => (passing, contact, progress),
+        2 => (contact, passing, 1.0),
+        _ => (passing, contact, 1.0 - progress),
+    };
     vec![PoseSample {
-        pose: contact,
-        sampling: PoseSampling::Cycle {
-            phase: phase.rem_euclid(1.0),
-        },
+        pose,
+        sampling: PoseSampling::Span { end, progress },
         weight: 1.0,
-        mirror_lower_body: false,
+        mirror_lower_body,
     }]
 }
 
@@ -786,7 +792,7 @@ fn airborne_sample(direction: Vec2, vertical_velocity: f32) -> PoseSample {
         pose,
         sampling: PoseSampling::Span { end, progress },
         weight: 1.0,
-        mirror_lower_body: false,
+        mirror_lower_body: 0.0,
     }
 }
 
@@ -801,7 +807,7 @@ fn out_and_back(start: SemanticPose, middle: SemanticPose, phase: f32) -> PoseSa
         pose,
         sampling: PoseSampling::Span { end, progress },
         weight: 1.0,
-        mirror_lower_body: false,
+        mirror_lower_body: 0.0,
     }
 }
 
@@ -821,7 +827,7 @@ fn through_transition(
         pose,
         sampling: PoseSampling::Span { end, progress },
         weight: 1.0,
-        mirror_lower_body: false,
+        mirror_lower_body: 0.0,
     }
 }
 
@@ -892,7 +898,7 @@ fn attack_samples(state: &SkeletonState) -> Vec<PoseSample> {
             progress: blend,
         },
         weight: 1.0,
-        mirror_lower_body: false,
+        mirror_lower_body: 0.0,
     }]
 }
 
@@ -1049,15 +1055,44 @@ mod tests {
         let evaluation = AnimationEvaluation::from_skeleton(&state);
         assert_eq!(evaluation.base.len(), 2);
         assert!(evaluation.base.iter().any(|sample| {
-            sample.pose == SemanticPose::WalkContact
-                && sample.sampling == (PoseSampling::Cycle { phase: 0.25 })
+            sample.pose == SemanticPose::WalkPassing
+                && sample.sampling
+                    == (PoseSampling::Span {
+                        end: SemanticPose::WalkContact,
+                        progress: 0.0,
+                    })
                 && sample.weight == 0.5
         }));
         assert!(evaluation.base.iter().any(|sample| {
-            sample.pose == SemanticPose::RunContact
-                && sample.sampling == (PoseSampling::Cycle { phase: 0.25 })
+            sample.pose == SemanticPose::RunFlight
+                && sample.sampling
+                    == (PoseSampling::Span {
+                        end: SemanticPose::RunContact,
+                        progress: 0.0,
+                    })
                 && sample.weight == 0.5
         }));
+    }
+
+    #[test]
+    fn sparse_gait_mirrors_and_closes_the_authored_half_cycle() {
+        let samples = [0.0, 0.25, 0.5, 0.75]
+            .map(|phase| gait_pair(phase, SemanticPose::WalkContact, SemanticPose::WalkPassing)[0]);
+        assert_eq!(samples[0].pose, SemanticPose::WalkContact);
+        assert_eq!(samples[1].pose, SemanticPose::WalkPassing);
+        assert_eq!(samples[2].pose, SemanticPose::WalkContact);
+        assert_eq!(samples[3].pose, SemanticPose::WalkPassing);
+        assert_eq!(
+            samples.map(|sample| sample.mirror_lower_body),
+            [0.0, 0.0, 1.0, 1.0]
+        );
+
+        let entering_mirror =
+            gait_pair(0.375, SemanticPose::WalkContact, SemanticPose::WalkPassing)[0];
+        let leaving_mirror =
+            gait_pair(0.875, SemanticPose::WalkContact, SemanticPose::WalkPassing)[0];
+        assert_eq!(entering_mirror.mirror_lower_body, 0.5);
+        assert_eq!(leaving_mirror.mirror_lower_body, 0.5);
     }
 
     #[test]
@@ -1080,7 +1115,7 @@ mod tests {
                     progress: 0.0,
                 },
                 weight: 1.0,
-                mirror_lower_body: false,
+                mirror_lower_body: 0.0,
             }]
         );
 

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -388,8 +388,10 @@ identifies the instant at which the weapon, hand, or claw crosses its canonical
 opponent-side contact plane. The engine remains responsible for authoritative
 collision and damage.
 
-Locomotion poses use the **left** side as their canonical first half-cycle.
-The runtime may construct the opposite half by mirroring lower-body motion.
+Locomotion semantic anchors use the **left** side as their canonical first
+half-cycle, while each authored gait file supplies its complete second half and
+closure. Lower-body mirroring is retained only as an explicit fallback for a
+resolved sample whose source lacks authored opposite-foot frames.
 Attack and guard poses are not assumed to be whole-body mirrorable because a
 weapon may remain in the same hand.
 

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1832)
+## Files (1833)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -30,6 +30,7 @@ development, or other wiki document before changing a subsystem.
 - `THIRD_PARTY_NOTICES.md` — Project documentation.
 - `assets/TownA.glb` — Binary game or UI asset.
 - `assets/TownB.glb` — Binary game or UI asset.
+- `assets/animations/biped/README.md` — Component overview and usage notes.
 - `assets/animations/biped/unarmed/attack_slash_lead_left_contact.glb` — Binary game or UI asset.
 - `assets/animations/biped/unarmed/attack_thrust_lead_left_contact.glb` — Binary game or UI asset.
 - `assets/animations/biped/unarmed/base.glb` — Binary game or UI asset.


### PR DESCRIPTION
## What changed

- mirror safe lower-body gait motion for opposite half-cycles
- layer bounded impact reactions from successful attack responses
- integrate both layers into the post-FK procedural pipeline
- document the per-motion runtime asset layout and export guidance

## Why

Sparse authored locomotion needs deterministic phase reuse, and combat outcomes need immediate client-side feedback without coupling damage authority to bone animation.

## Validation

- gait continuity and lower-body mirror tests
- tactical core and client suites at the final stack head
- formatting and generated project-map checks
