### PR TITLE
Gate tactical startup on SpacetimeDB identity

### DIFF
--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -20,7 +20,11 @@ use bevy::prelude::*;
 use bevy::time::Stopwatch;
 use clap::{ArgAction, Parser};
 
-use crate::{bot::MissionEnemy, stdb::SpacetimeDb, terrain::TerrainGenerator};
+use crate::{
+    bot::MissionEnemy,
+    stdb::{SpacetimeDb, SpacetimeDbReady},
+    terrain::TerrainGenerator,
+};
 use input::AccumulatedInput;
 
 /// Default [`Args::timeout`] time.
@@ -151,7 +155,7 @@ fn main() {
             (
                 check_mission_timeout,
                 spawn_connected_players.after(stdb::update_spacetimedb),
-                (setup_server, setup_stdb_callbacks).run_if(resource_added::<SpacetimeDb>),
+                (setup_server, setup_stdb_callbacks).run_if(resource_added::<SpacetimeDbReady>),
             ),
         )
         .add_systems(OnEnter(ServerState::Running), on_server_started)
@@ -555,6 +559,7 @@ fn check_mission_timeout(
 fn on_server_started(
     args: Res<Args>,
     conn: Res<SpacetimeDb>,
+    ready: Res<SpacetimeDbReady>,
     mut commands: Commands,
     server_addr: Single<&LocalAddr, With<AdventureSimulatorServer>>,
 ) -> Result {
@@ -629,6 +634,7 @@ fn on_join_request(
     loading_players: Query<(), With<LoadingPlayer>>,
     players: Query<(), With<Player>>,
     conn: Res<SpacetimeDb>,
+    ready: Res<SpacetimeDbReady>,
 ) -> Result {
     let Some(client) = join.client_id.entity() else {
         return Ok(());
@@ -644,7 +650,7 @@ fn on_join_request(
     // Until the netcode authenticates character ownership, deployments must
     // keep tactical clients within the trusted mission boundary.
     conn.reducers()
-        .enter_mission(join.player_id, conn.identity())?;
+        .enter_mission(join.player_id, ready.identity())?;
 
     commands.entity(client).insert(LoadingPlayer {
         requested_player_id: join.player_id,

--- a/crates/adventuresim-tactical-server/src/stdb.rs
+++ b/crates/adventuresim-tactical-server/src/stdb.rs
@@ -12,8 +12,31 @@ pub struct SpacetimeDbPlugin;
 impl Plugin for SpacetimeDbPlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, connect_spacetimedb)
-            .add_systems(Update, update_spacetimedb)
+            .add_systems(
+                Update,
+                (
+                    update_spacetimedb,
+                    publish_spacetimedb_ready.after(update_spacetimedb),
+                ),
+            )
             .add_systems(Last, disconnect_spacetimedb);
+    }
+}
+
+/// A SpacetimeDB connection whose initial identity handshake has completed.
+///
+/// `DbConnection::build` returns before the SDK necessarily receives this
+/// identity. Systems which invoke reducers with the server identity must wait
+/// for this resource instead of calling the SDK's panicking `identity()` API.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct SpacetimeDbReady {
+    identity: Identity,
+}
+
+impl SpacetimeDbReady {
+    /// Identity assigned to this tactical server connection.
+    pub fn identity(self) -> Identity {
+        self.identity
     }
 }
 
@@ -31,11 +54,6 @@ impl SpacetimeDb {
     /// Access spacetime db reducers.
     pub fn reducers(&self) -> &RemoteReducers {
         &self.conn.reducers
-    }
-
-    /// Get the server's SpacetimeDB identity.
-    pub fn identity(&self) -> Identity {
-        self.conn.identity()
     }
 
     /// Subscribe to `connected_players` and start collecting inserted rows.
@@ -73,6 +91,24 @@ impl SpacetimeDb {
 pub fn update_spacetimedb(stdb: Res<SpacetimeDb>) -> Result {
     stdb.conn.frame_tick()?;
     Ok(())
+}
+
+/// Publish readiness only after `frame_tick` receives the initial identity.
+fn publish_spacetimedb_ready(
+    mut commands: Commands,
+    stdb: Res<SpacetimeDb>,
+    ready: Option<Res<SpacetimeDbReady>>,
+) {
+    if ready.is_some() {
+        return;
+    }
+
+    let Some(identity) = stdb.conn.try_identity() else {
+        return;
+    };
+
+    info!("SpacetimeDB connection is ready: {identity}");
+    commands.insert_resource(SpacetimeDbReady { identity });
 }
 
 /// On app exit, close the connection cleanly.

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -265,6 +265,12 @@ The current tactical stack uses Bevy Replicon over Aeronet WebSockets:
    compatible private strategic outcome, and commits durable consequences
    idempotently.
 
+The SpacetimeDB SDK connection is asynchronous: constructing it does not mean
+the server identity has arrived. The child pumps that connection until the
+identity is available, then installs reducer subscriptions and opens the
+tactical WebSocket listener. Bot creation and player joins use that cached
+ready identity and never call the SDK's panicking pre-handshake accessor.
+
 The current combat prototype calculates attacks but does not yet apply tactical
 damage, so no client-controlled path can emit authoritative enemy deaths.
 Required-kill missions therefore fail closed unless the server's future combat


### PR DESCRIPTION
## What changed

- publish an explicit `SpacetimeDbReady` resource only after the SDK receives the tactical server identity
- start reducer subscriptions and the tactical WebSocket listener only after that readiness transition
- use the cached ready identity for bot creation and player enrollment
- remove tactical-server calls to the SDK's panicking pre-handshake `identity()` accessor
- document the asynchronous connection ordering in the tactical lifecycle

## Root cause

`DbConnection::build()` returns before SpacetimeDB necessarily delivers the connection identity. The tactical listener previously opened as soon as the connection resource existed, so bot creation or an immediate player join could call `identity()` while `try_identity()` was still `None`, causing the SDK's `unwrap()` panic.

## Impact

The tactical server now pumps SpacetimeDB until the identity handshake completes before it becomes reachable. Startup remains non-blocking, and both bot missions and immediate client joins use a known identity.

## Validation

- `cargo test -p adventuresim-tactical-server` (30 passed at the final stack head; 1 passed on this branch)
- `cargo test -p adventuresim-tactical-core` (12 passed plus doc tests at the final stack head)
- `cargo test -p adventuresim-tactical-client` (28 passed at the final stack head)
- disposable `readiness-demo` profile with one bot: tactical server remained alive and listened on port 23402 instead of panicking
- `cargo fmt --all -- --check`
- `python scripts/update_project_map.py --check`
- `git diff --check`
