### PR TITLE
Add tactical third-person camera toggle

### DIFF
--- a/crates/adventuresim-tactical-client/src/camera.rs
+++ b/crates/adventuresim-tactical-client/src/camera.rs
@@ -1,0 +1,82 @@
+use adventuresim_tactical_core::prelude::CharacterControllerCameraOf;
+use bevy::prelude::*;
+
+const THIRD_PERSON_DISTANCE: f32 = 3.5;
+const THIRD_PERSON_HEIGHT: f32 = 0.25;
+
+pub struct TacticalCameraPlugin;
+
+impl Plugin for TacticalCameraPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<CameraMode>()
+            .add_systems(Update, toggle_camera_mode)
+            .add_systems(
+                PostUpdate,
+                apply_third_person_offset.before(TransformSystems::Propagate),
+            );
+    }
+}
+
+#[derive(Resource, Default)]
+struct CameraMode {
+    third_person: bool,
+}
+
+fn toggle_camera_mode(keyboard: Res<ButtonInput<KeyCode>>, mut mode: ResMut<CameraMode>) {
+    if keyboard.just_pressed(KeyCode::F9) {
+        mode.third_person = !mode.third_person;
+        info!(
+            third_person = mode.third_person,
+            "Changed tactical camera mode"
+        );
+    }
+}
+
+fn apply_third_person_offset(
+    mode: Res<CameraMode>,
+    mut cameras: Query<&mut Transform, With<CharacterControllerCameraOf>>,
+) {
+    if !mode.third_person {
+        return;
+    }
+
+    for mut transform in &mut cameras {
+        let rotation = transform.rotation;
+        transform.translation += third_person_offset(rotation);
+    }
+}
+
+fn third_person_offset(rotation: Quat) -> Vec3 {
+    let back = rotation * Vec3::Z;
+    let horizontal_back = Vec3::new(back.x, 0.0, back.z)
+        .try_normalize()
+        .unwrap_or(Vec3::Z);
+    horizontal_back * THIRD_PERSON_DISTANCE + Vec3::Y * THIRD_PERSON_HEIGHT
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn f9_toggles_third_person_mode() {
+        let mut world = World::new();
+        let mut keyboard = ButtonInput::default();
+        keyboard.press(KeyCode::F9);
+        world.insert_resource(keyboard);
+        world.insert_resource(CameraMode::default());
+
+        world.run_system_cached(toggle_camera_mode).unwrap();
+
+        assert!(world.resource::<CameraMode>().third_person);
+    }
+
+    #[test]
+    fn third_person_offset_keeps_distance_independent_of_pitch() {
+        let rotation = Quat::from_euler(EulerRot::YXZ, 0.7, 1.2, 0.0);
+        let offset = third_person_offset(rotation);
+
+        assert!((offset.y - THIRD_PERSON_HEIGHT).abs() < 0.0001);
+        assert!((offset.xz().length() - THIRD_PERSON_DISTANCE).abs() < 0.0001);
+    }
+}

--- a/crates/adventuresim-tactical-client/src/main.rs
+++ b/crates/adventuresim-tactical-client/src/main.rs
@@ -32,6 +32,7 @@ use console_error_panic_hook;
 use wasm_bindgen::prelude::*;
 
 mod animation;
+mod camera;
 #[cfg(feature = "debug")]
 mod debug;
 mod player;
@@ -97,6 +98,7 @@ fn run(args: Args) {
         ui::UiPlugin,
         player::PlayerPlugin,
         animation::TacticalAnimationPlugin,
+        camera::TacticalCameraPlugin,
     ))
     .insert_resource(ClearColor(Color::srgb(0.1, 0.1, 0.15)))
     .add_systems(Startup, (setup_scene, setup_client))

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -148,7 +148,9 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                 Name::new("controls"),
                 Text::new(""),
                 children![
-                    TextSpan::new("WASD to move | Space to jump | Mouse to look around\n"),
+                    TextSpan::new(
+                        "WASD to move | Space to jump | Mouse to look around | F9 to toggle camera\n"
+                    ),
                     #[cfg(feature = "debug")]
                     TextSpan::new(
                         "DEBUG: F2 to toggle body | F3 to toggle hitbox | F4 to toggle hitscan"

--- a/wiki/client/controls.md
+++ b/wiki/client/controls.md
@@ -57,7 +57,10 @@ One feature we quite want in the game eventually is a split between *direct* and
 We posit control schemes for both modes below.
 
 ### Direct controls
-These are designed primarily for the first person, but we can add a third-person camera option after the MVP.
+These are designed primarily for first person. The tactical client defaults to
+first person and toggles its current centered third-person follow camera with
+<kbd>F9</kbd>. The third-person option intentionally does not yet adjust its
+distance around nearby walls or thin obstacles.
 
 > Halbe: I assume that first person is easier because with third-person cameras, you need to handle a lot of edge cases to avoid awkwardness in tight spaces or near thin obstacles like trees, not to mention smoothing out the motion or reconciling the shoulder offset when aiming. However, if I am mistaken in my assumptions, we should implement whichever is easier for the MVP.
 
@@ -65,6 +68,7 @@ These are designed primarily for the first person, but we can add a third-person
 |-|-|-|-|
 | <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> | Left Stick | Movement. | |
 | Mouse | Right Stick | Look. | |
+| <kbd>F9</kbd> | | Toggle first-/third-person camera. | Third person uses the same look direction and a centered follow offset. |
 | LMB | RT | Attack! | |
 | Release <kbd>SPACE</kbd> | Full LT | Dodge or jump. | <ul><li>A quick tap is more like a hop or dash. Holding the button for a bit before releasing makes it a full-body jump. You can tell whether you have held long enough for a full jump by the state of your character's animation.<li>LT has to be held all the way, then released, to jump. |
 | <kbd>SHIFT</kbd> | Partial LT | Crouch or duck. | <ul><li>When crouching and attacked, your character automatically ducks in an appropriate direction, but only if you were not crouching before the attack began.<li>LT is only held partially here, so releasing it to un-crouch does not cause you to jump.

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1833)
+## Files (1834)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1258,6 +1258,7 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-client/assets/ui.css` — Browser UI styling.
 - `crates/adventuresim-tactical-client/src/animation.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/animation/procedural.rs` — Rust source module.
+- `crates/adventuresim-tactical-client/src/camera.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/debug.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/player.rs` — Rust source module for this component.


### PR DESCRIPTION
## Summary

- add an F9 toggle between the existing first-person camera and a centered third-person follow camera
- keep third-person distance stable while looking up or down
- document the control in the HUD and controls guide

The camera defaults to first person. Third person currently has no wall-collision avoidance.

## Verification

- `cargo test -p adventuresim-tactical-client` (31 passed)
- `cargo check -p adventuresim-tactical-client --features debug`
- `python scripts/update_project_map.py --check`
- `git diff --check`