### PR TITLE
Add deterministic animation capture viewer

### DIFF
--- a/crates/adventuresim-tactical-client/Cargo.toml
+++ b/crates/adventuresim-tactical-client/Cargo.toml
@@ -51,3 +51,8 @@ workspace = true
 [[bin]]
 name = "adventuresim-tactical-client"
 doc = false
+
+[[bin]]
+name = "animation-viewer"
+path = "src/animation_viewer_main.rs"
+doc = false

--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -47,10 +47,31 @@ Use these conventions:
 - the armature bind pose is a T-pose, which is the final runtime fallback;
 - each motion GLB contains exactly one animation and preserves all authored
   in-betweens between its documented frame anchors;
-- locomotion exports provide the canonical contact and passing/flight poses;
-  the runtime interpolates them, mirrors only the lower body for the
-  opposite-foot half, and closes the normalized gait cycle; and
+- cyclic locomotion exports include their complete opposite-foot half and loop
+  closure; runtime gait phase traverses the loaded clip's actual duration while
+  catalog frame numbers continue to identify semantic anchors; and
 - packs in one fallback chain use identical bone names and hierarchy.
+
+## Deterministic animation capture
+
+The native `animation-viewer` binary exercises the same authored FK,
+procedural mirroring, and terrain IK plugin as the tactical client without a
+server or player input. It holds eight evenly spaced walk phases under a fixed
+camera, writes one PNG per phase plus `manifest.json`, validates that foot lead
+changes twice across the captured cycle, and exits. A missing rig, unresolved
+walk clip, or unbound foot times out with `failure.txt` rather than hanging.
+
+Run it from the repository root:
+
+```powershell
+cargo run -p adventuresim-tactical-client --bin animation-viewer -- --output target/animation-captures/walk
+```
+
+Use `--asset-root` when invoking it outside the repository root and
+`--frames-per-sample` to change the regular interval after the initial render
+warmup. The manifest records gait phase, lower-body mirror weight, and both
+knee/foot world positions so procedural regressions can be diagnosed without
+visual guesswork.
 
 The procedural humanoid pass recognizes these case-sensitive bone names:
 

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -1,0 +1,429 @@
+//! A network-free viewer that captures the real tactical animation pipeline.
+
+use std::{fs, path::PathBuf};
+
+use adventuresim_tactical_core::prelude::*;
+use bevy::{
+    app::AppExit,
+    prelude::*,
+    render::view::screenshot::{Screenshot, ScreenshotCaptured, save_to_disk},
+    window::PresentMode,
+};
+
+use crate::animation::{AnimationPlayback, BoneRole, HumanoidBone, TacticalAnimationPlugin};
+
+const WALK_PHASES: [f32; 8] = [0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875];
+
+pub(crate) fn run(output: PathBuf, asset_root: PathBuf, frames_per_sample: u32) {
+    fs::create_dir_all(&output).unwrap_or_else(|error| {
+        panic!("failed to create animation capture directory {output:?}: {error}")
+    });
+    let _ = fs::remove_file(output.join("failure.txt"));
+
+    App::new()
+        .add_plugins(
+            DefaultPlugins
+                .set(AssetPlugin {
+                    file_path: asset_root.to_string_lossy().into_owned(),
+                    ..default()
+                })
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        title: "Adventure Simulator Animation Viewer".into(),
+                        resolution: (960, 720).into(),
+                        present_mode: PresentMode::AutoVsync,
+                        ..default()
+                    }),
+                    ..default()
+                }),
+        )
+        .add_plugins(TacticalAnimationPlugin)
+        .insert_resource(ClearColor(Color::srgb(0.08, 0.1, 0.13)))
+        .insert_resource(CaptureSequence::new(output, frames_per_sample))
+        .add_systems(Startup, setup_viewer)
+        .add_systems(PreUpdate, drive_capture_phase)
+        .add_systems(Last, capture_settled_phase)
+        .run();
+}
+
+#[derive(Component)]
+struct CaptureSubject;
+
+#[derive(Component)]
+struct CaptureLabel;
+
+#[derive(Resource)]
+struct CaptureSequence {
+    output: PathBuf,
+    frames_per_sample: u32,
+    index: usize,
+    settled_frames: u32,
+    phase_applied: bool,
+    capture_in_flight: bool,
+    waiting_frames: u32,
+    samples: Vec<CaptureSample>,
+}
+
+impl CaptureSequence {
+    fn new(output: PathBuf, frames_per_sample: u32) -> Self {
+        Self {
+            output,
+            frames_per_sample,
+            index: 0,
+            settled_frames: 0,
+            phase_applied: false,
+            capture_in_flight: false,
+            waiting_frames: 0,
+            samples: Vec::with_capacity(WALK_PHASES.len()),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CaptureManifest {
+    animation: &'static str,
+    frames_per_sample: u32,
+    validation: CaptureValidation,
+    samples: Vec<CaptureSample>,
+}
+
+#[derive(Debug)]
+struct CaptureValidation {
+    complete_cycle: bool,
+    foot_separation_range: f32,
+    foot_lead_changes: usize,
+}
+
+#[derive(Debug)]
+struct CaptureSample {
+    index: usize,
+    gait_phase: f32,
+    lower_body_mirror: f32,
+    screenshot: String,
+    left_knee: Option<[f32; 3]>,
+    right_knee: Option<[f32; 3]>,
+    left_foot: Option<[f32; 3]>,
+    right_foot: Option<[f32; 3]>,
+}
+
+fn setup_viewer(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn(SceneTerrain::new(16, 16, 1.0, |_| 0.0));
+    commands.spawn((
+        Name::new("Animation viewer floor"),
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(16.0, 16.0))),
+        MeshMaterial3d(materials.add(StandardMaterial {
+            base_color: Color::srgb(0.22, 0.28, 0.2),
+            perceptual_roughness: 0.9,
+            ..default()
+        })),
+    ));
+
+    commands.spawn((
+        Name::new("Animation capture subject"),
+        CaptureSubject,
+        Player {
+            name: "Animation viewer".into(),
+        },
+        CharacterLook::default(),
+        SkeletonState {
+            local_velocity: Vec3::Z * 1.5,
+            grounded: true,
+            ..default()
+        },
+        Transform::from_xyz(0.0, 0.95, 0.0),
+        Visibility::Inherited,
+    ));
+
+    commands.spawn((
+        Name::new("Animation viewer sun"),
+        DirectionalLight {
+            shadows_enabled: true,
+            illuminance: 12_000.0,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 7.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+    commands.spawn(AmbientLight {
+        color: Color::WHITE,
+        brightness: 350.0,
+        affects_lightmapped_meshes: true,
+    });
+    commands.spawn((
+        Name::new("Animation viewer camera"),
+        Camera3d::default(),
+        Transform::from_xyz(3.2, 2.1, 4.5).looking_at(Vec3::new(0.0, 0.95, 0.0), Vec3::Y),
+    ));
+    commands.spawn((
+        CaptureLabel,
+        Text::new("Loading authored animation rig..."),
+        TextFont::from_font_size(24.0),
+        TextColor(Color::WHITE),
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(16),
+            left: px(16),
+            ..default()
+        },
+    ));
+}
+
+fn drive_capture_phase(
+    mut sequence: ResMut<CaptureSequence>,
+    mut subjects: Query<&mut SkeletonState, With<CaptureSubject>>,
+    mut labels: Query<&mut Text, With<CaptureLabel>>,
+) {
+    if sequence.phase_applied || sequence.capture_in_flight || sequence.index >= WALK_PHASES.len() {
+        return;
+    }
+    let phase = WALK_PHASES[sequence.index];
+    for mut skeleton in &mut subjects {
+        skeleton.gait_phase = phase;
+    }
+    for mut label in &mut labels {
+        **label = format!(
+            "walk | phase {phase:.3} | sample {} / {}",
+            sequence.index + 1,
+            WALK_PHASES.len()
+        );
+    }
+    sequence.phase_applied = true;
+    sequence.settled_frames = 0;
+}
+
+fn capture_settled_phase(
+    mut commands: Commands,
+    mut sequence: ResMut<CaptureSequence>,
+    subjects: Query<(Entity, &SkeletonState, Option<&AnimationPlayback>), With<CaptureSubject>>,
+    bones: Query<(&HumanoidBone, &GlobalTransform)>,
+    mut exit: MessageWriter<AppExit>,
+) {
+    if !sequence.phase_applied || sequence.capture_in_flight {
+        return;
+    }
+    let Ok((subject, skeleton, playback)) = subjects.single() else {
+        wait_or_fail(&mut sequence, "capture subject is missing", &mut exit);
+        return;
+    };
+    let Some(playback) = playback else {
+        wait_or_fail(
+            &mut sequence,
+            "capture subject has no AnimationPlayback",
+            &mut exit,
+        );
+        return;
+    };
+    if !playback.authored_pose_is_ready() {
+        wait_or_fail(
+            &mut sequence,
+            "authored walk clip has not resolved",
+            &mut exit,
+        );
+        return;
+    }
+    let mut left_knee = None;
+    let mut right_knee = None;
+    let mut left_foot = None;
+    let mut right_foot = None;
+    for (bone, transform) in &bones {
+        if bone.owner != subject {
+            continue;
+        }
+        let position = transform.translation().to_array();
+        match bone.role {
+            BoneRole::ShinLeft => left_knee = Some(position),
+            BoneRole::ShinRight => right_knee = Some(position),
+            BoneRole::FootLeft => left_foot = Some(position),
+            BoneRole::FootRight => right_foot = Some(position),
+            _ => {}
+        }
+    }
+    if left_foot.is_none() || right_foot.is_none() {
+        wait_or_fail(
+            &mut sequence,
+            "authored rig is missing bound foot bones",
+            &mut exit,
+        );
+        return;
+    }
+
+    sequence.waiting_frames = 0;
+    sequence.settled_frames += 1;
+    let required_frames = if sequence.index == 0 {
+        sequence.frames_per_sample.max(60)
+    } else {
+        sequence.frames_per_sample
+    };
+    if sequence.settled_frames < required_frames {
+        return;
+    }
+
+    let index = sequence.index;
+    let phase = skeleton.gait_phase;
+    let file_name = format!("walk-{index:02}-phase-{phase:.3}.png");
+    let path = sequence.output.join(&file_name);
+    sequence.samples.push(CaptureSample {
+        index,
+        gait_phase: phase,
+        lower_body_mirror: playback.lower_body_mirror,
+        screenshot: file_name,
+        left_knee,
+        right_knee,
+        left_foot,
+        right_foot,
+    });
+    sequence.capture_in_flight = true;
+
+    commands.spawn(Screenshot::primary_window()).observe(
+        move |captured: On<ScreenshotCaptured>,
+              mut sequence: ResMut<CaptureSequence>,
+              mut exit: MessageWriter<AppExit>| {
+            save_to_disk(&path)(captured);
+            sequence.index += 1;
+            sequence.phase_applied = false;
+            sequence.capture_in_flight = false;
+            if sequence.index == WALK_PHASES.len() {
+                let validation = CaptureValidation::from_samples(&sequence.samples);
+                let manifest = CaptureManifest {
+                    animation: "walk",
+                    frames_per_sample: sequence.frames_per_sample,
+                    validation,
+                    samples: std::mem::take(&mut sequence.samples),
+                };
+                let manifest_path = sequence.output.join("manifest.json");
+                fs::write(&manifest_path, manifest.to_json())
+                    .unwrap_or_else(|error| panic!("failed to write {manifest_path:?}: {error}"));
+                info!(path = ?manifest_path, "Animation capture completed");
+                if manifest.validation.complete_cycle {
+                    exit.write(AppExit::Success);
+                } else {
+                    let failure_path = sequence.output.join("failure.txt");
+                    fs::write(
+                        &failure_path,
+                        "captured foot coordinates do not traverse a complete gait cycle\n",
+                    )
+                    .unwrap_or_else(|error| panic!("failed to write {failure_path:?}: {error}"));
+                    exit.write(AppExit::Error(1.try_into().expect("one is non-zero")));
+                }
+            }
+        },
+    );
+}
+
+fn wait_or_fail(sequence: &mut CaptureSequence, reason: &str, exit: &mut MessageWriter<AppExit>) {
+    sequence.waiting_frames += 1;
+    if sequence.waiting_frames < 600 {
+        return;
+    }
+    let message = format!(
+        "animation viewer timed out after {} rendered frames: {reason}\n",
+        sequence.waiting_frames
+    );
+    let path = sequence.output.join("failure.txt");
+    fs::write(&path, &message).unwrap_or_else(|error| panic!("failed to write {path:?}: {error}"));
+    error!(%reason, path = ?path, "Animation capture failed");
+    exit.write(AppExit::Error(1.try_into().expect("one is non-zero")));
+}
+
+impl CaptureManifest {
+    fn to_json(&self) -> String {
+        let samples = self
+            .samples
+            .iter()
+            .map(CaptureSample::to_json)
+            .collect::<Vec<_>>()
+            .join(",\n");
+        format!(
+            concat!(
+                "{{\n",
+                "  \"animation\": \"{}\",\n",
+                "  \"frames_per_sample\": {},\n",
+                "  \"validation\": {{\n",
+                "    \"complete_cycle\": {},\n",
+                "    \"foot_separation_range\": {:.6},\n",
+                "    \"foot_lead_changes\": {}\n",
+                "  }},\n",
+                "  \"samples\": [\n{}\n  ]\n",
+                "}}\n"
+            ),
+            self.animation,
+            self.frames_per_sample,
+            self.validation.complete_cycle,
+            self.validation.foot_separation_range,
+            self.validation.foot_lead_changes,
+            samples
+        )
+    }
+}
+
+impl CaptureValidation {
+    fn from_samples(samples: &[CaptureSample]) -> Self {
+        let separations = samples
+            .iter()
+            .filter_map(CaptureSample::foot_separation)
+            .collect::<Vec<_>>();
+        let (minimum, maximum) = separations.iter().fold(
+            (f32::INFINITY, f32::NEG_INFINITY),
+            |(minimum, maximum), &value| (minimum.min(value), maximum.max(value)),
+        );
+        let foot_separation_range = if minimum.is_finite() && maximum.is_finite() {
+            maximum - minimum
+        } else {
+            0.0
+        };
+        let foot_lead_changes = separations
+            .iter()
+            .zip(separations.iter().cycle().skip(1))
+            .take(separations.len())
+            .filter(|(before, after)| before.signum() != after.signum())
+            .count();
+        Self {
+            complete_cycle: separations.len() == WALK_PHASES.len()
+                && foot_separation_range > 0.5
+                && foot_lead_changes >= 2,
+            foot_separation_range,
+            foot_lead_changes,
+        }
+    }
+}
+
+impl CaptureSample {
+    fn foot_separation(&self) -> Option<f32> {
+        Some(self.left_foot?[2] - self.right_foot?[2])
+    }
+
+    fn to_json(&self) -> String {
+        format!(
+            concat!(
+                "    {{\n",
+                "      \"index\": {},\n",
+                "      \"gait_phase\": {:.6},\n",
+                "      \"lower_body_mirror\": {:.6},\n",
+                "      \"screenshot\": \"{}\",\n",
+                "      \"left_knee\": {},\n",
+                "      \"right_knee\": {},\n",
+                "      \"left_foot\": {},\n",
+                "      \"right_foot\": {}\n",
+                "    }}"
+            ),
+            self.index,
+            self.gait_phase,
+            self.lower_body_mirror,
+            self.screenshot,
+            json_vec3(self.left_knee),
+            json_vec3(self.right_knee),
+            json_vec3(self.left_foot),
+            json_vec3(self.right_foot),
+        )
+    }
+}
+
+fn json_vec3(value: Option<[f32; 3]>) -> String {
+    value.map_or_else(
+        || "null".to_owned(),
+        |[x, y, z]| format!("[{x:.6}, {y:.6}, {z:.6}]"),
+    )
+}

--- a/crates/adventuresim-tactical-client/src/animation_viewer_main.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer_main.rs
@@ -1,0 +1,36 @@
+//! Deterministic native animation capture utility.
+
+mod animation;
+mod animation_viewer;
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(version, about = "Capture deterministic tactical animation phases")]
+struct Args {
+    /// Directory receiving PNG frames and manifest.json.
+    #[arg(long, default_value = "target/animation-captures/walk")]
+    output: PathBuf,
+
+    /// Repository asset directory containing animations/.
+    #[arg(long, default_value = "assets")]
+    asset_root: PathBuf,
+
+    /// Rendered frames allowed for each phase to settle before capture.
+    #[arg(long, default_value_t = 6)]
+    frames_per_sample: u32,
+}
+
+fn main() {
+    let args = Args::parse();
+    let asset_root = if args.asset_root.is_absolute() {
+        args.asset_root
+    } else {
+        std::env::current_dir()
+            .expect("animation viewer needs a working directory")
+            .join(args.asset_root)
+    };
+    animation_viewer::run(args.output, asset_root, args.frames_per_sample.max(1));
+}

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1834)
+## Files (1836)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1258,6 +1258,8 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-client/assets/ui.css` — Browser UI styling.
 - `crates/adventuresim-tactical-client/src/animation.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/animation/procedural.rs` — Rust source module.
+- `crates/adventuresim-tactical-client/src/animation_viewer.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-client/src/animation_viewer_main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/camera.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/debug.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/main.rs` — Rust source module for this component.


### PR DESCRIPTION
## What changed

- add a standalone native `animation-viewer` binary that runs the production tactical animation plugin without networking or input
- capture eight deterministic walk phases as PNGs under a fixed camera
- emit a machine-readable manifest with gait phase, mirror weight, and knee/foot world coordinates
- fail cleanly with diagnostics when the rig, clip, or canonical foot bones do not become ready
- validate that the captured gait changes foot lead twice before exiting successfully

## Why

Live-client observation made the sparse gait look like a two-pose ping-pong, but did not reveal whether the problem was clip sampling, procedural mirroring, IK, or an outdated executable. The capture harness makes those layers reproducible and independently inspectable.

Using it exposed that catalog frame 32 is a minimum semantic-frame contract while the current `walk.glb` clip is longer. The animation-layers branch beneath this PR now traverses the loaded clip's actual duration for cyclic locomotion, preserving semantic frame anchors for pose lookup and validation.

## Validation

- `cargo test --locked -p adventuresim-tactical-core --lib` (16 passed)
- `cargo test --locked -p adventuresim-tactical-client --bin adventuresim-tactical-client` (34 passed)
- `python scripts/update_project_map.py --check`
- final viewer capture: `complete_cycle: true`, foot-separation range `1.646135`, foot-lead changes `2`
