### PR TITLE
Improve sparse tactical locomotion quality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,8 @@ dependencies = [
  "bevy_flair",
  "clap",
  "console_error_panic_hook",
+ "serde",
+ "serde_json",
  "tracing",
  "tracing-subscriber",
  "tracing-tracy",

--- a/crates/adventuresim-tactical-client/Cargo.toml
+++ b/crates/adventuresim-tactical-client/Cargo.toml
@@ -17,6 +17,8 @@ bevy_flair.workspace = true
 adventuresim-tactical-core = { workspace = true, features = ["meshgen"] }
 adventuresim-tactical-netcode = { workspace = true, features = ["client"] }
 clap.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tracing.workspace = true
 tracing-tracy = { version = "0.11", optional = true }
 tracing-subscriber = { version = "0.3", optional = true }

--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -101,6 +101,10 @@ When support is high, terrain IK retains the foot's world-space horizontal
 plant until support releases; this prevents the character-following camera
 from concealing conveyor-belt foot skating.
 
+In debug builds, press `F8` to toggle only the final terrain leg-IK pass. The
+HUD reports whether it is on or off; authored FK, gait mirroring, and torso
+stabilization remain active for a useful before/after comparison.
+
 The procedural humanoid pass recognizes these case-sensitive bone names:
 
 ```text

--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -45,33 +45,61 @@ Use these conventions:
 - glTF coordinates and meters: +Y up, -Z forward, +X anatomical left;
 - the scene root stays at the origin and gameplay movement is not baked into it;
 - the armature bind pose is a T-pose, which is the final runtime fallback;
-- each motion GLB contains exactly one animation and preserves all authored
-  in-betweens between its documented frame anchors;
-- cyclic locomotion exports include their complete opposite-foot half and loop
-  closure; runtime gait phase traverses the loaded clip's actual duration while
-  catalog frame numbers continue to identify semantic anchors; and
+- each motion GLB contains exactly one animation and preserves its documented
+  semantic anchors;
+- locomotion uses only its contact and passing/flight anchor frames. The
+  runtime constructs contact -> passing -> mirrored contact -> mirrored
+  passing -> contact with smooth quarter-cycle interpolation; later exporter
+  keys cannot become accidental runtime gait poses; and
 - packs in one fallback chain use identical bone names and hierarchy.
+
+Lower-body reflection is evaluated in character space so anatomical left and
+right retain their lateral spacing while exchanging gait roles. Authored
+upper-body carriage remains intact; explicit hand targets and weapon
+constraints apply only when gameplay supplies them. Root, pelvis, spine, neck,
+and head motion is clamped around the authored bind pose before look and final
+IK, with a bounded procedural lift preserving the run's airborne beats.
 
 ## Deterministic animation capture
 
 The native `animation-viewer` binary exercises the same authored FK,
-procedural mirroring, and terrain IK plugin as the tactical client without a
-server or player input. It holds eight evenly spaced walk phases under a fixed
-camera, writes one PNG per phase plus `manifest.json`, validates that foot lead
-changes twice across the captured cycle, and exits. A missing rig, unresolved
-walk clip, or unbound foot times out with `failure.txt` rather than hanging.
+procedural mirroring, look pass, and terrain IK plugin as the tactical client
+without a server or player input. It advances the same server stride formula
+at a deterministic 60Hz through two-cycle 2.0m/s walk, 3.75m/s blend, and
+5.5m/s run scenarios plus a four-second start/run/stop transition. Every frame
+is captured from live-like third-person, side, and front views over a fixed
+one-metre world grid, with a skeleton overlay and yellow supported-foot / pink
+swing-foot markers. The output includes per-view PNG sequences, `manifest.json` bone and
+support telemetry, and an `index.html` normal/half/quarter-speed reviewer with
+representative contact sheets. A missing rig or unresolved locomotion clip
+times out with `failure.txt` rather than hanging.
 
 Run it from the repository root:
 
 ```powershell
-cargo run -p adventuresim-tactical-client --bin animation-viewer -- --output target/animation-captures/walk
+cargo run -p adventuresim-tactical-client --bin animation-viewer -- --output target/animation-captures/locomotion-review
 ```
 
 Use `--asset-root` when invoking it outside the repository root and
-`--frames-per-sample` to change the regular interval after the initial render
-warmup. The manifest records gait phase, lower-body mirror weight, and both
-knee/foot world positions so procedural regressions can be diagnosed without
-visual guesswork.
+`--frames-per-sample` to change the render settle interval (not the simulated
+60Hz sample interval). Open `index.html` after capture and review each scenario
+at normal speed before using slow motion. The manifest tracks pelvis, chest,
+head, shoulders, elbows, hands, hips, knees, and feet; finite transforms; loop
+seams; per-frame displacement and rotation spikes; knee direction; foot
+height/support/slip; and pelvis/head stability. These values are regression
+signals and do not establish biomechanical correctness without visual review.
+Capture fails for teleport-scale continuity, ground penetration, duplicate
+front/side/third-person image output, missing artifacts, or excessive
+supported-foot per-frame slip and planted-interval drift, and records the
+responsible frames.
+
+Walk keeps at least partial terrain support throughout its cycle. As locomotion
+blends toward run, support narrows around each foot contact until the authored
+run's quarter-cycle flight phases have zero leg-IK weight. This prevents terrain
+IK from converting a deliberately airborne swing into a kick or pop.
+When support is high, terrain IK retains the foot's world-space horizontal
+plant until support releases; this prevents the character-following camera
+from concealing conveyor-belt foot skating.
 
 The procedural humanoid pass recognizes these case-sensitive bone names:
 

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -64,7 +64,8 @@ impl Plugin for TacticalAnimationPlugin {
                 PostUpdate,
                 (
                     restore_authored_bind_pose,
-                    procedural::apply_lower_body_mirroring,
+                    procedural::apply_locomotion_facing,
+                    procedural::apply_gait_mirroring,
                     procedural::stabilize_locomotion_torso,
                     procedural::apply_head_and_torso_look,
                     procedural::apply_impact_reaction,

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -19,6 +19,7 @@ mod procedural;
 #[allow(unused_imports)]
 pub(crate) use procedural::{
     BoneRole, HandIkTarget, HandSide, HeldWeaponConstraint, HumanoidBone, HumanoidIkTargets,
+    gait_support_weights,
 };
 const HUMANOID_UNARMED_PACK: &str = "humanoid_unarmed";
 const BIPED_BASE_GLB: &str = "animations/biped/unarmed/base.glb";
@@ -62,8 +63,9 @@ impl Plugin for TacticalAnimationPlugin {
                 PostUpdate,
                 (
                     restore_authored_bind_pose,
-                    procedural::apply_head_and_torso_look,
                     procedural::apply_lower_body_mirroring,
+                    procedural::stabilize_locomotion_torso,
+                    procedural::apply_head_and_torso_look,
                     procedural::apply_impact_reaction,
                     procedural::apply_terrain_leg_ik,
                     procedural::apply_arm_and_weapon_constraints,
@@ -346,7 +348,10 @@ impl AnimationPackCatalog {
 #[derive(Debug, Clone)]
 struct LoadedClip {
     node: AnimationNodeIndex,
-    duration_seconds: f32,
+    /// The code-owned catalog range is authoritative. Exporters may retain
+    /// extra timeline keys, but locomotion must never sample beyond the
+    /// documented closure frame.
+    cycle_duration_seconds: f32,
 }
 
 #[derive(Resource, Default)]
@@ -417,8 +422,8 @@ struct AnimationGraphRevision(u64);
 
 #[derive(Component, Debug, Clone, Copy)]
 struct AuthoredBindTransform {
-    owner: Entity,
-    local: Transform,
+    pub(super) owner: Entity,
+    pub(super) local: Transform,
 }
 
 #[derive(Component, Debug, Clone, Copy)]
@@ -581,15 +586,19 @@ fn collect_loaded_packs(
         .into_iter()
         .zip(nodes)
         .map(|((key, handle), node)| {
-            let duration_seconds = clips
+            let source = &catalog.packs[&key.0].motions[&key.1];
+            let exported_duration = clips
                 .get(&handle)
                 .map(AnimationClip::duration)
-                .unwrap_or_default();
+                .unwrap_or(0.0);
+            let cycle_duration_seconds =
+                authoritative_cycle_duration(source.last_frame, exported_duration)
+                    .expect("processed motion already passed catalog-range validation");
             (
                 key,
                 LoadedClip {
                     node,
-                    duration_seconds,
+                    cycle_duration_seconds,
                 },
             )
         })
@@ -604,6 +613,10 @@ fn sole_animation(animations: &[Handle<AnimationClip>]) -> Option<&Handle<Animat
 
 fn frame_fits_clip(frame: u16, duration: f32) -> bool {
     frame_seconds(frame) <= duration + 0.5 / ANIMATION_FPS
+}
+
+fn authoritative_cycle_duration(last_frame: u16, exported_duration: f32) -> Option<f32> {
+    frame_fits_clip(last_frame, exported_duration).then(|| frame_seconds(last_frame))
 }
 
 fn frame_seconds(frame: u16) -> f32 {
@@ -965,7 +978,7 @@ fn append_resolved_sample(
         PoseSampling::Cycle { progress } => append_weighted(
             weighted,
             &start,
-            start.clip.duration_seconds * progress.rem_euclid(1.0),
+            start.clip.cycle_duration_seconds * progress.rem_euclid(1.0),
             sample.weight,
         ),
         PoseSampling::Span { end, progress } => {
@@ -1166,7 +1179,6 @@ pub fn spawn_fallback_t_pose(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::player::ClientPlayer;
 
     fn spawn_test_t_pose(
         In(owner): In<Entity>,
@@ -1274,16 +1286,16 @@ mod tests {
         };
         for pose in poses {
             let anchor = &catalog.packs[HUMANOID_UNARMED_PACK].poses[&pose];
-            let duration_seconds = catalog.packs[HUMANOID_UNARMED_PACK].motions[&anchor.motion]
-                .last_frame as f32
-                / ANIMATION_FPS;
+            let cycle_duration_seconds =
+                catalog.packs[HUMANOID_UNARMED_PACK].motions[&anchor.motion].last_frame as f32
+                    / ANIMATION_FPS;
             let next_node = AnimationNodeIndex::new(runtime.clips.len());
             runtime
                 .clips
                 .entry((HUMANOID_UNARMED_PACK.to_owned(), anchor.motion.clone()))
                 .or_insert(LoadedClip {
                     node: next_node,
-                    duration_seconds,
+                    cycle_duration_seconds,
                 });
         }
         runtime
@@ -1333,6 +1345,42 @@ mod tests {
         );
         assert_eq!(weighted.len(), 1);
         assert!((weighted[0].time_seconds - 16.0 / ANIMATION_FPS).abs() < 0.0001);
+    }
+
+    #[test]
+    fn complete_cycle_ignores_exported_keys_after_catalog_closure() {
+        let catalog = AnimationPackCatalog::default();
+        let mut runtime = runtime_with_available([SemanticPose::RunContact]);
+        let exported_clip_duration = 64.0 / ANIMATION_FPS;
+        runtime
+            .clips
+            .get_mut(&(HUMANOID_UNARMED_PACK.to_owned(), "run".to_owned()))
+            .unwrap()
+            .cycle_duration_seconds =
+            authoritative_cycle_duration(20, exported_clip_duration).unwrap();
+        let mut weighted = Vec::new();
+        append_resolved_sample(
+            &mut weighted,
+            &runtime,
+            &catalog,
+            HUMANOID_UNARMED_PACK,
+            PoseSample {
+                pose: SemanticPose::RunContact,
+                sampling: PoseSampling::Cycle { progress: 0.999 },
+                weight: 1.0,
+                mirror_lower_body: 0.0,
+            },
+        );
+        assert!(
+            weighted
+                .iter()
+                .all(|sample| sample.time_seconds <= 20.0 / ANIMATION_FPS)
+        );
+        assert!(
+            weighted
+                .iter()
+                .all(|sample| sample.time_seconds < exported_clip_duration)
+        );
     }
 
     #[test]
@@ -1407,12 +1455,14 @@ mod tests {
     }
 
     #[test]
-    fn authored_rig_attaches_to_the_client_controlled_player() {
+    fn authored_rig_attaches_to_a_player_with_skeleton_state() {
         let mut world = World::new();
         let mut runtime = AnimationRuntime::default();
         runtime.base_scene = Some(Handle::default());
         world.insert_resource(runtime);
-        let owner = world.spawn((Player::default(), ClientPlayer)).id();
+        let owner = world
+            .spawn((Player::default(), SkeletonState::default()))
+            .id();
 
         world.run_system_cached(attach_loaded_rig_scenes).unwrap();
         world.flush();

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -35,6 +35,7 @@ impl Plugin for TacticalAnimationPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<AnimationPackCatalog>()
             .init_resource::<AnimationRuntime>()
+            .init_resource::<TerrainIkEnabled>()
             .add_systems(Startup, request_animation_packs)
             .add_observer(on_successful_attack)
             .add_systems(
@@ -74,6 +75,17 @@ impl Plugin for TacticalAnimationPlugin {
                     .after(AnimationSystems)
                     .before(TransformSystems::Propagate),
             );
+    }
+}
+
+/// Runtime switch for the final terrain leg-IK pass. It defaults on in every
+/// build; the debug plugin exposes an F8 toggle without changing authored FK.
+#[derive(Resource, Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TerrainIkEnabled(pub bool);
+
+impl Default for TerrainIkEnabled {
+    fn default() -> Self {
+        Self(true)
     }
 }
 

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -450,6 +450,7 @@ pub(crate) struct HeldWeaponConstraint {
 /// then lowers the hips by the bounded residual. Weapon/hand constraints use
 /// the same final-pose seam when authored held-item rigs arrive.
 pub(super) fn apply_terrain_leg_ik(
+    enabled: Res<super::TerrainIkEnabled>,
     terrain: Query<&SceneTerrain>,
     owners: Query<&SkeletonState>,
     bones: Query<(Entity, &HumanoidBone, Option<&SoleUpAxis>)>,
@@ -458,6 +459,14 @@ pub(super) fn apply_terrain_leg_ik(
     mut transforms: ParamSet<(TransformHelper, Query<&mut Transform>)>,
     mut commands: Commands,
 ) {
+    if !enabled.0 {
+        // Discard plant targets while disabled so re-enabling IK starts from
+        // the current authored pose instead of snapping to a stale footprint.
+        for mut state in &mut ik_states {
+            state.0 = PoleMemory::default();
+        }
+        return;
+    }
     let Some(terrain) = terrain.iter().next() else {
         return;
     };

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use adventuresim_tactical_core::prelude::*;
 use bevy::{math::Affine3A, prelude::*};
 
-use super::{AnimationPlayback, AnimationRigScene, ImpactReaction};
+use super::{AnimationPlayback, AnimationRigScene, AuthoredBindTransform, ImpactReaction};
 
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct HumanoidBone {
@@ -184,7 +184,9 @@ pub(super) fn apply_head_and_torso_look(
 }
 
 /// Constructs the opposite gait half-cycle without mirroring handed upper-body
-/// carriage. The evaluator can continuously blend into or out of the mirror.
+/// carriage. Gait mirroring transitions only around the authored passing pose,
+/// where the legs are nearest one another; interpolating throughout contact
+/// folds the planted stride through itself.
 pub(super) fn apply_lower_body_mirroring(
     playbacks: Query<&AnimationPlayback>,
     parents: Query<&ChildOf>,
@@ -285,6 +287,61 @@ pub(super) fn apply_lower_body_mirroring(
     }
 }
 
+/// Removes exporter-scale torso excursions from ordinary locomotion while
+/// retaining a small authored weight shift. Gameplay root travel remains on
+/// the owner entity, and look is applied after this bounded pass.
+pub(super) fn stabilize_locomotion_torso(
+    owners: Query<&SkeletonState>,
+    mut bones: Query<(&HumanoidBone, &AuthoredBindTransform, &mut Transform)>,
+) {
+    for (bone, bind, mut transform) in &mut bones {
+        let Ok(skeleton) = owners.get(bone.owner) else {
+            continue;
+        };
+        if !skeleton.grounded
+            || skeleton.action != SkeletonAction::None
+            || skeleton.local_velocity.xz().length() <= 0.05
+            || !matches!(skeleton.posture, Posture::Upright | Posture::Crouched)
+        {
+            continue;
+        }
+        let (translation_limit, rotation_limit) = match bone.role {
+            BoneRole::Root => (Vec3::new(0.02, 0.02, 0.025), 6.0_f32.to_radians()),
+            BoneRole::Pelvis => (Vec3::new(0.035, 0.04, 0.045), 10.0_f32.to_radians()),
+            BoneRole::StomachOne | BoneRole::StomachTwo | BoneRole::Chest => {
+                (Vec3::splat(0.012), 12.0_f32.to_radians())
+            }
+            BoneRole::NeckOne | BoneRole::NeckTwo | BoneRole::Head => {
+                (Vec3::splat(0.008), 10.0_f32.to_radians())
+            }
+            _ => continue,
+        };
+        transform.translation = bind.local.translation
+            + (transform.translation - bind.local.translation)
+                .clamp(-translation_limit, translation_limit);
+        transform.rotation =
+            clamp_rotation_from_bind(bind.local.rotation, transform.rotation, rotation_limit);
+        if bone.role == BoneRole::Root {
+            let speed = skeleton.local_velocity.xz().length();
+            let run = locomotion_run_weight(speed);
+            let flight = (skeleton.gait_phase.rem_euclid(1.0) * std::f32::consts::TAU)
+                .sin()
+                .abs();
+            transform.translation.y += 0.085 * run * flight;
+        }
+    }
+}
+
+fn clamp_rotation_from_bind(bind: Quat, animated: Quat, maximum_angle: f32) -> Quat {
+    let delta = (bind.inverse() * animated).normalize();
+    let angle = Quat::IDENTITY.angle_between(delta);
+    if angle <= maximum_angle || angle <= f32::EPSILON {
+        animated.normalize()
+    } else {
+        (bind * Quat::IDENTITY.slerp(delta, maximum_angle / angle)).normalize()
+    }
+}
+
 #[derive(Clone, Copy)]
 struct MirrorBone {
     entity: Entity,
@@ -349,6 +406,8 @@ struct BoneSnapshot {
 struct PoleMemory {
     left_leg: Option<Vec3>,
     right_leg: Option<Vec3>,
+    left_foot_plant: Option<Vec3>,
+    right_foot_plant: Option<Vec3>,
     left_arm: Option<Vec3>,
     right_arm: Option<Vec3>,
 }
@@ -423,9 +482,8 @@ pub(super) fn apply_terrain_leg_ik(
             continue;
         }
         let phase = skeleton.gait_phase.rem_euclid(1.0);
-        let moving = skeleton.local_velocity.xz().length_squared() > 0.0025;
-        let left_weight = foot_plant_weight(phase, moving);
-        let right_weight = foot_plant_weight((phase + 0.5).rem_euclid(1.0), moving);
+        let ground_speed = skeleton.local_velocity.xz().length();
+        let (left_weight, right_weight) = gait_support_weights(phase, ground_speed);
         let legs = [
             (
                 BoneRole::ThighLeft,
@@ -507,12 +565,26 @@ pub(super) fn apply_terrain_leg_ik(
                 continue;
             };
             let foot_position = foot_snapshot.global.translation();
-            let Some(height) = terrain.height_at(foot_position.xz()) else {
+            let plant = if left {
+                &mut memory.left_foot_plant
+            } else {
+                &mut memory.right_foot_plant
+            };
+            if weight <= 0.05
+                || plant.is_some_and(|position| position.distance(foot_position) > 0.75)
+            {
+                *plant = None;
+            }
+            if weight >= 0.55 && plant.is_none() {
+                *plant = Some(foot_position);
+            }
+            let horizontal_target = plant.unwrap_or(foot_position);
+            let Some(height) = terrain.height_at(horizontal_target.xz()) else {
                 continue;
             };
             let desired_y = height + ankle_sole_offset(foot_snapshot.global.rotation());
-            let target = foot_position
-                + Vec3::Y * ((desired_y - foot_position.y).clamp(-0.35, 0.35) * weight);
+            let planted_target = Vec3::new(horizontal_target.x, desired_y, horizontal_target.z);
+            let target = foot_position.lerp(planted_target, weight);
             let remembered = if left {
                 memory.left_leg
             } else {
@@ -543,7 +615,7 @@ pub(super) fn apply_terrain_leg_ik(
                 }
             }
             if weight > 0.001
-                && let Some(normal) = terrain.normal_at(foot_position.xz())
+                && let Some(normal) = terrain.normal_at(horizontal_target.xz())
                 && let Some(&sole_axis) = sole_axes.get(&foot)
             {
                 align_foot_to_slope(foot, sole_axis, normal, weight, &parents, &mut transforms);
@@ -557,12 +629,42 @@ pub(super) fn apply_terrain_leg_ik(
     }
 }
 
-fn foot_plant_weight(phase: f32, moving: bool) -> f32 {
+fn locomotion_run_weight(speed: f32) -> f32 {
+    ((speed - 2.0) / (5.5 - 2.0)).clamp(0.0, 1.0)
+}
+
+pub(crate) fn gait_support_weights(phase: f32, speed: f32) -> (f32, f32) {
+    let run_weight = locomotion_run_weight(speed);
+    let locomotion = smoothstep(0.0, 0.75, speed);
+    let gait = |phase| foot_support_weight(phase, true, run_weight);
+    (
+        1.0_f32.lerp(gait(phase.rem_euclid(1.0)), locomotion),
+        1.0_f32.lerp(gait((phase + 0.5).rem_euclid(1.0)), locomotion),
+    )
+}
+
+fn foot_support_weight(phase: f32, moving: bool, run_weight: f32) -> f32 {
     if !moving {
         return 1.0;
     }
-    let contact = (phase * std::f32::consts::TAU).cos() * 0.5 + 0.5;
-    (0.2 + contact * 0.8).clamp(0.0, 1.0)
+    let run_weight = run_weight.clamp(0.0, 1.0);
+    // The canonical leg owns support from contact through passing, then hands
+    // off to its mirrored counterpart. This keeps the passing swing foot free
+    // instead of constraining both feet to a misleading 0.6 weight.
+    let walk_support = (1.0 - smoothstep(0.38, 0.50, phase)).max(smoothstep(0.88, 1.0, phase));
+
+    // A running foot supports only a compact interval around its contact.
+    // In particular, both legs must be free during the quarter-cycle flight
+    // phases; forcing a minimum IK weight there turns the authored swing into
+    // a visible kick/pop.
+    let distance_to_contact = phase.min(1.0 - phase);
+    let run_support = 1.0 - smoothstep(0.08, 0.20, distance_to_contact);
+    walk_support.lerp(run_support, run_weight).clamp(0.0, 1.0)
+}
+
+fn smoothstep(edge0: f32, edge1: f32, value: f32) -> f32 {
+    let t = ((value - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
 }
 
 fn ankle_sole_offset(_rotation: Quat) -> f32 {
@@ -1111,11 +1213,24 @@ mod tests {
 
     #[test]
     fn idle_plants_both_feet_and_gait_weight_is_continuous() {
-        assert_eq!(foot_plant_weight(0.25, false), 1.0);
-        assert_eq!(foot_plant_weight(0.75, false), 1.0);
-        let before = foot_plant_weight(0.5 - 0.0001, true);
-        let after = foot_plant_weight(0.5 + 0.0001, true);
+        assert_eq!(foot_support_weight(0.25, false, 1.0), 1.0);
+        assert_eq!(foot_support_weight(0.75, false, 1.0), 1.0);
+        let before = foot_support_weight(0.5 - 0.0001, true, 0.0);
+        let after = foot_support_weight(0.5 + 0.0001, true, 0.0);
         assert!((before - after).abs() < 0.001);
+    }
+
+    #[test]
+    fn run_has_unconstrained_flight_but_walk_retains_support() {
+        for phase in [0.25, 0.75] {
+            assert_eq!(foot_support_weight(phase, true, 1.0), 0.0);
+            let (left, right) = gait_support_weights(phase, 2.0);
+            assert!((left.max(right) - 1.0).abs() < 0.0001);
+            assert!(left.min(right) <= 0.0001);
+        }
+        assert_eq!(foot_support_weight(0.0, true, 1.0), 1.0);
+        assert_eq!(locomotion_run_weight(2.0), 0.0);
+        assert_eq!(locomotion_run_weight(5.5), 1.0);
     }
 
     #[test]
@@ -1206,6 +1321,23 @@ mod tests {
         let twice = mirrored_across_anatomical_center(mirrored_across_anatomical_center(original));
         assert!(twice.translation.abs_diff_eq(original.translation, 0.0001));
         assert!(twice.rotation.abs_diff_eq(original.rotation, 0.0001));
+    }
+
+    #[test]
+    fn anatomical_side_does_not_collapse_during_mirror_blend() {
+        let left = Transform::from_xyz(0.18, -0.1, 0.25);
+        let right = Transform::from_xyz(-0.18, -0.1, -0.25);
+        let mirrored_right = mirrored_across_anatomical_center(right);
+        let midpoint_x = left.translation.lerp(mirrored_right.translation, 0.5).x;
+        assert!((midpoint_x - 0.18).abs() < 0.0001);
+    }
+
+    #[test]
+    fn locomotion_rotation_clamp_stays_near_bind() {
+        let bind = Quat::from_rotation_y(0.2);
+        let animated = bind * Quat::from_rotation_x(1.0);
+        let bounded = clamp_rotation_from_bind(bind, animated, 0.15);
+        assert!(bind.angle_between(bounded) <= 0.1501);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -183,12 +183,40 @@ pub(super) fn apply_head_and_torso_look(
     }
 }
 
-/// Constructs the opposite gait half-cycle without mirroring handed upper-body
-/// carriage. Gait mirroring transitions only around the authored passing pose,
-/// where the legs are nearest one another; interpolating throughout contact
-/// folds the planted stride through itself.
-pub(super) fn apply_lower_body_mirroring(
+/// Turns ordinary locomotion toward travel while preserving look-relative
+/// facing for the guard-based attack and block actions. Runtime locomotion is
+/// expressed in the controller's -Z-forward frame, while the authored mesh is
+/// +Z-forward beneath a player root that already contains the half-turn.
+pub(super) fn apply_locomotion_facing(
+    owners: Query<&SkeletonState>,
+    mut rigs: Query<(&super::AnimationRigScene, &mut Transform)>,
+) {
+    for (rig, mut transform) in &mut rigs {
+        let Ok(skeleton) = owners.get(rig.0) else {
+            continue;
+        };
+        transform.rotation = locomotion_facing(skeleton.local_velocity, skeleton.action);
+    }
+}
+
+fn locomotion_facing(local_velocity: Vec3, action: SkeletonAction) -> Quat {
+    if matches!(action, SkeletonAction::Attack | SkeletonAction::Block) {
+        return Quat::IDENTITY;
+    }
+    let Some(direction) = local_velocity.xz().try_normalize() else {
+        return Quat::IDENTITY;
+    };
+    Quat::from_rotation_arc(Vec3::Z, -Vec3::new(direction.x, 0.0, direction.y)).normalize()
+}
+
+/// Constructs the opposite gait half-cycle for every bilateral limb chain.
+/// Gait mirroring transitions only around the authored passing pose, where the
+/// limbs are nearest neutral; interpolating throughout contact folds a planted
+/// stride through itself. The playback field retains its historical
+/// `lower_body_mirror` name, but drives arms and legs together.
+pub(super) fn apply_gait_mirroring(
     playbacks: Query<&AnimationPlayback>,
+    rig_scenes: Query<(Entity, &AnimationRigScene)>,
     parents: Query<&ChildOf>,
     mut transforms: ParamSet<(
         Query<(Entity, &HumanoidBone, &Transform)>,
@@ -204,9 +232,14 @@ pub(super) fn apply_lower_body_mirroring(
             .collect::<Vec<_>>()
     };
     let mut rigs = BTreeMap::<Entity, BTreeMap<BoneRole, MirrorBone>>::new();
-    let mut owner_globals = BTreeMap::<Entity, GlobalTransform>::new();
+    let mut rig_globals = BTreeMap::<Entity, GlobalTransform>::new();
     {
         let helper = transforms.p1();
+        for (entity, scene) in &rig_scenes {
+            if let Ok(global) = helper.compute_global_transform(entity) {
+                rig_globals.insert(scene.0, global);
+            }
+        }
         for (entity, bone, local) in locals {
             let Ok(global) = helper.compute_global_transform(entity) else {
                 continue;
@@ -215,11 +248,6 @@ pub(super) fn apply_lower_body_mirroring(
             let parent_global = parent
                 .and_then(|parent| helper.compute_global_transform(parent).ok())
                 .unwrap_or(GlobalTransform::IDENTITY);
-            if !owner_globals.contains_key(&bone.owner)
-                && let Ok(owner_global) = helper.compute_global_transform(bone.owner)
-            {
-                owner_globals.insert(bone.owner, owner_global);
-            }
             rigs.entry(bone.owner).or_default().insert(
                 bone.role,
                 MirrorBone {
@@ -240,11 +268,18 @@ pub(super) fn apply_lower_body_mirroring(
         if weight <= f32::EPSILON {
             continue;
         }
-        let Some(owner_global) = owner_globals.get(&owner) else {
+        let Some(rig_global) = rig_globals.get(&owner) else {
             continue;
         };
         let mut desired_globals = BTreeMap::<Entity, Affine3A>::new();
         for (left_role, right_role) in [
+            (BoneRole::ClavicleLeft, BoneRole::ClavicleRight),
+            (BoneRole::UpperArmLeft, BoneRole::UpperArmRight),
+            (BoneRole::UpperArmTwistLeft, BoneRole::UpperArmTwistRight),
+            (BoneRole::ForearmLeft, BoneRole::ForearmRight),
+            (BoneRole::ForearmTwistLeft, BoneRole::ForearmTwistRight),
+            (BoneRole::HandLeft, BoneRole::HandRight),
+            (BoneRole::WeaponLeft, BoneRole::WeaponRight),
             (BoneRole::ThighLeft, BoneRole::ThighRight),
             (BoneRole::ThighTwistLeft, BoneRole::ThighTwistRight),
             (BoneRole::ShinLeft, BoneRole::ShinRight),
@@ -257,11 +292,11 @@ pub(super) fn apply_lower_body_mirroring(
             };
             desired_globals.insert(
                 left.entity,
-                mirrored_global_affine(right.global, *owner_global),
+                mirrored_global_affine(right.global, *rig_global),
             );
             desired_globals.insert(
                 right.entity,
-                mirrored_global_affine(left.global, *owner_global),
+                mirrored_global_affine(left.global, *rig_global),
             );
         }
         let mut bones = transforms.p2();
@@ -453,6 +488,7 @@ pub(super) fn apply_terrain_leg_ik(
     enabled: Res<super::TerrainIkEnabled>,
     terrain: Query<&SceneTerrain>,
     owners: Query<&SkeletonState>,
+    rig_scenes: Query<(Entity, &AnimationRigScene)>,
     bones: Query<(Entity, &HumanoidBone, Option<&SoleUpAxis>)>,
     parents: Query<&ChildOf>,
     mut ik_states: Query<&mut ProceduralIkState>,
@@ -551,9 +587,14 @@ pub(super) fn apply_terrain_leg_ik(
                 transform.translation += local_delta;
             }
         }
-        let owner_rotation = transforms
-            .p0()
-            .compute_global_transform(owner)
+        // Pole memory belongs to the animated rig's facing frame, not the
+        // gameplay owner/look frame. Ordinary locomotion rotates the child rig
+        // toward travel, so owner-relative poles bend sideways during strafing
+        // and backwards during reversal.
+        let rig_rotation = rig_scenes
+            .iter()
+            .find(|(_, scene)| scene.0 == owner)
+            .and_then(|(entity, _)| transforms.p0().compute_global_transform(entity).ok())
             .map(|global| global.rotation())
             .unwrap_or(Quat::IDENTITY);
         let mut memory = ik_states
@@ -599,7 +640,7 @@ pub(super) fn apply_terrain_leg_ik(
             } else {
                 memory.right_leg
             };
-            let pole = pole_to_world(owner_rotation, remembered.unwrap_or(owner_pole));
+            let pole = pole_to_world(rig_rotation, remembered.unwrap_or(owner_pole));
             if let Some(solution) = solve_two_bone(
                 upper_snapshot.global.translation(),
                 lower_snapshot.global.translation(),
@@ -617,9 +658,9 @@ pub(super) fn apply_terrain_leg_ik(
                     .reject_from_normalized(solution.end_direction);
                 if let Some(valid) = bend.try_normalize() {
                     if left {
-                        memory.left_leg = Some(pole_to_owner(owner_rotation, valid));
+                        memory.left_leg = Some(pole_to_owner(rig_rotation, valid));
                     } else {
-                        memory.right_leg = Some(pole_to_owner(owner_rotation, valid));
+                        memory.right_leg = Some(pole_to_owner(rig_rotation, valid));
                     }
                 }
             }
@@ -660,7 +701,10 @@ fn foot_support_weight(phase: f32, moving: bool, run_weight: f32) -> f32 {
     // The canonical leg owns support from contact through passing, then hands
     // off to its mirrored counterpart. This keeps the passing swing foot free
     // instead of constraining both feet to a misleading 0.6 weight.
-    let walk_support = (1.0 - smoothstep(0.38, 0.50, phase)).max(smoothstep(0.88, 1.0, phase));
+    // Release over a substantial part of late stance. A four-frame release at
+    // ordinary walk speed makes the analytic knee visibly snap straight even
+    // when the foot target itself remains continuous.
+    let walk_support = (1.0 - smoothstep(0.28, 0.50, phase)).max(smoothstep(0.78, 1.0, phase));
 
     // A running foot supports only a compact interval around its contact.
     // In particular, both legs must be free during the quarter-cycle flight
@@ -715,14 +759,25 @@ fn solve_two_bone(
     let height = (upper_length * upper_length - along * along)
         .max(0.0)
         .sqrt();
-    let bend = (current_knee - root)
+    let pole_bend = pole_direction
         .reject_from_normalized(target_direction)
-        .try_normalize()
-        .or_else(|| {
-            pole_direction
-                .reject_from_normalized(target_direction)
-                .try_normalize()
-        })
+        .try_normalize();
+    let authored_bend = (current_knee - root)
+        .reject_from_normalized(target_direction)
+        .try_normalize();
+    // Preserve a strong authored bend inside the intended pole hemisphere,
+    // but fade continuously to the stable pole as the leg straightens. A hard
+    // hemisphere cutoff makes the knee pop when the projected authored bend
+    // crosses that cutoff during support release.
+    let stabilized_authored_bend = authored_bend.zip(pole_bend).and_then(|(authored, pole)| {
+        let alignment = authored.dot(pole);
+        let aligned = if alignment < 0.0 { -authored } else { authored };
+        pole.lerp(aligned, smoothstep(0.05, 0.5, alignment.abs()))
+            .try_normalize()
+    });
+    let bend = stabilized_authored_bend
+        .or(pole_bend)
+        .or(authored_bend)
         .or_else(|| target_direction.any_orthonormal_vector().try_normalize())?;
     let knee = root + target_direction * along + bend * height;
     (knee.is_finite() && end.is_finite()).then_some(TwoBoneSolution {
@@ -1188,7 +1243,7 @@ mod tests {
     }
 
     #[test]
-    fn authored_knee_bend_wins_over_fallback_pole() {
+    fn stable_pole_overrides_an_authored_knee_in_the_opposite_hemisphere() {
         let solved = solve_two_bone(
             Vec3::ZERO,
             Vec3::new(0.0, -1.0, 0.1),
@@ -1199,6 +1254,22 @@ mod tests {
             Vec3::NEG_Z,
         )
         .unwrap();
+        assert!(solved.knee.z < 0.0);
+    }
+
+    #[test]
+    fn authored_knee_bend_is_preserved_within_the_stable_pole_hemisphere() {
+        let solved = solve_two_bone(
+            Vec3::ZERO,
+            Vec3::new(0.1, -1.0, 0.1),
+            Vec3::NEG_Y * 2.0,
+            Vec3::new(0.0, -1.8, 0.0),
+            1.0,
+            1.0,
+            Vec3::Z,
+        )
+        .unwrap();
+        assert!(solved.knee.x > 0.0);
         assert!(solved.knee.z > 0.0);
     }
 
@@ -1320,7 +1391,7 @@ mod tests {
     }
 
     #[test]
-    fn lower_body_mirror_is_an_involution() {
+    fn gait_mirror_is_an_involution() {
         let original = Transform::from_xyz(0.3, -0.8, 0.2).with_rotation(Quat::from_euler(
             EulerRot::XYZ,
             0.2,
@@ -1330,6 +1401,18 @@ mod tests {
         let twice = mirrored_across_anatomical_center(mirrored_across_anatomical_center(original));
         assert!(twice.translation.abs_diff_eq(original.translation, 0.0001));
         assert!(twice.rotation.abs_diff_eq(original.rotation, 0.0001));
+    }
+
+    #[test]
+    fn locomotion_faces_travel_but_guard_actions_keep_authored_facing() {
+        let forward = locomotion_facing(Vec3::NEG_Z * 2.0, SkeletonAction::None);
+        assert!(forward.abs_diff_eq(Quat::IDENTITY, 0.0001));
+
+        let right = locomotion_facing(Vec3::X * 2.0, SkeletonAction::None);
+        assert!((right * Vec3::Z).abs_diff_eq(Vec3::NEG_X, 0.0001));
+
+        let guarded = locomotion_facing(Vec3::X * 2.0, SkeletonAction::Block);
+        assert!(guarded.abs_diff_eq(Quat::IDENTITY, 0.0001));
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -114,6 +114,7 @@ struct PlannedFrame {
     gait_phase: f32,
     distance: f32,
     time_seconds: f32,
+    local_direction: Vec2,
 }
 
 #[derive(Resource)]
@@ -231,6 +232,8 @@ struct FrameSample {
     speed_metres_per_second: f32,
     gait_phase: f32,
     root_distance_metres: f32,
+    root_position_metres: [f32; 3],
+    world_travel_direction: [f32; 3],
     left_support_weight: f32,
     right_support_weight: f32,
     screenshots: BTreeMap<String, String>,
@@ -248,6 +251,15 @@ fn stride_length(speed: f32) -> f32 {
 }
 
 fn steady_scenario(name: &'static str, speed: f32, cycles: f32) -> Vec<PlannedFrame> {
+    steady_scenario_in_direction(name, speed, cycles, Vec2::NEG_Y)
+}
+
+fn steady_scenario_in_direction(
+    name: &'static str,
+    speed: f32,
+    cycles: f32,
+    local_direction: Vec2,
+) -> Vec<PlannedFrame> {
     let cycle_duration = stride_length(speed) / speed;
     let duration = cycles * cycle_duration;
     let last_regular_frame = (duration * SAMPLE_HZ).floor() as usize;
@@ -280,6 +292,7 @@ fn steady_scenario(name: &'static str, speed: f32, cycles: f32) -> Vec<PlannedFr
             },
             distance: speed * time_seconds,
             time_seconds,
+            local_direction,
         })
         .collect()
 }
@@ -316,6 +329,7 @@ fn transition_scenario() -> Vec<PlannedFrame> {
                 gait_phase: phase,
                 distance,
                 time_seconds: t,
+                local_direction: Vec2::NEG_Y,
             }
         })
         .collect()
@@ -331,6 +345,8 @@ fn capture_plan() -> Vec<PlannedFrame> {
         steady_scenario("steady-walk-2.0", 2.0, 2.0),
         steady_scenario("walk-run-blend-3.75", 3.75, 2.0),
         steady_scenario("steady-run-5.5", 5.5, 2.0),
+        steady_scenario_in_direction("lateral-walk-2.0", 2.0, 1.0, Vec2::X),
+        steady_scenario_in_direction("reverse-walk-2.0", 2.0, 1.0, Vec2::Y),
         transition_scenario(),
     ]
     .into_iter()
@@ -343,14 +359,20 @@ fn setup_viewer(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn(SceneTerrain::new(64, 24, 1.0, |position| {
-        // Nearly flat live-like terrain exercises final foot IK without hiding
-        // discontinuities behind a perfectly featureless plane.
-        (position.x * 0.18).sin() * 0.018 + (position.y * 0.11).sin() * 0.012
-    }));
+    let terrain = SceneTerrain::new(64, 24, 1.0, |position| {
+        let centered = position - Vec2::new(32.0, 12.0);
+        // Deliberately visible, deterministic uneven ground. Its broad slope
+        // and smaller cross-wave expose overreaching leg solves and incorrect
+        // foot normals that the previous three-centimetre ripple concealed.
+        (centered.y * 0.22).sin() * 0.22
+            + (centered.x * 0.31).sin() * 0.10
+            + ((centered.x + centered.y) * 0.55).sin() * 0.035
+    });
+    let terrain_mesh = terrain.mesh();
+    commands.spawn(terrain);
     commands.spawn((
         Name::new("Animation review floor"),
-        Mesh3d(meshes.add(Plane3d::default().mesh().size(64.0, 24.0))),
+        Mesh3d(meshes.add(terrain_mesh)),
         MeshMaterial3d(materials.add(StandardMaterial {
             base_color: Color::srgb(0.18, 0.23, 0.16),
             perceptual_roughness: 0.95,
@@ -387,7 +409,7 @@ fn setup_viewer(
         },
         CharacterLook::default(),
         SkeletonState {
-            local_velocity: Vec3::Z * 2.0,
+            local_velocity: Vec3::NEG_Z * 2.0,
             grounded: true,
             ..default()
         },
@@ -430,6 +452,7 @@ fn setup_viewer(
 
 fn drive_sequence(
     mut sequence: ResMut<CaptureSequence>,
+    terrain: Single<&SceneTerrain>,
     mut subjects: Query<(&mut SkeletonState, &mut Transform), With<CaptureSubject>>,
     mut labels: Query<&mut Text, With<CaptureLabel>>,
 ) {
@@ -438,11 +461,16 @@ fn drive_sequence(
     }
     let frame = sequence.plan[sequence.index].clone();
     for (mut skeleton, mut transform) in &mut subjects {
-        skeleton.local_velocity = Vec3::Z * frame.speed;
+        skeleton.local_velocity =
+            Vec3::new(frame.local_direction.x, 0.0, frame.local_direction.y) * frame.speed;
         skeleton.gait_phase = frame.gait_phase;
         skeleton.grounded = true;
         skeleton.posture = Posture::Upright;
-        transform.translation = Vec3::new(0.0, 0.95, frame.distance);
+        // Gameplay's controller frame is half-turned relative to the authored
+        // mesh, so world travel is the negative local velocity direction.
+        let horizontal = -frame.local_direction * frame.distance;
+        let ground = terrain.height_at(horizontal).unwrap_or(0.0);
+        transform.translation = Vec3::new(horizontal.x, ground + 0.95, horizontal.y);
     }
     for mut label in &mut labels {
         **label = format!(
@@ -553,14 +581,22 @@ fn draw_skeleton_overlay(
 fn capture_frame(
     mut commands: Commands,
     mut sequence: ResMut<CaptureSequence>,
-    subjects: Query<(Entity, &SkeletonState, Option<&AnimationPlayback>), With<CaptureSubject>>,
+    subjects: Query<
+        (
+            Entity,
+            &SkeletonState,
+            &GlobalTransform,
+            Option<&AnimationPlayback>,
+        ),
+        With<CaptureSubject>,
+    >,
     bones: Query<(&HumanoidBone, &GlobalTransform)>,
     mut exit: MessageWriter<AppExit>,
 ) {
     if !sequence.applied || sequence.capture_in_flight {
         return;
     }
-    let Ok((subject, skeleton, playback)) = subjects.single() else {
+    let Ok((subject, skeleton, subject_global, playback)) = subjects.single() else {
         wait_or_fail(&mut sequence, "capture subject is missing", &mut exit);
         return;
     };
@@ -613,6 +649,13 @@ fn capture_frame(
             speed_metres_per_second: frame.speed,
             gait_phase: skeleton.gait_phase,
             root_distance_metres: frame.distance,
+            root_position_metres: subject_global.translation().to_array(),
+            world_travel_direction: Vec3::new(
+                -frame.local_direction.x,
+                0.0,
+                -frame.local_direction.y,
+            )
+            .to_array(),
             left_support_weight,
             right_support_weight,
             screenshots: VIEWS
@@ -782,7 +825,7 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
             && metrics.head_vertical_range_metres <= 0.20
             && metrics
                 .loop_seam_position_metres
-                .is_none_or(|value| value <= 0.01)
+                .is_none_or(|value| value <= 0.015)
             && metrics
                 .loop_seam_rotation_degrees
                 .is_none_or(|value| value <= 5.0)
@@ -852,8 +895,8 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
             let mut worst_rotation = None;
             for pair in frames.windows(2) {
                 let (before, after) = (pair[0], pair[1]);
-                let root_delta =
-                    Vec3::Z * (after.root_distance_metres - before.root_distance_metres);
+                let root_delta = Vec3::from_array(after.root_position_metres)
+                    - Vec3::from_array(before.root_position_metres);
                 for (name, before_bone) in &before.bones {
                     let Some(after_bone) = after.bones.get(name) else {
                         continue;
@@ -955,8 +998,8 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
                 worst_rotation,
                 loop_seam_position_metres: loop_position,
                 loop_seam_rotation_degrees: loop_rotation,
-                pelvis_vertical_range_metres: vertical_range(&frames, "pelvis"),
-                head_vertical_range_metres: vertical_range(&frames, "head"),
+                pelvis_vertical_range_metres: root_relative_vertical_range(&frames, "pelvis"),
+                head_vertical_range_metres: root_relative_vertical_range(&frames, "head"),
                 minimum_knee_forward_bend_metres: minimum_knee_bend(&frames),
                 maximum_supported_foot_slip_metres_per_frame: maximum_slip,
                 maximum_planted_foot_drift_metres: maximum_plant_drift,
@@ -971,7 +1014,8 @@ fn quat(bone: &BoneSample) -> Quat {
 }
 
 fn loop_seam(first: &FrameSample, last: &FrameSample) -> (f32, f32) {
-    let root_delta = Vec3::Z * (last.root_distance_metres - first.root_distance_metres);
+    let root_delta =
+        Vec3::from_array(last.root_position_metres) - Vec3::from_array(first.root_position_metres);
     first
         .bones
         .iter()
@@ -996,10 +1040,15 @@ fn loop_seam(first: &FrameSample, last: &FrameSample) -> (f32, f32) {
         })
 }
 
-fn vertical_range(frames: &[&FrameSample], bone: &str) -> f32 {
+fn root_relative_vertical_range(frames: &[&FrameSample], bone: &str) -> f32 {
     let (minimum, maximum) = frames
         .iter()
-        .filter_map(|frame| frame.bones.get(bone).map(|bone| bone.position[1]))
+        .filter_map(|frame| {
+            frame
+                .bones
+                .get(bone)
+                .map(|bone| bone.position[1] - frame.root_position_metres[1])
+        })
         .fold(
             (f32::INFINITY, f32::NEG_INFINITY),
             |(minimum, maximum), value| (minimum.min(value), maximum.max(value)),
@@ -1030,7 +1079,10 @@ fn minimum_knee_bend(frames: &[&FrameSample]) -> f32 {
             let axis = foot - hip;
             if axis.length_squared() > 0.0001 {
                 let closest = hip + axis * (knee - hip).dot(axis) / axis.length_squared();
-                minimum = minimum.min((knee - closest).z);
+                let forward = Vec3::from_array(frame.world_travel_direction)
+                    .try_normalize()
+                    .unwrap_or(Vec3::Z);
+                minimum = minimum.min((knee - closest).dot(forward));
             }
         }
     }
@@ -1151,6 +1203,8 @@ mod tests {
             speed_metres_per_second: 0.0,
             gait_phase: 0.0,
             root_distance_metres: 0.0,
+            root_position_metres: Vec3::ZERO.to_array(),
+            world_travel_direction: Vec3::Z.to_array(),
             left_support_weight: 1.0,
             right_support_weight: 1.0,
             screenshots,

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -1,6 +1,10 @@
-//! A network-free viewer that captures the real tactical animation pipeline.
+//! A network-free, reviewer-oriented capture of the real tactical animation pipeline.
 
-use std::{fs, path::PathBuf};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::PathBuf,
+};
 
 use adventuresim_tactical_core::prelude::*;
 use bevy::{
@@ -9,16 +13,41 @@ use bevy::{
     render::view::screenshot::{Screenshot, ScreenshotCaptured, save_to_disk},
     window::PresentMode,
 };
+use serde::Serialize;
 
-use crate::animation::{AnimationPlayback, BoneRole, HumanoidBone, TacticalAnimationPlugin};
+use crate::animation::{
+    AnimationPlayback, BoneRole, HumanoidBone, TacticalAnimationPlugin, gait_support_weights,
+};
 
-const WALK_PHASES: [f32; 8] = [0.0, 0.125, 0.25, 0.375, 0.5, 0.625, 0.75, 0.875];
+const SAMPLE_HZ: f32 = 60.0;
+const VIEWS: [CaptureView; 3] = [
+    CaptureView::ThirdPerson,
+    CaptureView::Side,
+    CaptureView::Front,
+];
+const TRACKED_BONE_NAMES: [&str; 15] = [
+    "pelvis",
+    "chest",
+    "head",
+    "left_shoulder",
+    "right_shoulder",
+    "left_elbow",
+    "right_elbow",
+    "left_hand",
+    "right_hand",
+    "left_hip",
+    "right_hip",
+    "left_knee",
+    "right_knee",
+    "left_foot",
+    "right_foot",
+];
 
-pub(crate) fn run(output: PathBuf, asset_root: PathBuf, frames_per_sample: u32) {
+pub(crate) fn run(output: PathBuf, asset_root: PathBuf, settle_frames: u32) -> AppExit {
     fs::create_dir_all(&output).unwrap_or_else(|error| {
         panic!("failed to create animation capture directory {output:?}: {error}")
     });
-    let _ = fs::remove_file(output.join("failure.txt"));
+    invalidate_previous_report(&output);
 
     App::new()
         .add_plugins(
@@ -29,7 +58,7 @@ pub(crate) fn run(output: PathBuf, asset_root: PathBuf, frames_per_sample: u32) 
                 })
                 .set(WindowPlugin {
                     primary_window: Some(Window {
-                        title: "Adventure Simulator Animation Viewer".into(),
+                        title: "Adventure Simulator Animation Review Capture".into(),
                         resolution: (960, 720).into(),
                         present_mode: PresentMode::AutoVsync,
                         ..default()
@@ -39,71 +68,274 @@ pub(crate) fn run(output: PathBuf, asset_root: PathBuf, frames_per_sample: u32) 
         )
         .add_plugins(TacticalAnimationPlugin)
         .insert_resource(ClearColor(Color::srgb(0.08, 0.1, 0.13)))
-        .insert_resource(CaptureSequence::new(output, frames_per_sample))
+        .insert_resource(CaptureSequence::new(output, settle_frames))
         .add_systems(Startup, setup_viewer)
-        .add_systems(PreUpdate, drive_capture_phase)
-        .add_systems(Last, capture_settled_phase)
-        .run();
+        .add_systems(PreUpdate, (drive_sequence, position_capture_camera).chain())
+        .add_systems(
+            PostUpdate,
+            draw_skeleton_overlay.after(TransformSystems::Propagate),
+        )
+        .add_systems(Last, capture_frame)
+        .run()
 }
 
 #[derive(Component)]
 struct CaptureSubject;
 
 #[derive(Component)]
+struct CaptureCamera;
+
+#[derive(Component)]
 struct CaptureLabel;
 
-#[derive(Resource)]
-struct CaptureSequence {
-    output: PathBuf,
-    frames_per_sample: u32,
-    index: usize,
-    settled_frames: u32,
-    phase_applied: bool,
-    capture_in_flight: bool,
-    waiting_frames: u32,
-    samples: Vec<CaptureSample>,
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CaptureView {
+    ThirdPerson,
+    Side,
+    Front,
 }
 
-impl CaptureSequence {
-    fn new(output: PathBuf, frames_per_sample: u32) -> Self {
-        Self {
-            output,
-            frames_per_sample,
-            index: 0,
-            settled_frames: 0,
-            phase_applied: false,
-            capture_in_flight: false,
-            waiting_frames: 0,
-            samples: Vec::with_capacity(WALK_PHASES.len()),
+impl CaptureView {
+    fn slug(self) -> &'static str {
+        match self {
+            Self::ThirdPerson => "third-person",
+            Self::Side => "side",
+            Self::Front => "front",
         }
     }
 }
 
-#[derive(Debug)]
-struct CaptureManifest {
-    animation: &'static str,
-    frames_per_sample: u32,
-    validation: CaptureValidation,
-    samples: Vec<CaptureSample>,
-}
-
-#[derive(Debug)]
-struct CaptureValidation {
-    complete_cycle: bool,
-    foot_separation_range: f32,
-    foot_lead_changes: usize,
-}
-
-#[derive(Debug)]
-struct CaptureSample {
-    index: usize,
+#[derive(Debug, Clone)]
+struct PlannedFrame {
+    scenario: &'static str,
+    scenario_frame: usize,
+    speed: f32,
     gait_phase: f32,
-    lower_body_mirror: f32,
-    screenshot: String,
-    left_knee: Option<[f32; 3]>,
-    right_knee: Option<[f32; 3]>,
-    left_foot: Option<[f32; 3]>,
-    right_foot: Option<[f32; 3]>,
+    distance: f32,
+    time_seconds: f32,
+}
+
+#[derive(Resource)]
+struct CaptureSequence {
+    output: PathBuf,
+    settle_frames: u32,
+    plan: Vec<PlannedFrame>,
+    index: usize,
+    view_index: usize,
+    applied: bool,
+    settled: u32,
+    waiting: u32,
+    capture_in_flight: bool,
+    view_fingerprints: Vec<u64>,
+    duplicate_view_frames: Vec<String>,
+    samples: Vec<FrameSample>,
+}
+
+impl CaptureSequence {
+    fn new(output: PathBuf, settle_frames: u32) -> Self {
+        Self {
+            output,
+            settle_frames: settle_frames.max(1),
+            plan: capture_plan(),
+            index: 0,
+            view_index: 0,
+            applied: false,
+            settled: 0,
+            waiting: 0,
+            capture_in_flight: false,
+            view_fingerprints: Vec::with_capacity(VIEWS.len()),
+            duplicate_view_frames: Vec::new(),
+            samples: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CaptureManifest {
+    sample_hz: f32,
+    pipeline: &'static str,
+    views: [CaptureView; 3],
+    validation: CaptureValidation,
+    scenarios: Vec<ScenarioMetrics>,
+    frames: Vec<FrameSample>,
+}
+
+#[derive(Debug, Serialize)]
+struct CaptureValidation {
+    finite_transforms: bool,
+    all_scenarios_complete: bool,
+    all_artifacts_written: bool,
+    continuity_within_review_bounds: bool,
+    biomechanics_within_review_bounds: bool,
+    no_ground_penetration: bool,
+    views_are_distinct: bool,
+    duplicate_view_frames: Vec<String>,
+    note: &'static str,
+}
+
+fn invalidate_previous_report(output: &std::path::Path) {
+    for name in ["manifest.json", "index.html", "failure.txt"] {
+        let path = output.join(name);
+        if let Err(error) = fs::remove_file(&path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            panic!("failed to invalidate previous animation report {path:?}: {error}");
+        }
+    }
+}
+
+fn capture_artifacts_written(output: &std::path::Path, frames: &[FrameSample]) -> bool {
+    frames.iter().all(|frame| {
+        VIEWS.iter().all(|view| {
+            frame
+                .screenshots
+                .get(view.slug())
+                .and_then(|name| fs::metadata(output.join(name)).ok())
+                .is_some_and(|metadata| metadata.len() > 0)
+        })
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct ScenarioMetrics {
+    scenario: String,
+    frame_count: usize,
+    maximum_root_relative_step_metres: f32,
+    worst_displacement: Option<ContinuityLocation>,
+    maximum_bone_rotation_step_degrees: f32,
+    worst_rotation: Option<ContinuityLocation>,
+    loop_seam_position_metres: Option<f32>,
+    loop_seam_rotation_degrees: Option<f32>,
+    pelvis_vertical_range_metres: f32,
+    head_vertical_range_metres: f32,
+    minimum_knee_forward_bend_metres: f32,
+    maximum_supported_foot_slip_metres_per_frame: f32,
+    maximum_planted_foot_drift_metres: f32,
+    minimum_foot_height_metres: f32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ContinuityLocation {
+    bone: String,
+    from_frame: usize,
+    to_frame: usize,
+    value: f32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct FrameSample {
+    scenario: String,
+    scenario_frame: usize,
+    time_seconds: f32,
+    speed_metres_per_second: f32,
+    gait_phase: f32,
+    root_distance_metres: f32,
+    left_support_weight: f32,
+    right_support_weight: f32,
+    screenshots: BTreeMap<String, String>,
+    bones: BTreeMap<String, BoneSample>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+struct BoneSample {
+    position: [f32; 3],
+    rotation_xyzw: [f32; 4],
+}
+
+fn stride_length(speed: f32) -> f32 {
+    (0.9 + speed * 0.16).clamp(0.9, 1.8)
+}
+
+fn steady_scenario(name: &'static str, speed: f32, cycles: f32) -> Vec<PlannedFrame> {
+    let cycle_duration = stride_length(speed) / speed;
+    let duration = cycles * cycle_duration;
+    let last_regular_frame = (duration * SAMPLE_HZ).floor() as usize;
+    let mut times = (0..=last_regular_frame)
+        .map(|frame| (frame as f32 / SAMPLE_HZ, false))
+        .collect::<Vec<_>>();
+    for cycle in 1..=cycles.round() as usize {
+        times.push((cycle as f32 * cycle_duration, true));
+    }
+    times.sort_by(|a, b| a.0.total_cmp(&b.0));
+    times.dedup_by(|a, b| {
+        if (a.0 - b.0).abs() < 0.00001 {
+            b.1 |= a.1;
+            true
+        } else {
+            false
+        }
+    });
+    times
+        .into_iter()
+        .enumerate()
+        .map(|(scenario_frame, (time_seconds, closure))| PlannedFrame {
+            scenario: name,
+            scenario_frame,
+            speed,
+            gait_phase: if closure {
+                0.0
+            } else {
+                (time_seconds / cycle_duration).rem_euclid(1.0)
+            },
+            distance: speed * time_seconds,
+            time_seconds,
+        })
+        .collect()
+}
+
+fn transition_scenario() -> Vec<PlannedFrame> {
+    let duration = 4.0;
+    let last_frame = (duration * SAMPLE_HZ) as usize;
+    let mut phase = 0.0;
+    let mut distance = 0.0;
+    (0..=last_frame)
+        .map(|frame| {
+            let t = frame as f32 / SAMPLE_HZ;
+            let speed = if t < 0.5 {
+                2.0 * smoothstep01(t / 0.5)
+            } else if t < 1.0 {
+                2.0
+            } else if t < 1.75 {
+                2.0 + 3.5 * smoothstep01((t - 1.0) / 0.75)
+            } else if t < 2.5 {
+                5.5
+            } else if t < 3.5 {
+                5.5 * (1.0 - smoothstep01((t - 2.5) / 1.0))
+            } else {
+                0.0
+            };
+            if frame > 0 {
+                phase = (phase + speed / stride_length(speed) / SAMPLE_HZ).rem_euclid(1.0);
+                distance += speed / SAMPLE_HZ;
+            }
+            PlannedFrame {
+                scenario: "start-stop-transition",
+                scenario_frame: frame,
+                speed,
+                gait_phase: phase,
+                distance,
+                time_seconds: t,
+            }
+        })
+        .collect()
+}
+
+fn smoothstep01(value: f32) -> f32 {
+    let value = value.clamp(0.0, 1.0);
+    value * value * (3.0 - 2.0 * value)
+}
+
+fn capture_plan() -> Vec<PlannedFrame> {
+    [
+        steady_scenario("steady-walk-2.0", 2.0, 2.0),
+        steady_scenario("walk-run-blend-3.75", 3.75, 2.0),
+        steady_scenario("steady-run-5.5", 5.5, 2.0),
+        transition_scenario(),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
 }
 
 fn setup_viewer(
@@ -111,35 +343,59 @@ fn setup_viewer(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    commands.spawn(SceneTerrain::new(16, 16, 1.0, |_| 0.0));
+    commands.spawn(SceneTerrain::new(64, 24, 1.0, |position| {
+        // Nearly flat live-like terrain exercises final foot IK without hiding
+        // discontinuities behind a perfectly featureless plane.
+        (position.x * 0.18).sin() * 0.018 + (position.y * 0.11).sin() * 0.012
+    }));
     commands.spawn((
-        Name::new("Animation viewer floor"),
-        Mesh3d(meshes.add(Plane3d::default().mesh().size(16.0, 16.0))),
+        Name::new("Animation review floor"),
+        Mesh3d(meshes.add(Plane3d::default().mesh().size(64.0, 24.0))),
         MeshMaterial3d(materials.add(StandardMaterial {
-            base_color: Color::srgb(0.22, 0.28, 0.2),
-            perceptual_roughness: 0.9,
+            base_color: Color::srgb(0.18, 0.23, 0.16),
+            perceptual_roughness: 0.95,
             ..default()
         })),
     ));
+    let grid_material = materials.add(StandardMaterial {
+        base_color: Color::srgb(0.72, 0.76, 0.58),
+        emissive: LinearRgba::new(0.08, 0.09, 0.05, 1.0),
+        perceptual_roughness: 1.0,
+        ..default()
+    });
+    let cross_line = meshes.add(Cuboid::new(8.0, 0.008, 0.025));
+    for metre in -2..=20 {
+        commands.spawn((
+            Name::new(format!("World grid metre {metre}")),
+            Mesh3d(cross_line.clone()),
+            MeshMaterial3d(grid_material.clone()),
+            Transform::from_xyz(0.0, 0.006, metre as f32),
+        ));
+    }
+    commands.spawn((
+        Name::new("World grid center line"),
+        Mesh3d(meshes.add(Cuboid::new(0.025, 0.009, 24.0))),
+        MeshMaterial3d(grid_material),
+        Transform::from_xyz(0.0, 0.008, 9.0),
+    ));
 
     commands.spawn((
-        Name::new("Animation capture subject"),
+        Name::new("Animation review subject"),
         CaptureSubject,
         Player {
-            name: "Animation viewer".into(),
+            name: "Animation review".into(),
         },
         CharacterLook::default(),
         SkeletonState {
-            local_velocity: Vec3::Z * 1.5,
+            local_velocity: Vec3::Z * 2.0,
             grounded: true,
             ..default()
         },
         Transform::from_xyz(0.0, 0.95, 0.0),
         Visibility::Inherited,
     ));
-
     commands.spawn((
-        Name::new("Animation viewer sun"),
+        Name::new("Animation review sun"),
         DirectionalLight {
             shadows_enabled: true,
             illuminance: 12_000.0,
@@ -153,14 +409,15 @@ fn setup_viewer(
         affects_lightmapped_meshes: true,
     });
     commands.spawn((
-        Name::new("Animation viewer camera"),
+        Name::new("Animation review camera"),
+        CaptureCamera,
         Camera3d::default(),
-        Transform::from_xyz(3.2, 2.1, 4.5).looking_at(Vec3::new(0.0, 0.95, 0.0), Vec3::Y),
+        Transform::from_xyz(3.2, 2.1, -4.5).looking_at(Vec3::Y, Vec3::Y),
     ));
     commands.spawn((
         CaptureLabel,
         Text::new("Loading authored animation rig..."),
-        TextFont::from_font_size(24.0),
+        TextFont::from_font_size(22.0),
         TextColor(Color::WHITE),
         Node {
             position_type: PositionType::Absolute,
@@ -171,37 +428,136 @@ fn setup_viewer(
     ));
 }
 
-fn drive_capture_phase(
+fn drive_sequence(
     mut sequence: ResMut<CaptureSequence>,
-    mut subjects: Query<&mut SkeletonState, With<CaptureSubject>>,
+    mut subjects: Query<(&mut SkeletonState, &mut Transform), With<CaptureSubject>>,
     mut labels: Query<&mut Text, With<CaptureLabel>>,
 ) {
-    if sequence.phase_applied || sequence.capture_in_flight || sequence.index >= WALK_PHASES.len() {
+    if sequence.applied || sequence.capture_in_flight || sequence.index >= sequence.plan.len() {
         return;
     }
-    let phase = WALK_PHASES[sequence.index];
-    for mut skeleton in &mut subjects {
-        skeleton.gait_phase = phase;
+    let frame = sequence.plan[sequence.index].clone();
+    for (mut skeleton, mut transform) in &mut subjects {
+        skeleton.local_velocity = Vec3::Z * frame.speed;
+        skeleton.gait_phase = frame.gait_phase;
+        skeleton.grounded = true;
+        skeleton.posture = Posture::Upright;
+        transform.translation = Vec3::new(0.0, 0.95, frame.distance);
     }
     for mut label in &mut labels {
         **label = format!(
-            "walk | phase {phase:.3} | sample {} / {}",
-            sequence.index + 1,
-            WALK_PHASES.len()
+            "{} | {:>4.2} m/s | phase {:>5.3} | {} view | 60 Hz frame {}",
+            frame.scenario,
+            frame.speed,
+            frame.gait_phase,
+            VIEWS[sequence.view_index].slug(),
+            frame.scenario_frame,
         );
     }
-    sequence.phase_applied = true;
-    sequence.settled_frames = 0;
+    sequence.applied = true;
+    sequence.settled = 0;
 }
 
-fn capture_settled_phase(
+fn position_capture_camera(
+    sequence: Res<CaptureSequence>,
+    subjects: Query<&Transform, With<CaptureSubject>>,
+    mut cameras: Query<&mut Transform, (With<CaptureCamera>, Without<CaptureSubject>)>,
+    mut labels: Query<&mut Text, With<CaptureLabel>>,
+) {
+    let (Ok(subject), Ok(mut camera)) = (subjects.single(), cameras.single_mut()) else {
+        return;
+    };
+    let focus = subject.translation + Vec3::Y * 0.95;
+    let view = VIEWS[sequence.view_index.min(VIEWS.len() - 1)];
+    camera.translation = focus
+        + match view {
+            CaptureView::ThirdPerson => Vec3::new(3.2, 1.6, 4.5),
+            CaptureView::Side => Vec3::new(5.0, 0.45, 0.0),
+            CaptureView::Front => Vec3::new(0.0, 0.45, -5.0),
+        };
+    camera.look_at(focus, Vec3::Y);
+    if sequence.applied
+        && let Some(frame) = sequence.plan.get(sequence.index)
+    {
+        for mut label in &mut labels {
+            **label = format!(
+                "{} | {:>4.2} m/s | phase {:>5.3} | {} view | 60 Hz frame {}",
+                frame.scenario,
+                frame.speed,
+                frame.gait_phase,
+                view.slug(),
+                frame.scenario_frame,
+            );
+        }
+    }
+}
+
+fn draw_skeleton_overlay(
+    mut gizmos: Gizmos,
+    subjects: Query<(Entity, &SkeletonState), With<CaptureSubject>>,
+    bones: Query<(&HumanoidBone, &GlobalTransform)>,
+) {
+    let Ok((subject, skeleton)) = subjects.single() else {
+        return;
+    };
+    let positions = bones
+        .iter()
+        .filter(|(bone, _)| bone.owner == subject)
+        .map(|(bone, transform)| (bone.role, transform.translation()))
+        .collect::<BTreeMap<_, _>>();
+    let connections = [
+        (BoneRole::Pelvis, BoneRole::Chest),
+        (BoneRole::Chest, BoneRole::Head),
+        (BoneRole::Chest, BoneRole::UpperArmLeft),
+        (BoneRole::UpperArmLeft, BoneRole::ForearmLeft),
+        (BoneRole::ForearmLeft, BoneRole::HandLeft),
+        (BoneRole::Chest, BoneRole::UpperArmRight),
+        (BoneRole::UpperArmRight, BoneRole::ForearmRight),
+        (BoneRole::ForearmRight, BoneRole::HandRight),
+        (BoneRole::Pelvis, BoneRole::ThighLeft),
+        (BoneRole::ThighLeft, BoneRole::ShinLeft),
+        (BoneRole::ShinLeft, BoneRole::FootLeft),
+        (BoneRole::Pelvis, BoneRole::ThighRight),
+        (BoneRole::ThighRight, BoneRole::ShinRight),
+        (BoneRole::ShinRight, BoneRole::FootRight),
+    ];
+    for (start, end) in connections {
+        if let (Some(&start), Some(&end)) = (positions.get(&start), positions.get(&end)) {
+            gizmos.line(start, end, Color::srgba(0.1, 0.9, 1.0, 0.8));
+        }
+    }
+    let (left_support, right_support) =
+        gait_support_weights(skeleton.gait_phase, skeleton.local_velocity.xz().length());
+    for (role, support) in [
+        (BoneRole::FootLeft, left_support),
+        (BoneRole::FootRight, right_support),
+    ] {
+        let Some(&position) = positions.get(&role) else {
+            continue;
+        };
+        let color = if support >= 0.55 {
+            Color::srgb(1.0, 0.8, 0.05)
+        } else {
+            Color::srgb(1.0, 0.1, 0.7)
+        };
+        gizmos.line(position - Vec3::X * 0.09, position + Vec3::X * 0.09, color);
+        gizmos.line(position - Vec3::Z * 0.09, position + Vec3::Z * 0.09, color);
+        gizmos.line(
+            position,
+            position + Vec3::Y * (0.05 + support * 0.15),
+            color,
+        );
+    }
+}
+
+fn capture_frame(
     mut commands: Commands,
     mut sequence: ResMut<CaptureSequence>,
     subjects: Query<(Entity, &SkeletonState, Option<&AnimationPlayback>), With<CaptureSubject>>,
     bones: Query<(&HumanoidBone, &GlobalTransform)>,
     mut exit: MessageWriter<AppExit>,
 ) {
-    if !sequence.phase_applied || sequence.capture_in_flight {
+    if !sequence.applied || sequence.capture_in_flight {
         return;
     }
     let Ok((subject, skeleton, playback)) = subjects.single() else {
@@ -219,108 +575,173 @@ fn capture_settled_phase(
     if !playback.authored_pose_is_ready() {
         wait_or_fail(
             &mut sequence,
-            "authored walk clip has not resolved",
+            "authored locomotion clip has not resolved",
             &mut exit,
         );
         return;
     }
-    let mut left_knee = None;
-    let mut right_knee = None;
-    let mut left_foot = None;
-    let mut right_foot = None;
-    for (bone, transform) in &bones {
-        if bone.owner != subject {
-            continue;
-        }
-        let position = transform.translation().to_array();
-        match bone.role {
-            BoneRole::ShinLeft => left_knee = Some(position),
-            BoneRole::ShinRight => right_knee = Some(position),
-            BoneRole::FootLeft => left_foot = Some(position),
-            BoneRole::FootRight => right_foot = Some(position),
-            _ => {}
-        }
-    }
-    if left_foot.is_none() || right_foot.is_none() {
-        wait_or_fail(
-            &mut sequence,
-            "authored rig is missing bound foot bones",
-            &mut exit,
-        );
-        return;
-    }
-
-    sequence.waiting_frames = 0;
-    sequence.settled_frames += 1;
-    let required_frames = if sequence.index == 0 {
-        sequence.frames_per_sample.max(60)
+    sequence.waiting = 0;
+    sequence.settled += 1;
+    let required = if sequence.index == 0 {
+        sequence.settle_frames.max(60)
     } else {
-        sequence.frames_per_sample
+        // A view change needs one complete render before requesting the next
+        // asynchronous screenshot; otherwise two paths may receive the same
+        // previously rendered camera image.
+        sequence.settle_frames.max(2)
     };
-    if sequence.settled_frames < required_frames {
+    if sequence.settled < required {
         return;
     }
 
-    let index = sequence.index;
-    let phase = skeleton.gait_phase;
-    let file_name = format!("walk-{index:02}-phase-{phase:.3}.png");
+    let frame = sequence.plan[sequence.index].clone();
+    let view = VIEWS[sequence.view_index];
+    let file_name = format!(
+        "{}-{:04}-{}.png",
+        frame.scenario,
+        frame.scenario_frame,
+        view.slug()
+    );
     let path = sequence.output.join(&file_name);
-    sequence.samples.push(CaptureSample {
-        index,
-        gait_phase: phase,
-        lower_body_mirror: playback.lower_body_mirror,
-        screenshot: file_name,
-        left_knee,
-        right_knee,
-        left_foot,
-        right_foot,
-    });
+    if sequence.view_index == 0 {
+        let (left_support_weight, right_support_weight) =
+            gait_support_weights(skeleton.gait_phase, frame.speed);
+        sequence.samples.push(FrameSample {
+            scenario: frame.scenario.to_owned(),
+            scenario_frame: frame.scenario_frame,
+            time_seconds: frame.time_seconds,
+            speed_metres_per_second: frame.speed,
+            gait_phase: skeleton.gait_phase,
+            root_distance_metres: frame.distance,
+            left_support_weight,
+            right_support_weight,
+            screenshots: VIEWS
+                .into_iter()
+                .map(|view| {
+                    (
+                        view.slug().to_owned(),
+                        format!(
+                            "{}-{:04}-{}.png",
+                            frame.scenario,
+                            frame.scenario_frame,
+                            view.slug()
+                        ),
+                    )
+                })
+                .collect(),
+            bones: collect_bones(subject, &bones),
+        });
+    }
     sequence.capture_in_flight = true;
-
+    let frame_key = format!("{}:{}", frame.scenario, frame.scenario_frame);
     commands.spawn(Screenshot::primary_window()).observe(
         move |captured: On<ScreenshotCaptured>,
               mut sequence: ResMut<CaptureSequence>,
               mut exit: MessageWriter<AppExit>| {
+            sequence
+                .view_fingerprints
+                .push(visual_fingerprint(&captured.image));
             save_to_disk(&path)(captured);
-            sequence.index += 1;
-            sequence.phase_applied = false;
             sequence.capture_in_flight = false;
-            if sequence.index == WALK_PHASES.len() {
-                let validation = CaptureValidation::from_samples(&sequence.samples);
-                let manifest = CaptureManifest {
-                    animation: "walk",
-                    frames_per_sample: sequence.frames_per_sample,
-                    validation,
-                    samples: std::mem::take(&mut sequence.samples),
-                };
-                let manifest_path = sequence.output.join("manifest.json");
-                fs::write(&manifest_path, manifest.to_json())
-                    .unwrap_or_else(|error| panic!("failed to write {manifest_path:?}: {error}"));
-                info!(path = ?manifest_path, "Animation capture completed");
-                if manifest.validation.complete_cycle {
-                    exit.write(AppExit::Success);
-                } else {
-                    let failure_path = sequence.output.join("failure.txt");
-                    fs::write(
-                        &failure_path,
-                        "captured foot coordinates do not traverse a complete gait cycle\n",
-                    )
-                    .unwrap_or_else(|error| panic!("failed to write {failure_path:?}: {error}"));
-                    exit.write(AppExit::Error(1.try_into().expect("one is non-zero")));
-                }
+            sequence.view_index += 1;
+            sequence.settled = 0;
+            if sequence.view_index < VIEWS.len() {
+                return;
+            }
+            if sequence
+                .view_fingerprints
+                .iter()
+                .copied()
+                .collect::<BTreeSet<_>>()
+                .len()
+                != VIEWS.len()
+            {
+                sequence.duplicate_view_frames.push(frame_key.clone());
+            }
+            sequence.view_fingerprints.clear();
+            sequence.view_index = 0;
+            sequence.index += 1;
+            sequence.applied = false;
+            if sequence.index == sequence.plan.len() {
+                finish_capture(&mut sequence, &mut exit);
             }
         },
     );
 }
 
+fn visual_fingerprint(image: &Image) -> u64 {
+    let Some(data) = image.data.as_deref() else {
+        return 0;
+    };
+    let width = image.texture_descriptor.size.width as usize;
+    let height = image.texture_descriptor.size.height as usize;
+    let stride = width.saturating_mul(4);
+    if stride == 0 || data.len() < stride.saturating_mul(height) {
+        return 0;
+    }
+    // Ignore the top UI label and hash a regular sample of the rendered 3D
+    // view. This catches accidentally identical camera outputs cheaply.
+    let mut hash = 0xcbf29ce484222325_u64;
+    for y in (96.min(height)..height).step_by(8) {
+        for x in (0..width).step_by(8) {
+            for channel in 0..3 {
+                hash ^= data[y * stride + x * 4 + channel] as u64;
+                hash = hash.wrapping_mul(0x100000001b3);
+            }
+        }
+    }
+    hash
+}
+
+fn collect_bones(
+    subject: Entity,
+    bones: &Query<(&HumanoidBone, &GlobalTransform)>,
+) -> BTreeMap<String, BoneSample> {
+    bones
+        .iter()
+        .filter(|(bone, _)| bone.owner == subject && tracked_bone(bone.role).is_some())
+        .map(|(bone, transform)| {
+            let rotation = transform.rotation();
+            (
+                tracked_bone(bone.role).unwrap().to_owned(),
+                BoneSample {
+                    position: transform.translation().to_array(),
+                    rotation_xyzw: [rotation.x, rotation.y, rotation.z, rotation.w],
+                },
+            )
+        })
+        .collect()
+}
+
+fn tracked_bone(role: BoneRole) -> Option<&'static str> {
+    Some(match role {
+        BoneRole::Pelvis => "pelvis",
+        BoneRole::Chest => "chest",
+        BoneRole::Head => "head",
+        BoneRole::UpperArmLeft => "left_shoulder",
+        BoneRole::UpperArmRight => "right_shoulder",
+        BoneRole::ForearmLeft => "left_elbow",
+        BoneRole::ForearmRight => "right_elbow",
+        BoneRole::HandLeft => "left_hand",
+        BoneRole::HandRight => "right_hand",
+        BoneRole::ThighLeft => "left_hip",
+        BoneRole::ThighRight => "right_hip",
+        BoneRole::ShinLeft => "left_knee",
+        BoneRole::ShinRight => "right_knee",
+        BoneRole::FootLeft => "left_foot",
+        BoneRole::FootRight => "right_foot",
+        _ => return None,
+    })
+}
+
 fn wait_or_fail(sequence: &mut CaptureSequence, reason: &str, exit: &mut MessageWriter<AppExit>) {
-    sequence.waiting_frames += 1;
-    if sequence.waiting_frames < 600 {
+    sequence.waiting += 1;
+    if sequence.waiting < 1200 {
         return;
     }
     let message = format!(
         "animation viewer timed out after {} rendered frames: {reason}\n",
-        sequence.waiting_frames
+        sequence.waiting
     );
     let path = sequence.output.join("failure.txt");
     fs::write(&path, &message).unwrap_or_else(|error| panic!("failed to write {path:?}: {error}"));
@@ -328,102 +749,447 @@ fn wait_or_fail(sequence: &mut CaptureSequence, reason: &str, exit: &mut Message
     exit.write(AppExit::Error(1.try_into().expect("one is non-zero")));
 }
 
-impl CaptureManifest {
-    fn to_json(&self) -> String {
-        let samples = self
-            .samples
-            .iter()
-            .map(CaptureSample::to_json)
-            .collect::<Vec<_>>()
-            .join(",\n");
-        format!(
-            concat!(
-                "{{\n",
-                "  \"animation\": \"{}\",\n",
-                "  \"frames_per_sample\": {},\n",
-                "  \"validation\": {{\n",
-                "    \"complete_cycle\": {},\n",
-                "    \"foot_separation_range\": {:.6},\n",
-                "    \"foot_lead_changes\": {}\n",
-                "  }},\n",
-                "  \"samples\": [\n{}\n  ]\n",
-                "}}\n"
-            ),
-            self.animation,
-            self.frames_per_sample,
-            self.validation.complete_cycle,
-            self.validation.foot_separation_range,
-            self.validation.foot_lead_changes,
-            samples
+fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppExit>) {
+    let frames = std::mem::take(&mut sequence.samples);
+    let scenarios = scenario_metrics(&frames);
+    let finite_transforms = frames.iter().all(|frame| {
+        frame.bones.values().all(|bone| {
+            bone.position.into_iter().all(f32::is_finite)
+                && bone.rotation_xyzw.into_iter().all(f32::is_finite)
+        })
+    });
+    let all_scenarios_complete = frames.len() == sequence.plan.len()
+        && frames.iter().zip(&sequence.plan).all(|(frame, planned)| {
+            frame.scenario == planned.scenario
+                && frame.scenario_frame == planned.scenario_frame
+                && TRACKED_BONE_NAMES
+                    .iter()
+                    .all(|name| frame.bones.contains_key(*name))
+        });
+    let all_artifacts_written = capture_artifacts_written(&sequence.output, &frames);
+    let continuity_within_review_bounds = scenarios.iter().all(|metrics| {
+        metrics.maximum_root_relative_step_metres <= 0.20
+            && metrics.maximum_bone_rotation_step_degrees <= 60.0
+    });
+    let no_ground_penetration = scenarios
+        .iter()
+        .all(|metrics| metrics.minimum_foot_height_metres >= -0.08);
+    let biomechanics_within_review_bounds = scenarios.iter().all(|metrics| {
+        metrics.maximum_supported_foot_slip_metres_per_frame <= 0.035
+            && metrics.maximum_planted_foot_drift_metres <= 0.035
+            && metrics.minimum_knee_forward_bend_metres >= -0.08
+            && metrics.pelvis_vertical_range_metres <= 0.20
+            && metrics.head_vertical_range_metres <= 0.20
+            && metrics
+                .loop_seam_position_metres
+                .is_none_or(|value| value <= 0.01)
+            && metrics
+                .loop_seam_rotation_degrees
+                .is_none_or(|value| value <= 5.0)
+    });
+    let views_are_distinct = sequence.duplicate_view_frames.is_empty();
+    let manifest = CaptureManifest {
+        sample_hz: SAMPLE_HZ,
+        pipeline: "authored FK plus final tactical mirroring, look, and terrain leg IK",
+        views: VIEWS,
+        validation: CaptureValidation {
+            finite_transforms,
+            all_scenarios_complete,
+            all_artifacts_written,
+            continuity_within_review_bounds,
+            biomechanics_within_review_bounds,
+            no_ground_penetration,
+            views_are_distinct,
+            duplicate_view_frames: sequence.duplicate_view_frames.clone(),
+            note: "Continuity metrics are regression signals, not biomechanical proof; review index.html at normal and slow speed.",
+        },
+        scenarios,
+        frames,
+    };
+    let manifest_path = sequence.output.join("manifest.json");
+    fs::write(
+        &manifest_path,
+        serde_json::to_string_pretty(&manifest).expect("capture manifest must serialize"),
+    )
+    .unwrap_or_else(|error| panic!("failed to write {manifest_path:?}: {error}"));
+    let index_path = sequence.output.join("index.html");
+    fs::write(&index_path, review_html(&manifest))
+        .unwrap_or_else(|error| panic!("failed to write {index_path:?}: {error}"));
+    info!(path = ?index_path, "Animation review capture completed");
+    if finite_transforms
+        && all_scenarios_complete
+        && all_artifacts_written
+        && continuity_within_review_bounds
+        && biomechanics_within_review_bounds
+        && no_ground_penetration
+        && views_are_distinct
+    {
+        exit.write(AppExit::Success);
+    } else {
+        let failure_path = sequence.output.join("failure.txt");
+        fs::write(
+            &failure_path,
+            "capture failed artifact/completeness/continuity/biomechanics/penetration/distinct-view validation; inspect manifest.json\n",
         )
+        .unwrap_or_else(|error| panic!("failed to write {failure_path:?}: {error}"));
+        exit.write(AppExit::Error(1.try_into().expect("one is non-zero")));
     }
 }
 
-impl CaptureValidation {
-    fn from_samples(samples: &[CaptureSample]) -> Self {
-        let separations = samples
-            .iter()
-            .filter_map(CaptureSample::foot_separation)
-            .collect::<Vec<_>>();
-        let (minimum, maximum) = separations.iter().fold(
+fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
+    let mut grouped = BTreeMap::<&str, Vec<&FrameSample>>::new();
+    for frame in frames {
+        grouped.entry(&frame.scenario).or_default().push(frame);
+    }
+    grouped
+        .into_iter()
+        .map(|(scenario, frames)| {
+            let mut maximum_step = 0.0_f32;
+            let mut maximum_rotation = 0.0_f32;
+            let mut maximum_slip = 0.0_f32;
+            let mut maximum_plant_drift = 0.0_f32;
+            let mut worst_displacement = None;
+            let mut worst_rotation = None;
+            for pair in frames.windows(2) {
+                let (before, after) = (pair[0], pair[1]);
+                let root_delta =
+                    Vec3::Z * (after.root_distance_metres - before.root_distance_metres);
+                for (name, before_bone) in &before.bones {
+                    let Some(after_bone) = after.bones.get(name) else {
+                        continue;
+                    };
+                    let displacement = (Vec3::from_array(after_bone.position)
+                        - Vec3::from_array(before_bone.position)
+                        - root_delta)
+                        .length();
+                    if displacement > maximum_step {
+                        maximum_step = displacement;
+                        worst_displacement = Some(ContinuityLocation {
+                            bone: name.clone(),
+                            from_frame: before.scenario_frame,
+                            to_frame: after.scenario_frame,
+                            value: displacement,
+                        });
+                    }
+                    let rotation = quat(after_bone)
+                        .angle_between(quat(before_bone))
+                        .to_degrees();
+                    if rotation > maximum_rotation {
+                        maximum_rotation = rotation;
+                        worst_rotation = Some(ContinuityLocation {
+                            bone: name.clone(),
+                            from_frame: before.scenario_frame,
+                            to_frame: after.scenario_frame,
+                            value: rotation,
+                        });
+                    }
+                }
+                for (foot, support) in [
+                    (
+                        "left_foot",
+                        before.left_support_weight.min(after.left_support_weight),
+                    ),
+                    (
+                        "right_foot",
+                        before.right_support_weight.min(after.right_support_weight),
+                    ),
+                ] {
+                    if support >= 0.9
+                        && let (Some(a), Some(b)) = (before.bones.get(foot), after.bones.get(foot))
+                    {
+                        maximum_slip = maximum_slip.max(
+                            (Vec3::from_array(b.position) - Vec3::from_array(a.position))
+                                .xz()
+                                .length(),
+                        );
+                    }
+                }
+            }
+            for (foot, left) in [("left_foot", true), ("right_foot", false)] {
+                let mut anchor = None;
+                for frame in &frames {
+                    let support = if left {
+                        frame.left_support_weight
+                    } else {
+                        frame.right_support_weight
+                    };
+                    if support >= 0.9 {
+                        let Some(position) = frame
+                            .bones
+                            .get(foot)
+                            .map(|bone| Vec3::from_array(bone.position).xz())
+                        else {
+                            continue;
+                        };
+                        let origin = anchor.get_or_insert(position);
+                        maximum_plant_drift = maximum_plant_drift.max(position.distance(*origin));
+                    } else {
+                        anchor = None;
+                    }
+                }
+            }
+            let looped = scenario != "start-stop-transition";
+            let (loop_position, loop_rotation) = if looped {
+                let closures = frames
+                    .iter()
+                    .copied()
+                    .filter(|frame| frame.gait_phase.abs() < 0.0001)
+                    .collect::<Vec<_>>();
+                closures
+                    .get(closures.len().saturating_sub(2))
+                    .copied()
+                    .zip(closures.last().copied())
+                    .map(|(first, last)| loop_seam(first, last))
+                    .map_or((None, None), |(position, rotation)| {
+                        (Some(position), Some(rotation))
+                    })
+            } else {
+                (None, None)
+            };
+            ScenarioMetrics {
+                scenario: scenario.to_owned(),
+                frame_count: frames.len(),
+                maximum_root_relative_step_metres: maximum_step,
+                worst_displacement,
+                maximum_bone_rotation_step_degrees: maximum_rotation,
+                worst_rotation,
+                loop_seam_position_metres: loop_position,
+                loop_seam_rotation_degrees: loop_rotation,
+                pelvis_vertical_range_metres: vertical_range(&frames, "pelvis"),
+                head_vertical_range_metres: vertical_range(&frames, "head"),
+                minimum_knee_forward_bend_metres: minimum_knee_bend(&frames),
+                maximum_supported_foot_slip_metres_per_frame: maximum_slip,
+                maximum_planted_foot_drift_metres: maximum_plant_drift,
+                minimum_foot_height_metres: minimum_foot_height(&frames),
+            }
+        })
+        .collect()
+}
+
+fn quat(bone: &BoneSample) -> Quat {
+    Quat::from_array(bone.rotation_xyzw).normalize()
+}
+
+fn loop_seam(first: &FrameSample, last: &FrameSample) -> (f32, f32) {
+    let root_delta = Vec3::Z * (last.root_distance_metres - first.root_distance_metres);
+    first
+        .bones
+        .iter()
+        .fold((0.0_f32, 0.0_f32), |metrics, (name, a)| {
+            // Stateful foot locking intentionally changes the lower-body
+            // contact solution with world position and fixed-step aliasing.
+            // Its continuity is gated by per-frame plant slip/drift instead;
+            // this seam metric checks the repeatable authored upper body.
+            if name.ends_with("_hip") || name.ends_with("_knee") || name.ends_with("_foot") {
+                return metrics;
+            }
+            let Some(b) = last.bones.get(name) else {
+                return metrics;
+            };
+            (
+                metrics.0.max(
+                    (Vec3::from_array(b.position) - Vec3::from_array(a.position) - root_delta)
+                        .length(),
+                ),
+                metrics.1.max(quat(a).angle_between(quat(b)).to_degrees()),
+            )
+        })
+}
+
+fn vertical_range(frames: &[&FrameSample], bone: &str) -> f32 {
+    let (minimum, maximum) = frames
+        .iter()
+        .filter_map(|frame| frame.bones.get(bone).map(|bone| bone.position[1]))
+        .fold(
             (f32::INFINITY, f32::NEG_INFINITY),
-            |(minimum, maximum), &value| (minimum.min(value), maximum.max(value)),
+            |(minimum, maximum), value| (minimum.min(value), maximum.max(value)),
         );
-        let foot_separation_range = if minimum.is_finite() && maximum.is_finite() {
-            maximum - minimum
-        } else {
-            0.0
-        };
-        let foot_lead_changes = separations
-            .iter()
-            .zip(separations.iter().cycle().skip(1))
-            .take(separations.len())
-            .filter(|(before, after)| before.signum() != after.signum())
-            .count();
-        Self {
-            complete_cycle: separations.len() == WALK_PHASES.len()
-                && foot_separation_range > 0.5
-                && foot_lead_changes >= 2,
-            foot_separation_range,
-            foot_lead_changes,
+    if minimum.is_finite() && maximum.is_finite() {
+        maximum - minimum
+    } else {
+        0.0
+    }
+}
+
+fn minimum_knee_bend(frames: &[&FrameSample]) -> f32 {
+    let mut minimum = f32::INFINITY;
+    for frame in frames {
+        for side in ["left", "right"] {
+            let (Some(hip), Some(knee), Some(foot)) = (
+                frame.bones.get(&format!("{side}_hip")),
+                frame.bones.get(&format!("{side}_knee")),
+                frame.bones.get(&format!("{side}_foot")),
+            ) else {
+                continue;
+            };
+            let (hip, knee, foot) = (
+                Vec3::from_array(hip.position),
+                Vec3::from_array(knee.position),
+                Vec3::from_array(foot.position),
+            );
+            let axis = foot - hip;
+            if axis.length_squared() > 0.0001 {
+                let closest = hip + axis * (knee - hip).dot(axis) / axis.length_squared();
+                minimum = minimum.min((knee - closest).z);
+            }
         }
     }
+    if minimum.is_finite() { minimum } else { 0.0 }
 }
 
-impl CaptureSample {
-    fn foot_separation(&self) -> Option<f32> {
-        Some(self.left_foot?[2] - self.right_foot?[2])
-    }
-
-    fn to_json(&self) -> String {
-        format!(
-            concat!(
-                "    {{\n",
-                "      \"index\": {},\n",
-                "      \"gait_phase\": {:.6},\n",
-                "      \"lower_body_mirror\": {:.6},\n",
-                "      \"screenshot\": \"{}\",\n",
-                "      \"left_knee\": {},\n",
-                "      \"right_knee\": {},\n",
-                "      \"left_foot\": {},\n",
-                "      \"right_foot\": {}\n",
-                "    }}"
-            ),
-            self.index,
-            self.gait_phase,
-            self.lower_body_mirror,
-            self.screenshot,
-            json_vec3(self.left_knee),
-            json_vec3(self.right_knee),
-            json_vec3(self.left_foot),
-            json_vec3(self.right_foot),
-        )
-    }
+fn minimum_foot_height(frames: &[&FrameSample]) -> f32 {
+    let minimum = frames
+        .iter()
+        .flat_map(|frame| [frame.bones.get("left_foot"), frame.bones.get("right_foot")])
+        .flatten()
+        .map(|foot| foot.position[1])
+        .fold(f32::INFINITY, f32::min);
+    if minimum.is_finite() { minimum } else { -1.0 }
 }
 
-fn json_vec3(value: Option<[f32; 3]>) -> String {
-    value.map_or_else(
-        || "null".to_owned(),
-        |[x, y, z]| format!("[{x:.6}, {y:.6}, {z:.6}]"),
+fn review_html(manifest: &CaptureManifest) -> String {
+    let frame_json = serde_json::to_string(&manifest.frames).expect("review frames must serialize");
+    let scenario_names_json = serde_json::to_string(
+        &manifest
+            .scenarios
+            .iter()
+            .map(|scenario| scenario.scenario.as_str())
+            .collect::<Vec<_>>(),
     )
+    .expect("review scenario names must serialize");
+    let scenario_buttons = manifest
+        .scenarios
+        .iter()
+        .map(|scenario| {
+            format!(
+                "<button data-scenario=\"{}\">{}</button>",
+                scenario.scenario, scenario.scenario
+            )
+        })
+        .collect::<String>();
+    let metrics = manifest
+        .scenarios
+        .iter()
+        .map(|scenario| {
+            let describe = |worst: &Option<ContinuityLocation>, unit: &str| {
+                worst.as_ref().map_or("&mdash;".to_owned(), |worst| {
+                    format!(
+                        "{} {}&rarr;{} ({:.4}{unit})",
+                        worst.bone, worst.from_frame, worst.to_frame, worst.value
+                    )
+                })
+            };
+            format!(
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{:.4}</td><td>{:.4}</td><td>{:.4}</td></tr>",
+                scenario.scenario,
+                scenario.frame_count,
+                describe(&scenario.worst_displacement, "m"),
+                describe(&scenario.worst_rotation, "deg"),
+                scenario.loop_seam_position_metres.map_or("&mdash;".into(), |value| format!("{value:.4}")),
+                scenario.loop_seam_rotation_degrees.map_or("&mdash;".into(), |value| format!("{value:.2}")),
+                scenario.maximum_supported_foot_slip_metres_per_frame,
+                scenario.maximum_planted_foot_drift_metres,
+                scenario.minimum_foot_height_metres,
+            )
+        })
+        .collect::<String>();
+    format!(
+        r#"<!doctype html>
+<html><head><meta charset="utf-8"><title>Animation review</title><style>
+body{{font:15px system-ui;background:#111820;color:#e8eef5;margin:24px}}button,select{{margin:4px;padding:8px}}img{{max-width:min(960px,100%);background:#222}}table{{border-collapse:collapse;margin-top:20px}}td,th{{border:1px solid #526171;padding:6px}}.note{{max-width:960px;color:#b9c7d5}}#contact{{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:8px;margin-top:20px}}#contact img{{width:100%}}
+</style></head><body><h1>Tactical locomotion review</h1>
+<p class="note">This is the real base mesh and TacticalAnimationPlugin, sampled at 60 Hz with live stride phase, root travel, final mirroring/look/terrain IK, and a cyan skeleton overlay. Use normal speed first, then slow motion. Metrics flag continuity for investigation; they are not biomechanical proof.</p>
+<div>{scenario_buttons}</div><label>View <select id="view"><option value="third-person">third person</option><option value="side">side</option><option value="front">front</option></select></label>
+<label>Playback <select id="rate"><option value="1">normal</option><option value="2">half speed</option><option value="4">quarter speed</option></select></label>
+<p id="telemetry"></p><img id="player"><div id="contact"></div>
+<table><thead><tr><th>scenario</th><th>frames</th><th>worst root-relative displacement</th><th>worst rotation</th><th>loop seam m</th><th>loop seam deg</th><th>supported slip m/frame</th><th>planted interval drift m</th><th>minimum foot height m</th></tr></thead><tbody>{metrics}</tbody></table>
+<script>const all={frame_json},scenarioNames={scenario_names_json};let scenario=scenarioNames[0]||"",i=0,timer;const player=document.querySelector('#player'),view=document.querySelector('#view'),rate=document.querySelector('#rate'),telemetry=document.querySelector('#telemetry');
+function frames(){{return all.filter(x=>x.scenario===scenario)}}function show(){{const list=frames(),f=list.length?list[i%list.length]:null;if(!f){{player.removeAttribute('src');telemetry.textContent='No completed capture frames';return}}player.src=f.screenshots[view.value];telemetry.textContent=`${{f.scenario}} frame ${{f.scenario_frame}} | ${{f.speed_metres_per_second.toFixed(2)}} m/s | phase ${{f.gait_phase.toFixed(3)}} | support L ${{f.left_support_weight.toFixed(2)}} R ${{f.right_support_weight.toFixed(2)}}`;}}
+function play(){{clearInterval(timer);timer=setInterval(()=>{{i=(i+1)%frames().length;show()}},1000/60*Number(rate.value))}}function contacts(){{const f=frames(),step=Math.max(1,Math.floor(f.length/12)),box=document.querySelector('#contact');box.innerHTML='';for(let n=0;n<f.length;n+=step){{let x=document.createElement('img');x.src=f[n].screenshots[view.value];x.title=`frame ${{f[n].scenario_frame}} phase ${{f[n].gait_phase.toFixed(3)}}`;box.appendChild(x)}}}}
+document.querySelectorAll('button').forEach(b=>b.onclick=()=>{{scenario=b.dataset.scenario;i=0;show();contacts();play()}});view.onchange=()=>{{show();contacts()}};rate.onchange=play;show();contacts();play();</script></body></html>"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_test_output(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "adventuresim-animation-viewer-{name}-{}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn report_invalidation_preserves_unrelated_files() {
+        let output = unique_test_output("invalidate");
+        fs::create_dir_all(&output).unwrap();
+        for name in ["manifest.json", "index.html", "failure.txt", "notes.txt"] {
+            fs::write(output.join(name), b"old").unwrap();
+        }
+        invalidate_previous_report(&output);
+        assert!(!output.join("manifest.json").exists());
+        assert!(!output.join("index.html").exists());
+        assert!(!output.join("failure.txt").exists());
+        assert!(output.join("notes.txt").exists());
+        fs::remove_dir_all(output).unwrap();
+    }
+
+    #[test]
+    fn capture_requires_every_nonempty_view_artifact() {
+        let output = unique_test_output("artifacts");
+        fs::create_dir_all(&output).unwrap();
+        let screenshots = VIEWS
+            .into_iter()
+            .map(|view| (view.slug().to_owned(), format!("{}.png", view.slug())))
+            .collect::<BTreeMap<_, _>>();
+        let frame = FrameSample {
+            scenario: "test".into(),
+            scenario_frame: 0,
+            time_seconds: 0.0,
+            speed_metres_per_second: 0.0,
+            gait_phase: 0.0,
+            root_distance_metres: 0.0,
+            left_support_weight: 1.0,
+            right_support_weight: 1.0,
+            screenshots,
+            bones: BTreeMap::new(),
+        };
+        for name in frame.screenshots.values() {
+            fs::write(output.join(name), b"png").unwrap();
+        }
+        assert!(capture_artifacts_written(
+            &output,
+            std::slice::from_ref(&frame)
+        ));
+        fs::write(output.join("front.png"), b"").unwrap();
+        assert!(!capture_artifacts_written(&output, &[frame]));
+        fs::remove_dir_all(output).unwrap();
+    }
+
+    #[test]
+    fn steady_scenarios_close_exactly_after_two_cycles() {
+        for (name, speed) in [("walk", 2.0), ("blend", 3.75), ("run", 5.5)] {
+            let frames = steady_scenario(name, speed, 2.0);
+            assert_eq!(frames.first().unwrap().gait_phase, 0.0);
+            assert!(frames.last().unwrap().gait_phase.abs() < 0.0001);
+            assert!(frames.len() > 30);
+            for pair in frames.windows(2) {
+                assert!(pair[1].time_seconds > pair[0].time_seconds);
+                assert!(pair[1].time_seconds - pair[0].time_seconds <= 1.0 / SAMPLE_HZ + 0.0001);
+            }
+        }
+    }
+
+    #[test]
+    fn transition_uses_server_stride_formula_without_non_finite_state() {
+        let frames = transition_scenario();
+        assert_eq!(frames.len(), 241);
+        assert!(frames.iter().all(|frame| frame.speed.is_finite()
+            && frame.gait_phase.is_finite()
+            && frame.distance.is_finite()));
+        assert_eq!(frames.first().unwrap().speed, 0.0);
+        assert_eq!(frames.last().unwrap().speed, 0.0);
+    }
 }

--- a/crates/adventuresim-tactical-client/src/animation_viewer_main.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer_main.rs
@@ -8,18 +8,21 @@ use std::path::PathBuf;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
-#[command(version, about = "Capture deterministic tactical animation phases")]
+#[command(
+    version,
+    about = "Capture deterministic tactical locomotion review sequences"
+)]
 struct Args {
-    /// Directory receiving PNG frames and manifest.json.
-    #[arg(long, default_value = "target/animation-captures/walk")]
+    /// Directory receiving per-view PNGs, manifest.json, and index.html.
+    #[arg(long, default_value = "target/animation-captures/locomotion-review")]
     output: PathBuf,
 
     /// Repository asset directory containing animations/.
     #[arg(long, default_value = "assets")]
     asset_root: PathBuf,
 
-    /// Rendered frames allowed for each phase to settle before capture.
-    #[arg(long, default_value_t = 6)]
+    /// Rendered frames allowed for each deterministic sample to settle.
+    #[arg(long, default_value_t = 1)]
     frames_per_sample: u32,
 }
 
@@ -32,5 +35,8 @@ fn main() {
             .expect("animation viewer needs a working directory")
             .join(args.asset_root)
     };
-    animation_viewer::run(args.output, asset_root, args.frames_per_sample.max(1));
+    let exit = animation_viewer::run(args.output, asset_root, args.frames_per_sample.max(1));
+    if let bevy::app::AppExit::Error(code) = exit {
+        std::process::exit(code.get() as i32);
+    }
 }

--- a/crates/adventuresim-tactical-client/src/debug.rs
+++ b/crates/adventuresim-tactical-client/src/debug.rs
@@ -1,7 +1,10 @@
 use adventuresim_tactical_core::prelude::*;
 use bevy::{color::palettes::tailwind, prelude::*};
 
-use crate::player::{ClientPlayer, HitPerformed, LimbHitbox};
+use crate::{
+    animation::TerrainIkEnabled,
+    player::{ClientPlayer, HitPerformed, LimbHitbox},
+};
 
 pub struct DebugPlugin;
 
@@ -41,6 +44,7 @@ struct DebugRay {
 fn toggle_debug_visuals(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut config: ResMut<DebugVisualsConfig>,
+    mut terrain_ik: ResMut<TerrainIkEnabled>,
     q_colliders: Query<(Entity, Option<&LimbHitbox>), (With<Collider>, Without<ClientPlayer>)>,
     mut cmd: Commands,
 ) {
@@ -73,6 +77,11 @@ fn toggle_debug_visuals(
 
     if keyboard.just_pressed(KeyCode::F4) {
         config.raycast = !config.raycast;
+    }
+
+    if keyboard.just_pressed(KeyCode::F8) {
+        terrain_ik.0 = !terrain_ik.0;
+        info!(enabled = terrain_ik.0, "Terrain leg IK toggled");
     }
 }
 
@@ -140,5 +149,35 @@ fn draw_debug_rays(
                 color.set_alpha(alpha);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn f8_toggles_terrain_ik() {
+        let mut app = App::new();
+        app.init_resource::<ButtonInput<KeyCode>>()
+            .init_resource::<DebugVisualsConfig>()
+            .init_resource::<TerrainIkEnabled>()
+            .add_systems(Update, toggle_debug_visuals);
+
+        app.world_mut()
+            .resource_mut::<ButtonInput<KeyCode>>()
+            .press(KeyCode::F8);
+        app.update();
+        assert!(!app.world().resource::<TerrainIkEnabled>().0);
+
+        {
+            let mut keyboard = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            keyboard.release(KeyCode::F8);
+            keyboard.clear_just_pressed(KeyCode::F8);
+            keyboard.clear_just_released(KeyCode::F8);
+            keyboard.press(KeyCode::F8);
+        }
+        app.update();
+        assert!(app.world().resource::<TerrainIkEnabled>().0);
     }
 }

--- a/crates/adventuresim-tactical-client/src/debug.rs
+++ b/crates/adventuresim-tactical-client/src/debug.rs
@@ -1,4 +1,7 @@
 use adventuresim_tactical_core::prelude::*;
+use adventuresim_tactical_netcode::{
+    bevy_replicon::prelude::ClientTriggerExt, prelude::DebugGameTimeScaleRequest,
+};
 use bevy::{color::palettes::tailwind, prelude::*};
 
 use crate::{
@@ -11,11 +14,17 @@ pub struct DebugPlugin;
 impl Plugin for DebugPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<DebugVisualsConfig>()
+            .init_resource::<DebugGameSpeed>()
             .register_required_components_with::<Collider, _>(|| DebugRender::none())
             .add_systems(Update, toggle_debug_visuals)
             .add_systems(Update, draw_debug_rays)
             .add_observer(on_hit_performed);
     }
+}
+
+#[derive(Resource, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct DebugGameSpeed {
+    pub(crate) quarter_speed: bool,
 }
 
 #[derive(Resource)]
@@ -45,9 +54,22 @@ fn toggle_debug_visuals(
     keyboard: Res<ButtonInput<KeyCode>>,
     mut config: ResMut<DebugVisualsConfig>,
     mut terrain_ik: ResMut<TerrainIkEnabled>,
+    mut game_speed: ResMut<DebugGameSpeed>,
+    mut virtual_time: ResMut<Time<Virtual>>,
     q_colliders: Query<(Entity, Option<&LimbHitbox>), (With<Collider>, Without<ClientPlayer>)>,
     mut cmd: Commands,
 ) {
+    if keyboard.just_pressed(KeyCode::F7) {
+        game_speed.quarter_speed = !game_speed.quarter_speed;
+        let request = DebugGameTimeScaleRequest {
+            quarter_speed: game_speed.quarter_speed,
+        };
+        let relative_speed = request.relative_speed();
+        virtual_time.set_relative_speed(relative_speed);
+        cmd.client_trigger(request);
+        info!(relative_speed, "Debug game speed toggled");
+    }
+
     if keyboard.just_pressed(KeyCode::F2) {
         config.physics_colliders = !config.physics_colliders;
         for (entity, hitbox) in &q_colliders {
@@ -161,7 +183,9 @@ mod tests {
         let mut app = App::new();
         app.init_resource::<ButtonInput<KeyCode>>()
             .init_resource::<DebugVisualsConfig>()
+            .init_resource::<DebugGameSpeed>()
             .init_resource::<TerrainIkEnabled>()
+            .init_resource::<Time<Virtual>>()
             .add_systems(Update, toggle_debug_visuals);
 
         app.world_mut()

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -19,6 +19,7 @@ use bevy_flair::prelude::*;
 
 use crate::{
     Args,
+    animation::TerrainIkEnabled,
     player::{AttackState, ClientPlayer},
 };
 
@@ -38,6 +39,8 @@ impl Plugin for UiPlugin {
                     update_combat_state_ui.run_if(any_with_component::<ClientPlayer>),
                     update_items_ui.run_if(any_with_component::<ClientPlayer>),
                     update_attack_timer_ui.run_if(any_with_component::<ClientPlayer>),
+                    #[cfg(feature = "debug")]
+                    update_terrain_ik_debug_ui,
                 ),
             )
             .add_observer(on_new_player_added_hook)
@@ -91,6 +94,10 @@ struct AttackTimerSpan;
 
 #[derive(Component)]
 struct CombatStateSpan;
+
+#[cfg(feature = "debug")]
+#[derive(Component)]
+struct TerrainIkDebugSpan;
 
 #[derive(Component)]
 struct TacticalOutcomeBanner;
@@ -154,7 +161,9 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                     #[cfg(feature = "debug")]
                     TextSpan::new(
                         "DEBUG: F2 to toggle body | F3 to toggle hitbox | F4 to toggle hitscan"
-                    )
+                    ),
+                    #[cfg(feature = "debug")]
+                    (TerrainIkDebugSpan, TextSpan::new(" | F8 terrain IK: ON"))
                 ],
             ),
             (
@@ -338,6 +347,20 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
             ),
         ],
     ));
+}
+
+#[cfg(feature = "debug")]
+fn update_terrain_ik_debug_ui(
+    enabled: Res<TerrainIkEnabled>,
+    mut span: Single<&mut TextSpan, With<TerrainIkDebugSpan>>,
+) {
+    if enabled.is_changed() {
+        span.0 = if enabled.0 {
+            " | F8 terrain IK: ON".to_owned()
+        } else {
+            " | F8 terrain IK: OFF".to_owned()
+        };
+    }
 }
 
 fn combat_state_label(state: &TacticalCombatState) -> String {

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -17,9 +17,12 @@ use bevy::{
 };
 use bevy_flair::prelude::*;
 
+#[cfg(feature = "debug")]
+use crate::animation::TerrainIkEnabled;
+#[cfg(feature = "debug")]
+use crate::debug::DebugGameSpeed;
 use crate::{
     Args,
-    animation::TerrainIkEnabled,
     player::{AttackState, ClientPlayer},
 };
 
@@ -41,6 +44,8 @@ impl Plugin for UiPlugin {
                     update_attack_timer_ui.run_if(any_with_component::<ClientPlayer>),
                     #[cfg(feature = "debug")]
                     update_terrain_ik_debug_ui,
+                    #[cfg(feature = "debug")]
+                    update_game_speed_debug_ui,
                 ),
             )
             .add_observer(on_new_player_added_hook)
@@ -99,6 +104,10 @@ struct CombatStateSpan;
 #[derive(Component)]
 struct TerrainIkDebugSpan;
 
+#[cfg(feature = "debug")]
+#[derive(Component)]
+struct GameSpeedDebugSpan;
+
 #[derive(Component)]
 struct TacticalOutcomeBanner;
 
@@ -153,16 +162,15 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
             ),
             (
                 Name::new("controls"),
-                Text::new(""),
+                Text::new(
+                    "WASD to move | Space to jump | Mouse to look around | F9 to toggle camera\n",
+                ),
+                #[cfg(feature = "debug")]
                 children![
-                    TextSpan::new(
-                        "WASD to move | Space to jump | Mouse to look around | F9 to toggle camera\n"
-                    ),
-                    #[cfg(feature = "debug")]
                     TextSpan::new(
                         "DEBUG: F2 to toggle body | F3 to toggle hitbox | F4 to toggle hitscan"
                     ),
-                    #[cfg(feature = "debug")]
+                    (GameSpeedDebugSpan, TextSpan::new(" | F7 game speed: 1x")),
                     (TerrainIkDebugSpan, TextSpan::new(" | F8 terrain IK: ON"))
                 ],
             ),
@@ -359,6 +367,20 @@ fn update_terrain_ik_debug_ui(
             " | F8 terrain IK: ON".to_owned()
         } else {
             " | F8 terrain IK: OFF".to_owned()
+        };
+    }
+}
+
+#[cfg(feature = "debug")]
+fn update_game_speed_debug_ui(
+    speed: Res<DebugGameSpeed>,
+    mut span: Single<&mut TextSpan, With<GameSpeedDebugSpan>>,
+) {
+    if speed.is_changed() {
+        span.0 = if speed.quarter_speed {
+            " | F7 game speed: 1/4x".to_owned()
+        } else {
+            " | F7 game speed: 1x".to_owned()
         };
     }
 }

--- a/crates/adventuresim-tactical-core/src/animation.rs
+++ b/crates/adventuresim-tactical-core/src/animation.rs
@@ -685,23 +685,30 @@ fn gait_or_idle(
 }
 
 fn locomotion_samples(speed: f32, phase: f32, crouch: f32) -> Vec<PoseSample> {
-    if speed < 0.05 {
-        return weighted_pair(SemanticPose::IdleRelaxed, SemanticPose::CrouchIdle, crouch);
-    }
     const WALK_REFERENCE_SPEED: f32 = 2.0;
     const RUN_REFERENCE_SPEED: f32 = 5.5;
+    const LOCOMOTION_BLEND_SPEED: f32 = 0.75;
+    let locomotion = smoothstep01(speed / LOCOMOTION_BLEND_SPEED);
     let run = ((speed - WALK_REFERENCE_SPEED) / (RUN_REFERENCE_SPEED - WALK_REFERENCE_SPEED))
         .clamp(0.0, 1.0);
-    let mut samples = Vec::with_capacity(6);
+    let mut samples = Vec::with_capacity(8);
+    let mut idle = weighted_pair(SemanticPose::IdleRelaxed, SemanticPose::CrouchIdle, crouch);
+    // The idle lower body is authored symmetrically. Give every contribution
+    // the same reflection coordinate before Bevy blends it, so the client
+    // never has to average incompatible mirrored and unmirrored semantics.
+    for sample in &mut idle {
+        sample.mirror_lower_body = gait_mirror(phase);
+    }
+    append_scaled(&mut samples, idle, 1.0 - locomotion);
     append_scaled(
         &mut samples,
         gait_pair(phase, SemanticPose::WalkContact, SemanticPose::WalkPassing),
-        (1.0 - run) * (1.0 - crouch),
+        locomotion * (1.0 - run) * (1.0 - crouch),
     );
     append_scaled(
         &mut samples,
         gait_pair(phase, SemanticPose::RunContact, SemanticPose::RunFlight),
-        run * (1.0 - crouch),
+        locomotion * run * (1.0 - crouch),
     );
     append_scaled(
         &mut samples,
@@ -710,7 +717,7 @@ fn locomotion_samples(speed: f32, phase: f32, crouch: f32) -> Vec<PoseSample> {
             SemanticPose::CrouchWalkContact,
             SemanticPose::CrouchWalkPassing,
         ),
-        crouch,
+        locomotion * crouch,
     );
     samples.retain(|sample| sample.weight > f32::EPSILON);
     samples
@@ -745,15 +752,53 @@ fn weighted_pair(a: SemanticPose, b: SemanticPose, b_weight: f32) -> Vec<PoseSam
     samples
 }
 
-fn gait_pair(phase: f32, contact: SemanticPose, _passing: SemanticPose) -> Vec<PoseSample> {
+fn gait_mirror(phase: f32) -> f32 {
+    let phase = phase.rem_euclid(1.0);
+    if phase < 0.15 {
+        0.0
+    } else if phase < 0.35 {
+        smoothstep01((phase - 0.15) / 0.20)
+    } else if phase < 0.65 {
+        1.0
+    } else if phase < 0.85 {
+        1.0 - smoothstep01((phase - 0.65) / 0.20)
+    } else {
+        0.0
+    }
+}
+
+fn gait_pair(phase: f32, contact: SemanticPose, passing: SemanticPose) -> Vec<PoseSample> {
+    let phase = phase.rem_euclid(1.0);
+    let quarter = phase * 4.0;
+    let index = quarter.floor() as u8;
+    let progress = smoothstep01(quarter.fract());
+    let (start, end) = match index {
+        0 => (contact, passing),
+        1 => (passing, contact),
+        2 => (contact, passing),
+        _ => (passing, contact),
+    };
+    // Swap anatomical sides only near each passing pose. A hard swap pops,
+    // while blending throughout contact folds the planted stride through
+    // itself. The 20%-cycle windows keep interpolation around the pose where
+    // the legs are closest and preserve the authored contact silhouettes.
+    let mirror = gait_mirror(phase);
+    // Contact and passing are authoritative timestamps in the same sparse
+    // motion file. Sample the interval directly instead of asking Bevy to
+    // blend two times on one animation-graph node: a node has only one seek
+    // position, so the latter sample would overwrite the former and create a
+    // hard quarter-cycle pose swap.
     vec![PoseSample {
-        pose: contact,
-        sampling: PoseSampling::Cycle {
-            progress: phase.rem_euclid(1.0),
-        },
+        pose: start,
+        sampling: PoseSampling::Span { end, progress },
         weight: 1.0,
-        mirror_lower_body: 0.0,
+        mirror_lower_body: mirror,
     }]
+}
+
+fn smoothstep01(value: f32) -> f32 {
+    let value = value.clamp(0.0, 1.0);
+    value * value * (3.0 - 2.0 * value)
 }
 
 fn directional_jump_poses(direction: Vec2) -> [SemanticPose; 3] {
@@ -1051,36 +1096,94 @@ mod tests {
         let evaluation = AnimationEvaluation::from_skeleton(&state);
         assert_eq!(evaluation.base.len(), 2);
         assert!(evaluation.base.iter().any(|sample| {
-            sample.pose == SemanticPose::WalkContact
-                && sample.sampling == (PoseSampling::Cycle { progress: 0.25 })
+            sample.pose == SemanticPose::WalkPassing
+                && sample.sampling
+                    == PoseSampling::Span {
+                        end: SemanticPose::WalkContact,
+                        progress: 0.0,
+                    }
                 && sample.weight == 0.5
         }));
         assert!(evaluation.base.iter().any(|sample| {
-            sample.pose == SemanticPose::RunContact
-                && sample.sampling == (PoseSampling::Cycle { progress: 0.25 })
+            sample.pose == SemanticPose::RunFlight
+                && sample.sampling
+                    == PoseSampling::Span {
+                        end: SemanticPose::RunContact,
+                        progress: 0.0,
+                    }
                 && sample.weight == 0.5
         }));
     }
 
     #[test]
-    fn gait_samples_the_complete_authored_cycle() {
+    fn low_speed_idle_and_gait_contributions_share_mirror_semantics() {
+        let evaluation = AnimationEvaluation::from_skeleton(&SkeletonState {
+            local_velocity: Vec3::new(0.25, 0.0, 0.0),
+            gait_phase: 0.25,
+            ..default()
+        });
+        assert!(evaluation.base.len() >= 2);
+        let mirror = evaluation.base[0].mirror_lower_body;
+        assert!(
+            evaluation
+                .base
+                .iter()
+                .all(|sample| (sample.mirror_lower_body - mirror).abs() < 0.0001)
+        );
+    }
+
+    #[test]
+    fn gait_constructs_four_quarters_from_sparse_authoritative_anchors() {
         let samples = [0.0, 0.25, 0.5, 0.75]
             .map(|phase| gait_pair(phase, SemanticPose::WalkContact, SemanticPose::WalkPassing)[0]);
-        assert!(
-            samples
-                .iter()
-                .all(|sample| sample.pose == SemanticPose::WalkContact)
+        assert_eq!(
+            samples.map(|sample| sample.pose),
+            [
+                SemanticPose::WalkContact,
+                SemanticPose::WalkPassing,
+                SemanticPose::WalkContact,
+                SemanticPose::WalkPassing,
+            ]
         );
         assert_eq!(
             samples.map(|sample| sample.sampling),
             [
-                PoseSampling::Cycle { progress: 0.0 },
-                PoseSampling::Cycle { progress: 0.25 },
-                PoseSampling::Cycle { progress: 0.5 },
-                PoseSampling::Cycle { progress: 0.75 },
+                PoseSampling::Span {
+                    end: SemanticPose::WalkPassing,
+                    progress: 0.0,
+                },
+                PoseSampling::Span {
+                    end: SemanticPose::WalkContact,
+                    progress: 0.0,
+                },
+                PoseSampling::Span {
+                    end: SemanticPose::WalkPassing,
+                    progress: 0.0,
+                },
+                PoseSampling::Span {
+                    end: SemanticPose::WalkContact,
+                    progress: 0.0,
+                },
             ]
         );
-        assert!(samples.iter().all(|sample| sample.mirror_lower_body == 0.0));
+        for (actual, expected) in samples
+            .map(|sample| sample.mirror_lower_body)
+            .into_iter()
+            .zip([0.0, 0.5, 1.0, 0.5])
+        {
+            assert!((actual - expected).abs() < 0.0001);
+        }
+        let between = gait_pair(0.375, SemanticPose::WalkContact, SemanticPose::WalkPassing);
+        assert_eq!(between.len(), 1);
+        assert_eq!(
+            between[0].sampling,
+            PoseSampling::Span {
+                end: SemanticPose::WalkContact,
+                progress: 0.5,
+            }
+        );
+        assert_eq!(between[0].weight, 1.0);
+        assert_eq!(between[0].mirror_lower_body, 1.0);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-core/src/scene.rs
+++ b/crates/adventuresim-tactical-core/src/scene.rs
@@ -134,8 +134,12 @@ impl SceneTerrain {
 
         let mut positions = Vec::with_capacity(self.heightmap.len());
         let mut uvs = Vec::with_capacity(self.heightmap.len());
-        for x in 0..self.grid_width() {
-            for z in 0..self.grid_depth() {
+        // Keep vertices in the same row-major (z * width + x) order used by
+        // height sampling and the triangle indices below. Iterating x first
+        // transposed the storage without transposing the indices, which made
+        // otherwise smooth terrain render as long shredded triangles.
+        for z in 0..self.grid_depth() {
+            for x in 0..self.grid_width() {
                 let i = z * self.grid_width() + x;
                 let y = self.heightmap[i];
 
@@ -157,11 +161,11 @@ impl SceneTerrain {
 
                 indices.extend_from_slice(&[
                     i,
+                    i + self.grid_width() as u32 + 1,
                     i + 1,
-                    i + self.grid_width() as u32 + 1,
                     i,
-                    i + self.grid_width() as u32 + 1,
                     i + self.grid_width() as u32,
+                    i + self.grid_width() as u32 + 1,
                 ]);
             }
         }
@@ -179,6 +183,22 @@ mod tests {
         let terrain = SceneTerrain::new(2, 2, 2.0, |point| point.x + point.y * 2.0);
         assert!((terrain.height_at(Vec2::new(-1.0, -1.0)).unwrap() - 1.5).abs() < 0.0001);
         assert_eq!(terrain.height_at(Vec2::new(-3.0, 0.0)), None);
+    }
+
+    #[test]
+    fn mesh_vertices_follow_heightmap_row_major_order() {
+        let terrain = SceneTerrain::new(2, 2, 1.0, |point| point.x + point.y * 10.0);
+        let (positions, indices, _) = terrain.mesh_components();
+
+        assert_eq!(positions[0][1], 0.0);
+        assert_eq!(positions[1][1], 1.0);
+        assert_eq!(positions[2][1], 2.0);
+        assert_eq!(positions[3][1], 10.0);
+
+        let a = Vec3::from_array(positions[indices[0] as usize]);
+        let b = Vec3::from_array(positions[indices[1] as usize]);
+        let c = Vec3::from_array(positions[indices[2] as usize]);
+        assert!((b - a).cross(c - a).y > 0.0);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-netcode/src/lib.rs
+++ b/crates/adventuresim-tactical-netcode/src/lib.rs
@@ -18,8 +18,8 @@ pub mod prelude {
     #[cfg(feature = "client")]
     pub use crate::client::AdventureSimulatorClient;
     pub use crate::message::{
-        DefendRequest, JoinRequest, MeleeActionRequest, PlayerInputRequest, RangedActionRequest,
-        TacticalOutcome, TacticalOutcomeResponse,
+        DebugGameTimeScaleRequest, DefendRequest, JoinRequest, MeleeActionRequest,
+        PlayerInputRequest, RangedActionRequest, TacticalOutcome, TacticalOutcomeResponse,
     };
     #[cfg(feature = "server")]
     pub use crate::server::AdventureSimulatorServer;

--- a/crates/adventuresim-tactical-netcode/src/message.rs
+++ b/crates/adventuresim-tactical-netcode/src/message.rs
@@ -26,6 +26,42 @@ pub struct PlayerInputRequest {
     pub jump: bool,
 }
 
+/// Debug-build request to run the tactical simulation at normal or quarter
+/// speed. Production servers intentionally do not install a handler for it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Event, Serialize, Deserialize)]
+pub struct DebugGameTimeScaleRequest {
+    pub quarter_speed: bool,
+}
+
+impl DebugGameTimeScaleRequest {
+    pub const fn relative_speed(self) -> f32 {
+        if self.quarter_speed { 0.25 } else { 1.0 }
+    }
+}
+
+#[cfg(test)]
+mod debug_game_time_scale_tests {
+    use super::DebugGameTimeScaleRequest;
+
+    #[test]
+    fn request_maps_to_normal_or_quarter_speed() {
+        assert_eq!(
+            DebugGameTimeScaleRequest {
+                quarter_speed: false
+            }
+            .relative_speed(),
+            1.0
+        );
+        assert_eq!(
+            DebugGameTimeScaleRequest {
+                quarter_speed: true
+            }
+            .relative_speed(),
+            0.25
+        );
+    }
+}
+
 /// Both melee phases share one mapped ordered stream, so a completion cannot
 /// overtake its server-observed start.
 #[derive(Debug, Clone, Copy, Event, Serialize, Deserialize, MapEntities)]

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -5,8 +5,8 @@ use bevy_replicon::prelude::*;
 
 use crate::FIXED_TIMESTEP_HZ;
 use crate::message::{
-    DefendRequest, JoinRequest, MeleeActionRequest, PlayerInputRequest, RangedActionRequest,
-    SuccessfulAttackResponse, TacticalOutcomeResponse,
+    DebugGameTimeScaleRequest, DefendRequest, JoinRequest, MeleeActionRequest, PlayerInputRequest,
+    RangedActionRequest, SuccessfulAttackResponse, TacticalOutcomeResponse,
 };
 
 #[derive(Default)]
@@ -41,6 +41,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .replicate::<SceneTerrain>()
             .add_client_event::<JoinRequest>(Channel::Ordered)
             .add_client_event::<PlayerInputRequest>(Channel::Unreliable)
+            .add_client_event::<DebugGameTimeScaleRequest>(Channel::Ordered)
             .add_client_event::<DefendRequest>(Channel::Unreliable)
             .add_mapped_client_event::<MeleeActionRequest>(Channel::Ordered)
             .add_mapped_client_event::<RangedActionRequest>(Channel::Ordered)

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -16,6 +16,10 @@ use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::{Replicated, ServerState},
     prelude::{AdventureSimulatorNetPlugins, AdventureSimulatorServer},
 };
+#[cfg(feature = "debug")]
+use adventuresim_tactical_netcode::{
+    bevy_replicon::prelude::FromClient, prelude::DebugGameTimeScaleRequest,
+};
 use bevy::ecs::schedule::ApplyDeferred;
 use bevy::prelude::*;
 use clap::{ArgAction, Parser};
@@ -72,59 +76,71 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-    App::new()
-        .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
-            filter: "tactical_server=info,bevy_app=warn,bevy_ecs=warn".to_string(),
-            ..default()
-        }))
-        .add_plugins((
-            AdventureSimulatorCorePlugins
-                .build()
-                .set(AdventureSimulatorPhysicsPlugin {
-                    enable_simulation: true,
-                }),
-            AdventureSimulatorNetPlugins,
-        ))
-        .add_plugins((
-            stdb::SpacetimeDbPlugin,
-            combat::CombatPlugin,
-            bot::BotPlugin,
-        ))
-        .insert_resource(MissionState::new(
-            (!args.no_timeout)
-                .then_some(args.timeout)
-                .map(|duration| Timer::from_seconds(duration, TimerMode::Once)),
-            args.required_enemy_kills,
-            NonZeroU32::new(args.expected_party_members)
-                .expect("clap validates at least one expected party member"),
-        ))
-        .insert_resource(args)
-        .add_systems(
-            Update,
-            (
-                (check_terminal_combat_outcome, check_mission_timeout)
-                    .chain()
-                    .after(CombatSet::Condition)
-                    .after(spawn_connected_players)
-                    .after(process_terminal_submission_results),
-                process_terminal_submission_results.after(stdb::update_spacetimedb),
-                fail_stalled_terminal_submission
-                    .after(process_terminal_submission_results)
-                    .before(check_terminal_combat_outcome),
-                finish_terminal_presentation.after(check_mission_timeout),
-                (spawn_connected_players, ApplyDeferred)
-                    .chain()
-                    .in_set(PlayerProjectionSet::Spawn)
-                    .after(stdb::update_spacetimedb),
-                (setup_server, setup_stdb_callbacks).run_if(resource_added::<SpacetimeDbReady>),
-            ),
-        )
-        .add_systems(OnEnter(ServerState::Running), on_server_started)
-        .add_systems(FixedPostUpdate, update_skeleton_locomotion)
-        .add_observer(on_join_request)
-        .add_observer(on_player_input)
-        .add_observer(on_client_disconnected)
-        .run();
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
+        filter: "tactical_server=info,bevy_app=warn,bevy_ecs=warn".to_string(),
+        ..default()
+    }))
+    .add_plugins((
+        AdventureSimulatorCorePlugins
+            .build()
+            .set(AdventureSimulatorPhysicsPlugin {
+                enable_simulation: true,
+            }),
+        AdventureSimulatorNetPlugins,
+    ))
+    .add_plugins((
+        stdb::SpacetimeDbPlugin,
+        combat::CombatPlugin,
+        bot::BotPlugin,
+    ))
+    .insert_resource(MissionState::new(
+        (!args.no_timeout)
+            .then_some(args.timeout)
+            .map(|duration| Timer::from_seconds(duration, TimerMode::Once)),
+        args.required_enemy_kills,
+        NonZeroU32::new(args.expected_party_members)
+            .expect("clap validates at least one expected party member"),
+    ))
+    .insert_resource(args)
+    .add_systems(
+        Update,
+        (
+            (check_terminal_combat_outcome, check_mission_timeout)
+                .chain()
+                .after(CombatSet::Condition)
+                .after(spawn_connected_players)
+                .after(process_terminal_submission_results),
+            process_terminal_submission_results.after(stdb::update_spacetimedb),
+            fail_stalled_terminal_submission
+                .after(process_terminal_submission_results)
+                .before(check_terminal_combat_outcome),
+            finish_terminal_presentation.after(check_mission_timeout),
+            (spawn_connected_players, ApplyDeferred)
+                .chain()
+                .in_set(PlayerProjectionSet::Spawn)
+                .after(stdb::update_spacetimedb),
+            (setup_server, setup_stdb_callbacks).run_if(resource_added::<SpacetimeDbReady>),
+        ),
+    )
+    .add_systems(OnEnter(ServerState::Running), on_server_started)
+    .add_systems(FixedPostUpdate, update_skeleton_locomotion)
+    .add_observer(on_join_request)
+    .add_observer(on_player_input)
+    .add_observer(on_client_disconnected);
+    #[cfg(feature = "debug")]
+    app.add_observer(on_debug_game_time_scale_request);
+    app.run();
+}
+
+#[cfg(feature = "debug")]
+fn on_debug_game_time_scale_request(
+    request: On<FromClient<DebugGameTimeScaleRequest>>,
+    mut virtual_time: ResMut<Time<Virtual>>,
+) {
+    let relative_speed = request.relative_speed();
+    virtual_time.set_relative_speed(relative_speed);
+    info!(relative_speed, "Debug tactical game speed changed");
 }
 
 fn setup_server(mut commands: Commands, args: Res<Args>) {

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -430,6 +430,21 @@ procedural pelvis lowering, additional hip and knee flexion, shortened stride,
 and foot IK to the ordinary gait instead of requiring a separate crouch-walk
 cycle.
 
+Contact and passing/flight anchors are authoritative sparse gait inputs. The
+evaluator constructs four smooth quarters: contact to passing, passing to the
+character-space mirrored contact, mirrored contact to mirrored passing, and
+mirrored passing back to contact. It does not traverse later exported gait
+timeline data. Character-space reflection retains anatomical lateral spacing
+rather than swapping bones discretely. Terrain leg IK preserves continuous
+support for walking, narrows support through the walk/run blend, and releases
+both feet during the authored run flight phase. During high support it also
+locks the stance foot horizontally in world space until release, preventing
+visible skating as the gameplay root advances. Authored upper-body carriage
+remains intact unless an explicit hand or weapon constraint takes priority.
+Locomotion also bounds root, pelvis, torso, neck, and head excursions around
+bind before look and final IK, then restores a bounded vertical lift at each
+run flight beat.
+
 During ordinary travel the body turns toward its velocity, so forward walk and
 run also serve diagonal and lateral travel. During combat, the torso remains
 oriented toward the opponent and a procedural stance-step planner provides

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -451,6 +451,10 @@ run flight beat.
 Debug clients expose `F8` as a runtime terrain leg-IK toggle. Disabling it
 leaves authored FK, gait mirroring, and torso stabilization intact and clears
 stored foot plants so re-enabling IK cannot snap to an obsolete target.
+Debug clients also expose `F7` to toggle the connected local tactical mission
+between normal and quarter-speed game time. Both client presentation and the
+authoritative server clock change together, so movement, physics, combat, and
+animation remain synchronized during slow-motion inspection.
 
 During ordinary travel the body turns toward its velocity, so forward walk and
 run also serve diagonal and lateral travel. During combat, the torso remains

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -397,9 +397,9 @@ opponent-side contact plane. The engine remains responsible for authoritative
 collision and damage.
 
 Locomotion semantic anchors use the **left** side as their canonical first
-half-cycle, while each authored gait file supplies its complete second half and
-closure. Lower-body mirroring is retained only as an explicit fallback for a
-resolved sample whose source lacks authored opposite-foot frames.
+half-cycle. When a sparse gait source contains only that half, the runtime
+reflects the complete bilateral limb motion—including clavicles, arms, hands,
+legs, feet, and twist bones—to construct the opposite half and closure.
 Attack and guard poses are not assumed to be whole-body mirrorable because a
 weapon may remain in the same hand.
 
@@ -411,8 +411,9 @@ fallback chain.
 
 ### Standing and locomotion
 
-The opposite half of each gait cycle can be produced by mirroring lower-body
-motion while preserving handed upper-body carriage.
+The opposite half of each sparse unarmed gait cycle is produced by mirroring
+both the arm swing and leg motion. Packs with handed upper-body carriage use an
+explicit weapon or hand constraint after gait reconstruction.
 
 | Pose | Animator brief |
 |---|---|
@@ -439,8 +440,10 @@ rather than swapping bones discretely. Terrain leg IK preserves continuous
 support for walking, narrows support through the walk/run blend, and releases
 both feet during the authored run flight phase. During high support it also
 locks the stance foot horizontally in world space until release, preventing
-visible skating as the gameplay root advances. Authored upper-body carriage
-remains intact unless an explicit hand or weapon constraint takes priority.
+visible skating as the gameplay root advances. Arm and leg swing share the
+same phase reconstruction before terrain IK; only the legs receive the final
+terrain solve. An explicit hand or weapon constraint can then override the
+reconstructed arm carriage.
 Locomotion also bounds root, pelvis, torso, neck, and head excursions around
 bind before look and final IK, then restores a bounded vertical lift at each
 run flight beat.

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -445,6 +445,10 @@ Locomotion also bounds root, pelvis, torso, neck, and head excursions around
 bind before look and final IK, then restores a bounded vertical lift at each
 run flight beat.
 
+Debug clients expose `F8` as a runtime terrain leg-IK toggle. Disabling it
+leaves authored FK, gait mirroring, and torso stabilization intact and clears
+stored foot plants so re-enabling IK cannot snap to an obsolete target.
+
 During ordinary travel the body turns toward its velocity, so forward walk and
 run also serve diagonal and lateral travel. During combat, the torso remains
 oriented toward the opponent and a procedural stance-step planner provides


### PR DESCRIPTION
Stacked on #169 (codex/tactical-animation-capture).

This change makes two-anchor walk/run inputs produce a stable full gait: catalog-bounded sampling, four-quarter procedural mirroring, low-speed locomotion blending, bounded torso motion with run flight lift, gait-aware terrain IK, and world-space stance-foot locking.

It also upgrades animation-viewer into a deterministic 60 Hz multi-view review harness with a fixed metre grid, support markers, complete bone telemetry, HTML playback/contact sheets, artifact integrity checks, and hard continuity/biomechanics gates.

Final locomotion-review-v11 passes all validation. Independent visual review found no remaining animation blocker; planted interval drift is about 2 cm or less for walk/run and effectively zero for the blend.

Verification:
- just fmt
- just check
- cargo test -p adventuresim-tactical-core
- cargo test -p adventuresim-tactical-client --bin animation-viewer
- cargo test -p adventuresim-tactical-client --bin adventuresim-tactical-client
- scripts/update_project_map.py --check
- deterministic native V11 capture and independent visual review