### PR TITLE
Integrate social concerns into conversations

### DIFF
--- a/content/dialogue/examples.yaml
+++ b/content/dialogue/examples.yaml
@@ -27,7 +27,7 @@
         "assistant": { "kind": "npc" }
       },
       "topics": [{
-        "id": "special-order", "label": "Special order", "initially_known": true,
+        "id": "special-order", "label": "Special order", "category": "quest", "initially_known": true,
         "responses": [{
           "id": "take-order", "priority": 0,
           "turns": [

--- a/content/dialogue/organizations.yaml
+++ b/content/dialogue/organizations.yaml
@@ -603,6 +603,7 @@
         {
           "id": "referred-testimony",
           "label": "What I saw",
+          "category": "quest",
           "initially_known": true,
           "conditions": {
             "op": "fact",
@@ -633,6 +634,7 @@
         {
           "id": "return-recovered-property",
           "label": "Return recovered property",
+          "category": "quest",
           "initially_known": true,
           "responses": [
             {
@@ -656,6 +658,7 @@
         {
           "id": "expose-false-account",
           "label": "Challenge the account",
+          "category": "quest",
           "initially_known": true,
           "responses": [
             {

--- a/content/dialogue/services.yaml
+++ b/content/dialogue/services.yaml
@@ -104,7 +104,7 @@
             "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "The contract is still in your hands. Return when the work is complete." }] }],
             "effects": [], "prompt": null }]
         },
-        { "id": "referred-testimony", "label": "What I saw", "initially_known": true,
+        { "id": "referred-testimony", "label": "What I saw", "category": "quest", "initially_known": true,
           "conditions": { "op": "fact", "key": { "kind": "participant_referral_contact", "role": "professional" }, "equals": true },
           "responses": [{ "id": "hear-referred-testimony", "priority": 0,
             "turns": [
@@ -113,12 +113,12 @@
             ],
             "effects": [{ "kind": "receive_referred_testimony" }], "prompt": null }]
         },
-        { "id": "return-recovered-property", "label": "Return recovered property", "initially_known": true,
+        { "id": "return-recovered-property", "label": "Return recovered property", "category": "quest", "initially_known": true,
           "responses": [{ "id": "return-recovered-property", "priority": 0,
             "turns": [{ "speaker": "player", "fragments": [{ "kind": "text", "value": "I found the missing property and brought it back." }] }, { "speaker": "professional", "fragments": [{ "kind": "text", "value": "Then the matter is finally put right. I will see that it returns to its proper place." }] }],
             "effects": [{ "kind": "investigation_action", "action": "return_asset" }], "prompt": null }]
         },
-        { "id": "expose-false-account", "label": "Challenge the account", "initially_known": true,
+        { "id": "expose-false-account", "label": "Challenge the account", "category": "quest", "initially_known": true,
           "responses": [{ "id": "expose-false-account", "priority": 0,
             "turns": [{ "speaker": "player", "fragments": [{ "kind": "text", "value": "The evidence contradicts the story that was told." }] }, { "speaker": "professional", "fragments": [{ "kind": "text", "value": "Then say plainly what you have proved. This claim will not stand unchallenged." }] }],
             "effects": [{ "kind": "investigation_action", "action": "expose" }], "prompt": null }]
@@ -148,7 +148,7 @@
           ],
           "effects": [], "prompt": null
         }] },
-        { "id": "referred-testimony", "label": "What I saw", "initially_known": true,
+        { "id": "referred-testimony", "label": "What I saw", "category": "quest", "initially_known": true,
           "conditions": { "op": "fact", "key": { "kind": "participant_referral_contact", "role": "herbalist" }, "equals": true },
           "responses": [{ "id": "hear-referred-testimony", "priority": 0,
             "turns": [
@@ -181,7 +181,7 @@
             { "id": "yes", "label": "I profess this faith.", "effects": [{ "kind": "set_flag", "flag": "profess-local-faith", "value": true }], "result_turns": [{ "speaker": "cleric", "fragments": [{ "kind": "text", "value": "Welcome to the congregation. Your profession of faith has been recorded." }] }] },
             { "id": "no", "label": "I am only asking.", "result_turns": [{ "speaker": "cleric", "fragments": [{ "kind": "text", "value": "Then listen and consider; no profession is required." }] }] }
           ] } }] },
-        { "id": "referred-testimony", "label": "What I saw", "initially_known": true,
+        { "id": "referred-testimony", "label": "What I saw", "category": "quest", "initially_known": true,
           "conditions": { "op": "fact", "key": { "kind": "participant_referral_contact", "role": "cleric" }, "equals": true },
           "responses": [{ "id": "hear-referred-testimony", "priority": 0,
             "turns": [
@@ -204,7 +204,7 @@
         { "id": "local-default", "priority": 0, "turns": [{ "speaker": "local", "fragments": [{ "kind": "text", "value": "Good day, traveler. What brings you among the people here?" }] }], "effects": [], "prompt": null }
       ],
       "topics": [
-        { "id": "referred-testimony", "label": "What I saw", "initially_known": true,
+        { "id": "referred-testimony", "label": "What I saw", "category": "quest", "initially_known": true,
           "conditions": { "op": "fact", "key": { "kind": "participant_referral_contact", "role": "local" }, "equals": true },
           "responses": [{ "id": "hear-referred-testimony", "priority": 0,
             "turns": [
@@ -213,12 +213,12 @@
             ],
             "effects": [{ "kind": "receive_referred_testimony" }], "prompt": null }]
         },
-        { "id": "return-recovered-property", "label": "Return recovered property", "initially_known": true,
+        { "id": "return-recovered-property", "label": "Return recovered property", "category": "quest", "initially_known": true,
           "responses": [{ "id": "return-recovered-property", "priority": 0,
             "turns": [{ "speaker": "player", "fragments": [{ "kind": "text", "value": "I found the missing property and brought it back." }] }, { "speaker": "local", "fragments": [{ "kind": "text", "value": "Then the matter is finally put right. I will see that it returns to its proper place." }] }],
             "effects": [{ "kind": "investigation_action", "action": "return_asset" }], "prompt": null }]
         },
-        { "id": "expose-false-account", "label": "Challenge the account", "initially_known": true,
+        { "id": "expose-false-account", "label": "Challenge the account", "category": "quest", "initially_known": true,
           "responses": [{ "id": "expose-false-account", "priority": 0,
             "turns": [{ "speaker": "player", "fragments": [{ "kind": "text", "value": "The evidence contradicts the story that was told." }] }, { "speaker": "local", "fragments": [{ "kind": "text", "value": "Then say plainly what you have proved. This claim will not stand unchallenged." }] }],
             "effects": [{ "kind": "investigation_action", "action": "expose" }], "prompt": null }]
@@ -232,7 +232,7 @@
           "turns": [{ "speaker": "employer", "fragments": [{ "kind": "text", "value": "An adventuring company is looking for capable hands." }] }],
           "effects": [{ "kind": "learn_topic", "topic": "open-roles" }], "prompt": null }]
       },
-      { "id": "referred-testimony", "label": "What I saw", "initially_known": true,
+      { "id": "referred-testimony", "label": "What I saw", "category": "quest", "initially_known": true,
         "conditions": { "op": "fact", "key": { "kind": "participant_referral_contact", "role": "employer" }, "equals": true },
         "responses": [{ "id": "hear-referred-testimony", "priority": 0,
           "turns": [

--- a/content/dialogue/services.yaml
+++ b/content/dialogue/services.yaml
@@ -85,7 +85,7 @@
               ] }
           }]
         },
-        { "id": "quest", "label": "Work", "initially_known": true,
+        { "id": "quest", "label": "Work", "category": "quest", "initially_known": true,
           "responses": [{ "id": "quest-turn-in", "priority": 20, "conditions": { "op": "fact", "key": { "kind": "contract_state", "contract": "selected-service-contract" }, "equals": "readytoreport" },
             "turns": [{ "speaker": "professional", "fragments": [{ "kind": "text", "value": "You have completed the work. Shall we settle the contract?" }] }],
             "effects": [], "prompt": { "id": "turn-in-work", "respondent": "player", "mode": "yes_no", "choices": [

--- a/crates/adventuresim-dialogue/src/authoring_schema.rs
+++ b/crates/adventuresim-dialogue/src/authoring_schema.rs
@@ -44,10 +44,20 @@ pub struct AuthoringTopic {
     pub id: String,
     pub label: String,
     #[serde(default)]
+    pub category: TopicCategory,
+    #[serde(default)]
     pub initially_known: bool,
     #[serde(default)]
     pub conditions: Condition,
     pub responses: Vec<AuthoringResponse>,
+}
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TopicCategory {
+    Quest,
+    #[default]
+    Lore,
+    About,
 }
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/adventuresim-dialogue/src/lib.rs
+++ b/crates/adventuresim-dialogue/src/lib.rs
@@ -53,11 +53,24 @@ pub enum ParticipantKind {
 pub struct Topic {
     pub id: String,
     pub label: String,
+    /// Presentation grouping. Discovery remains controlled by the authoritative
+    /// known-topic rows; this metadata never makes a topic visible by itself.
+    #[serde(default)]
+    pub category: TopicCategory,
     #[serde(default)]
     pub initially_known: bool,
     #[serde(default)]
     pub conditions: Condition,
     pub responses: Vec<Response>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TopicCategory {
+    Quest,
+    #[default]
+    Lore,
+    About,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -826,6 +839,14 @@ pub fn source_for_topic(conversation_id: &str, topic_id: &str) -> Option<&'stati
     None
 }
 
+pub fn category_for_topic(conversation_id: &str, topic_id: &str) -> Option<TopicCategory> {
+    conversation(conversation_id)?
+        .topics
+        .iter()
+        .find(|topic| topic.id == topic_id)
+        .map(|topic| topic.category)
+}
+
 pub fn source_for_choice(
     conversation_id: &str,
     topic_id: &str,
@@ -946,6 +967,19 @@ pub fn github_edit_url_for_location(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn topic_categories_are_typed_and_default_to_lore() {
+        assert_eq!(
+            category_for_topic("service-professions", "quest"),
+            Some(TopicCategory::Quest)
+        );
+        assert_eq!(
+            category_for_topic("service-professions", "profession"),
+            Some(TopicCategory::Lore)
+        );
+        assert_eq!(category_for_topic("service-professions", "hidden"), None);
+    }
     #[test]
     fn compiled_catalog_is_valid_and_has_source_spans() {
         validate(catalog()).unwrap();

--- a/crates/adventuresim-dialogue/src/lib.rs
+++ b/crates/adventuresim-dialogue/src/lib.rs
@@ -840,7 +840,7 @@ pub fn source_for_topic(conversation_id: &str, topic_id: &str) -> Option<&'stati
 }
 
 pub fn category_for_topic(conversation_id: &str, topic_id: &str) -> Option<TopicCategory> {
-    conversation(conversation_id)?
+    find_conversation(conversation_id)?
         .topics
         .iter()
         .find(|topic| topic.id == topic_id)
@@ -979,6 +979,17 @@ mod tests {
             Some(TopicCategory::Lore)
         );
         assert_eq!(category_for_topic("service-professions", "hidden"), None);
+        for (conversation, topic) in [
+            ("service-professions", "referred-testimony"),
+            ("service-professions", "return-recovered-property"),
+            ("service-professions", "expose-false-account"),
+            ("organization-representative", "referred-testimony"),
+        ] {
+            assert_eq!(
+                category_for_topic(conversation, topic),
+                Some(TopicCategory::Quest)
+            );
+        }
     }
     #[test]
     fn compiled_catalog_is_valid_and_has_source_spans() {

--- a/crates/adventuresim-stdb-client/src/backend_local_chat_message_type.rs
+++ b/crates/adventuresim-stdb-client/src/backend_local_chat_message_type.rs
@@ -11,7 +11,7 @@ pub struct BackendLocalChatMessage {
     pub owner_character_id: u64,
     pub conversation_kind: String,
     pub subject_party_id: String,
-    pub subject_resident_character_id: Option<u64>,
+    pub subject_resident_character_id: String,
     pub sender_id: u64,
     pub sender_name: String,
     pub body: String,
@@ -30,8 +30,7 @@ pub struct BackendLocalChatMessageCols {
     pub owner_character_id: __sdk::__query_builder::Col<BackendLocalChatMessage, u64>,
     pub conversation_kind: __sdk::__query_builder::Col<BackendLocalChatMessage, String>,
     pub subject_party_id: __sdk::__query_builder::Col<BackendLocalChatMessage, String>,
-    pub subject_resident_character_id:
-        __sdk::__query_builder::Col<BackendLocalChatMessage, Option<u64>>,
+    pub subject_resident_character_id: __sdk::__query_builder::Col<BackendLocalChatMessage, String>,
     pub sender_id: __sdk::__query_builder::Col<BackendLocalChatMessage, u64>,
     pub sender_name: __sdk::__query_builder::Col<BackendLocalChatMessage, String>,
     pub body: __sdk::__query_builder::Col<BackendLocalChatMessage, String>,

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_schema.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_schema.rs
@@ -22,7 +22,7 @@ pub struct BackendLocalChatMessage {
     pub owner_character_id: u64,
     pub conversation_kind: String,
     pub subject_party_id: String,
-    pub subject_resident_character_id: Option<u64>,
+    pub subject_resident_character_id: String,
     pub sender_id: u64,
     pub sender_name: String,
     pub body: String,
@@ -64,7 +64,7 @@ fn project_local_chat_message(
                 owner_character_id,
                 "player".into(),
                 row.other_party_id.clone(),
-                None,
+                String::new(),
             );
         }
         if row.other_party_id != row.audience_party_id {
@@ -73,7 +73,7 @@ fn project_local_chat_message(
                     owner_character_id,
                     "player".into(),
                     row.audience_party_id.clone(),
-                    None,
+                    String::new(),
                 );
             }
         }
@@ -83,7 +83,7 @@ fn project_local_chat_message(
                 owner_character_id,
                 "npc".into(),
                 String::new(),
-                row.resident_character_id,
+                row.resident_character_id.map_or_else(String::new, |id| id.to_string()),
             );
         }
     }

--- a/crates/strategic-web/src/routes/dialogue.rs
+++ b/crates/strategic-web/src/routes/dialogue.rs
@@ -230,6 +230,16 @@ struct NpcSocialView {
     courtship_exposed: bool,
     wedding_countdown_days: Option<u64>,
     romantic_actions: Vec<RomanceAction>,
+    social_revision: String,
+    about_topics: Vec<NpcAboutTopic>,
+    trait_impression_available: bool,
+}
+
+#[derive(Serialize)]
+struct NpcAboutTopic {
+    id: &'static str,
+    question: &'static str,
+    answer: String,
 }
 
 #[derive(Serialize)]
@@ -630,6 +640,9 @@ mod npc_navigation_tests {
             courtship_exposed: false,
             wedding_countdown_days: None,
             romantic_actions: vec![RomanceAction::ScheduleWedding],
+            social_revision: "42:test".into(),
+            about_topics: vec![],
+            trait_impression_available: false,
         };
         let value = serde_json::to_value(view).unwrap();
         assert_eq!(value["affinity"], "trusted");
@@ -669,7 +682,7 @@ mod npc_navigation_tests {
     fn romantic_rejections_use_stable_codes_instead_of_prose_matching() {
         assert_eq!(
             romantic_rejection_message(CourtshipRejectionCode::FatherApproval),
-            "My family would not approve of a formal courtship."
+            "My family would not bless a formal courtship."
         );
         let source = include_str!("dialogue.rs");
         let mapper = source
@@ -969,23 +982,80 @@ async fn npc_social_view(
             .saturating_sub(actor_minute)
             .div_ceil(1_440)
     });
+    let affinity = relationship
+        .as_ref()
+        .map_or(AffinityBand::Reserved, |row| row.affinity_band);
+    let familiarity = relationship
+        .as_ref()
+        .map_or(FamiliarityBand::New, |row| row.familiarity_band);
+    let morale = relationship
+        .as_ref()
+        .map_or(MoraleBand::Uncertain, |row| row.morale_band);
+    let affinity_words = match affinity {
+        AffinityBand::Hostile => "with open enmity",
+        AffinityBand::Reserved => "with reserve",
+        AffinityBand::Warm => "with warmth",
+        AffinityBand::Trusted => "as one dear and trusted",
+    };
+    let familiarity_words = match familiarity {
+        FamiliarityBand::New => "scarcely know thee",
+        FamiliarityBand::Known => "know thee somewhat",
+        FamiliarityBand::Familiar => "know thee well",
+        FamiliarityBand::WellKnown => "know thee as an old companion",
+    };
+    let morale_words = match morale {
+        MoraleBand::Uncertain => "I cannot well name my present humour.",
+        MoraleBand::Distressed => "My spirit is sorely troubled.",
+        MoraleBand::Guarded => "My spirit is wary, yet I endure.",
+        MoraleBand::Settled => "My spirit rests in good order.",
+    };
+    let pledge = if let Some(days) = wedding_countdown_days {
+        format!("Our wedding day shall come in {days} days.")
+    } else if courtship_kind.is_some() {
+        "Our courtship yet stands, as thou knowest.".to_owned()
+    } else {
+        "I have no pledge that I may declare to thee.".to_owned()
+    };
+    let about_topics = vec![
+        NpcAboutTopic {
+            id: "regard",
+            question: "How stand I in thy regard?",
+            answer: format!("I hold thee {affinity_words}."),
+        },
+        NpcAboutTopic {
+            id: "familiarity",
+            question: "How well knowest thou me?",
+            answer: format!("I {familiarity_words}."),
+        },
+        NpcAboutTopic {
+            id: "morale",
+            question: "How fares thy spirit?",
+            answer: morale_words.to_owned(),
+        },
+        NpcAboutTopic {
+            id: "pledge",
+            question: "Art thou pledged to another?",
+            answer: pledge,
+        },
+    ];
+    let social_revision = format!(
+        "{}:{:?}:{:?}:{:?}:{:?}",
+        npc.character_id, affinity, familiarity, morale, wedding_countdown_days
+    );
     Ok(NpcSocialView {
         resident_character_id: npc.character_id.to_string(),
         name: npc.name,
-        affinity: relationship
-            .as_ref()
-            .map_or(AffinityBand::Reserved, |row| row.affinity_band),
-        familiarity: relationship
-            .as_ref()
-            .map_or(FamiliarityBand::New, |row| row.familiarity_band),
-        morale: relationship
-            .as_ref()
-            .map_or(MoraleBand::Uncertain, |row| row.morale_band),
+        affinity,
+        familiarity,
+        morale,
         last_outcome,
         courtship_kind,
         courtship_exposed,
         wedding_countdown_days,
         romantic_actions,
+        social_revision,
+        about_topics,
+        trait_impression_available: false,
     })
 }
 
@@ -1010,32 +1080,28 @@ async fn active_commitment_with(
 
 fn romantic_rejection_message(code: CourtshipRejectionCode) -> &'static str {
     match code {
-        CourtshipRejectionCode::Affinity => {
-            "I care for you, but I am not ready for that relationship."
-        }
-        CourtshipRejectionCode::FatherApproval => {
-            "My family would not approve of a formal courtship."
-        }
+        CourtshipRejectionCode::Affinity => "I care for thee, yet am not ready for such a bond.",
+        CourtshipRejectionCode::FatherApproval => "My family would not bless a formal courtship.",
         CourtshipRejectionCode::FormalRoute => {
-            "I cannot agree unless we approach this through the available route."
+            "I cannot consent unless we pursue the proper course."
         }
-        CourtshipRejectionCode::MutualAttraction => "I care for you, but not romantically.",
+        CourtshipRejectionCode::MutualAttraction => "I care for thee, but not as a lover.",
         CourtshipRejectionCode::ExclusiveCommitment => {
-            "I cannot make that promise while one of us is already committed."
+            "I cannot plight my troth whilst one of us is already pledged."
         }
         CourtshipRejectionCode::AlreadyMarried => {
-            "I cannot agree while one of us is already married."
+            "I cannot consent whilst one of us is already wed."
         }
-        CourtshipRejectionCode::CoLocation => "We need to be together before we can speak of that.",
-        CourtshipRejectionCode::IneligibleCharacter => "I cannot enter that courtship.",
-        CourtshipRejectionCode::CloseRelative => "We are too closely related for courtship.",
+        CourtshipRejectionCode::CoLocation => "We must meet before we speak of such a bond.",
+        CourtshipRejectionCode::IneligibleCharacter => "I cannot enter such a courtship.",
+        CourtshipRejectionCode::CloseRelative => "Our blood lies too near for courtship.",
         CourtshipRejectionCode::ActiveCourtshipRequired => {
-            "We must be courting before we can plan a wedding."
+            "We must first be courting ere we appoint a wedding."
         }
         CourtshipRejectionCode::CeremonySettlementRequired => {
-            "We must first agree where the ceremony will be held."
+            "We must first agree where the ceremony shall be held."
         }
-        CourtshipRejectionCode::ResidenceRequired => "We need a suitable home before the wedding.",
+        CourtshipRejectionCode::ResidenceRequired => "We must have a fitting home ere we wed.",
     }
 }
 
@@ -1065,17 +1131,17 @@ async fn npc_romance_action(
         RomanceAction::FormalCourtship => (
             "begin_formal_courtship",
             vec![json!(character_id), json!(resident_character_id)],
-            "Yes. Let us seek my family's blessing and proceed openly.",
+            "Yea. Let us seek my family's blessing and proceed openly.",
         ),
         RomanceAction::InformalCourtship => (
             "begin_informal_courtship",
             vec![json!(character_id), json!(resident_character_id)],
-            "Yes. We will keep this between ourselves.",
+            "Yea. We shall keep this between ourselves.",
         ),
         RomanceAction::ScheduleWedding => (
             "schedule_wedding",
             vec![json!(character_id), json!(resident_character_id)],
-            "Then it is settled. One year from today.",
+            "Then is it settled: one year from this day.",
         ),
         RomanceAction::CancelWedding => {
             let Some(commitment) =
@@ -1084,7 +1150,7 @@ async fn npc_romance_action(
                 let view = npc_social_view(&state, character_id, npc, None).await?;
                 return Ok(Json(NpcRomanceActionResult {
                     ok: false,
-                    message: "There is no wedding between us to cancel.".into(),
+                    message: "There is no wedding betwixt us to forswear.".into(),
                     view,
                 }));
             };
@@ -1098,7 +1164,7 @@ async fn npc_romance_action(
                             .expect("projected active commitment has an id")
                     ),
                 ],
-                "I understand. The wedding will not go forward.",
+                "I understand. The wedding shall not go forward.",
             )
         }
     };
@@ -1117,7 +1183,7 @@ async fn npc_romance_action(
                     error = %error_text,
                     "romantic action rejected"
                 );
-                (false, "I cannot make that promise right now.".into())
+                (false, "I cannot make that promise at this hour.".into())
             }
         }
     };

--- a/crates/strategic-web/src/routes/dialogue.rs
+++ b/crates/strategic-web/src/routes/dialogue.rs
@@ -323,6 +323,7 @@ struct ClaimView {
 struct TopicView {
     id: String,
     label: String,
+    category: adventuresim_dialogue::TopicCategory,
     source: Option<EditSource>,
 }
 #[derive(Serialize)]
@@ -1346,6 +1347,11 @@ async fn build_view(
     let topics = topics
         .into_iter()
         .map(|topic| TopicView {
+            category: adventuresim_dialogue::category_for_topic(
+                &session.conversation_id,
+                &topic.topic_id,
+            )
+            .unwrap_or_default(),
             id: topic.topic_id,
             label: topic.label,
             source: serde_json::from_str::<Option<adventuresim_dialogue::SourceRef>>(

--- a/crates/strategic-web/src/routes/dialogue.rs
+++ b/crates/strategic-web/src/routes/dialogue.rs
@@ -1039,8 +1039,14 @@ async fn npc_social_view(
         },
     ];
     let social_revision = format!(
-        "{}:{:?}:{:?}:{:?}:{:?}",
-        npc.character_id, affinity, familiarity, morale, wedding_countdown_days
+        "{}:{:?}:{:?}:{:?}:{:?}:{:?}:{}",
+        npc.character_id,
+        affinity,
+        familiarity,
+        morale,
+        wedding_countdown_days,
+        courtship_kind,
+        courtship_exposed
     );
     Ok(NpcSocialView {
         resident_character_id: npc.character_id.to_string(),

--- a/crates/strategic-web/src/routes/local_chat.rs
+++ b/crates/strategic-web/src/routes/local_chat.rs
@@ -122,6 +122,12 @@ enum ConversationSelector {
     PlayerParty(String),
 }
 
+fn npc_history_matches_subject(subject_resident_character_id: Option<u64>, expected: &str) -> bool {
+    expected
+        .parse::<u64>()
+        .is_ok_and(|expected| subject_resident_character_id == Some(expected))
+}
+
 async fn actor_and_selector(
     state: &AppState,
     actor_id: u64,
@@ -240,10 +246,7 @@ async fn messages(
             .await
             .map_err(|e| (StatusCode::FORBIDDEN, e))?;
     let selector_filter = match &selector {
-        ConversationSelector::Npc(resident_character_id) => format!(
-            "conversation_kind = 'npc' AND subject_resident_character_id = {}",
-            sql_string_literal(resident_character_id)
-        ),
+        ConversationSelector::Npc(_) => "conversation_kind = 'npc'".to_owned(),
         ConversationSelector::PlayerParty(party_id) => format!(
             "conversation_kind = 'player' AND subject_party_id = {}",
             sql_string_literal(party_id)
@@ -256,6 +259,14 @@ async fn messages(
         ))
         .await
         .map_err(|error| (StatusCode::SERVICE_UNAVAILABLE, error.to_string()))?;
+    if let ConversationSelector::Npc(resident_character_id) = &selector {
+        messages.retain(|message| {
+            npc_history_matches_subject(
+                message.subject_resident_character_id,
+                resident_character_id,
+            )
+        });
+    }
     // Close the gap between the authority read and returning private message bodies.
     actor_and_selector(&state, actor_id, &kind, &subject_id, &query.location_id)
         .await
@@ -386,7 +397,16 @@ async fn incoming(State(state): State<AppState>, session: Session) -> Json<Vec<I
 mod tests {
     use super::{
         LocalNpcPresenceRow, LocalNpcRow, npc_authority_matches, npc_history_location_is_navigable,
+        npc_history_matches_subject,
     };
+
+    #[test]
+    fn npc_history_filters_optional_subjects_after_the_owner_scoped_query() {
+        assert!(npc_history_matches_subject(Some(42), "42"));
+        assert!(!npc_history_matches_subject(Some(7), "42"));
+        assert!(!npc_history_matches_subject(None, "42"));
+        assert!(!npc_history_matches_subject(Some(42), "not-an-id"));
+    }
     use crate::spacetimedb::SettlementCategory;
 
     #[test]

--- a/crates/strategic-web/src/routes/local_chat.rs
+++ b/crates/strategic-web/src/routes/local_chat.rs
@@ -122,12 +122,6 @@ enum ConversationSelector {
     PlayerParty(String),
 }
 
-fn npc_history_matches_subject(subject_resident_character_id: Option<u64>, expected: &str) -> bool {
-    expected
-        .parse::<u64>()
-        .is_ok_and(|expected| subject_resident_character_id == Some(expected))
-}
-
 async fn actor_and_selector(
     state: &AppState,
     actor_id: u64,
@@ -246,7 +240,10 @@ async fn messages(
             .await
             .map_err(|e| (StatusCode::FORBIDDEN, e))?;
     let selector_filter = match &selector {
-        ConversationSelector::Npc(_) => "conversation_kind = 'npc'".to_owned(),
+        ConversationSelector::Npc(resident_character_id) => format!(
+            "conversation_kind = 'npc' AND subject_resident_character_id = {}",
+            sql_string_literal(resident_character_id)
+        ),
         ConversationSelector::PlayerParty(party_id) => format!(
             "conversation_kind = 'player' AND subject_party_id = {}",
             sql_string_literal(party_id)
@@ -259,14 +256,6 @@ async fn messages(
         ))
         .await
         .map_err(|error| (StatusCode::SERVICE_UNAVAILABLE, error.to_string()))?;
-    if let ConversationSelector::Npc(resident_character_id) = &selector {
-        messages.retain(|message| {
-            npc_history_matches_subject(
-                message.subject_resident_character_id,
-                resident_character_id,
-            )
-        });
-    }
     // Close the gap between the authority read and returning private message bodies.
     actor_and_selector(&state, actor_id, &kind, &subject_id, &query.location_id)
         .await
@@ -397,16 +386,8 @@ async fn incoming(State(state): State<AppState>, session: Session) -> Json<Vec<I
 mod tests {
     use super::{
         LocalNpcPresenceRow, LocalNpcRow, npc_authority_matches, npc_history_location_is_navigable,
-        npc_history_matches_subject,
     };
 
-    #[test]
-    fn npc_history_filters_optional_subjects_after_the_owner_scoped_query() {
-        assert!(npc_history_matches_subject(Some(42), "42"));
-        assert!(!npc_history_matches_subject(Some(7), "42"));
-        assert!(!npc_history_matches_subject(None, "42"));
-        assert!(!npc_history_matches_subject(Some(42), "not-an-id"));
-    }
     use crate::spacetimedb::SettlementCategory;
 
     #[test]

--- a/crates/strategic-web/src/routes/settlements/party/social.rs
+++ b/crates/strategic-web/src/routes/settlements/party/social.rs
@@ -1,3 +1,25 @@
+fn observer_safe_relationship_answer(
+    status: &crate::spacetimedb::BackendCharacterRelationshipStatus,
+    observer_id: u64,
+) -> String {
+    let observer_is_partner = status.courtship_partner_id == Some(observer_id)
+        || status.wedding_partner_id == Some(observer_id);
+    let courtship_is_public = status.courtship_kind.as_ref().is_some_and(|kind| {
+        !matches!(kind, crate::spacetimedb::CourtshipKind::Informal)
+            || status.courtship_exposed
+            || observer_is_partner
+    });
+    if status.wedding_commitment_id.is_some() && (status.courtship_exposed || observer_is_partner) {
+        "I am promised in marriage, and the appointed day draws nigh.".to_owned()
+    } else if status.spouse_id.is_some() {
+        "I am wed, and bound in marriage.".to_owned()
+    } else if status.courtship_partner_id.is_some() && courtship_is_public {
+        "I am in courtship, though I shall not name whom without cause.".to_owned()
+    } else {
+        "I have no public pledge of courtship to declare.".to_owned()
+    }
+}
+
 pub(super) async fn party_social(
     State(state): State<AppState>,
     Path((kind, id, target_id)): Path<(String, String, u64)>,
@@ -153,17 +175,8 @@ pub(super) async fn party_social(
         .await
         .ok()
         .flatten()
-        .map(|status| {
-            if status.wedding_commitment_id.is_some() {
-                "I am promised in marriage, and the appointed day draws nigh.".to_owned()
-            } else if status.spouse_id.is_some() {
-                "I am wed, and bound in marriage.".to_owned()
-            } else if status.courtship_partner_id.is_some() {
-                "I am in courtship, though I shall not name whom without cause.".to_owned()
-            } else {
-                "I am neither wed nor pledged in courtship.".to_owned()
-            }
-        });
+        .map(|status| observer_safe_relationship_answer(&status, active.id));
+
     let actor_personality_result = state
         .db
         .query::<CharacterPersonality>(&format!(
@@ -539,15 +552,15 @@ pub(super) fn social_feedback(
             is_error: true,
         }),
         Some("chat_positive") => Some(SocialFeedback {
-            message: "The conversation brings you closer.",
+            message: "Thy conversation hath drawn you closer.",
             is_error: false,
         }),
         Some("chat_mixed") => Some(SocialFeedback {
-            message: "The conversation has warm moments and awkward ones.",
+            message: "Your speech held both warmth and uneasy pauses.",
             is_error: false,
         }),
         Some("chat_negative") => Some(SocialFeedback {
-            message: "The conversation leaves some friction between you.",
+            message: "Your words have left some discord betwixt you.",
             is_error: false,
         }),
         Some("chat_unavailable") => Some(SocialFeedback {
@@ -555,5 +568,35 @@ pub(super) fn social_feedback(
             is_error: true,
         }),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod relationship_privacy_tests {
+    use super::*;
+
+    fn informal(exposed: bool) -> crate::spacetimedb::BackendCharacterRelationshipStatus {
+        crate::spacetimedb::BackendCharacterRelationshipStatus {
+            character_id: 2,
+            spouse_id: None,
+            courtship_partner_id: Some(7),
+            courtship_kind: Some(crate::spacetimedb::CourtshipKind::Informal),
+            courtship_exposed: exposed,
+            wedding_commitment_id: None,
+            wedding_partner_id: None,
+            wedding_effective_minute: None,
+            wedding_settlement_id: None,
+            pregnancy_due_minute: None,
+            pregnancy_child_id: None,
+        }
+    }
+
+    #[test]
+    fn informal_courtship_is_visible_only_to_partner_or_after_exposure() {
+        assert!(
+            observer_safe_relationship_answer(&informal(false), 9).contains("no public pledge")
+        );
+        assert!(observer_safe_relationship_answer(&informal(false), 7).contains("in courtship"));
+        assert!(observer_safe_relationship_answer(&informal(true), 9).contains("in courtship"));
     }
 }

--- a/crates/strategic-web/src/routes/settlements/party/social.rs
+++ b/crates/strategic-web/src/routes/settlements/party/social.rs
@@ -145,6 +145,25 @@ pub(super) async fn party_social(
             .flatten()
             .is_some_and(|row| row.enabled)
     };
+    let relationship_answer = state
+        .db
+        .query_one::<crate::spacetimedb::BackendCharacterRelationshipStatus>(&format!(
+            "SELECT * FROM backend_character_relationship_statuses WHERE character_id = {target_id}"
+        ))
+        .await
+        .ok()
+        .flatten()
+        .map(|status| {
+            if status.wedding_commitment_id.is_some() {
+                "I am promised in marriage, and the appointed day draws nigh.".to_owned()
+            } else if status.spouse_id.is_some() {
+                "I am wed, and bound in marriage.".to_owned()
+            } else if status.courtship_partner_id.is_some() {
+                "I am in courtship, though I shall not name whom without cause.".to_owned()
+            } else {
+                "I am neither wed nor pledged in courtship.".to_owned()
+            }
+        });
     let actor_personality_result = state
         .db
         .query::<CharacterPersonality>(&format!(
@@ -240,6 +259,7 @@ pub(super) async fn party_social(
             adventuresim_core::social::SocialActionKind::Flirt,
         ),
         prayer_disabled_reason,
+        relationship_answer,
         feedback: social_feedback(building.social_feedback.as_deref()),
         unavailable: !beliefs_available || !affinity_available || !familiarity_available,
     };
@@ -320,8 +340,17 @@ pub(super) async fn set_automatic_social_chat(
     {
         tracing::warn!(%error, actor_id, target_id, "automatic social chat preference rejected");
     }
-    Redirect::to(&building.append_to(&state, &kind, &id, format!("/locations/{kind}/{id}/party/{target_id}/social")).await)
-        .into_response()
+    Redirect::to(
+        &building
+            .append_to(
+                &state,
+                &kind,
+                &id,
+                format!("/locations/{kind}/{id}/party/{target_id}/social"),
+            )
+            .await,
+    )
+    .into_response()
 }
 
 pub(super) async fn perform_social_action(
@@ -371,9 +400,18 @@ pub(super) async fn perform_social_action(
             social_action_error_feedback(&error.to_string())
         }
     };
-    Redirect::to(&building.append_to(&state, &kind, &id, format!(
-        "/locations/{kind}/{id}/party/{target_id}/social?social_feedback={feedback}"
-    )).await)
+    Redirect::to(
+        &building
+            .append_to(
+                &state,
+                &kind,
+                &id,
+                format!(
+                    "/locations/{kind}/{id}/party/{target_id}/social?social_feedback={feedback}"
+                ),
+            )
+            .await,
+    )
     .into_response()
 }
 
@@ -419,9 +457,18 @@ pub(super) async fn chat_with_party_member(
             "chat_unavailable"
         }
     };
-    Redirect::to(&building.append_to(&state, &kind, &id, format!(
-        "/locations/{kind}/{id}/party/{target_id}/social?social_feedback={feedback}"
-    )).await)
+    Redirect::to(
+        &building
+            .append_to(
+                &state,
+                &kind,
+                &id,
+                format!(
+                    "/locations/{kind}/{id}/party/{target_id}/social?social_feedback={feedback}"
+                ),
+            )
+            .await,
+    )
     .into_response()
 }
 
@@ -466,7 +513,9 @@ pub(super) fn social_action_blocked_by_actor(
     !actor_allows_social_action(action, mirth, courtship)
 }
 
-pub(super) fn social_feedback(value: Option<&str>) -> Option<crate::templates::settlement::SocialFeedback> {
+pub(super) fn social_feedback(
+    value: Option<&str>,
+) -> Option<crate::templates::settlement::SocialFeedback> {
     use crate::templates::settlement::SocialFeedback;
     match value {
         Some("addressed") => Some(SocialFeedback {

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -1218,7 +1218,7 @@ pub struct BackendLocalChatMessage {
     pub owner_character_id: u64,
     pub conversation_kind: String,
     pub subject_party_id: String,
-    pub subject_resident_character_id: Option<u64>,
+    pub subject_resident_character_id: String,
     pub sender_id: u64,
     pub sender_name: String,
     pub body: String,

--- a/crates/strategic-web/src/spacetimedb/types.rs
+++ b/crates/strategic-web/src/spacetimedb/types.rs
@@ -1218,7 +1218,7 @@ pub struct BackendLocalChatMessage {
     pub owner_character_id: u64,
     pub conversation_kind: String,
     pub subject_party_id: String,
-    pub subject_resident_character_id: String,
+    pub subject_resident_character_id: Option<u64>,
     pub sender_id: u64,
     pub sender_name: String,
     pub body: String,

--- a/crates/strategic-web/src/templates/layout.rs
+++ b/crates/strategic-web/src/templates/layout.rs
@@ -197,7 +197,7 @@ fn page_shell(title: &str, header: Markup, content: Markup, scripts: ScriptProfi
                 script src="/static/party-recruitment.js?v=party-recruitment-live-3" defer {}
                 script src="/static/physiology-dialog.js?v=visual-notebook-2" defer {}
                     script src="/static/service-quests.js?v=apprentice-system-1" defer {}
-                    script src="/static/dialogue-client.js?v=contextual-social-topics-1-errantry-retry-1" defer {}
+                    script src="/static/dialogue-client.js?v=social-chat-integration-1" defer {}
                     script src="/static/physical-evidence.js?v=deterministic-inspection-1" defer {}
                     script src="/static/developer-quest-editor.js?v=road-encounter-demo-1" defer {}
                     script src="/static/chat-resize.js?v=counterparty-portraits-1" defer {}

--- a/crates/strategic-web/src/templates/settlement/character_details.rs
+++ b/crates/strategic-web/src/templates/settlement/character_details.rs
@@ -15,7 +15,7 @@ use super::{
     },
     chrome::{party_portrait_overlay, visual_stage},
     context::LocationView,
-    social::{player_chat_area, settlement_chat_area},
+    social::player_chat_area,
     trade::{cooking_activity_dialog, religious_demand_rail},
 };
 use crate::medical::MedicalPresentation;
@@ -307,7 +307,7 @@ pub fn party_personal_page(
         false,
     );
     let center_after = character_action_dialog
-        .unwrap_or_else(|| settlement_chat_area(&active_character.name, Some(active_character)));
+        .unwrap_or_else(|| player_chat_area(location, active_character, active_character));
     let foraging_open = foraging_dialog.is_some();
     let after = html! {
         (physiology_dialog(medical, "physiology-chart-dialog", &active_character.name))
@@ -428,8 +428,8 @@ pub fn party_stats_page(
         Some(selected.id),
         false,
     );
-    let center_after =
-        character_action_dialog.unwrap_or_else(|| player_chat_area(selected, active_character));
+    let center_after = character_action_dialog
+        .unwrap_or_else(|| player_chat_area(location, selected, active_character));
     let right_after = html! {
         @if selected.id != active_character.id {
                 @if active_character.party_id == selected.party_id {

--- a/crates/strategic-web/src/templates/settlement/character_details.rs
+++ b/crates/strategic-web/src/templates/settlement/character_details.rs
@@ -306,7 +306,8 @@ pub fn party_personal_page(
         Some(active_character.id),
         false,
     );
-    let center_after = settlement_chat_area(&active_character.name, Some(active_character));
+    let center_after = character_action_dialog
+        .unwrap_or_else(|| settlement_chat_area(&active_character.name, Some(active_character)));
     let foraging_open = foraging_dialog.is_some();
     let after = html! {
         (physiology_dialog(medical, "physiology-chart-dialog", &active_character.name))
@@ -330,8 +331,6 @@ pub fn party_personal_page(
             ))
         } @else if let Some(dialog) = foraging_dialog {
             (dialog)
-        } @else {
-            @if let Some(dialog) = character_action_dialog { (dialog) }
         }
     };
     let content = character_sheet_markup(CharacterSheetView {
@@ -429,7 +428,8 @@ pub fn party_stats_page(
         Some(selected.id),
         false,
     );
-    let center_after = player_chat_area(selected, active_character);
+    let center_after =
+        character_action_dialog.unwrap_or_else(|| player_chat_area(selected, active_character));
     let right_after = html! {
         @if selected.id != active_character.id {
                 @if active_character.party_id == selected.party_id {
@@ -459,10 +459,7 @@ pub fn party_stats_page(
                 }
             }
     };
-    let after = html! {
-        @if let Some(dialog) = character_action_dialog { (dialog) }
-        (physiology_dialog(medical, "physiology-chart-dialog", &selected.name))
-    };
+    let after = html! { (physiology_dialog(medical, "physiology-chart-dialog", &selected.name)) };
     let content = character_sheet_markup(CharacterSheetView {
         character: selected,
         capability,

--- a/crates/strategic-web/src/templates/settlement/character_health.rs
+++ b/crates/strategic-web/src/templates/settlement/character_health.rs
@@ -1850,7 +1850,7 @@ mod tests {
         assert!(!markup.contains("class=\"incapacitation-source incapacitation-fear\""));
         assert!(markup.contains("href=\"/social\" title=\"Open Recent Tidings\""));
         assert!(markup.contains("/static/icons/game/conversation.svg"));
-        assert!(markup.contains("aria-haspopup=\"dialog\" aria-expanded=\"false\""));
+        assert!(!markup.contains("href=\"/social\" title=\"Open Recent Tidings\" aria-haspopup"));
         let water = markup.find("Water").expect("water meter");
         let wetness = markup
             .find("class=\"wetness-status\"")

--- a/crates/strategic-web/src/templates/settlement/character_health.rs
+++ b/crates/strategic-web/src/templates/settlement/character_health.rs
@@ -536,8 +536,8 @@ pub(super) fn strategic_condition_rail(
                         strong class="metric-label" { (decorative_game_icon("sun")) span { "Morale" } }
                         span class="morale-meter-value" { (format!("{:+.1}", condition.morale)) }
                         a class=(if social_open { "character-menu-button is-open" } else { "character-menu-button" })
-                            href=(social_href) title="Open social menu" aria-label="Open social menu"
-                            aria-haspopup="dialog" aria-expanded=(social_open) {
+                            href=(social_href) title="Open Recent Tidings" aria-label="Open conversation to Recent Tidings"
+                            aria-current=[social_open.then_some("page")] {
                             span class="stat-icon" style="--stat-icon: url('/static/icons/game/conversation.svg')" aria-hidden="true" {}
                             @if social_open { span class="sr-only" { " (open)" } }
                         }
@@ -1848,7 +1848,7 @@ mod tests {
         assert!(sources < morale);
         assert!(morale < temperature);
         assert!(!markup.contains("class=\"incapacitation-source incapacitation-fear\""));
-        assert!(markup.contains("href=\"/social\" title=\"Open social menu\""));
+        assert!(markup.contains("href=\"/social\" title=\"Open Recent Tidings\""));
         assert!(markup.contains("/static/icons/game/conversation.svg"));
         assert!(markup.contains("aria-haspopup=\"dialog\" aria-expanded=\"false\""));
         let water = markup.find("Water").expect("water meter");

--- a/crates/strategic-web/src/templates/settlement/chrome.rs
+++ b/crates/strategic-web/src/templates/settlement/chrome.rs
@@ -960,7 +960,7 @@ mod tests {
         assert!(!quiet_markup.contains("party-social-notification"));
         assert!(quiet_markup.contains("class=\"party-portrait-action party-social-action\""));
         assert!(quiet_markup.contains("/party/12/social"));
-        assert!(quiet_markup.contains("aria-label=\"Talk to Greta\""));
+        assert!(quiet_markup.contains("aria-label=\"Open conversation with Greta\""));
 
         let mut automatic = quiet;
         automatic.social_notification_count = 2;

--- a/crates/strategic-web/src/templates/settlement/chrome.rs
+++ b/crates/strategic-web/src/templates/settlement/chrome.rs
@@ -837,9 +837,8 @@ pub(crate) fn party_portrait_overlay(
                     span class="party-portrait-actions" aria-label=(format!("Actions for {}", member.name)) {
                             a href=(format!("{}/party/{}/social", location_path, member.id))
                                 class=(format!("party-portrait-action party-social-action{}", if persistently_notified { " party-social-notified" } else { "" }))
-                                title=(if notified { format!("Talk to {} about {} morale concerns", member.name, member.social_notification_count) } else { format!("Talk to {}", member.name) })
-                                aria-label=(if notified { format!("Talk to {} about {} unaddressed morale concerns", member.name, member.social_notification_count) } else { format!("Talk to {}", member.name) })
-                                aria-haspopup="dialog" {
+                                title=(if notified { format!("Open {}'s Recent Tidings ({} morale concerns)", member.name, member.social_notification_count) } else { format!("Talk to {}", member.name) })
+                                aria-label=(if notified { format!("Open conversation with {} to Recent Tidings; {} unaddressed morale concerns", member.name, member.social_notification_count) } else { format!("Open conversation with {}", member.name) }) {
                                 span class="party-action-icon"
                                     style="--party-action-icon: url('/static/icons/game/conversation.svg')"
                                     aria-hidden="true" {}

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -200,7 +200,8 @@ pub fn party_social_dialog(
     };
     html! {
         section class="settlement-chat social-conversation-dock" aria-label=(format!("Conversation with {}", selected.name))
-          data-social-conversation data-social-subject=(selected.id) data-social-self=[is_self.then_some("true")] {
+          data-social-conversation data-social-subject=(selected.id) data-social-self=[is_self.then_some("true")]
+          data-local-chat-kind="player" data-local-chat-subject=(selected.id) {
           div class="settlement-chat-layout" {
             div class="settlement-chat-conversation" {
               header class="conversation-dock-header" {
@@ -235,10 +236,10 @@ pub fn party_social_dialog(
                           ul class="perceived-traits" aria-label="Perceived personality traits" {
                             @for belief in &social.beliefs {
                               @let (axis, value) = perceived_trait(belief.axis, belief.perceived_value);
-                              li class="perceived-trait" style=(belief_style(belief.confidence)) tabindex="0" {
+                              li class="perceived-trait" style=(belief_style(belief.confidence)) tabindex="0"
+                                data-strategic-tooltip=(belief_tooltip(belief)) {
                                 strong { (value) }
-                                span { (axis) ": " (format!("{:.0}% confidence", belief.confidence.clamp(0.0, 1.0) * 100.0)) }
-                                small { (personality_reaction_hint(belief.axis, belief.perceived_value)) }
+                                span class="visually-hidden" { (axis) "; hover or focus for confidence and approach hints" }
                               }
                             }
                           }
@@ -270,12 +271,6 @@ pub fn party_social_dialog(
                 aria-labelledby=(format!("conversation-tab-lore-{}", selected.id)) hidden { p class="conversation-empty" { "No discovered lore is ready to discuss." } }
               section role="tabpanel" class="conversation-panel social-rail" id=(format!("conversation-panel-tidings-{}", selected.id))
                 aria-labelledby=(format!("conversation-tab-tidings-{}", selected.id)) data-social-panel data-target-id=(selected.id) {
-            @if let Some(feedback) = &social.feedback {
-                p class=(if feedback.is_error { "social-feedback social-feedback-error" } else { "social-feedback social-feedback-result" })
-                    role=(if feedback.is_error { "alert" } else { "status" }) {
-                    (feedback.message)
-                }
-            }
             @if !is_self {
                 (sidebar_section("Spend time together", html! {
                     form class="social-chat-activity" method="post" action=(&chat_href)
@@ -432,9 +427,18 @@ pub fn party_social_dialog(
                         }
                     }
                 }
+                div class="settlement-chat-messages" aria-live="polite" data-social-message-stream {
+                    @if let Some(feedback) = &social.feedback {
+                        div class=(if feedback.is_error { "chat-system-message social-feedback social-feedback-error" } else { "chat-system-message social-feedback social-feedback-result" })
+                            data-chat-channel="info" role=(if feedback.is_error { "alert" } else { "status" }) {
+                            span class="chat-timestamp" { "[--:--] " }
+                            (feedback.message)
+                        }
+                    }
+                }
                 @if !is_self {
                     div class="settlement-chat-composer" {
-                        div class="settlement-chat-input-shell" {
+                        div class="settlement-chat-input-shell" { span class="settlement-chat-completion" data-dialogue-completion aria-hidden="true" {}
                             input type="text" name="body" aria-label="Local message" autocomplete="off" placeholder=(format!("Speak with {}", selected.name));
                         }
                         button type="button" class="btn btn-primary btn-icon" aria-label="Send message" { (decorative_game_icon("plain-arrow")) }
@@ -450,7 +454,7 @@ pub fn party_social_dialog(
 /// filters are present so their messages can join the same stream as their
 /// backends become available.
 pub(crate) fn settlement_chat_area(location: &str, active_character: Option<&Character>) -> Markup {
-    chat_area(location, active_character, None, None, None, &[])
+    chat_area(location, active_character, None, None, None, None, &[])
 }
 
 pub(crate) fn settlement_chat_area_with_info(
@@ -458,10 +462,22 @@ pub(crate) fn settlement_chat_area_with_info(
     active_character: Option<&Character>,
     info_messages: &[String],
 ) -> Markup {
-    chat_area(location, active_character, None, None, None, info_messages)
+    chat_area(
+        location,
+        active_character,
+        None,
+        None,
+        None,
+        None,
+        info_messages,
+    )
 }
 
-pub(super) fn player_chat_area(subject: &Character, active_character: &Character) -> Markup {
+pub(super) fn player_chat_area(
+    location: &LocationView,
+    subject: &Character,
+    active_character: &Character,
+) -> Markup {
     let context = ("player", subject.id.to_string());
     chat_area(
         &subject.name,
@@ -469,6 +485,11 @@ pub(super) fn player_chat_area(subject: &Character, active_character: &Character
         None,
         Some(context),
         None,
+        Some(location.preserve_building(format!(
+            "{}/party/{}/social",
+            location.base_path(),
+            subject.id
+        ))),
         &[],
     )
 }
@@ -510,18 +531,24 @@ pub(super) fn settlement_resident_chat_area(
         Some((settlement_id, service_id.unwrap_or(""))),
         Some(("npc", String::new())),
         Some(location_id),
+        None,
         &[],
     )
 }
 
 fn chat_area(
     location: &str,
-    _active_character: Option<&Character>,
+    active_character: Option<&Character>,
     service_context: Option<(&str, &str)>,
     local_context: Option<(&str, String)>,
     local_location_id: Option<&str>,
+    party_social_href: Option<String>,
     info_messages: &[String],
 ) -> Markup {
+    let is_self_chat = local_context.as_ref().is_some_and(|(kind, subject)| {
+        *kind == "player"
+            && active_character.is_some_and(|active| subject == &active.id.to_string())
+    });
     html! {
         section class="settlement-chat" aria-label="Settlement chat"
             data-service-quest-settlement=[service_context.map(|context| context.0)]
@@ -532,7 +559,8 @@ fn chat_area(
                 .map(|_| adventuresim_core::strategic_economy::NPC_HERBALIST_EXAM_FEE)]
             data-local-chat-kind=[local_context.as_ref().map(|context| context.0)]
             data-local-chat-subject=[local_context.as_ref().map(|context| context.1.as_str())]
-            data-local-chat-location=[local_location_id] {
+            data-local-chat-location=[local_location_id]
+            data-party-social-href=[party_social_href.as_deref()] {
             div class="settlement-chat-resize" role="separator" aria-label="Resize chat"
                 aria-orientation="horizontal" aria-valuemin="128" aria-valuemax="640"
                 aria-valuenow="184" tabindex="0" title="Drag to resize chat" {
@@ -594,12 +622,12 @@ fn chat_area(
                     div class="settlement-chat-composer" {
                         div class="settlement-chat-input-shell" {
                             span class="settlement-chat-completion" data-dialogue-completion aria-hidden="true" {}
-                            input type="text" name="body" disabled[local_context.is_none()]
+                            input type="text" name="body" disabled[local_context.is_none() || is_self_chat]
                                 aria-label="Local message"
                                 autocomplete="off"
-                                placeholder=(format!("Message {location} (Local)"));
+                                placeholder=(if is_self_chat { "Select Recent Tidings to reflect".to_owned() } else { format!("Message {location} (Local)") });
                         }
-                        button type="button" class="btn btn-primary btn-icon" disabled[local_context.is_none()]
+                        button type="button" class="btn btn-primary btn-icon" disabled[local_context.is_none() || is_self_chat]
                             aria-label="Send message" {
                             (decorative_game_icon("plain-arrow"))
                         }
@@ -751,6 +779,33 @@ mod tests {
         assert!(markup.contains("Negative morale, -2.0"));
         assert!(markup.contains("--social-topic-color:color-mix"));
         assert!(!markup.contains("Local fame"));
+        assert!(markup.contains("data-local-chat-kind=\"player\" data-local-chat-subject=\"2\""));
+        assert!(markup.contains("class=\"settlement-chat-messages\""));
+        assert!(markup.contains("class=\"settlement-chat-composer\""));
+
+        let self_markup = party_social_dialog(
+            &location,
+            &actor,
+            &actor,
+            &[CharacterMoraleSource {
+                id: "self-concern".into(),
+                character_id: actor.id,
+                kind: "defeat".into(),
+                label: "A private defeat".into(),
+                magnitude: -1.0,
+            }],
+            &SocialPresentation::default(),
+        )
+        .into_string();
+        assert!(self_markup.contains("value=\"reflect\""));
+        assert!(self_markup.contains("data-social-self=\"true\""));
+        assert!(!self_markup.contains("class=\"settlement-chat-composer\""));
+        let ordinary_self = player_chat_area(&location, &actor, &actor).into_string();
+        assert!(ordinary_self.contains(
+            "data-party-social-href=\"/locations/settlement/lubeck/party/1/social?building=inn\""
+        ));
+        assert!(ordinary_self.contains("placeholder=\"Select Recent Tidings to reflect\""));
+        assert!(ordinary_self.contains("name=\"body\" disabled"));
 
         let feedback_social = SocialPresentation {
             feedback: Some(SocialFeedback {
@@ -996,9 +1051,10 @@ mod tests {
 
     #[test]
     fn chat_uses_one_stream_with_all_channel_filters() {
-        let markup = chat_area("Lubeck", None, None, None, None, &[]).into_string();
+        let markup = chat_area("Lubeck", None, None, None, None, None, &[]).into_string();
 
-        assert!(!markup.contains("role=\"tablist\""));
+        assert!(markup.contains("role=\"tablist\""));
+        assert!(markup.contains("data-dialogue-category=\"tidings\""));
         for channel in ["local", "party", "settlement", "dm", "guild", "info"] {
             assert!(
                 markup.contains(&format!("data-chat-filter=\"{channel}\"")),

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -2,7 +2,6 @@ use maud::{Markup, html};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::{
-    character_details::religion_name,
     context::LocationView,
     trade::{item_name_with_food_lot, trade_inventory_table_header},
 };
@@ -23,6 +22,7 @@ pub struct SocialPresentation {
     pub joke_blocked: bool,
     pub flirt_blocked: bool,
     pub prayer_disabled_reason: Option<String>,
+    pub relationship_answer: Option<String>,
     pub feedback: Option<SocialFeedback>,
     pub unavailable: bool,
 }
@@ -158,8 +158,8 @@ fn belief_tooltip(belief: &crate::spacetimedb::SocialBelief) -> String {
     )
 }
 
-/// Dedicated social view. It intentionally receives observer-specific beliefs
-/// rather than authoritative personality.
+/// Conversation Dock projection. It intentionally receives observer-specific
+/// beliefs rather than authoritative personality.
 pub fn party_social_dialog(
     location: &LocationView,
     selected: &Character,
@@ -191,27 +191,85 @@ pub fn party_social_dialog(
         _ => "Neutral",
     };
     let is_self = selected.id == active_character.id;
-    let affinity_certainty = if social.familiarity_hours >= 48.0 {
-        "fairly certain"
-    } else if social.familiarity_hours >= 8.0 {
-        "tentative"
-    } else {
-        "uncertain"
+    let affinity_face = match social.affinity {
+        value if value >= 50.0 => ("very-warm", "Very warm regard", "☺"),
+        value if value >= 15.0 => ("warm", "Warm regard", "🙂"),
+        value if value <= -50.0 => ("hostile", "Hostile regard", "☹"),
+        value if value <= -15.0 => ("cold", "Cold regard", "🙁"),
+        _ => ("neutral", "Neutral regard", "😐"),
     };
-    let close_href = location.preserve_building(if is_self {
-        format!("{}/party/{}", location.base_path(), selected.id)
-    } else {
-        format!("{}/party/{}/stats", location.base_path(), selected.id)
-    });
     html! {
-        div class="character-action-overlay" data-character-action-dialog {
-            a class="character-action-backdrop" href=(&close_href) aria-label="Close social dialog" {}
-            section class="character-action-dialog social-dialog" role="dialog" aria-modal="true" aria-labelledby="social-dialog-title" tabindex="-1" {
-                header class="character-action-dialog-header" {
-                    h2 id="social-dialog-title" { "Social — " (selected.name) }
-                    a class="character-action-dialog-close" href=(&close_href) aria-label="Close social dialog" { "×" }
+        section class="settlement-chat social-conversation-dock" aria-label=(format!("Conversation with {}", selected.name))
+          data-social-conversation data-social-subject=(selected.id) data-social-self=[is_self.then_some("true")] {
+          div class="settlement-chat-layout" {
+            div class="settlement-chat-conversation" {
+              header class="conversation-dock-header" {
+                div class="settlement-chat-filters" role="group" aria-label="Visible chat channels" {
+                  @for (channel, label, abbreviation) in [("local", "Local", "L"), ("party", "Party", "P"), ("info", "Info", "I")] {
+                    label class=(format!("chat-channel-filter chat-channel-filter-{channel}")) title=(label) {
+                      input type="checkbox" checked data-chat-filter=(channel) aria-label=(label) title=(label);
+                      span aria-hidden="true" { (abbreviation) }
+                    }
+                  }
                 }
-                div class="social-rail" data-social-panel data-target-id=(selected.id) {
+                div class="conversation-dock-tools" {
+                  @if !is_self {
+                    div class=(format!("affinity-popover affinity-{}", affinity_face.0)) data-affinity-popover {
+                      button type="button" class="affinity-face" aria-label=(affinity_face.1)
+                        aria-expanded="false" aria-controls=(format!("affinity-details-{}", selected.id))
+                        data-affinity-trigger data-strategic-tooltip=(format!("{}; click to pin details", affinity_face.1)) {
+                        span aria-hidden="true" { (affinity_face.2) }
+                      }
+                      section id=(format!("affinity-details-{}", selected.id)) class="affinity-details"
+                        data-affinity-details aria-label=(format!("Your impression of {}", selected.name)) {
+                        h3 { "Thy impression" }
+                        dl class="social-biography" {
+                          div { dt { "Regard" } dd { (affinity_label) } }
+                          div { dt { "Familiarity" } dd { (familiarity_label(social.familiarity_hours)) } }
+                        }
+                        @if social.unavailable {
+                          p class="social-unavailable" role="status" { "Your impressions are unavailable right now." }
+                        } @else if social.beliefs.is_empty() {
+                          p class="text-muted small-copy" { "You have not formed a confident impression of their character yet." }
+                        } @else {
+                          ul class="perceived-traits" aria-label="Perceived personality traits" {
+                            @for belief in &social.beliefs {
+                              @let (axis, value) = perceived_trait(belief.axis, belief.perceived_value);
+                              li class="perceived-trait" style=(belief_style(belief.confidence)) tabindex="0" {
+                                strong { (value) }
+                                span { (axis) ": " (format!("{:.0}% confidence", belief.confidence.clamp(0.0, 1.0) * 100.0)) }
+                                small { (personality_reaction_hint(belief.axis, belief.perceived_value)) }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                  div class="conversation-tabs" role="tablist" aria-label="Conversation topics" {
+                    @for (id, label, icon, selected_tab) in [
+                      ("quests", "Quests", "bookmark", false),
+                      ("lore", "Lore", "open-book", false),
+                      ("tidings", "Recent Tidings", "calendar", true),
+                      ("about", "Of Thee", "person", false),
+                    ] {
+                      button type="button" role="tab" class="conversation-tab"
+                        id=(format!("conversation-tab-{id}-{}", selected.id))
+                        aria-controls=(format!("conversation-panel-{id}-{}", selected.id))
+                        aria-selected=(if selected_tab { "true" } else { "false" }) tabindex=(if selected_tab { "0" } else { "-1" })
+                        data-conversation-tab=(id) data-strategic-tooltip=(if id == "about" { "About this person" } else { label }) {
+                        (decorative_game_icon(icon)) span class="visually-hidden" { (label) }
+                      }
+                    }
+                  }
+                }
+              }
+              section role="tabpanel" class="conversation-panel" id=(format!("conversation-panel-quests-{}", selected.id))
+                aria-labelledby=(format!("conversation-tab-quests-{}", selected.id)) hidden { p class="conversation-empty" { "No discovered quest matter is ready to discuss." } }
+              section role="tabpanel" class="conversation-panel" id=(format!("conversation-panel-lore-{}", selected.id))
+                aria-labelledby=(format!("conversation-tab-lore-{}", selected.id)) hidden { p class="conversation-empty" { "No discovered lore is ready to discuss." } }
+              section role="tabpanel" class="conversation-panel social-rail" id=(format!("conversation-panel-tidings-{}", selected.id))
+                aria-labelledby=(format!("conversation-tab-tidings-{}", selected.id)) data-social-panel data-target-id=(selected.id) {
             @if let Some(feedback) = &social.feedback {
                 p class=(if feedback.is_error { "social-feedback social-feedback-error" } else { "social-feedback social-feedback-result" })
                     role=(if feedback.is_error { "alert" } else { "status" }) {
@@ -255,42 +313,23 @@ pub fn party_social_dialog(
                     }
                 }
             }
-            (sidebar_section("What you believe", html! {
-                dl class="social-biography" {
-                    div { dt { "Age" } dd { (selected.age_years) } }
-                    div { dt { "Religion" } dd { (religion_name(social.religion_id.as_deref())) } }
-                    div { dt { "Local fame" } dd { (format!("{:.1}", social.fame)) } }
-                    div { dt { "Local infamy" } dd { (format!("{:.1}", social.infamy)) } }
-                    @if !is_self {
-                        div { dt { "Affinity toward you" } dd { (affinity_label) " (" (affinity_certainty) ")" } }
-                        div { dt { "Familiarity" } dd { (familiarity_label(social.familiarity_hours)) } }
-                    }
-                }
-                @if social.unavailable {
-                    p class="social-unavailable" role="status" { "Your impressions are unavailable right now." }
-                } @else if social.beliefs.is_empty() {
-                    p class="text-muted small-copy" { "You have not formed a confident impression of their personality yet." }
-                } @else {
-                    ul class="perceived-traits" aria-label="Perceived personality traits" {
-                        @for belief in &social.beliefs {
-                            @let (_, value) = perceived_trait(belief.axis, belief.perceived_value);
-                            li class="perceived-trait" style=(belief_style(belief.confidence))
-                                tabindex="0" data-strategic-tooltip=(belief_tooltip(belief)) {
-                                (value)
-                            }
-                        }
-                    }
-                }
-            }))
-            (sidebar_section("Morale sources", html! {
+            (sidebar_section("Recent Tidings", html! {
                 @if morale_sources.is_empty() { p class="text-muted" { "No current morale effects." } }
                 div class="social-source-list" {
                     @for source in morale_sources {
                         @let topic = adventuresim_core::social::topic_for_source_kind(&source.kind);
                         @let addressed = source.magnitude < 0.0 && social.addressed_source_ids.contains(&source.id);
-                        article class=(if addressed { "social-source social-source-negative social-source-addressed" } else if source.magnitude < 0.0 { "social-source social-source-negative" } else { "social-source social-source-positive" }) {
+                        @let magnitude = source.magnitude.clamp(-5.0, 5.0);
+                        @let topic_color = if magnitude < 0.0 {
+                            format!("color-mix(in srgb, #d7b650 {:.0}%, #cf4f4f)", (100.0 - magnitude.abs() * 18.0).max(10.0))
+                        } else if magnitude > 0.0 {
+                            format!("color-mix(in srgb, #d7b650 {:.0}%, #4fae67)", (100.0 - magnitude * 18.0).max(10.0))
+                        } else { "#d7b650".to_owned() };
+                        @let strength = if magnitude > 0.0 { format!("Positive morale, {magnitude:+.1}") } else if magnitude < 0.0 { format!("Negative morale, {magnitude:+.1}") } else { "Neutral morale, +0.0".to_owned() };
+                        article class=(if addressed { "social-source social-source-negative social-source-addressed" } else if source.magnitude < 0.0 { "social-source social-source-negative" } else if source.magnitude > 0.0 { "social-source social-source-positive" } else { "social-source social-source-neutral" })
+                            style=(format!("--social-topic-color:{topic_color}")) aria-label=(format!("{}: {strength}", source.label)) {
                             div class="social-source-context" {
-                                div { strong { (&source.label) } span { (format!("{:+.1}", source.magnitude)) } }
+                                div { strong { (&source.label) } span class="social-source-strength" { (&strength) } }
                                 @if addressed {
                                     p class="social-addressed-status" { "Addressed by you" }
                                 }
@@ -373,6 +412,35 @@ pub fn party_social_dialog(
                 }
             }))
                 }
+                section role="tabpanel" class="conversation-panel about-person-panel"
+                    id=(format!("conversation-panel-about-{}", selected.id))
+                    aria-labelledby=(format!("conversation-tab-about-{}", selected.id)) hidden data-about-person=(selected.name) {
+                    @if is_self {
+                        p { "To know thyself, seek thy Recent Tidings and reflect thereupon." }
+                    } @else {
+                        h3 { "Of Thee" }
+                        p class="text-muted small-copy" { "Ask, and hear the answer in their own words." }
+                        div class="about-person-topics" {
+                            @for (question, answer) in [
+                                ("How stand I in thy regard?", format!("I hold thee in {} regard.", affinity_label.to_ascii_lowercase())),
+                                ("How well knowest thou me?", format!("I have known thee for {}.", familiarity_label(social.familiarity_hours))),
+                                ("How fares thy spirit?", if morale_sources.iter().any(|source| source.magnitude < 0.0) { "My spirit is troubled; look to the recent tidings, and thou shalt know why.".to_owned() } else { "My spirit rests easily enough at present.".to_owned() }),
+                                ("Art thou pledged to another?", social.relationship_answer.clone().unwrap_or_else(|| "I shall speak of courtship or marriage only when such suit is lawful between us.".to_owned())),
+                            ] {
+                                button type="button" class="about-person-topic" data-about-question=(question) data-about-answer=(answer) { (question) }
+                            }
+                        }
+                    }
+                }
+                @if !is_self {
+                    div class="settlement-chat-composer" {
+                        div class="settlement-chat-input-shell" {
+                            input type="text" name="body" aria-label="Local message" autocomplete="off" placeholder=(format!("Speak with {}", selected.name));
+                        }
+                        button type="button" class="btn btn-primary btn-icon" aria-label="Send message" { (decorative_game_icon("plain-arrow")) }
+                    }
+                }
+            }
             }
         }
     }
@@ -472,6 +540,7 @@ fn chat_area(
             }
             div class="settlement-chat-layout" {
                 div class="settlement-chat-conversation" {
+                  header class="conversation-dock-header" {
                     div class="settlement-chat-filters" role="group" aria-label="Visible chat channels" {
                         @for (channel, label, abbreviation) in [
                             ("local", "Local", "L"),
@@ -487,6 +556,28 @@ fn chat_area(
                                 span aria-hidden="true" { (abbreviation) }
                             }
                         }
+                    }
+                    div class="conversation-tabs" role="tablist" aria-label="Conversation topics" data-dialogue-category-tabs {
+                      @for (id, label, icon, selected_tab) in [
+                        ("quest", "Quests", "bookmark", false),
+                        ("lore", "Lore", "open-book", true),
+                        ("tidings", "Recent Tidings", "calendar", false),
+                        ("about", "Of Thee", "person", false),
+                      ] {
+                        button type="button" role="tab" class="conversation-tab" id=(format!("dialogue-category-tab-{id}"))
+                          aria-controls=(format!("dialogue-category-panel-{id}")) aria-selected=(if selected_tab { "true" } else { "false" })
+                          tabindex=(if selected_tab { "0" } else { "-1" }) data-dialogue-category=(id)
+                          data-strategic-tooltip=(if id == "about" { "About this person" } else { label }) {
+                          (decorative_game_icon(icon)) span class="visually-hidden" { (label) }
+                        }
+                      }
+                    }
+                  }
+                    @for (id, label, selected_panel) in [("quest", "Quests", false), ("lore", "Lore", true), ("tidings", "Recent Tidings", false), ("about", "Of Thee", false)] {
+                      section role="tabpanel" class="dialogue-category-panel" id=(format!("dialogue-category-panel-{id}"))
+                        aria-labelledby=(format!("dialogue-category-tab-{id}")) hidden[!selected_panel] data-dialogue-category-panel=(id) {
+                        p class="conversation-empty" data-dialogue-category-empty { "No discovered " (label) " topics are ready to discuss." }
+                      }
                     }
                     div class="settlement-chat-messages" aria-live="polite" {
                         @if local_context.is_none() { div class="chat-system-message" data-chat-channel="info" {
@@ -653,6 +744,13 @@ mod tests {
         assert!(markup.contains("social-source-addressed"));
         assert!(markup.contains("Addressed by you"));
         assert!(!markup.contains("class=\"social-actions\""));
+        assert!(markup.contains("role=\"tablist\" aria-label=\"Conversation topics\""));
+        assert!(markup.contains(">Recent Tidings</span>"));
+        assert!(markup.contains("data-affinity-trigger"));
+        assert!(markup.contains("aria-expanded=\"false\""));
+        assert!(markup.contains("Negative morale, -2.0"));
+        assert!(markup.contains("--social-topic-color:color-mix"));
+        assert!(!markup.contains("Local fame"));
 
         let feedback_social = SocialPresentation {
             feedback: Some(SocialFeedback {

--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -2,6 +2,7 @@ use maud::{Markup, html};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::{
+    character_details::religion_name,
     context::LocationView,
     trade::{item_name_with_food_lot, trade_inventory_table_header},
 };
@@ -109,6 +110,22 @@ fn familiarity_label(hours: f32) -> String {
         "<1 hours".into()
     } else {
         format!("{:.0} hours", hours.max(0.0))
+    }
+}
+
+fn reputation_answer(fame: f32, infamy: f32) -> &'static str {
+    match (fame, infamy) {
+        (good, ill) if good >= 0.5 && ill >= 0.5 => {
+            "My name is much abroad here, for deeds both praised and blamed."
+        }
+        (good, _) if good >= 0.5 => "Folk here speak well of me, and my good name is widely known.",
+        (_, ill) if ill >= 0.5 => "Ill report follows me here, and many speak my name with care.",
+        (good, ill) if good >= 0.15 && ill >= 0.15 => {
+            "Some speak well of me, and some ill; my name is not unknown here."
+        }
+        (good, _) if good >= 0.15 => "I have won some small good report in these parts.",
+        (_, ill) if ill >= 0.15 => "Some little ill report follows me in these parts.",
+        _ => "My name bears little report in these parts, either fair or foul.",
     }
 }
 
@@ -249,7 +266,7 @@ pub fn party_social_dialog(
                   }
                   div class="conversation-tabs" role="tablist" aria-label="Conversation topics" {
                     @for (id, label, icon, selected_tab) in [
-                      ("quests", "Quests", "bookmark", false),
+                      ("quests", "Quests", "treasure-map", false),
                       ("lore", "Lore", "open-book", false),
                       ("tidings", "Recent Tidings", "calendar", true),
                       ("about", "Of Thee", "person", false),
@@ -421,6 +438,9 @@ pub fn party_social_dialog(
                                 ("How well knowest thou me?", format!("I have known thee for {}.", familiarity_label(social.familiarity_hours))),
                                 ("How fares thy spirit?", if morale_sources.iter().any(|source| source.magnitude < 0.0) { "My spirit is troubled; look to the recent tidings, and thou shalt know why.".to_owned() } else { "My spirit rests easily enough at present.".to_owned() }),
                                 ("Art thou pledged to another?", social.relationship_answer.clone().unwrap_or_else(|| "I shall speak of courtship or marriage only when such suit is lawful between us.".to_owned())),
+                                ("How many years hast thou seen?", format!("I have seen {} years.", selected.age_years)),
+                                ("What faith dost thou profess?", match religion_name(social.religion_id.as_deref()) { "None" => "I profess no settled faith.".to_owned(), faith => format!("I am of the {faith} confession.") }),
+                                ("What report dost thou bear in these parts?", reputation_answer(social.fame, social.infamy).to_owned()),
                             ] {
                                 button type="button" class="about-person-topic" data-about-question=(question) data-about-answer=(answer) { (question) }
                             }
@@ -587,7 +607,7 @@ fn chat_area(
                     }
                     div class="conversation-tabs" role="tablist" aria-label="Conversation topics" data-dialogue-category-tabs {
                       @for (id, label, icon, selected_tab) in [
-                        ("quest", "Quests", "bookmark", false),
+                        ("quest", "Quests", "treasure-map", false),
                         ("lore", "Lore", "open-book", true),
                         ("tidings", "Recent Tidings", "calendar", false),
                         ("about", "Of Thee", "person", false),
@@ -746,6 +766,9 @@ mod tests {
             active_building: Some("inn".into()),
         };
         let social = SocialPresentation {
+            religion_id: Some("lutheran".into()),
+            fame: 0.6,
+            infamy: 0.2,
             automatic_chat_enabled: true,
             addressed_source_ids: vec!["concern".into()],
             ..Default::default()
@@ -779,6 +802,12 @@ mod tests {
         assert!(markup.contains("Negative morale, -2.0"));
         assert!(markup.contains("--social-topic-color:color-mix"));
         assert!(!markup.contains("Local fame"));
+        assert!(markup.contains("How many years hast thou seen?"));
+        assert!(markup.contains("I have seen 20 years."));
+        assert!(markup.contains("What faith dost thou profess?"));
+        assert!(markup.contains("I am of the Lutheran confession."));
+        assert!(markup.contains("What report dost thou bear in these parts?"));
+        assert!(markup.contains("Folk here speak well of me"));
         assert!(markup.contains("data-local-chat-kind=\"player\" data-local-chat-subject=\"2\""));
         assert!(markup.contains("class=\"settlement-chat-messages\""));
         assert!(markup.contains("class=\"settlement-chat-composer\""));
@@ -816,7 +845,10 @@ mod tests {
         };
         let feedback_markup =
             party_social_dialog(&location, &target, &actor, &[], &feedback_social).into_string();
-        assert!(feedback_markup.contains("class=\"social-feedback social-feedback-error\""));
+        assert!(
+            feedback_markup
+                .contains("class=\"chat-system-message social-feedback social-feedback-error\"")
+        );
         assert!(feedback_markup.contains("role=\"alert\""));
         assert!(feedback_markup.contains("That approach needs time"));
 

--- a/crates/strategic-web/src/templates/settlement/trade.rs
+++ b/crates/strategic-web/src/templates/settlement/trade.rs
@@ -245,7 +245,7 @@ pub fn party_inventory_page(
         main class="center-content settlement-main party-member-stage" {
             (party_portrait_overlay(party_members, Some(active_character), &location.base_path(), Some(selected.id), false))
             (visual_stage("character", &selected.name, "Party member and trading companion"))
-            (player_chat_area(selected, active_character))
+            (player_chat_area(location, selected, active_character))
             form id="party-offer" class="party-offer" action=(format!("{}/party/{}/inventory/offer", location.base_path(), selected.id)) method="post" hidden
                 role="dialog" aria-modal="true" aria-label="Confirm party item offer" tabindex="-1" {
                 span class="party-offer-summary" { "Review and send the staged item offer." }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -3644,6 +3644,7 @@ button.party-portrait-action {
 .affinity-popover:hover .affinity-details,
 .affinity-popover:focus-within .affinity-details,
 .affinity-popover.is-pinned .affinity-details { display: block; }
+.affinity-popover.is-closing .affinity-details { display: none !important; }
 .affinity-details h3 { margin: 0 0 .55rem; }
 .affinity-details .perceived-traits { display: grid; gap: .45rem; padding: 0; margin: .65rem 0 0; list-style: none; }
 .affinity-details .perceived-trait { display: grid; gap: .15rem; padding: .4rem; border-left: 3px solid color-mix(in srgb, var(--accent) var(--belief-confidence), var(--border-color)); }

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -3555,8 +3555,10 @@ button.party-portrait-action {
   cursor: help;
 }
 .social-source { overflow: hidden; border: 1px solid var(--border-color); border-radius: 0.4rem; background: var(--panel-bg); }
-.social-source-negative { border-left: 3px solid var(--danger); }
-.social-source-positive { border-left: 3px solid var(--success); }
+.social-source-negative,
+.social-source-positive,
+.social-source-neutral { border-left: 4px solid var(--social-topic-color, #d7b650); }
+.social-source-strength { color: var(--social-topic-color, #d7b650); font-weight: 800; }
 .social-source-addressed {
   border-left-color: #8b6fc7;
   background-image: repeating-linear-gradient(
@@ -3580,6 +3582,79 @@ button.party-portrait-action {
 .social-action .game-icon { width: 1.15rem; height: 1.15rem; }
 .social-action-label { white-space: nowrap; }
 .social-unavailable { color: var(--danger); }
+
+.social-conversation-dock { min-height: 22rem; }
+.conversation-dock-header {
+  position: relative;
+  z-index: 4;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: .75rem;
+  padding: .45rem .6rem;
+  border-bottom: 1px solid var(--border-color);
+}
+.conversation-dock-tools,
+.conversation-tabs { display: flex; align-items: center; gap: .3rem; }
+.conversation-tab,
+.affinity-face {
+  display: inline-grid;
+  width: 2.15rem;
+  height: 2.15rem;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: .35rem;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.conversation-tab .game-icon { width: 1.25rem; height: 1.25rem; }
+.conversation-tab[aria-selected="true"] { border-color: var(--accent-gold-light); background: color-mix(in srgb, var(--accent) 16%, transparent); color: var(--accent-gold-light); }
+.conversation-tab:focus-visible,
+.affinity-face:focus-visible { outline: 2px solid currentColor; outline-offset: 2px; }
+.conversation-panel { min-height: 12rem; max-height: 28rem; padding: .7rem; overflow: auto; }
+.conversation-panel[hidden] { display: none; }
+.dialogue-category-panel { padding: .45rem .7rem; border-bottom: 1px solid var(--border-color); }
+.dialogue-category-panel[hidden] { display: none; }
+.dialogue-category-topic-list { display: flex; flex-wrap: wrap; gap: .45rem; padding: 0; margin: 0; list-style: none; }
+.conversation-empty { color: var(--text-muted); font-style: italic; }
+.affinity-popover { position: relative; --affinity-color: #d7b650; }
+.affinity-neutral { --affinity-color: #d7b650; }
+.affinity-warm { --affinity-color: #8dbb55; }
+.affinity-very-warm,
+.affinity-trusted { --affinity-color: #4fae67; }
+.affinity-cold,
+.affinity-reserved { --affinity-color: #d87952; }
+.affinity-hostile { --affinity-color: #cf4f4f; }
+.affinity-face { border-color: color-mix(in srgb, var(--affinity-color) 70%, var(--border-color)); color: var(--affinity-color); font-size: 1.25rem; }
+.affinity-details {
+  position: absolute;
+  top: calc(100% + .35rem);
+  right: 0;
+  display: none;
+  width: min(24rem, 80vw);
+  max-height: 24rem;
+  padding: .75rem;
+  overflow: auto;
+  border: 1px solid var(--affinity-color);
+  border-radius: .45rem;
+  background: var(--panel-bg);
+  box-shadow: 0 .6rem 1.4rem rgb(0 0 0 / .42);
+}
+.affinity-popover:hover .affinity-details,
+.affinity-popover:focus-within .affinity-details,
+.affinity-popover.is-pinned .affinity-details { display: block; }
+.affinity-details h3 { margin: 0 0 .55rem; }
+.affinity-details .perceived-traits { display: grid; gap: .45rem; padding: 0; margin: .65rem 0 0; list-style: none; }
+.affinity-details .perceived-trait { display: grid; gap: .15rem; padding: .4rem; border-left: 3px solid color-mix(in srgb, var(--accent) var(--belief-confidence), var(--border-color)); }
+.affinity-details .perceived-trait span,
+.affinity-details .perceived-trait small { color: var(--text-muted); }
+.about-person-topics { display: flex; flex-wrap: wrap; gap: .4rem; }
+.about-person-topic { padding: .45rem .6rem; border: 1px solid var(--border-color); border-radius: .35rem; background: var(--panel-bg); color: var(--text); cursor: pointer; }
+.about-person-topic:hover,
+.about-person-topic:focus-visible { border-color: var(--accent-gold-light); }
+.about-person-exchange { margin-top: .75rem; }
+.about-person-exchange p { margin: .25rem 0; }
 
 .fervor-meter {
   position: relative;

--- a/crates/strategic-web/static/css/strategic.css
+++ b/crates/strategic-web/static/css/strategic.css
@@ -3588,6 +3588,7 @@ button.party-portrait-action {
   position: relative;
   z-index: 4;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   gap: .75rem;
@@ -3596,6 +3597,7 @@ button.party-portrait-action {
 }
 .conversation-dock-tools,
 .conversation-tabs { display: flex; align-items: center; gap: .3rem; }
+.conversation-tabs { margin-left: auto; }
 .conversation-tab,
 .affinity-face {
   display: inline-grid;

--- a/crates/strategic-web/static/dialogue-client.js
+++ b/crates/strategic-web/static/dialogue-client.js
@@ -160,8 +160,7 @@
       });
       if (focus) tab.focus();
     };
-    tabs.forEach((tab, index) => {
-      tab.addEventListener("click", async () => {
+    const activateRequested = async (tab, focus = false) => {
         if (tab.dataset.dialogueCategory === "tidings" && dockChat?.dataset.partySocialHref) {
           const response = await window.strategicFetch(dockChat.dataset.partySocialHref, { headers: { Accept: "text/html" } });
           if (!response.ok) { window.reportStrategicError(new Error(`Recent Tidings failed (${response.status})`), "open Recent Tidings"); return; }
@@ -170,13 +169,15 @@
           if (!replacement) { window.reportStrategicError(new Error("Recent Tidings response was incomplete"), "open Recent Tidings"); return; }
           dockChat.replaceWith(replacement); document.dispatchEvent(new Event("strategic-page-mounted")); return;
         }
-        activate(tab);
-      }, { signal });
+        activate(tab, focus);
+    };
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("click", () => void activateRequested(tab), { signal });
       tab.addEventListener("keydown", (event) => {
         if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
         event.preventDefault();
         const next = event.key === "Home" ? 0 : event.key === "End" ? tabs.length - 1 : (index + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) % tabs.length;
-        activate(tabs[next], true);
+        void activateRequested(tabs[next], true);
       }, { signal });
     });
   });
@@ -395,7 +396,9 @@
       const social = await response.json(); if (!contextMutationCurrent(binding)) return;
       currentSocial = social;
       const reaction = ({ positive: "I am glad we passed this time together.", mixed: "Our words stumbled at times, yet I am glad we spoke.", negative: "Let us leave our speech here, lest it sour further." })[currentSocial.last_outcome] || "I thank thee for speaking with me.";
-      removeContextPrompt(); appendContextExchange(choice.label, reaction); renderRelationshipVitals(); renderContextTopics();
+      removeContextPrompt(); appendContextExchange(choice.label, reaction);
+      if (currentView) renderCategoryTopics(currentView, { sessionId: currentView.session_id, revision: currentView.revision, selectionGeneration, npcId: chat.dataset.localChatSubject || "" });
+      renderRelationshipVitals(); renderContextTopics();
     } catch (error) { if (contextMutationCurrent(binding)) window.reportStrategicError(error, "choose conversation response"); }
     finally { finishContextMutation(binding); }
   };
@@ -406,7 +409,9 @@
       if (!response.ok) throw new Error(`Relationship response failed (${response.status})`);
       const result = await response.json(); if (!contextMutationCurrent(binding)) return;
       if (!result || typeof result.ok !== "boolean" || typeof result.message !== "string" || !result.view) throw new Error("Relationship response returned an invalid result");
-      currentSocial = result.view; removeContextPrompt(); appendContextExchange(responseView.line, result.message); renderRelationshipVitals(); renderContextTopics();
+      currentSocial = result.view; removeContextPrompt(); appendContextExchange(responseView.line, result.message);
+      if (currentView) renderCategoryTopics(currentView, { sessionId: currentView.session_id, revision: currentView.revision, selectionGeneration, npcId: chat.dataset.localChatSubject || "" });
+      renderRelationshipVitals(); renderContextTopics();
     } catch (error) { if (contextMutationCurrent(binding)) window.reportStrategicError(error, "choose relationship response"); }
     finally { finishContextMutation(binding); }
   };

--- a/crates/strategic-web/static/dialogue-client.js
+++ b/crates/strategic-web/static/dialogue-client.js
@@ -106,6 +106,21 @@
     && binding.sessionId === currentView?.session_id
     && binding.revision === currentView?.revision
   );
+  const affinityPresentation = (value) => {
+    const score = Number.isFinite(Number(value)) ? Number(value) : 0;
+    if (score >= 50) return { band: "very-warm", label: "Very warm regard", face: "☺" };
+    if (score >= 15) return { band: "warm", label: "Warm regard", face: "🙂" };
+    if (score <= -50) return { band: "hostile", label: "Hostile regard", face: "☹" };
+    if (score <= -15) return { band: "cold", label: "Cold regard", face: "🙁" };
+    return { band: "neutral", label: "Neutral regard", face: "😐" };
+  };
+  const moraleTopicPresentation = (value) => {
+    const score = Math.max(-5, Math.min(5, Number(value) || 0));
+    const direction = score < 0 ? "negative" : score > 0 ? "positive" : "neutral";
+    const endpoint = score < 0 ? "#cf4f4f" : score > 0 ? "#4fae67" : "#d7b650";
+    const yellow = score === 0 ? 100 : Math.max(10, 100 - Math.abs(score) * 18);
+    return { direction, label: `${direction[0].toUpperCase()}${direction.slice(1)} morale, ${score >= 0 ? "+" : ""}${score.toFixed(1)}`, color: `color-mix(in srgb, #d7b650 ${yellow}%, ${endpoint})` };
+  };
 
   if (typeof module !== "undefined" && module.exports) {
     module.exports = {
@@ -121,6 +136,8 @@
       socialDurationChoices,
       contextualMutationIsCurrent,
       courtshipPresentation,
+      affinityPresentation,
+      moraleTopicPresentation,
     };
   }
   if (typeof document === "undefined") return;
@@ -130,6 +147,80 @@
   lifecycle?.abort();
   lifecycle = new AbortController();
   const { signal } = lifecycle;
+  document.querySelectorAll("[data-dialogue-category-tabs]").forEach((tablist) => {
+    const tabs = [...tablist.querySelectorAll("[role='tab']")];
+    const activate = (tab, focus = false) => {
+      tabs.forEach((candidate) => {
+        const selected = candidate === tab;
+        candidate.setAttribute("aria-selected", String(selected));
+        candidate.tabIndex = selected ? 0 : -1;
+        const panel = document.getElementById(candidate.getAttribute("aria-controls"));
+        if (panel) panel.hidden = !selected;
+      });
+      if (focus) tab.focus();
+    };
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("click", () => activate(tab), { signal });
+      tab.addEventListener("keydown", (event) => {
+        if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+        event.preventDefault();
+        const next = event.key === "Home" ? 0 : event.key === "End" ? tabs.length - 1 : (index + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) % tabs.length;
+        activate(tabs[next], true);
+      }, { signal });
+    });
+  });
+  document.querySelectorAll("[data-social-conversation]").forEach((dock) => {
+    const tabs = [...dock.querySelectorAll("[role='tab'][data-conversation-tab]")];
+    const activate = (tab, focus = false) => {
+      tabs.forEach((candidate) => {
+        const selected = candidate === tab;
+        candidate.setAttribute("aria-selected", String(selected));
+        candidate.tabIndex = selected ? 0 : -1;
+        const panel = dock.querySelector(`#${CSS.escape(candidate.getAttribute("aria-controls"))}`);
+        if (panel) panel.hidden = !selected;
+      });
+      if (focus) tab.focus();
+    };
+    tabs.forEach((tab, index) => {
+      tab.addEventListener("click", () => activate(tab), { signal });
+      tab.addEventListener("keydown", (event) => {
+        if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+        event.preventDefault();
+        const next = event.key === "Home" ? 0 : event.key === "End" ? tabs.length - 1
+          : (index + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) % tabs.length;
+        activate(tabs[next], true);
+      }, { signal });
+    });
+    const popover = dock.querySelector("[data-affinity-popover]");
+    const trigger = popover?.querySelector("[data-affinity-trigger]");
+    const closeAffinity = () => {
+      if (!popover) return;
+      popover.classList.remove("is-pinned");
+      trigger?.setAttribute("aria-expanded", "false");
+    };
+    trigger?.addEventListener("click", (event) => {
+      event.stopPropagation();
+      const pinned = popover.classList.toggle("is-pinned");
+      trigger.setAttribute("aria-expanded", String(pinned));
+    }, { signal });
+    dock.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape" || !popover?.classList.contains("is-pinned")) return;
+      event.preventDefault(); closeAffinity(); trigger?.focus();
+    }, { signal });
+    document.addEventListener("click", (event) => {
+      if (popover && !popover.contains(event.target)) closeAffinity();
+    }, { signal });
+    dock.querySelectorAll("[data-about-question]").forEach((topic) => topic.addEventListener("click", () => {
+      const panel = topic.closest("[data-about-person]");
+      panel.querySelector("[data-about-exchange]")?.remove();
+      const exchange = document.createElement("div");
+      exchange.dataset.aboutExchange = "true";
+      exchange.className = "about-person-exchange";
+      const question = document.createElement("p"); question.className = "chat-player-message"; question.textContent = topic.dataset.aboutQuestion;
+      const answer = document.createElement("p"); answer.className = "chat-npc-message"; answer.textContent = topic.dataset.aboutAnswer;
+      exchange.append(question, answer); panel.append(exchange);
+    }, { signal }));
+  });
   const chat = document.querySelector("[data-local-chat-subject][data-dialogue-catalog-revision]");
   if (!chat) return;
   const messages = chat.querySelector(".settlement-chat-messages");
@@ -175,57 +266,55 @@
     row.append(timestamp, name, document.createTextNode(body));
     return row;
   };
-  const visualVital = (kind, value, icon) => {
-    const label = relationshipLabel(value);
-    const vital = document.createElement("span");
-    vital.className = `npc-relationship-vital npc-relationship-${kind}`;
-    vital.title = `${kind}: ${label}`;
-    vital.setAttribute("aria-label", vital.title);
-    const glyph = document.createElement("span"); glyph.className = "game-icon"; glyph.style.setProperty("--game-icon", `url('/static/icons/game/${icon}.svg')`); glyph.setAttribute("aria-hidden", "true");
-    const percent = Math.round(relationshipLevel(kind, value) * 100);
-    const track = document.createElement("span"); track.className = "npc-relationship-meter"; track.setAttribute("role", "meter"); track.setAttribute("aria-valuemin", "0"); track.setAttribute("aria-valuemax", "100"); track.setAttribute("aria-valuenow", String(percent)); track.setAttribute("aria-valuetext", label);
-    const fill = document.createElement("span"); fill.style.width = `${percent}%`; fill.setAttribute("aria-hidden", "true");
-    track.append(fill); vital.append(glyph, track);
-    return vital;
-  };
   const renderRelationshipVitals = () => {
     if (!npcDescription) return;
-    npcDescription.querySelector("[data-npc-relationship-vitals]")?.remove();
     if (!currentSocial) return;
-    const vitals = document.createElement("div");
-    vitals.className = "npc-relationship-vitals";
-    vitals.dataset.npcRelationshipVitals = "true";
-    vitals.setAttribute("role", "group");
-    vitals.setAttribute("aria-label", `Your relationship with ${currentSocial.name}`);
-    vitals.append(
-      visualVital("affinity", currentSocial.affinity, "heart-beats"),
-      visualVital("familiarity", currentSocial.familiarity, "conversation"),
-      visualVital("morale", currentSocial.morale, "sun"),
-    );
-    if (currentSocial.courtship_kind) {
-      const presentation = courtshipPresentation(currentSocial.courtship_kind, currentSocial.courtship_exposed);
-      const courtship = document.createElement("span");
-      courtship.className = "npc-relationship-state";
-      courtship.title = presentation.label;
-      courtship.setAttribute("role", "img");
-      courtship.setAttribute("aria-label", courtship.title);
-      const icon = document.createElement("span"); icon.className = "game-icon"; icon.style.setProperty("--game-icon", `url('/static/icons/game/${presentation.icon}.svg')`); icon.setAttribute("aria-hidden", "true");
-      courtship.append(icon); vitals.append(courtship);
+    // Relationship state is spoken under Of Thee. The header retains only a
+    // qualitative, non-authoritative regard face as an at-a-glance invitation.
+    const header = chat.querySelector(".conversation-dock-header");
+    header?.querySelector("[data-npc-affinity-face]")?.remove();
+    if (header) {
+      const face = document.createElement("button"); face.type = "button"; face.dataset.npcAffinityFace = "true"; face.className = `affinity-face affinity-${currentSocial.affinity || "neutral"}`;
+      const presentation = ({ hostile: ["☹", "Hostile regard"], reserved: ["🙁", "Reserved regard"], warm: ["🙂", "Warm regard"], trusted: ["☺", "Very warm regard"] })[currentSocial.affinity] || ["😐", "Neutral regard"];
+      face.textContent = presentation[0]; face.setAttribute("aria-label", presentation[1]); face.title = `${presentation[1]}; ask under Of Thee for more`;
+      header.insertBefore(face, header.querySelector("[data-dialogue-category-tabs]"));
     }
-    if (Number.isFinite(currentSocial.wedding_countdown_days)) {
-      const wedding = document.createElement("span");
-      wedding.className = "npc-relationship-state npc-wedding-progress";
-      wedding.title = `Wedding in ${currentSocial.wedding_countdown_days} days`;
-      const percent = Math.round(Math.max(0, Math.min(100, (365 - currentSocial.wedding_countdown_days) / 365 * 100)));
-      wedding.setAttribute("role", "meter"); wedding.setAttribute("aria-valuemin", "0"); wedding.setAttribute("aria-valuemax", "100"); wedding.setAttribute("aria-valuenow", String(percent)); wedding.setAttribute("aria-valuetext", wedding.title);
-      wedding.style.setProperty("--wedding-progress", `${percent}%`);
-      const icon = document.createElement("span"); icon.className = "game-icon"; icon.style.setProperty("--game-icon", "url('/static/icons/game/calendar.svg')"); icon.setAttribute("aria-hidden", "true");
-      wedding.append(icon); vitals.append(wedding);
-    }
-    npcDescription.append(vitals);
   };
   const topicAnchor = (topic, binding) => {
     const anchor = document.createElement("a"); anchor.href = "#"; anchor.className = "chat-quest-link"; anchor.textContent = topic.label; anchor.dataset.dialogueTopic = topic.id; anchor.dataset.dialogueSession = binding.sessionId; anchor.dataset.dialogueRevision = String(binding.revision); anchor.dataset.dialogueGeneration = String(binding.selectionGeneration); anchor.dataset.dialogueNpc = binding.npcId; const edit = sourceLink(topic.source); if (!edit) return anchor; const fragment = document.createDocumentFragment(); fragment.append(anchor, edit); return fragment;
+  };
+  const renderCategoryTopics = (view, binding) => {
+    document.querySelectorAll("[data-dialogue-category-panel]").forEach((panel) => {
+      panel.replaceChildren();
+      const category = panel.dataset.dialogueCategoryPanel;
+      if (category === "tidings") {
+        const unavailable = document.createElement("p"); unavailable.className = "conversation-empty";
+        unavailable.textContent = "Their private recent tidings are not thine to inspect."; panel.append(unavailable); return;
+      }
+      if (category === "about") {
+        const topics = document.createElement("div"); topics.className = "about-person-topics";
+        const questions = currentSocial ? [
+          ["How stand I in thy regard?", `I hold thee in ${relationshipLabel(currentSocial.affinity)} regard.`],
+          ["How well knowest thou me?", `I know thee as one ${relationshipLabel(currentSocial.familiarity)} to me.`],
+          ["How fares thy spirit?", `My spirit is ${relationshipLabel(currentSocial.morale)} at present.`],
+          ["Art thou pledged to another?", Number.isFinite(currentSocial.wedding_countdown_days)
+            ? `Our wedding day shall come in ${currentSocial.wedding_countdown_days} days.`
+            : currentSocial.courtship_kind ? `Our ${relationshipLabel(currentSocial.courtship_kind)} courtship yet stands.` : "I am under no pledge that I shall declare to thee."],
+        ] : [];
+        questions.forEach(([question, answer]) => {
+          const button = document.createElement("button"); button.type = "button"; button.className = "about-person-topic"; button.textContent = question;
+          button.addEventListener("click", () => appendContextExchange(question, answer), { signal }); topics.append(button);
+        });
+        if (topics.childElementCount) panel.append(topics);
+        else { const empty = document.createElement("p"); empty.className = "conversation-empty"; empty.textContent = "No private answer is available."; panel.append(empty); }
+        return;
+      }
+      const known = (view.topics || []).filter((topic) => (topic.category || "lore") === category);
+      if (!known.length) { const empty = document.createElement("p"); empty.className = "conversation-empty"; empty.textContent = `No discovered ${category} topics are ready to discuss.`; panel.append(empty); return; }
+      const list = document.createElement("ul"); list.className = "dialogue-category-topic-list";
+      known.forEach((topic) => { const item = document.createElement("li"); item.append(topicAnchor(topic, { ...binding, topicId: topic.id })); list.append(item); });
+      panel.append(list);
+    });
   };
   const renderPrompt = (prompt) => {
     if (!prompt) return;
@@ -268,7 +357,9 @@
     if (!response.ok) return null;
     const social = await response.json();
     if (generation !== selectionGeneration || social.resident_character_id !== chat.dataset.localChatSubject) return null;
-    currentSocial = social; renderRelationshipVitals(); renderContextTopics(); return social;
+    currentSocial = social;
+    if (currentView) renderCategoryTopics(currentView, { sessionId: currentView.session_id, revision: currentView.revision, selectionGeneration, npcId: chat.dataset.localChatSubject || "" });
+    renderRelationshipVitals(); renderContextTopics(); return social;
   };
   const chooseSocialResponse = async (choice) => {
     const binding = beginContextMutation(); if (!binding) return;
@@ -434,6 +525,7 @@
       selectionGeneration,
       npcId: chat.dataset.localChatSubject || "",
     };
+    renderCategoryTopics(view, binding);
     messages?.querySelectorAll("[data-dialogue-scripted]").forEach((node) => node.remove());
     view.events.forEach((event) => {
       const row = document.createElement("div");

--- a/crates/strategic-web/static/dialogue-client.js
+++ b/crates/strategic-web/static/dialogue-client.js
@@ -80,15 +80,15 @@
     return index < 0 ? 0 : (index + 1) / bands.length;
   };
   const socialDurationChoices = Object.freeze([
-    { id: "brief", minutes: 15, icon: "conversation", label: "Do you have a moment to talk?", detail: "A brief fifteen-minute conversation." },
-    { id: "visit", minutes: 60, icon: "sun", label: "I would like to stay and talk awhile.", detail: "An unhurried one-hour visit." },
-    { id: "evening", minutes: 240, icon: "calendar", label: "Shall we spend the evening together?", detail: "A long four-hour conversation." },
+    { id: "brief", minutes: 15, icon: "conversation", label: "Hast thou a moment to speak?", detail: "A brief fifteen-minute conversation." },
+    { id: "visit", minutes: 60, icon: "sun", label: "I would tarry and speak with thee awhile.", detail: "An unhurried one-hour visit." },
+    { id: "evening", minutes: 240, icon: "calendar", label: "Shall we pass the evening together?", detail: "A long four-hour conversation." },
   ]);
   const romanticResponse = (action) => ({
-    formal_courtship: { icon: "rose", label: "Ask for a formal courtship", line: "I would like to seek your family's leave to court you." },
-    informal_courtship: { icon: "lockpicks", label: "Propose a private courtship", line: "Would you court me, even if we must keep it between us?" },
-    schedule_wedding: { icon: "calendar", label: "Plan the wedding", line: "Let us choose the day and make our promise." },
-    cancel_wedding: { icon: "broken-heart", label: "Cancel the wedding", line: "I cannot go forward with the wedding as planned." },
+    formal_courtship: { icon: "rose", label: "Ask for a formal courtship", line: "I would seek thy family's leave to court thee." },
+    informal_courtship: { icon: "lockpicks", label: "Propose a private courtship", line: "Wilt thou court me, though we keep it between ourselves?" },
+    schedule_wedding: { icon: "calendar", label: "Plan the wedding", line: "Let us appoint the day and plight our troth." },
+    cancel_wedding: { icon: "broken-heart", label: "Cancel the wedding", line: "I cannot go forward with our wedding as appointed." },
   })[action] || null;
   const courtshipPresentation = (kind, exposed) => {
     const informal = kind === "informal";
@@ -148,6 +148,7 @@
   lifecycle = new AbortController();
   const { signal } = lifecycle;
   document.querySelectorAll("[data-dialogue-category-tabs]").forEach((tablist) => {
+    const dockChat = tablist.closest(".settlement-chat");
     const tabs = [...tablist.querySelectorAll("[role='tab']")];
     const activate = (tab, focus = false) => {
       tabs.forEach((candidate) => {
@@ -160,7 +161,17 @@
       if (focus) tab.focus();
     };
     tabs.forEach((tab, index) => {
-      tab.addEventListener("click", () => activate(tab), { signal });
+      tab.addEventListener("click", async () => {
+        if (tab.dataset.dialogueCategory === "tidings" && dockChat?.dataset.partySocialHref) {
+          const response = await window.strategicFetch(dockChat.dataset.partySocialHref, { headers: { Accept: "text/html" } });
+          if (!response.ok) { window.reportStrategicError(new Error(`Recent Tidings failed (${response.status})`), "open Recent Tidings"); return; }
+          const page = new DOMParser().parseFromString(await response.text(), "text/html");
+          const replacement = page.querySelector("[data-social-conversation]");
+          if (!replacement) { window.reportStrategicError(new Error("Recent Tidings response was incomplete"), "open Recent Tidings"); return; }
+          dockChat.replaceWith(replacement); document.dispatchEvent(new Event("strategic-page-mounted")); return;
+        }
+        activate(tab);
+      }, { signal });
       tab.addEventListener("keydown", (event) => {
         if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
         event.preventDefault();
@@ -196,29 +207,35 @@
     const closeAffinity = () => {
       if (!popover) return;
       popover.classList.remove("is-pinned");
+      popover.classList.add("is-closing");
       trigger?.setAttribute("aria-expanded", "false");
     };
+    popover?.addEventListener("pointerenter", () => popover.classList.remove("is-closing"), { signal });
+    popover?.addEventListener("focusin", () => popover.classList.remove("is-closing"), { signal });
     trigger?.addEventListener("click", (event) => {
       event.stopPropagation();
+      popover.classList.remove("is-closing");
       const pinned = popover.classList.toggle("is-pinned");
+      if (!pinned) popover.classList.add("is-closing");
       trigger.setAttribute("aria-expanded", String(pinned));
     }, { signal });
     dock.addEventListener("keydown", (event) => {
       if (event.key !== "Escape" || !popover?.classList.contains("is-pinned")) return;
-      event.preventDefault(); closeAffinity(); trigger?.focus();
+      event.preventDefault(); trigger?.focus(); closeAffinity();
     }, { signal });
     document.addEventListener("click", (event) => {
       if (popover && !popover.contains(event.target)) closeAffinity();
     }, { signal });
     dock.querySelectorAll("[data-about-question]").forEach((topic) => topic.addEventListener("click", () => {
       const panel = topic.closest("[data-about-person]");
-      panel.querySelector("[data-about-exchange]")?.remove();
+      const stream = dock.querySelector("[data-social-message-stream]");
+      stream?.querySelector("[data-about-exchange]")?.remove();
       const exchange = document.createElement("div");
       exchange.dataset.aboutExchange = "true";
       exchange.className = "about-person-exchange";
       const question = document.createElement("p"); question.className = "chat-player-message"; question.textContent = topic.dataset.aboutQuestion;
       const answer = document.createElement("p"); answer.className = "chat-npc-message"; answer.textContent = topic.dataset.aboutAnswer;
-      exchange.append(question, answer); panel.append(exchange);
+      exchange.append(question, answer); stream?.append(exchange);
     }, { signal }));
   });
   const chat = document.querySelector("[data-local-chat-subject][data-dialogue-catalog-revision]");
@@ -272,12 +289,24 @@
     // Relationship state is spoken under Of Thee. The header retains only a
     // qualitative, non-authoritative regard face as an at-a-glance invitation.
     const header = chat.querySelector(".conversation-dock-header");
-    header?.querySelector("[data-npc-affinity-face]")?.remove();
+    header?.querySelector("[data-npc-affinity-popover]")?.remove();
     if (header) {
-      const face = document.createElement("button"); face.type = "button"; face.dataset.npcAffinityFace = "true"; face.className = `affinity-face affinity-${currentSocial.affinity || "neutral"}`;
+      const popover = document.createElement("div"); popover.dataset.npcAffinityPopover = "true"; popover.className = `affinity-popover affinity-${currentSocial.affinity || "neutral"}`;
+      const face = document.createElement("button"); face.type = "button"; face.dataset.npcAffinityFace = "true"; face.className = "affinity-face";
       const presentation = ({ hostile: ["☹", "Hostile regard"], reserved: ["🙁", "Reserved regard"], warm: ["🙂", "Warm regard"], trusted: ["☺", "Very warm regard"] })[currentSocial.affinity] || ["😐", "Neutral regard"];
-      face.textContent = presentation[0]; face.setAttribute("aria-label", presentation[1]); face.title = `${presentation[1]}; ask under Of Thee for more`;
-      header.insertBefore(face, header.querySelector("[data-dialogue-category-tabs]"));
+      const details = document.createElement("section"); details.className = "affinity-details"; details.id = `npc-affinity-${currentSocial.resident_character_id}`; details.dataset.affinityDetails = "true";
+      face.textContent = presentation[0]; face.setAttribute("aria-label", presentation[1]); face.title = `${presentation[1]}; ask under Of Thee for more`; face.setAttribute("aria-expanded", "false"); face.setAttribute("aria-controls", details.id);
+      const heading = document.createElement("h3"); heading.textContent = "Thy impression";
+      const familiarity = document.createElement("p"); familiarity.textContent = `Familiarity: ${relationshipLabel(currentSocial.familiarity)}.`;
+      const unavailable = document.createElement("p"); unavailable.className = "text-muted small-copy"; unavailable.textContent = "No observer-safe trait impression is available.";
+      details.append(heading, familiarity, unavailable); popover.append(face, details);
+      const close = () => { popover.classList.remove("is-pinned"); popover.classList.add("is-closing"); face.setAttribute("aria-expanded", "false"); };
+      face.addEventListener("click", (event) => { event.stopPropagation(); popover.classList.remove("is-closing"); const pinned = popover.classList.toggle("is-pinned"); if (!pinned) popover.classList.add("is-closing"); face.setAttribute("aria-expanded", String(pinned)); }, { signal });
+      popover.addEventListener("pointerenter", () => popover.classList.remove("is-closing"), { signal });
+      popover.addEventListener("focusin", () => popover.classList.remove("is-closing"), { signal });
+      document.addEventListener("click", (event) => { if (!popover.contains(event.target)) close(); }, { signal });
+      popover.addEventListener("keydown", (event) => { if (event.key === "Escape") { event.preventDefault(); face.focus(); close(); } }, { signal });
+      header.insertBefore(popover, header.querySelector("[data-dialogue-category-tabs]"));
     }
   };
   const topicAnchor = (topic, binding) => {
@@ -293,17 +322,14 @@
       }
       if (category === "about") {
         const topics = document.createElement("div"); topics.className = "about-person-topics";
-        const questions = currentSocial ? [
-          ["How stand I in thy regard?", `I hold thee in ${relationshipLabel(currentSocial.affinity)} regard.`],
-          ["How well knowest thou me?", `I know thee as one ${relationshipLabel(currentSocial.familiarity)} to me.`],
-          ["How fares thy spirit?", `My spirit is ${relationshipLabel(currentSocial.morale)} at present.`],
-          ["Art thou pledged to another?", Number.isFinite(currentSocial.wedding_countdown_days)
-            ? `Our wedding day shall come in ${currentSocial.wedding_countdown_days} days.`
-            : currentSocial.courtship_kind ? `Our ${relationshipLabel(currentSocial.courtship_kind)} courtship yet stands.` : "I am under no pledge that I shall declare to thee."],
-        ] : [];
-        questions.forEach(([question, answer]) => {
+        const questions = currentSocial?.about_topics || [];
+        questions.forEach(({ question, answer }) => {
           const button = document.createElement("button"); button.type = "button"; button.className = "about-person-topic"; button.textContent = question;
-          button.addEventListener("click", () => appendContextExchange(question, answer), { signal }); topics.append(button);
+          button.dataset.socialRevision = currentSocial.social_revision; button.dataset.socialSubject = currentSocial.resident_character_id;
+          button.addEventListener("click", () => {
+            if (button.dataset.socialRevision !== currentSocial?.social_revision || button.dataset.socialSubject !== chat.dataset.localChatSubject) return;
+            appendContextExchange(question, answer);
+          }, { signal }); topics.append(button);
         });
         if (topics.childElementCount) panel.append(topics);
         else { const empty = document.createElement("p"); empty.className = "conversation-empty"; empty.textContent = "No private answer is available."; panel.append(empty); }
@@ -368,7 +394,7 @@
       if (!response.ok) throw new Error(`Conversation failed (${response.status})`);
       const social = await response.json(); if (!contextMutationCurrent(binding)) return;
       currentSocial = social;
-      const reaction = ({ positive: "I am glad we had this time together.", mixed: "That was awkward in places, but I am glad we spoke.", negative: "I think we should leave the conversation there." })[currentSocial.last_outcome] || "Thank you for speaking with me.";
+      const reaction = ({ positive: "I am glad we passed this time together.", mixed: "Our words stumbled at times, yet I am glad we spoke.", negative: "Let us leave our speech here, lest it sour further." })[currentSocial.last_outcome] || "I thank thee for speaking with me.";
       removeContextPrompt(); appendContextExchange(choice.label, reaction); renderRelationshipVitals(); renderContextTopics();
     } catch (error) { if (contextMutationCurrent(binding)) window.reportStrategicError(error, "choose conversation response"); }
     finally { finishContextMutation(binding); }
@@ -700,6 +726,10 @@
     chat.dispatchEvent(new Event("local-chat-subject-changed"));
     currentView = null;
     currentSocial = null;
+    chat.querySelector("[data-npc-affinity-popover]")?.remove();
+    document.querySelectorAll("[data-dialogue-category-panel]").forEach((panel) => {
+      panel.replaceChildren(); const loading = document.createElement("p"); loading.className = "conversation-empty"; loading.textContent = "Loading this person's conversation…"; panel.append(loading);
+    });
     messages?.querySelectorAll("[data-dialogue-scripted], [data-dialogue-contextual], [data-dialogue-context-prompt], [data-dialogue-context-topics]").forEach((node) => node.remove());
     refreshCompletion();
     npcStrip?.querySelectorAll(".settlement-npc-portrait").forEach((candidate) => {

--- a/crates/strategic-web/tests/character-action-dialog.test.cjs
+++ b/crates/strategic-web/tests/character-action-dialog.test.cjs
@@ -64,12 +64,13 @@ test("automatic social preference submits immediately when the checkbox changes"
   assert.equal(submitAutomaticChatToggle({ matches: () => false }), false);
 });
 
-test("character actions use one dialog and raised-button contract", () => {
+test("modal character actions retain the raised-button contract while social uses the dock", () => {
   assert.match(template, /data-character-action-dialog/);
   assert.match(template, /aria-haspopup="dialog" aria-expanded=\(open\)/);
   assert.match(template, /character-menu-button limb-surgery-button/);
   assert.match(template, /role="dialog" aria-modal="true" aria-labelledby="surgery-dialog-title"/);
-  assert.match(template, /role="dialog" aria-modal="true" aria-labelledby="social-dialog-title"/);
+  assert.match(template, /data-social-conversation/);
+  assert.doesNotMatch(socialTemplate, /aria-labelledby="social-dialog-title"/);
   assert.match(template, /role="dialog" aria-modal="true" aria-labelledby="cooking-dialog-title"/);
   assert.match(styles, /\.character-menu-button[\s\S]*background: var\(--tactile-background\)/);
   assert.match(styles, /\.character-menu-button[\s\S]*box-shadow: var\(--tactile-shadow\)/);
@@ -82,7 +83,7 @@ test("character actions use one dialog and raised-button contract", () => {
   assert.match(styles, /\.social-dialog \{ width: min\(40rem, 100%\); \}/);
 });
 
-test("social and surgery inject overlays into the ordinary character renderers", () => {
+test("social replaces the ordinary chat dock while surgery remains an overlay", () => {
   assert.match(routes, /render_party_personal\([\s\S]*Some\(dialog\)/);
   assert.match(routes, /render_party_stats\([\s\S]*Some\(dialog\)/);
   const socialStart = socialTemplate.indexOf("pub fn party_social_dialog");
@@ -92,6 +93,8 @@ test("social and surgery inject overlays into the ordinary character renderers",
   const surgeryEnd = healthTemplate.indexOf("pub(super) fn strategic_condition_rail", surgeryStart);
   const surgeryDialog = healthTemplate.slice(surgeryStart, surgeryEnd);
   assert.doesNotMatch(socialDialog, /left-sidebar|right-sidebar|render_layout/);
+  assert.match(socialDialog, /role="tablist"/);
+  assert.match(socialDialog, /Recent Tidings/);
   assert.doesNotMatch(surgeryDialog, /left-sidebar|right-sidebar|render_layout/);
   assert.match(socialDialog, /preserve_building/);
   assert.match(surgeryDialog, /preserve_building/);

--- a/crates/strategic-web/tests/character-action-dialog.test.cjs
+++ b/crates/strategic-web/tests/character-action-dialog.test.cjs
@@ -95,6 +95,9 @@ test("social replaces the ordinary chat dock while surgery remains an overlay", 
   assert.doesNotMatch(socialDialog, /left-sidebar|right-sidebar|render_layout/);
   assert.match(socialDialog, /role="tablist"/);
   assert.match(socialDialog, /Recent Tidings/);
+  assert.match(socialDialog, /class="settlement-chat-messages"/);
+  assert.match(socialDialog, /data-local-chat-kind="player"/);
+  assert.match(socialDialog, /data-strategic-tooltip=\(belief_tooltip\(belief\)\)/);
   assert.doesNotMatch(surgeryDialog, /left-sidebar|right-sidebar|render_layout/);
   assert.match(socialDialog, /preserve_building/);
   assert.match(surgeryDialog, /preserve_building/);

--- a/crates/strategic-web/tests/dialogue-client.test.cjs
+++ b/crates/strategic-web/tests/dialogue-client.test.cjs
@@ -168,6 +168,10 @@ test("socializing and romance are dialogue responses with a qualitative regard f
   assert.match(source, /ask under Of Thee for more/);
   assert.match(source, /currentView\.open_prompt \|\| contextualMutation/);
   assert.match(source, /const render = \(view\) => \{[\s\S]*?removeContextPrompt\(\);/);
+  const socialMutation = source.slice(source.indexOf("const chooseSocialResponse"), source.indexOf("const chooseRomanticResponse"));
+  const romanceMutation = source.slice(source.indexOf("const chooseRomanticResponse"), source.indexOf("const renderContextPrompt"));
+  assert.match(socialMutation, /renderCategoryTopics\(currentView/);
+  assert.match(romanceMutation, /renderCategoryTopics\(currentView/);
   assert.doesNotMatch(source, /success_chance|personality_fit|morale_delta/);
 });
 
@@ -197,6 +201,8 @@ test("NPC switches clear subject-bound social state before asynchronous refresh"
 
 test("party portrait chat deep-loads the authorized social dock into the functional stream", () => {
   assert.match(source, /dockChat\.dataset\.partySocialHref/);
+  assert.match(source, /const activateRequested = async \(tab, focus = false\)/);
+  assert.match(source, /void activateRequested\(tabs\[next\], true\)/);
   assert.match(source, /querySelector\("\[data-social-conversation\]"\)/);
   assert.match(source, /dockChat\.replaceWith\(replacement\)/);
 });

--- a/crates/strategic-web/tests/dialogue-client.test.cjs
+++ b/crates/strategic-web/tests/dialogue-client.test.cjs
@@ -16,6 +16,8 @@ const {
   socialDurationChoices,
   contextualMutationIsCurrent,
   courtshipPresentation,
+  affinityPresentation,
+  moraleTopicPresentation,
 } = require("../static/dialogue-client.js");
 
 test("errantry acceptance reuses its action ID after a lost response", async () => {
@@ -71,9 +73,9 @@ test("dialogue client is schema-driven with stable authoritative actions", () =>
   assert.doesNotMatch(source, /professionDetails|openQuestOffer|beginHerbalistConversation|dialogueActions/);
 });
 
-test("authored topics stay inline while contextual social topics use icon controls", () => {
-  assert.doesNotMatch(source, /data-dialogue-topic-pane/);
-  assert.doesNotMatch(source, /topicList\.replaceChildren/);
+test("discovered authored topics use typed category tabs while contextual actions stay inline", () => {
+  assert.match(source, /topic\.category \|\| "lore"/);
+  assert.match(source, /data-dialogue-category-panel/);
   assert.match(source, /row\.append\(topicAnchor/);
   assert.match(source, /dialogue-context-topics/);
   assert.match(source, /contextTopicButton\("social", "conversation"/);
@@ -149,7 +151,7 @@ test("settlement NPCs reuse the circular party portrait structure", () => {
   assert.doesNotMatch(source, /npc-social-summary/);
 });
 
-test("socializing and romance are dialogue responses with visual relationship meters", () => {
+test("socializing and romance are dialogue responses with a qualitative regard face", () => {
   assert.equal(relationshipLabel("well_known"), "well known");
   assert.equal(relationshipLevel("affinity", "trusted"), 1);
   assert.equal(relationshipLevel("morale", "guarded"), 2 / 3);
@@ -161,12 +163,24 @@ test("socializing and romance are dialogue responses with visual relationship me
   assert.deepEqual(courtshipPresentation("informal", true), { icon: "eye-target", label: "informal courtship; known to family" });
   assert.match(source, /dataset\.dialogueContextPrompt/);
   assert.match(source, /appendContextExchange/);
-  assert.match(source, /npc-relationship-meter/);
+  assert.match(source, /data\.npcAffinityFace/);
   assert.match(source, /requested_minutes: choice\.minutes/);
-  assert.match(source, /track\.setAttribute\("role", "meter"\)/);
+  assert.match(source, /ask under Of Thee for more/);
   assert.match(source, /currentView\.open_prompt \|\| contextualMutation/);
   assert.match(source, /const render = \(view\) => \{[\s\S]*?removeContextPrompt\(\);/);
   assert.doesNotMatch(source, /success_chance|personality_fit|morale_delta/);
+});
+
+test("morale topics and affinity faces combine color with accessible qualitative wording", () => {
+  assert.deepEqual(affinityPresentation(0), { band: "neutral", label: "Neutral regard", face: "😐" });
+  assert.equal(affinityPresentation(70).band, "very-warm");
+  assert.equal(affinityPresentation(-70).band, "hostile");
+  assert.equal(moraleTopicPresentation(0).label, "Neutral morale, +0.0");
+  assert.equal(moraleTopicPresentation(4).direction, "positive");
+  assert.equal(moraleTopicPresentation(-4).direction, "negative");
+  assert.notEqual(moraleTopicPresentation(1).color, moraleTopicPresentation(5).color);
+  assert.match(dialogueCss, /affinity-popover\.is-pinned/);
+  assert.match(source, /event\.key !== "Escape"/);
 });
 
 test("contextual mutations are bound to the active NPC, path, session, revision, and operation", () => {

--- a/crates/strategic-web/tests/dialogue-client.test.cjs
+++ b/crates/strategic-web/tests/dialogue-client.test.cjs
@@ -163,7 +163,7 @@ test("socializing and romance are dialogue responses with a qualitative regard f
   assert.deepEqual(courtshipPresentation("informal", true), { icon: "eye-target", label: "informal courtship; known to family" });
   assert.match(source, /dataset\.dialogueContextPrompt/);
   assert.match(source, /appendContextExchange/);
-  assert.match(source, /data\.npcAffinityFace/);
+  assert.match(source, /face\.dataset\.npcAffinityFace/);
   assert.match(source, /requested_minutes: choice\.minutes/);
   assert.match(source, /ask under Of Thee for more/);
   assert.match(source, /currentView\.open_prompt \|\| contextualMutation/);
@@ -181,6 +181,24 @@ test("morale topics and affinity faces combine color with accessible qualitative
   assert.notEqual(moraleTopicPresentation(1).color, moraleTopicPresentation(5).color);
   assert.match(dialogueCss, /affinity-popover\.is-pinned/);
   assert.match(source, /event\.key !== "Escape"/);
+  assert.match(source, /is-closing/);
+  assert.match(dialogueCss, /is-closing \.affinity-details/);
+});
+
+test("NPC switches clear subject-bound social state before asynchronous refresh", () => {
+  const selectNpc = source.slice(source.indexOf("const selectNpc"), source.indexOf("const loadPeople"));
+  assert.match(selectNpc, /currentSocial = null/);
+  assert.match(selectNpc, /data-npc-affinity-popover/);
+  assert.match(selectNpc, /data-dialogue-category-panel/);
+  assert.match(selectNpc, /Loading this person's conversation/);
+  assert.match(source, /button\.dataset\.socialRevision !== currentSocial\?\.social_revision/);
+  assert.match(source, /button\.dataset\.socialSubject !== chat\.dataset\.localChatSubject/);
+});
+
+test("party portrait chat deep-loads the authorized social dock into the functional stream", () => {
+  assert.match(source, /dockChat\.dataset\.partySocialHref/);
+  assert.match(source, /querySelector\("\[data-social-conversation\]"\)/);
+  assert.match(source, /dockChat\.replaceWith\(replacement\)/);
 });
 
 test("contextual mutations are bound to the active NPC, path, session, revision, and operation", () => {

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -588,13 +588,14 @@ Start the isolated strategic stack with the guarded visual fixtures:
 just web-isolated-strategic social-demo 23100
 ```
 
-Select **Social Demo**, open **Greta the Guard**, and press the raised Social
-icon beside the Morale meter.
+Select **Social Demo**, open **Greta the Guard**, and open their conversation
+from the portrait action. Use **Recent Tidings** for morale concerns and
+**Of Thee** for observer-safe questions about Greta.
 The fixture includes defeat and injury penalties, established Familiarity,
 positive Affinity, exact multi-valued observer beliefs, presentation, and one
 deliberately incorrect perceived sensitivity. Greta professes Lutheranism, and
 Social Demo has direct Lutheran study plus correlated Catholic knowledge, so
-the themed Prayer response is immediately usable. The Social rail shows
+the themed Prayer response is immediately usable. The conversation dock offers
 Insight, Charm, Command, Deception, and target-specific Religion; Lighten Mood
 and Flirt are distinct Charm
 approaches, and repeated supported observations demonstrate the

--- a/wiki/reference/dialogue.md
+++ b/wiki/reference/dialogue.md
@@ -266,6 +266,16 @@ matches its choices, shows a unique prefix as grey inline completion, and lets
 Tab accept it. Multi-select answers use comma-separated choice labels. Other
 text continues through the independent free-form chat stream.
 
+Of Thee answers are server-authored observer-safe projections bound to the
+selected subject and projection revision. They are appended as transient
+contextual exchanges in the same visible message stream and are not durable
+free-form chat history. Switching subjects clears them before the next request;
+late responses cannot be attributed to the newly selected person. Party
+portraits retain ordinary profile selection, while choosing Recent Tidings
+deep-loads that subject's authorized social projection into the same functional
+chat dock. Self-selection disables free-form posting and exposes reflection in
+Recent Tidings.
+
 ## Developer mode and source editing
 
 The hammer button immediately left of the character portrait toggles developer

--- a/wiki/reference/dialogue.md
+++ b/wiki/reference/dialogue.md
@@ -254,9 +254,14 @@ nonmembers see joining, suspended members see dues only where dues exist, and
 current members can follow a gated chain through dues, promotion, and
 presentation without seeing actions unavailable in their current state.
 
-The web conversation surface exposes topics only as highlighted phrases in
-NPC dialogue. Clicking one asks about that subject; there is no separate list
-of generic or undiscovered topics. While a prompt is open, the shared composer
+The web conversation surface exposes discovered topics both as highlighted
+phrases in NPC dialogue and in four icon tabs: **Quests**, **Lore**, **Recent
+Tidings**, and **Of Thee**. Each compiled topic carries a typed presentation
+category; the browser never infers it from an ID. The tab list is built only
+from owner-scoped authoritative topic-option rows, so it cannot reveal an
+undiscovered topic. Recent Tidings is privacy-safe for residents when detailed
+source authorization is absent, while Of Thee expresses qualitative
+relationship state as spoken questions and answers. While a prompt is open, the shared composer
 matches its choices, shows a unique prefix as grey inline completion, and lets
 Tab accept it. Multi-select answers use comma-separated choice labels. Other
 text continues through the independent free-form chat stream.

--- a/wiki/shared/morale.md
+++ b/wiki/shared/morale.md
@@ -7,10 +7,10 @@ separate consequence: a successful approach can release bound testimony, while
 a benign concern yields only clarification. This separation prevents morale or
 affinity results from becoming a hidden-truth oracle.
 
-The character-sheet morale meter is informational. A raised Social meta-skill
-icon beside its heading opens the observer-specific morale sources, beliefs,
-and available social actions in a modal dialog without replacing either
-character rail. The icon remains inset while that dialog is open; the privacy
+The character-sheet morale meter is informational. Its conversation icon opens
+the selected character's **Recent Tidings** in the shared Conversation Dock,
+with observer-specific morale sources, beliefs, and available social actions.
+The privacy
 boundary remains the active observer's beliefs rather than authoritative
 personality state. Manual response buttons show a response-specific icon and
 short label; hovering the icon explains the contextual approach, skill, and
@@ -173,7 +173,7 @@ It is therefore an explanation of the current net morale, like a treated
 injury segment, rather than extra morale. Color, striping, and meter text all
 identify the segment.
 
-Each negative morale point produces one percentage point of fear incapacitation, so -100 morale is the meaningful left endpoint of the meter. The center represents neutral morale. The right side shows the character's allocated share of the party's current ally-restoration percentage relative to the party's present `5% × aggregate Command` limit. Selecting the meter opens the dedicated social panel and source actions.
+Each negative morale point produces one percentage point of fear incapacitation, so -100 morale is the meaningful left endpoint of the meter. The center represents neutral morale. The right side shows the character's allocated share of the party's current ally-restoration percentage relative to the party's present `5% × aggregate Command` limit. Selecting the meter opens Recent Tidings and its source actions. Every current source remains a distinct card. Signed, accessibly worded strength accompanies a yellow neutral color that moves toward green for increasingly positive values and toward red for increasingly negative values. Positive and neutral sources are read-only.
 
 The strategic condition and morale-source tables are refreshable projections.
 Durable state includes private personality scores and immutable development
@@ -243,7 +243,7 @@ The incident temporarily occupies the party's active-encounter slot while preser
 
 Morale sources are not dialogue memories. Each source has a closed topic such
 as defeat, injury, fatigue, hunger, faith, or filth. The character page's
-Morale meter opens a social panel where a party member can listen, commiserate,
+The morale meter opens Recent Tidings where a party member can listen, commiserate,
 use humor, rally with Command, offer a deceptive reframe, or flirt. Labels are
 generic and grounded in the durable source; the game does not invent incidental
 details about a battle or conversation.

--- a/wiki/strategic/character.md
+++ b/wiki/strategic/character.md
@@ -48,7 +48,12 @@ after they separate.
 
 Relationship systems distinguish **pairwise-soft** history from canonical,
 exclusive history. Affinity, familiarity, and ordinary Socializing are
-pairwise-soft: they may be updated on the acting character's clock and never
+presented in the Conversation Dock rather than a separate Social modal. The
+header's qualitative regard face opens an observer-only impression containing
+familiarity, perceived traits, confidence, and approach hints; it can be pinned
+for pointer or keyboard inspection. Self-selection omits the chat composer and
+uses Recent Tidings for reflection. Age, faith, fame, and infamy remain on the
+biography. These pairwise-soft values may be updated on the acting character's clock and never
 consume another character's schedule. A person who is engaged or married can
 therefore still become a close friend of somebody whose personal date is in
 their past. The resulting friendship does not create romantic eligibility.

--- a/wiki/strategic/character.md
+++ b/wiki/strategic/character.md
@@ -52,8 +52,9 @@ presented in the Conversation Dock rather than a separate Social modal. The
 header's qualitative regard face opens an observer-only impression containing
 familiarity, perceived traits, confidence, and approach hints; it can be pinned
 for pointer or keyboard inspection. Self-selection omits the chat composer and
-uses Recent Tidings for reflection. Age, faith, fame, and infamy remain on the
-biography. These pairwise-soft values may be updated on the acting character's clock and never
+uses Recent Tidings for reflection. Age, faith, and local reputation remain on
+the biography and are also expressed naturally as questions and answers under
+Of Thee. These pairwise-soft values may be updated on the acting character's clock and never
 consume another character's schedule. A person who is engaged or married can
 therefore still become a close friend of somebody whose personal date is in
 their past. The resulting friendship does not create romantic eligibility.


### PR DESCRIPTION
## Summary
- unify quests, lore, recent tidings, and Of Thee topics in the conversation dock
- show morale strength and qualitative affinity with observer-safe, pinnable familiarity and trait details
- support self-reflection through the player portrait and express relationship/social state through period-appropriate dialogue
- keep private chat history owner-scoped and bounded with exact database-side subject filtering

## Verification
- cargo test -p strategic-web local_chat
- cargo test -p strategic-web dialogue
- cargo test -p adventuresim-dialogue
- Node client tests: 41 passed
- cargo check -p adventuresim-stdb-module -p strategic-web
- just verify-db-client
- just dialogue-check
- project map check and git diff --check
- live Playwright walkthrough at 1440x900 and 1024x768, including pinned affinity details, Of Thee dialogue, self Recent Tidings keyboard navigation, and NPC history retrieval

## Demo
The isolated local stack is running at http://127.0.0.1:23101.