### PR TITLE
Stabilize tactical locomotion facing and terrain IK

### DIFF
--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -19,7 +19,7 @@ mod procedural;
 #[allow(unused_imports)]
 pub(crate) use procedural::{
     BoneRole, HandIkTarget, HandSide, HeldWeaponConstraint, HumanoidBone, HumanoidIkTargets,
-    ProceduralIkState, gait_support_weights,
+    ProceduralAnimationClock, ProceduralIkState, gait_support_weights,
 };
 const HUMANOID_UNARMED_PACK: &str = "humanoid_unarmed";
 const BIPED_BASE_GLB: &str = "animations/biped/unarmed/base.glb";
@@ -47,6 +47,7 @@ impl Plugin for TacticalAnimationPlugin {
         app.init_resource::<AnimationPackCatalog>()
             .init_resource::<AnimationRuntime>()
             .init_resource::<TerrainIkEnabled>()
+            .init_resource::<ProceduralAnimationClock>()
             .add_systems(Startup, request_animation_packs)
             .add_observer(on_successful_attack)
             .add_systems(
@@ -75,7 +76,6 @@ impl Plugin for TacticalAnimationPlugin {
                 PostUpdate,
                 (
                     restore_authored_bind_pose,
-                    procedural::apply_locomotion_facing,
                     procedural::apply_gait_mirroring,
                     procedural::stabilize_locomotion_torso,
                     procedural::apply_head_and_torso_look,

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -183,32 +183,6 @@ pub(super) fn apply_head_and_torso_look(
     }
 }
 
-/// Turns ordinary locomotion toward travel while preserving look-relative
-/// facing for the guard-based attack and block actions. Runtime locomotion is
-/// expressed in the controller's -Z-forward frame, while the authored mesh is
-/// +Z-forward beneath a player root that already contains the half-turn.
-pub(super) fn apply_locomotion_facing(
-    owners: Query<&SkeletonState>,
-    mut rigs: Query<(&super::AnimationRigScene, &mut Transform)>,
-) {
-    for (rig, mut transform) in &mut rigs {
-        let Ok(skeleton) = owners.get(rig.0) else {
-            continue;
-        };
-        transform.rotation = locomotion_facing(skeleton.local_velocity, skeleton.action);
-    }
-}
-
-fn locomotion_facing(local_velocity: Vec3, action: SkeletonAction) -> Quat {
-    if matches!(action, SkeletonAction::Attack | SkeletonAction::Block) {
-        return Quat::IDENTITY;
-    }
-    let Some(direction) = local_velocity.xz().try_normalize() else {
-        return Quat::IDENTITY;
-    };
-    Quat::from_rotation_arc(Vec3::Z, -Vec3::new(direction.x, 0.0, direction.y)).normalize()
-}
-
 /// Constructs the opposite gait half-cycle for every bilateral limb chain.
 /// Gait mirroring transitions only around the authored passing pose, where the
 /// limbs are nearest neutral; interpolating throughout contact folds a planted
@@ -362,7 +336,7 @@ pub(super) fn stabilize_locomotion_torso(
             let flight = (skeleton.gait_phase.rem_euclid(1.0) * std::f32::consts::TAU)
                 .sin()
                 .abs();
-            transform.translation.y += 0.085 * run * flight;
+            transform.translation.y += 0.06 * run * flight;
         }
     }
 }
@@ -443,9 +417,43 @@ struct PoleMemory {
     right_leg: Option<Vec3>,
     left_foot_plant: Option<Vec3>,
     right_foot_plant: Option<Vec3>,
+    left_foot_target: Option<Vec3>,
+    right_foot_target: Option<Vec3>,
+    left_foot_world_target: Option<Vec3>,
+    right_foot_world_target: Option<Vec3>,
+    left_support_weight: Option<f32>,
+    right_support_weight: Option<f32>,
+    left_release_active: bool,
+    right_release_active: bool,
     left_arm: Option<Vec3>,
     right_arm: Option<Vec3>,
+    pelvis_shift: f32,
+    evaluation_tick: Option<u64>,
 }
+
+/// Optional deterministic clock for tools that render the same simulation
+/// tick more than once. Gameplay leaves the override unset and advances from
+/// Bevy's render delta.
+#[derive(Resource, Debug, Clone, Copy, Default)]
+pub(crate) struct ProceduralAnimationClock {
+    fixed_tick: Option<(u64, f32)>,
+}
+
+impl ProceduralAnimationClock {
+    pub(crate) fn set_fixed_tick(&mut self, tick: u64, delta_seconds: f32) {
+        self.fixed_tick = Some((tick, delta_seconds.max(0.0)));
+    }
+}
+
+const MIN_INTER_FOOT_SEPARATION: f32 = 0.16;
+const FOOT_TRACK_INNER: f32 = MIN_INTER_FOOT_SEPARATION * 0.5;
+const FOOT_TRACK_OUTER: f32 = 0.55;
+const MAX_PLANT_DISCONTINUITY: f32 = 2.0;
+const MAX_FOOT_TARGET_SPEED: f32 = 12.0;
+const MAX_FOOT_TARGET_STEP: f32 = 0.2;
+const PELVIS_CORRECTION_SPEED: f32 = 1.6;
+const MAX_PELVIS_CORRECTION_STEP: f32 = 0.05;
+const MIN_KNEE_FLEXION: f32 = 20.0_f32.to_radians();
 
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub(crate) struct ProceduralIkState(PoleMemory);
@@ -492,6 +500,8 @@ pub(crate) struct HeldWeaponConstraint {
 /// the same final-pose seam when authored held-item rigs arrive.
 pub(super) fn apply_terrain_leg_ik(
     enabled: Res<super::TerrainIkEnabled>,
+    time: Res<Time>,
+    clock: Res<ProceduralAnimationClock>,
     terrain: Query<&SceneTerrain>,
     owners: Query<&SkeletonState>,
     rig_scenes: Query<(Entity, &AnimationRigScene)>,
@@ -529,7 +539,10 @@ pub(super) fn apply_terrain_leg_ik(
         let Ok(skeleton) = owners.get(owner) else {
             continue;
         };
-        if !skeleton.grounded || matches!(skeleton.posture, Posture::Prone | Posture::Supine) {
+        if !skeleton.grounded || skeleton.posture != Posture::Upright {
+            if let Ok(mut state) = ik_states.get_mut(owner) {
+                state.0 = PoleMemory::default();
+            }
             continue;
         }
         let phase = skeleton.gait_phase.rem_euclid(1.0);
@@ -541,7 +554,6 @@ pub(super) fn apply_terrain_leg_ik(
                 BoneRole::ShinLeft,
                 BoneRole::FootLeft,
                 left_weight,
-                Vec3::Z,
                 true,
             ),
             (
@@ -549,25 +561,92 @@ pub(super) fn apply_terrain_leg_ik(
                 BoneRole::ShinRight,
                 BoneRole::FootRight,
                 right_weight,
-                Vec3::Z,
                 false,
             ),
         ];
-        let mut hip_shift = 0.0_f32;
-        for (_, _, foot_role, weight, _, _) in legs {
-            let Some(&foot) = rig.get(&foot_role) else {
-                continue;
-            };
-            let Ok(global) = transforms.p0().compute_global_transform(foot) else {
-                continue;
-            };
-            let position = global.translation();
-            if let Some(height) = terrain.height_at(position.xz()) {
-                let desired_ankle = height + ankle_sole_offset(global.rotation());
-                hip_shift =
-                    hip_shift.min(((desired_ankle - position.y) * weight).clamp(-0.18, 0.0));
+        let mut memory = ik_states
+            .get_mut(owner)
+            .map(|state| state.0)
+            .unwrap_or_default();
+        let state_delta_seconds = match clock.fixed_tick {
+            Some((tick, _)) if memory.evaluation_tick == Some(tick) => 0.0,
+            Some((tick, delta_seconds)) => {
+                memory.evaluation_tick = Some(tick);
+                delta_seconds
             }
+            None => time.delta_secs(),
+        };
+        // Pole, plant, and pelvis reach all belong to the server-owned
+        // authored-body frame. The child rig carries no locomotion yaw.
+        let (rig_origin, rig_rotation) = rig_scenes
+            .iter()
+            .find(|(_, scene)| scene.0 == owner)
+            .and_then(|(entity, _)| transforms.p0().compute_global_transform(entity).ok())
+            .map(|global| (global.translation(), global.rotation()))
+            .unwrap_or((Vec3::ZERO, Quat::IDENTITY));
+        let mut desired_hip_shift = 0.0_f32;
+        for (upper_role, lower_role, foot_role, weight, left) in legs {
+            let (Some(&upper), Some(&lower), Some(&foot)) = (
+                rig.get(&upper_role),
+                rig.get(&lower_role),
+                rig.get(&foot_role),
+            ) else {
+                continue;
+            };
+            let Some((upper_snapshot, lower_snapshot, foot_snapshot)) =
+                snapshot_chain(upper, lower, foot, &parents, &transforms.p0())
+            else {
+                continue;
+            };
+            let position = foot_snapshot.global.translation();
+            if let Some(height) = terrain.height_at(position.xz()) {
+                let desired_ankle = height + ankle_sole_offset(foot_snapshot.global.rotation());
+                desired_hip_shift = desired_hip_shift
+                    .min(((desired_ankle - position.y) * weight).clamp(-0.18, 0.0));
+            }
+            let plant = if left {
+                memory.left_foot_plant
+            } else {
+                memory.right_foot_plant
+            };
+            let Some(plant) = plant else { continue };
+            let side = anatomical_side(
+                rig_rotation,
+                rig_origin,
+                upper_snapshot.global.translation(),
+                left,
+            );
+            let horizontal_target = constrain_foot_to_track(plant, rig_origin, rig_rotation, side);
+            let Some(height) = terrain.height_at(horizontal_target.xz()) else {
+                continue;
+            };
+            let target_y = height + ankle_sole_offset(foot_snapshot.global.rotation());
+            let upper_length = upper_snapshot
+                .global
+                .translation()
+                .distance(lower_snapshot.global.translation());
+            let lower_length = lower_snapshot
+                .global
+                .translation()
+                .distance(foot_snapshot.global.translation());
+            let reach = maximum_reach(upper_length, lower_length);
+            let horizontal_distance = (horizontal_target - upper_snapshot.global.translation())
+                .xz()
+                .length();
+            let maximum_vertical = (reach * reach - horizontal_distance * horizontal_distance)
+                .max(0.0)
+                .sqrt();
+            let reach_shift = target_y + maximum_vertical - upper_snapshot.global.translation().y;
+            desired_hip_shift = desired_hip_shift.min((reach_shift * weight).clamp(-0.25, 0.0));
         }
+        // Couple both legs through one bounded, continuous pelvis correction.
+        // The authored pose is restored each frame, so this retained scalar is
+        // the only temporal state and cannot accumulate transform drift.
+        if state_delta_seconds > 0.0 {
+            memory.pelvis_shift =
+                advance_pelvis_shift(memory.pelvis_shift, desired_hip_shift, state_delta_seconds);
+        }
+        let hip_shift = memory.pelvis_shift;
         if hip_shift < -0.001
             && let Some(&pelvis) = rig.get(&BoneRole::Pelvis)
         {
@@ -593,21 +672,7 @@ pub(super) fn apply_terrain_leg_ik(
                 transform.translation += local_delta;
             }
         }
-        // Pole memory belongs to the animated rig's facing frame, not the
-        // gameplay owner/look frame. Ordinary locomotion rotates the child rig
-        // toward travel, so owner-relative poles bend sideways during strafing
-        // and backwards during reversal.
-        let rig_rotation = rig_scenes
-            .iter()
-            .find(|(_, scene)| scene.0 == owner)
-            .and_then(|(entity, _)| transforms.p0().compute_global_transform(entity).ok())
-            .map(|global| global.rotation())
-            .unwrap_or(Quat::IDENTITY);
-        let mut memory = ik_states
-            .get_mut(owner)
-            .map(|state| state.0)
-            .unwrap_or_default();
-        for (upper_role, lower_role, foot_role, weight, owner_pole, left) in legs {
+        for (upper_role, lower_role, foot_role, weight, left) in legs {
             let (Some(&upper), Some(&lower), Some(&foot)) = (
                 rig.get(&upper_role),
                 rig.get(&lower_role),
@@ -621,47 +686,162 @@ pub(super) fn apply_terrain_leg_ik(
                 continue;
             };
             let foot_position = foot_snapshot.global.translation();
-            let plant = if left {
-                &mut memory.left_foot_plant
+            let mut plant = if left {
+                memory.left_foot_plant
             } else {
-                &mut memory.right_foot_plant
+                memory.right_foot_plant
             };
-            // Keep the world-space plant through the support interval. The
-            // analytic solver already clamps unreachable targets; dropping a
-            // plant at a fixed distance repins it to the authored swing pose
-            // in one frame and produces a visible kick/pop. Retain only a
-            // broad teleport guard for genuinely discontinuous owner motion.
+            let side = anatomical_side(
+                rig_rotation,
+                rig_origin,
+                upper_snapshot.global.translation(),
+                left,
+            );
+            let upper_length = upper_snapshot
+                .global
+                .translation()
+                .distance(lower_snapshot.global.translation());
+            let lower_length = lower_snapshot.global.translation().distance(foot_position);
             if weight <= 0.05
-                || plant.is_some_and(|position| position.distance(foot_position) > 2.0)
+                || plant.is_some_and(|position| !plant_is_continuous(position, foot_position))
             {
-                *plant = None;
+                plant = None;
             }
-            if weight >= 0.55 && plant.is_none() {
-                *plant = Some(foot_position);
+            // Do not memorize a footprint while the swing foot is merely
+            // approaching the ground. Capturing that stale position early
+            // makes the pelvis outrun it, forcing the reach limiter to drag a
+            // fully weighted foot and drive the knee toward extension.
+            if weight >= 0.95 && plant.is_none() {
+                let visible_contact = if left {
+                    memory.left_foot_world_target
+                } else {
+                    memory.right_foot_world_target
+                }
+                .unwrap_or(foot_position);
+                plant = Some(constrain_foot_to_track(
+                    visible_contact,
+                    rig_origin,
+                    rig_rotation,
+                    side,
+                ));
             }
-            let horizontal_target = plant.unwrap_or(foot_position);
+            let mut horizontal_target = constrain_foot_to_track(
+                plant.unwrap_or(foot_position),
+                rig_origin,
+                rig_rotation,
+                side,
+            );
             let Some(height) = terrain.height_at(horizontal_target.xz()) else {
                 continue;
             };
-            let desired_y = height + ankle_sole_offset(foot_snapshot.global.rotation());
-            let planted_target = Vec3::new(horizontal_target.x, desired_y, horizontal_target.z);
-            let target = foot_position.lerp(planted_target, weight);
+            let sole_offset = ankle_sole_offset(foot_snapshot.global.rotation());
+            let mut planted_target = Vec3::new(
+                horizontal_target.x,
+                height + sole_offset,
+                horizontal_target.z,
+            );
+            // A turning or advancing pelvis can make an otherwise valid plant
+            // unreachable before its support weight releases. Slide that
+            // target only as far as anatomical reach requires instead of
+            // dropping and reacquiring it in one frame. Re-store the adjusted
+            // target so successive turns follow the side corridor continuously.
+            planted_target = constrain_target_to_reach(
+                planted_target,
+                upper_snapshot.global.translation(),
+                maximum_reach(upper_length, lower_length),
+            );
+            horizontal_target.x = planted_target.x;
+            horizontal_target.z = planted_target.z;
+            plant = plant.map(|_| horizontal_target);
+            if left {
+                memory.left_foot_plant = plant;
+            } else {
+                memory.right_foot_plant = plant;
+            }
+            // Sparse authored locomotion poses can move the swing foot much
+            // farther than one rendered frame should permit when support is
+            // released. Follow that desired pose at a bounded velocity so the
+            // final IK target cannot teleport, while still converging all the
+            // way back to the unconstrained authored swing during flight.
+            let mut desired_target = foot_position.lerp(planted_target, weight);
+            // An unloaded sparse swing pose can dip below uneven terrain,
+            // especially when the forward gait is reused in reverse. Preserve
+            // exact stance contact while giving the free foot a small
+            // support-weighted clearance floor.
+            desired_target.y = desired_target
+                .y
+                .max(planted_target.y + 0.05 * (1.0 - weight));
+            let desired_owner_target = rig_rotation.inverse() * (desired_target - rig_origin);
+            let (previous_owner_target, previous_support, mut release_active) = if left {
+                (
+                    memory.left_foot_target,
+                    memory.left_support_weight,
+                    memory.left_release_active,
+                )
+            } else {
+                (
+                    memory.right_foot_target,
+                    memory.right_support_weight,
+                    memory.right_release_active,
+                )
+            };
+            if let Some(previous_support) = previous_support {
+                if weight + 0.001 < previous_support {
+                    release_active = true;
+                } else if weight > previous_support + 0.001 {
+                    // Contact acquisition should lock immediately. The long
+                    // swing interval has already brought the authored foot
+                    // close to its next plant, and filtering acquisition is
+                    // perceived as skating under load.
+                    release_active = false;
+                }
+            }
+            let owner_target = if release_active {
+                advance_foot_target(
+                    previous_owner_target,
+                    desired_owner_target,
+                    state_delta_seconds,
+                )
+            } else {
+                desired_owner_target
+            };
+            if owner_target.distance_squared(desired_owner_target) <= 0.000001 {
+                release_active = false;
+            }
+            if left {
+                memory.left_foot_target = Some(owner_target);
+                if state_delta_seconds > 0.0 || memory.left_support_weight.is_none() {
+                    memory.left_support_weight = Some(weight);
+                }
+                memory.left_release_active = release_active;
+            } else {
+                memory.right_foot_target = Some(owner_target);
+                if state_delta_seconds > 0.0 || memory.right_support_weight.is_none() {
+                    memory.right_support_weight = Some(weight);
+                }
+                memory.right_release_active = release_active;
+            }
+            let target = rig_origin + rig_rotation * owner_target;
+            if left {
+                memory.left_foot_world_target = Some(target);
+            } else {
+                memory.right_foot_world_target = Some(target);
+            }
             let remembered = if left {
                 memory.left_leg
             } else {
                 memory.right_leg
             };
-            let pole = pole_to_world(rig_rotation, remembered.unwrap_or(owner_pole));
+            let canonical_pole = canonical_knee_pole(side);
+            let remembered = remembered.filter(|pole| pole.dot(canonical_pole) > 0.2);
+            let pole = pole_to_world(rig_rotation, remembered.unwrap_or(canonical_pole));
             if let Some(solution) = solve_two_bone(
                 upper_snapshot.global.translation(),
                 lower_snapshot.global.translation(),
                 foot_position,
                 target,
-                upper_snapshot
-                    .global
-                    .translation()
-                    .distance(lower_snapshot.global.translation()),
-                lower_snapshot.global.translation().distance(foot_position),
+                upper_length,
+                lower_length,
                 pole,
             ) {
                 apply_two_bone_solution(upper, lower, foot, solution, &parents, &mut transforms);
@@ -735,6 +915,70 @@ fn ankle_sole_offset(_rotation: Quat) -> f32 {
     0.085
 }
 
+fn anatomical_side(rig_rotation: Quat, rig_origin: Vec3, hip: Vec3, left: bool) -> f32 {
+    let hip_x = (rig_rotation.inverse() * (hip - rig_origin)).x;
+    if hip_x.abs() > 0.001 {
+        hip_x.signum()
+    } else if left {
+        -1.0
+    } else {
+        1.0
+    }
+}
+
+fn constrain_foot_to_track(world: Vec3, rig_origin: Vec3, rig_rotation: Quat, side: f32) -> Vec3 {
+    let mut local = rig_rotation.inverse() * (world - rig_origin);
+    let signed_x = (local.x * side).clamp(FOOT_TRACK_INNER, FOOT_TRACK_OUTER);
+    local.x = signed_x * side;
+    rig_origin + rig_rotation * local
+}
+
+fn maximum_reach(upper_length: f32, lower_length: f32) -> f32 {
+    (upper_length * upper_length
+        + lower_length * lower_length
+        + 2.0 * upper_length * lower_length * MIN_KNEE_FLEXION.cos())
+    .sqrt()
+}
+
+fn constrain_target_to_reach(target: Vec3, root: Vec3, maximum_reach: f32) -> Vec3 {
+    let vertical = target.y - root.y;
+    let maximum_horizontal = (maximum_reach * maximum_reach - vertical * vertical)
+        .max(0.0)
+        .sqrt();
+    let horizontal = (target - root).xz().clamp_length_max(maximum_horizontal);
+    Vec3::new(root.x + horizontal.x, target.y, root.z + horizontal.y)
+}
+
+fn plant_is_continuous(plant: Vec3, current_foot: Vec3) -> bool {
+    plant.is_finite()
+        && current_foot.is_finite()
+        && plant.distance(current_foot) <= MAX_PLANT_DISCONTINUITY
+}
+
+fn advance_foot_target(previous: Option<Vec3>, desired: Vec3, delta_seconds: f32) -> Vec3 {
+    let Some(previous) = previous.filter(|position| position.is_finite()) else {
+        return desired;
+    };
+    if !desired.is_finite() {
+        return previous;
+    }
+    if previous.distance(desired) > MAX_PLANT_DISCONTINUITY {
+        return desired;
+    }
+    let maximum_step = (MAX_FOOT_TARGET_SPEED * delta_seconds.max(0.0)).min(MAX_FOOT_TARGET_STEP);
+    previous + (desired - previous).clamp_length_max(maximum_step)
+}
+
+fn advance_pelvis_shift(current: f32, desired: f32, delta_seconds: f32) -> f32 {
+    let maximum_step =
+        (PELVIS_CORRECTION_SPEED * delta_seconds.max(0.0)).min(MAX_PELVIS_CORRECTION_STEP);
+    current + (desired - current).clamp(-maximum_step, maximum_step)
+}
+
+fn canonical_knee_pole(side: f32) -> Vec3 {
+    (Vec3::Z + Vec3::X * side * 0.18).normalize()
+}
+
 #[derive(Debug, Clone, Copy)]
 struct TwoBoneSolution {
     knee: Vec3,
@@ -762,7 +1006,7 @@ fn solve_two_bone(
         .unwrap_or(Vec3::NEG_Y);
     let distance = target_offset.length().clamp(
         (upper_length - lower_length).abs() + 0.0001,
-        upper_length + lower_length - 0.0001,
+        maximum_reach(upper_length, lower_length),
     );
     let end = root + target_direction * distance;
     let along = (upper_length * upper_length - lower_length * lower_length + distance * distance)
@@ -776,15 +1020,17 @@ fn solve_two_bone(
     let authored_bend = (current_knee - root)
         .reject_from_normalized(target_direction)
         .try_normalize();
-    // Preserve a strong authored bend inside the intended pole hemisphere,
-    // but fade continuously to the stable pole as the leg straightens. A hard
-    // hemisphere cutoff makes the knee pop when the projected authored bend
-    // crosses that cutoff during support release.
+    // Preserve authored continuity only while it remains in the anatomical
+    // hemisphere. Never flip a valid authored bend through a straight-leg
+    // singularity merely to satisfy a pole chosen on the opposite side.
     let stabilized_authored_bend = authored_bend.zip(pole_bend).and_then(|(authored, pole)| {
         let alignment = authored.dot(pole);
-        let aligned = if alignment < 0.0 { -authored } else { authored };
-        pole.lerp(aligned, smoothstep(0.05, 0.5, alignment.abs()))
-            .try_normalize()
+        (alignment > 0.05)
+            .then(|| {
+                pole.lerp(authored, smoothstep(0.05, 0.5, alignment))
+                    .try_normalize()
+            })
+            .flatten()
     });
     let bend = stabilized_authored_bend
         .or(pole_bend)
@@ -1415,15 +1661,81 @@ mod tests {
     }
 
     #[test]
-    fn locomotion_faces_travel_but_guard_actions_keep_authored_facing() {
-        let forward = locomotion_facing(Vec3::NEG_Z * 2.0, SkeletonAction::None);
-        assert!(forward.abs_diff_eq(Quat::IDENTITY, 0.0001));
+    fn foot_tracks_prevent_crossing_and_keep_minimum_separation() {
+        let rotation = Quat::from_rotation_y(0.6);
+        let origin = Vec3::new(2.0, 0.0, -3.0);
+        let left = constrain_foot_to_track(origin, origin, rotation, -1.0);
+        let right = constrain_foot_to_track(origin, origin, rotation, 1.0);
+        let left_local = rotation.inverse() * (left - origin);
+        let right_local = rotation.inverse() * (right - origin);
+        assert!(left_local.x < 0.0 && right_local.x > 0.0);
+        assert!(right_local.x - left_local.x >= MIN_INTER_FOOT_SEPARATION - 0.0001);
+    }
 
-        let right = locomotion_facing(Vec3::X * 2.0, SkeletonAction::None);
-        assert!((right * Vec3::Z).abs_diff_eq(Vec3::NEG_X, 0.0001));
+    #[test]
+    fn plant_releases_only_on_a_real_discontinuity_and_reach_slides_continuously() {
+        let foot = Vec3::new(-0.2, -1.8, 0.0);
+        assert!(plant_is_continuous(foot, foot));
+        assert!(!plant_is_continuous(Vec3::NAN, foot));
+        assert!(!plant_is_continuous(foot + Vec3::X * 2.1, foot));
 
-        let guarded = locomotion_facing(Vec3::X * 2.0, SkeletonAction::Block);
-        assert!(guarded.abs_diff_eq(Quat::IDENTITY, 0.0001));
+        let root = Vec3::Y;
+        let target = Vec3::new(-0.2, 0.0, 3.0);
+        let constrained = constrain_target_to_reach(target, root, 1.5);
+        assert!(constrained.distance(root) <= 1.5001);
+        assert_eq!(constrained.y, target.y);
+    }
+
+    #[test]
+    fn sparse_swing_targets_advance_at_a_bounded_speed() {
+        let previous = Vec3::ZERO;
+        let desired = Vec3::X;
+        let advanced = advance_foot_target(Some(previous), desired, 1.0 / 64.0);
+        assert!((advanced.length() - 0.1875).abs() < 0.0001);
+        let hitch_advanced = advance_foot_target(Some(previous), desired, 1.0);
+        assert!((hitch_advanced.length() - MAX_FOOT_TARGET_STEP).abs() < 0.0001);
+        assert_eq!(advance_foot_target(None, desired, 1.0 / 64.0), desired);
+        assert_eq!(
+            advance_foot_target(Some(previous), Vec3::NAN, 1.0 / 64.0),
+            previous
+        );
+    }
+
+    #[test]
+    fn pelvis_smoothing_depends_on_elapsed_time_not_evaluation_count() {
+        fn simulate(step_seconds: f32, evaluations: usize) -> f32 {
+            (0..evaluations).fold(0.0, |current, _| {
+                advance_pelvis_shift(current, -1.0, step_seconds)
+            })
+        }
+
+        let at_64_hz = simulate(1.0 / 64.0, 16);
+        let at_128_hz = simulate(1.0 / 128.0, 32);
+        assert!((at_64_hz - at_128_hz).abs() < 0.0001);
+        assert!((at_64_hz + 0.4).abs() < 0.0001);
+
+        let after_hitch = advance_pelvis_shift(0.0, -1.0, 1.0);
+        assert!((after_hitch + MAX_PELVIS_CORRECTION_STEP).abs() < 0.0001);
+    }
+
+    #[test]
+    fn leg_solver_keeps_minimum_flexion_and_anatomical_hemisphere() {
+        let pole = canonical_knee_pole(-1.0);
+        let solved = solve_two_bone(
+            Vec3::ZERO,
+            Vec3::new(0.0, -1.0, -0.1),
+            Vec3::NEG_Y * 2.0,
+            Vec3::NEG_Y * 20.0,
+            1.0,
+            1.0,
+            pole,
+        )
+        .unwrap();
+        assert!(solved.end.length() <= maximum_reach(1.0, 1.0) + 0.0001);
+        let bend = (solved.knee)
+            .reject_from_normalized(solved.end_direction)
+            .normalize();
+        assert!(bend.dot(pole) > 0.0);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -19,8 +19,8 @@ use bevy::{
 use serde::Serialize;
 
 use crate::animation::{
-    AnimationPlayback, BoneRole, HumanoidBone, ProceduralIkState, TacticalAnimationPlugin,
-    gait_support_weights,
+    AnimationPlayback, BoneRole, HumanoidBone, ProceduralAnimationClock, ProceduralIkState,
+    TacticalAnimationPlugin, gait_support_weights,
 };
 use crate::{
     camera::{CameraMode, TacticalCameraPlugin, TacticalCameraSet, third_person_offset},
@@ -150,6 +150,9 @@ struct PlannedFrame {
     speed: f32,
     time_seconds: f32,
     local_direction: Vec2,
+    camera_yaw: f32,
+    camera_pitch: f32,
+    action: SkeletonAction,
 }
 
 #[derive(Resource)]
@@ -260,6 +263,14 @@ struct ScenarioMetrics {
     pelvis_vertical_range_metres: f32,
     head_vertical_range_metres: f32,
     minimum_knee_forward_bend_metres: f32,
+    minimum_signed_foot_track_metres: f32,
+    minimum_inter_foot_separation_metres: f32,
+    minimum_knee_flexion_degrees: f32,
+    minimum_knee_hemisphere_dot: f32,
+    maximum_facing_motion_error_degrees: f32,
+    maximum_facing_tracking_excess_degrees: f32,
+    maximum_guard_facing_error_degrees: f32,
+    final_facing_motion_error_degrees: f32,
     maximum_supported_foot_slip_metres_per_frame: f32,
     maximum_planted_foot_drift_metres: f32,
     minimum_foot_clearance_metres: f32,
@@ -283,6 +294,10 @@ struct FrameSample {
     root_distance_metres: f32,
     root_position_metres: [f32; 3],
     world_travel_direction: [f32; 3],
+    desired_body_forward_direction: [f32; 3],
+    body_forward_direction: [f32; 3],
+    body_rotation_xyzw: [f32; 4],
+    guard_action: bool,
     left_support_weight: f32,
     right_support_weight: f32,
     screenshots: BTreeMap<String, String>,
@@ -324,6 +339,9 @@ fn steady_scenario_in_direction(
             speed,
             time_seconds: scenario_frame as f32 / SAMPLE_HZ,
             local_direction,
+            camera_yaw: 0.0,
+            camera_pitch: 0.0,
+            action: SkeletonAction::None,
         })
         .collect()
 }
@@ -353,6 +371,9 @@ fn transition_scenario() -> Vec<PlannedFrame> {
                 speed,
                 time_seconds: t,
                 local_direction: Vec2::NEG_Y,
+                camera_yaw: 0.0,
+                camera_pitch: 0.0,
+                action: SkeletonAction::None,
             }
         })
         .collect()
@@ -370,11 +391,57 @@ fn capture_plan() -> Vec<PlannedFrame> {
         steady_scenario("steady-run-5.5", 5.5, 2.0),
         steady_scenario_in_direction("lateral-walk-2.0", 2.0, 1.0, Vec2::X),
         steady_scenario_in_direction("reverse-walk-2.0", 2.0, 1.0, Vec2::Y),
+        turning_scenario("gradual-camera-turn", false),
+        turning_scenario("half-turn-reversal", true),
+        guard_plant_turn_scenario(),
+        steady_scenario_in_direction("cross-slope-walk", 2.0, 1.0, Vec2::X),
         transition_scenario(),
     ]
     .into_iter()
     .flatten()
     .collect()
+}
+
+fn turning_scenario(name: &'static str, reversal: bool) -> Vec<PlannedFrame> {
+    (0..=64)
+        .map(|frame| {
+            let progress = frame as f32 / 64.0;
+            PlannedFrame {
+                scenario: name,
+                scenario_frame: frame,
+                speed: 2.0,
+                time_seconds: progress,
+                local_direction: Vec2::NEG_Y,
+                camera_yaw: if reversal && frame > 0 {
+                    std::f32::consts::PI
+                } else if reversal {
+                    0.0
+                } else {
+                    std::f32::consts::FRAC_PI_2 * progress
+                },
+                camera_pitch: 0.55 * progress,
+                action: SkeletonAction::None,
+            }
+        })
+        .collect()
+}
+
+fn guard_plant_turn_scenario() -> Vec<PlannedFrame> {
+    (0..=64)
+        .map(|frame| {
+            let progress = frame as f32 / 64.0;
+            PlannedFrame {
+                scenario: "planted-guard-turn",
+                scenario_frame: frame,
+                speed: 0.35,
+                time_seconds: progress,
+                local_direction: Vec2::X,
+                camera_yaw: std::f32::consts::FRAC_PI_2 * progress,
+                camera_pitch: 0.0,
+                action: SkeletonAction::Block,
+            }
+        })
+        .collect()
 }
 
 fn setup_viewer(mut commands: Commands) {
@@ -419,11 +486,13 @@ fn setup_viewer(mut commands: Commands) {
 
 fn drive_sequence(
     mut sequence: ResMut<CaptureSequence>,
+    mut procedural_clock: ResMut<ProceduralAnimationClock>,
     terrain: Single<&SceneTerrain>,
     mut subjects: Query<
         (
             &mut SkeletonState,
             &mut Transform,
+            &mut CharacterLook,
             Option<&AnimationPlayback>,
             Option<&mut ProceduralIkState>,
         ),
@@ -436,7 +505,7 @@ fn drive_sequence(
     }
     let frame = sequence.plan[sequence.index].clone();
     let mut gait_phase = 0.0;
-    for (mut skeleton, mut transform, playback, ik_state) in &mut subjects {
+    for (mut skeleton, mut transform, mut look, playback, ik_state) in &mut subjects {
         let Some(playback) = playback else {
             return;
         };
@@ -454,22 +523,40 @@ fn drive_sequence(
             }
             let ground = terrain.height_at(Vec2::ZERO).unwrap_or_default();
             transform.translation = Vec3::new(0.0, ground + 0.95, 0.0);
+            transform.rotation = Quat::from_rotation_y(std::f32::consts::PI);
         }
 
-        let orientation = Quat::from_rotation_y(std::f32::consts::PI);
+        let orientation =
+            Quat::from_euler(EulerRot::YXZ, frame.camera_yaw, frame.camera_pitch, 0.0);
+        look.yaw = frame.camera_yaw;
+        look.pitch = frame.camera_pitch;
         let local_velocity =
             Vec3::new(frame.local_direction.x, 0.0, frame.local_direction.y) * frame.speed;
-        let world_velocity = orientation * local_velocity;
+        let world_velocity = controller_yaw(orientation) * local_velocity;
         let delta_seconds = if frame.scenario_frame == 0 {
             0.0
         } else {
             sequence.simulation_tick += 1;
             1.0 / SAMPLE_HZ
         };
+        procedural_clock.set_fixed_tick(sequence.simulation_tick, delta_seconds);
         let horizontal = transform.translation.xz() + world_velocity.xz() * delta_seconds;
         let ground = terrain.height_at(horizontal).unwrap_or_default();
         transform.translation = Vec3::new(horizontal.x, ground + 0.95, horizontal.y);
-        transform.rotation = orientation;
+        if frame.action != SkeletonAction::None {
+            skeleton.begin_action(
+                frame.action,
+                sequence.simulation_tick,
+                sequence.simulation_tick + 64,
+            );
+        }
+        transform.rotation = advance_body_facing(
+            transform.rotation,
+            orientation,
+            world_velocity,
+            frame.action,
+            delta_seconds,
+        );
         sequence.scenario_distance += frame.speed * delta_seconds;
         project_skeleton_locomotion(
             &mut skeleton,
@@ -689,12 +776,24 @@ fn capture_frame(
             gait_phase: skeleton.gait_phase,
             root_distance_metres,
             root_position_metres: subject_global.translation().to_array(),
-            world_travel_direction: Vec3::new(
-                -frame.local_direction.x,
-                0.0,
-                -frame.local_direction.y,
-            )
+            world_travel_direction: (controller_yaw(Quat::from_rotation_y(frame.camera_yaw))
+                * Vec3::new(frame.local_direction.x, 0.0, frame.local_direction.y))
+            .normalize_or_zero()
             .to_array(),
+            desired_body_forward_direction: if matches!(
+                frame.action,
+                SkeletonAction::Attack | SkeletonAction::Block
+            ) {
+                (controller_yaw(Quat::from_rotation_y(frame.camera_yaw)) * Vec3::NEG_Z).to_array()
+            } else {
+                (controller_yaw(Quat::from_rotation_y(frame.camera_yaw))
+                    * Vec3::new(frame.local_direction.x, 0.0, frame.local_direction.y))
+                .normalize_or_zero()
+                .to_array()
+            },
+            body_forward_direction: (subject_global.rotation() * Vec3::Z).to_array(),
+            body_rotation_xyzw: subject_global.rotation().to_array(),
+            guard_action: matches!(frame.action, SkeletonAction::Attack | SkeletonAction::Block),
             left_support_weight,
             right_support_weight,
             screenshots: VIEWS
@@ -863,10 +962,15 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
     let biomechanics_within_review_bounds = scenarios.iter().all(|metrics| {
         metrics.maximum_supported_foot_slip_metres_per_frame <= 0.035
             && metrics.maximum_planted_foot_drift_metres <= 0.035
-            && metrics.minimum_knee_forward_bend_metres >= -0.08
+            && metrics.minimum_signed_foot_track_metres >= -0.01
+            && metrics.minimum_inter_foot_separation_metres >= 0.08
+            && metrics.minimum_knee_flexion_degrees >= 4.0
+            && metrics.minimum_knee_hemisphere_dot >= 0.0
+            && metrics.maximum_facing_tracking_excess_degrees <= 0.2
+            && metrics.final_facing_motion_error_degrees <= 3.0
             && metrics.pelvis_vertical_range_metres <= 0.20
             && metrics.head_vertical_range_metres <= 0.20
-            && if metrics.scenario == "start-stop-transition" {
+            && if !expects_loop_seam(&metrics.scenario) {
                 metrics.loop_seam_position_metres.is_none()
                     && metrics.loop_seam_rotation_degrees.is_none()
             } else {
@@ -943,16 +1047,16 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
             let mut worst_rotation = None;
             for pair in frames.windows(2) {
                 let (before, after) = (pair[0], pair[1]);
-                let root_delta = Vec3::from_array(after.root_position_metres)
-                    - Vec3::from_array(before.root_position_metres);
+                let body_turn = Quat::from_array(before.body_rotation_xyzw)
+                    .angle_between(Quat::from_array(after.body_rotation_xyzw))
+                    .to_degrees();
                 for (name, before_bone) in &before.bones {
                     let Some(after_bone) = after.bones.get(name) else {
                         continue;
                     };
-                    let displacement = (Vec3::from_array(after_bone.position)
-                        - Vec3::from_array(before_bone.position)
-                        - root_delta)
-                        .length();
+                    let displacement = body_local(after, name)
+                        .zip(body_local(before, name))
+                        .map_or(f32::INFINITY, |(after, before)| after.distance(before));
                     if displacement > maximum_step {
                         maximum_step = displacement;
                         worst_displacement = Some(ContinuityLocation {
@@ -962,8 +1066,8 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
                             value: displacement,
                         });
                     }
-                    let rotation = quat(after_bone)
-                        .angle_between(quat(before_bone))
+                    let rotation = body_local_rotation(after, after_bone)
+                        .angle_between(body_local_rotation(before, before_bone))
                         .to_degrees();
                     if rotation > maximum_rotation {
                         maximum_rotation = rotation;
@@ -985,7 +1089,11 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
                         before.right_support_weight.min(after.right_support_weight),
                     ),
                 ] {
+                    // A body turn deliberately slides an old world plant onto
+                    // its new anatomical side corridor. Treat that bounded
+                    // adaptation separately from skating under a stable body.
                     if support >= 0.9
+                        && body_turn <= 0.5
                         && let (Some(a), Some(b)) = (before.bones.get(foot), after.bones.get(foot))
                     {
                         maximum_slip = maximum_slip.max(
@@ -998,7 +1106,15 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
             }
             for (foot, left) in [("left_foot", true), ("right_foot", false)] {
                 let mut anchor = None;
+                let mut previous_body_rotation = None;
                 for frame in &frames {
+                    let body_rotation = Quat::from_array(frame.body_rotation_xyzw);
+                    if previous_body_rotation.is_some_and(|previous: Quat| {
+                        previous.angle_between(body_rotation).to_degrees() > 0.5
+                    }) {
+                        anchor = None;
+                    }
+                    previous_body_rotation = Some(body_rotation);
                     let support = if left {
                         frame.left_support_weight
                     } else {
@@ -1019,7 +1135,7 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
                     }
                 }
             }
-            let looped = scenario != "start-stop-transition";
+            let looped = expects_loop_seam(scenario);
             let (loop_position, loop_rotation) = if looped {
                 let seams = frames
                     .windows(2)
@@ -1049,6 +1165,14 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
                 pelvis_vertical_range_metres: root_relative_vertical_range(&frames, "pelvis"),
                 head_vertical_range_metres: root_relative_vertical_range(&frames, "head"),
                 minimum_knee_forward_bend_metres: minimum_knee_bend(&frames),
+                minimum_signed_foot_track_metres: minimum_signed_foot_track(&frames),
+                minimum_inter_foot_separation_metres: minimum_inter_foot_separation(&frames),
+                minimum_knee_flexion_degrees: minimum_knee_flexion(&frames),
+                minimum_knee_hemisphere_dot: minimum_knee_hemisphere(&frames),
+                maximum_facing_motion_error_degrees: maximum_facing_error(&frames),
+                maximum_facing_tracking_excess_degrees: maximum_facing_tracking_excess(&frames),
+                maximum_guard_facing_error_degrees: maximum_guard_facing_error(&frames),
+                final_facing_motion_error_degrees: final_facing_error(&frames),
                 maximum_supported_foot_slip_metres_per_frame: maximum_slip,
                 maximum_planted_foot_drift_metres: maximum_plant_drift,
                 minimum_foot_clearance_metres: minimum_foot_clearance(&frames),
@@ -1057,13 +1181,157 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
         .collect()
 }
 
+fn expects_loop_seam(scenario: &str) -> bool {
+    !matches!(
+        scenario,
+        "start-stop-transition"
+            | "gradual-camera-turn"
+            | "half-turn-reversal"
+            | "planted-guard-turn"
+    )
+}
+
 fn quat(bone: &BoneSample) -> Quat {
     Quat::from_array(bone.rotation_xyzw).normalize()
 }
 
+fn body_local(frame: &FrameSample, bone: &str) -> Option<Vec3> {
+    let world = Vec3::from_array(frame.bones.get(bone)?.position)
+        - Vec3::from_array(frame.root_position_metres);
+    Some(Quat::from_array(frame.body_rotation_xyzw).inverse() * world)
+}
+
+fn body_local_rotation(frame: &FrameSample, bone: &BoneSample) -> Quat {
+    Quat::from_array(frame.body_rotation_xyzw).inverse() * quat(bone)
+}
+
+fn minimum_signed_foot_track(frames: &[&FrameSample]) -> f32 {
+    frames
+        .iter()
+        .flat_map(|frame| {
+            [("left_hip", "left_foot"), ("right_hip", "right_foot")].map(|(hip, foot)| {
+                let side = body_local(frame, hip).map_or(1.0, |value| value.x.signum());
+                body_local(frame, foot).map_or(f32::INFINITY, |value| value.x * side)
+            })
+        })
+        .fold(f32::INFINITY, f32::min)
+}
+
+fn minimum_inter_foot_separation(frames: &[&FrameSample]) -> f32 {
+    frames
+        .iter()
+        .filter_map(|frame| {
+            Some((body_local(frame, "left_foot")?.x - body_local(frame, "right_foot")?.x).abs())
+        })
+        .fold(f32::INFINITY, f32::min)
+}
+
+fn minimum_knee_flexion(frames: &[&FrameSample]) -> f32 {
+    frames
+        .iter()
+        .flat_map(|frame| {
+            [
+                ("left_hip", "left_knee", "left_foot"),
+                ("right_hip", "right_knee", "right_foot"),
+            ]
+            .map(|(hip, knee, foot)| {
+                let (Some(hip), Some(knee), Some(foot)) = (
+                    body_local(frame, hip),
+                    body_local(frame, knee),
+                    body_local(frame, foot),
+                ) else {
+                    return f32::INFINITY;
+                };
+                180.0 - (hip - knee).angle_between(foot - knee).to_degrees()
+            })
+        })
+        .fold(f32::INFINITY, f32::min)
+}
+
+fn minimum_knee_hemisphere(frames: &[&FrameSample]) -> f32 {
+    frames
+        .iter()
+        .flat_map(|frame| {
+            [
+                ("left_hip", "left_knee", "left_foot"),
+                ("right_hip", "right_knee", "right_foot"),
+            ]
+            .map(|(hip, knee, foot)| {
+                let (Some(hip), Some(knee), Some(foot)) = (
+                    body_local(frame, hip),
+                    body_local(frame, knee),
+                    body_local(frame, foot),
+                ) else {
+                    return f32::INFINITY;
+                };
+                let Some(axis) = (foot - hip).try_normalize() else {
+                    return f32::INFINITY;
+                };
+                let Some(bend) = (knee - hip).reject_from_normalized(axis).try_normalize() else {
+                    return -1.0;
+                };
+                let side = hip.x.signum();
+                bend.dot((Vec3::Z + Vec3::X * side * 0.18).normalize())
+            })
+        })
+        .fold(f32::INFINITY, f32::min)
+}
+
+fn maximum_facing_error(frames: &[&FrameSample]) -> f32 {
+    frames
+        .iter()
+        .filter(|frame| frame.speed_metres_per_second > 0.05)
+        .map(|frame| {
+            Vec3::from_array(frame.body_forward_direction)
+                .angle_between(Vec3::from_array(frame.desired_body_forward_direction))
+                .to_degrees()
+        })
+        .fold(0.0, f32::max)
+}
+
+fn maximum_facing_tracking_excess(frames: &[&FrameSample]) -> f32 {
+    frames
+        .windows(2)
+        .filter(|pair| pair[1].speed_metres_per_second > 0.05)
+        .map(|pair| {
+            let before = Vec3::from_array(pair[0].body_forward_direction);
+            let actual = Vec3::from_array(pair[1].body_forward_direction);
+            let desired = Vec3::from_array(pair[1].desired_body_forward_direction);
+            let elapsed = (pair[1].time_seconds - pair[0].time_seconds).max(0.0);
+            let permitted_residual =
+                (before.angle_between(desired) - BODY_TURN_SPEED_RADIANS * elapsed).max(0.0);
+            (actual.angle_between(desired) - permitted_residual)
+                .abs()
+                .to_degrees()
+        })
+        .fold(0.0, f32::max)
+}
+
+fn maximum_guard_facing_error(frames: &[&FrameSample]) -> f32 {
+    frames
+        .iter()
+        .filter(|frame| frame.guard_action && frame.speed_metres_per_second > 0.05)
+        .map(|frame| {
+            Vec3::from_array(frame.body_forward_direction)
+                .angle_between(Vec3::from_array(frame.desired_body_forward_direction))
+                .to_degrees()
+        })
+        .fold(0.0, f32::max)
+}
+
+fn final_facing_error(frames: &[&FrameSample]) -> f32 {
+    frames
+        .iter()
+        .rev()
+        .find(|frame| frame.speed_metres_per_second > 0.05)
+        .map_or(0.0, |frame| {
+            Vec3::from_array(frame.body_forward_direction)
+                .angle_between(Vec3::from_array(frame.desired_body_forward_direction))
+                .to_degrees()
+        })
+}
+
 fn loop_seam(first: &FrameSample, last: &FrameSample) -> (f32, f32) {
-    let root_delta =
-        Vec3::from_array(last.root_position_metres) - Vec3::from_array(first.root_position_metres);
     first
         .bones
         .iter()
@@ -1080,10 +1348,15 @@ fn loop_seam(first: &FrameSample, last: &FrameSample) -> (f32, f32) {
             };
             (
                 metrics.0.max(
-                    (Vec3::from_array(b.position) - Vec3::from_array(a.position) - root_delta)
-                        .length(),
+                    body_local(last, name)
+                        .zip(body_local(first, name))
+                        .map_or(f32::INFINITY, |(last, first)| last.distance(first)),
                 ),
-                metrics.1.max(quat(a).angle_between(quat(b)).to_degrees()),
+                metrics.1.max(
+                    body_local_rotation(first, a)
+                        .angle_between(body_local_rotation(last, b))
+                        .to_degrees(),
+                ),
             )
         })
 }
@@ -1180,7 +1453,7 @@ fn review_html(manifest: &CaptureManifest) -> String {
                 })
             };
             format!(
-                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{:.4}</td><td>{:.4}</td><td>{:.4}</td></tr>",
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{:.4}</td><td>{:.4}</td><td>{:.4}</td><td>{:.4}</td><td>{:.2}</td><td>{:.3}</td><td>{:.2}</td><td>{:.2}</td><td>{:.2}</td><td>{:.2}</td><td>{:.4}</td></tr>",
                 scenario.scenario,
                 scenario.frame_count,
                 describe(&scenario.worst_displacement, "m"),
@@ -1189,6 +1462,14 @@ fn review_html(manifest: &CaptureManifest) -> String {
                 scenario.loop_seam_rotation_degrees.map_or("&mdash;".into(), |value| format!("{value:.2}")),
                 scenario.maximum_supported_foot_slip_metres_per_frame,
                 scenario.maximum_planted_foot_drift_metres,
+                scenario.minimum_signed_foot_track_metres,
+                scenario.minimum_inter_foot_separation_metres,
+                scenario.minimum_knee_flexion_degrees,
+                scenario.minimum_knee_hemisphere_dot,
+                scenario.maximum_facing_motion_error_degrees,
+                scenario.maximum_facing_tracking_excess_degrees,
+                scenario.maximum_guard_facing_error_degrees,
+                scenario.final_facing_motion_error_degrees,
                 scenario.minimum_foot_clearance_metres,
             )
         })
@@ -1202,7 +1483,7 @@ body{{font:15px system-ui;background:#111820;color:#e8eef5;margin:24px}}button,s
 <div>{scenario_buttons}</div><label>View <select id="view"><option value="gameplay">gameplay (raw)</option><option value="side">side diagnostic</option><option value="front">front diagnostic</option></select></label>
 <label>Playback <select id="rate"><option value="1">normal</option><option value="2">half speed</option><option value="4">quarter speed</option></select></label>
 <p id="telemetry"></p><img id="player"><div id="contact"></div>
-<table><thead><tr><th>scenario</th><th>frames</th><th>worst root-relative displacement</th><th>worst rotation</th><th>loop seam m</th><th>loop seam deg</th><th>supported slip m/frame</th><th>planted interval drift m</th><th>minimum terrain-relative foot clearance m</th></tr></thead><tbody>{metrics}</tbody></table>
+<table><thead><tr><th>scenario</th><th>frames</th><th>worst root-relative displacement</th><th>worst rotation</th><th>loop seam m</th><th>loop seam deg</th><th>supported slip m/frame</th><th>planted interval drift m</th><th>signed foot track m</th><th>inter-foot separation m</th><th>knee flexion deg</th><th>knee hemisphere dot</th><th>maximum facing error deg</th><th>tracking excess deg</th><th>guard facing error deg</th><th>final facing error deg</th><th>minimum terrain-relative foot clearance m</th></tr></thead><tbody>{metrics}</tbody></table>
 <script>const all={frame_json},scenarioNames={scenario_names_json};let scenario=scenarioNames[0]||"",i=0,timer;const player=document.querySelector('#player'),view=document.querySelector('#view'),rate=document.querySelector('#rate'),telemetry=document.querySelector('#telemetry');
 function frames(){{return all.filter(x=>x.scenario===scenario)}}function show(){{const list=frames(),f=list.length?list[i%list.length]:null;if(!f){{player.removeAttribute('src');telemetry.textContent='No completed capture frames';return}}player.src=f.screenshots[view.value];telemetry.textContent=`${{f.scenario}} frame ${{f.scenario_frame}} | ${{f.speed_metres_per_second.toFixed(2)}} m/s | phase ${{f.gait_phase.toFixed(3)}} | support L ${{f.left_support_weight.toFixed(2)}} R ${{f.right_support_weight.toFixed(2)}}`;}}
 function play(){{clearInterval(timer);timer=setInterval(()=>{{i=(i+1)%frames().length;show()}},1000/64*Number(rate.value))}}function contacts(){{const f=frames(),step=Math.max(1,Math.floor(f.length/12)),box=document.querySelector('#contact');box.innerHTML='';for(let n=0;n<f.length;n+=step){{let x=document.createElement('img');x.src=f[n].screenshots[view.value];x.title=`frame ${{f[n].scenario_frame}} phase ${{f[n].gait_phase.toFixed(3)}}`;box.appendChild(x)}}}}
@@ -1253,6 +1534,10 @@ mod tests {
             root_distance_metres: 0.0,
             root_position_metres: Vec3::ZERO.to_array(),
             world_travel_direction: Vec3::Z.to_array(),
+            desired_body_forward_direction: Vec3::Z.to_array(),
+            body_forward_direction: Vec3::Z.to_array(),
+            body_rotation_xyzw: Quat::IDENTITY.to_array(),
+            guard_action: false,
             left_support_weight: 1.0,
             right_support_weight: 1.0,
             screenshots,
@@ -1294,5 +1579,52 @@ mod tests {
             && frame.local_direction.is_finite()));
         assert_eq!(frames.first().unwrap().speed, 0.0);
         assert_eq!(frames.last().unwrap().speed, 0.0);
+    }
+
+    #[test]
+    fn manifest_metrics_detect_crossed_feet_and_facing_mismatch() {
+        let bone = |position: Vec3| BoneSample {
+            position: position.to_array(),
+            rotation_xyzw: Quat::IDENTITY.to_array(),
+            terrain_clearance_metres: Some(0.0),
+        };
+        let bones = BTreeMap::from([
+            ("left_hip".into(), bone(Vec3::new(-0.15, 1.0, 0.0))),
+            ("left_knee".into(), bone(Vec3::new(-0.1, 0.5, 0.2))),
+            ("left_foot".into(), bone(Vec3::new(0.12, 0.0, 0.0))),
+            ("right_hip".into(), bone(Vec3::new(0.15, 1.0, 0.0))),
+            ("right_knee".into(), bone(Vec3::new(0.1, 0.5, 0.2))),
+            ("right_foot".into(), bone(Vec3::new(-0.12, 0.0, 0.0))),
+        ]);
+        let mut frame = FrameSample {
+            scenario: "metric-test".into(),
+            scenario_frame: 0,
+            time_seconds: 0.0,
+            speed_metres_per_second: 2.0,
+            gait_phase: 0.0,
+            root_distance_metres: 0.0,
+            root_position_metres: Vec3::ZERO.to_array(),
+            world_travel_direction: Vec3::NEG_Z.to_array(),
+            desired_body_forward_direction: Vec3::NEG_Z.to_array(),
+            body_forward_direction: Vec3::Z.to_array(),
+            body_rotation_xyzw: Quat::IDENTITY.to_array(),
+            guard_action: false,
+            left_support_weight: 1.0,
+            right_support_weight: 1.0,
+            screenshots: BTreeMap::new(),
+            bones,
+        };
+        let frames = [&frame];
+        assert!(minimum_signed_foot_track(&frames) < 0.0);
+        assert!(maximum_facing_error(&frames) > 179.0);
+
+        let mut previous = frame.clone();
+        previous.desired_body_forward_direction = Vec3::Z.to_array();
+        frame.scenario_frame = 1;
+        frame.time_seconds = 1.0 / SAMPLE_HZ;
+        assert!(maximum_facing_tracking_excess(&[&previous, &frame]) > 8.0);
+
+        frame.guard_action = true;
+        assert!(maximum_guard_facing_error(&[&frame]) > 179.0);
     }
 }

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -62,10 +62,7 @@ impl Plugin for PlayerPlugin {
             .add_observer(on_parry_fired)
             .add_systems(
                 Update,
-                (
-                    update_character_look_rotation.run_if(any_with_component::<CharacterLook>),
-                    update_attack_state_system.run_if(any_with_component::<AttackState>),
-                ),
+                update_attack_state_system.run_if(any_with_component::<AttackState>),
             );
     }
 }
@@ -311,17 +308,6 @@ fn on_attack_fired_hook(
         cmd.client_trigger(RangedActionRequest::Start);
     } else {
         cmd.client_trigger(MeleeActionRequest::Start);
-    }
-}
-
-fn update_character_look_rotation(
-    mut q_characters: Query<
-        (&mut Transform, &CharacterLook),
-        (Changed<CharacterLook>, Without<ControlledPlayer>),
-    >,
-) {
-    for (mut transform, look) in &mut q_characters {
-        transform.rotation = Quat::from_rotation_y(look.yaw + std::f32::consts::PI);
     }
 }
 

--- a/crates/adventuresim-tactical-core/src/animation.rs
+++ b/crates/adventuresim-tactical-core/src/animation.rs
@@ -597,11 +597,64 @@ pub struct SkeletonLocomotionInput {
     pub tick: u64,
 }
 
+/// Maximum server-authoritative body turn speed during ordinary locomotion.
+pub const BODY_TURN_SPEED_RADIANS: f32 = 10.0;
+
+/// Returns the controller's yaw without allowing camera pitch or roll to tilt
+/// planar locomotion into or out of the ground plane.
+pub fn controller_yaw(orientation: Quat) -> Quat {
+    let forward = orientation * Vec3::NEG_Z;
+    let Some(flat_forward) = forward.xz().try_normalize() else {
+        return Quat::IDENTITY;
+    };
+    Quat::from_rotation_y((-flat_forward.x).atan2(-flat_forward.y))
+}
+
+/// Advances the authored body's +Z forward axis toward its single desired
+/// world direction. Attack and block are the current guard boundary and keep
+/// look-facing; all other moving states face authoritative planar velocity.
+/// At exactly 180 degrees the positive turn direction is chosen consistently,
+/// avoiding a normalize-through-zero snap.
+pub fn advance_body_facing(
+    current: Quat,
+    controller_orientation: Quat,
+    linear_velocity: Vec3,
+    action: SkeletonAction,
+    delta_seconds: f32,
+) -> Quat {
+    let current_yaw = body_yaw(current);
+    let desired_forward = if matches!(action, SkeletonAction::Attack | SkeletonAction::Block) {
+        controller_yaw(controller_orientation) * Vec3::NEG_Z
+    } else {
+        if linear_velocity.xz().length() <= 0.05 {
+            return Quat::from_rotation_y(current_yaw);
+        }
+        let Some(direction) = linear_velocity.xz().try_normalize() else {
+            return Quat::from_rotation_y(current_yaw);
+        };
+        Vec3::new(direction.x, 0.0, direction.y)
+    };
+    let desired_yaw = desired_forward.x.atan2(desired_forward.z);
+    let mut delta = (desired_yaw - current_yaw + std::f32::consts::PI)
+        .rem_euclid(std::f32::consts::TAU)
+        - std::f32::consts::PI;
+    if (delta + std::f32::consts::PI).abs() <= 1.0e-5 {
+        delta = std::f32::consts::PI;
+    }
+    let maximum = (BODY_TURN_SPEED_RADIANS * delta_seconds.max(0.0)).min(std::f32::consts::PI);
+    Quat::from_rotation_y(current_yaw + delta.clamp(-maximum, maximum))
+}
+
+fn body_yaw(rotation: Quat) -> f32 {
+    let forward = rotation * Vec3::Z;
+    forward.x.atan2(forward.z)
+}
+
 /// Projects controller motion into the compact replicated animation state.
 /// Bone evaluation remains client-only; this is the shared server seam that
 /// keeps deterministic captures on the same stride and posture rules.
 pub fn project_skeleton_locomotion(skeleton: &mut SkeletonState, input: SkeletonLocomotionInput) {
-    let local_velocity = input.orientation.inverse() * input.linear_velocity;
+    let local_velocity = controller_yaw(input.orientation).inverse() * input.linear_velocity;
     skeleton.local_velocity = local_velocity;
     skeleton.grounded = input.grounded;
     skeleton.posture = if input.grounded {
@@ -1153,6 +1206,52 @@ mod tests {
         assert!((state.local_velocity - local_velocity).length() < 0.0001);
         assert!((state.gait_phase - 2.0 / (0.9 + 2.0 * 0.16) / 64.0).abs() < 0.0001);
         assert_eq!(state.lead_foot, LeadFoot::Left);
+    }
+
+    #[test]
+    fn planar_projection_ignores_camera_pitch() {
+        let yaw = 0.7;
+        let orientation = Quat::from_euler(EulerRot::YXZ, yaw, 1.25, 0.0);
+        let world_velocity = Quat::from_rotation_y(yaw) * Vec3::NEG_Z * 3.0;
+        let mut state = SkeletonState::default();
+        project_skeleton_locomotion(
+            &mut state,
+            SkeletonLocomotionInput {
+                orientation,
+                linear_velocity: world_velocity,
+                grounded: true,
+                crouching: false,
+                delta_seconds: 1.0 / 64.0,
+                tick: 1,
+            },
+        );
+        assert!(state.local_velocity.abs_diff_eq(Vec3::NEG_Z * 3.0, 0.0001));
+    }
+
+    #[test]
+    fn body_facing_is_bounded_and_uses_stable_half_turn() {
+        let first = advance_body_facing(
+            Quat::IDENTITY,
+            Quat::IDENTITY,
+            Vec3::NEG_Z,
+            SkeletonAction::None,
+            1.0 / 64.0,
+        );
+        let angle = Quat::IDENTITY.angle_between(first);
+        assert!((angle - BODY_TURN_SPEED_RADIANS / 64.0).abs() < 0.0001);
+        assert!(
+            (first * Vec3::Z).x > 0.0,
+            "exact reversal chooses positive yaw"
+        );
+    }
+
+    #[test]
+    fn guard_faces_look_while_locomotion_faces_world_velocity() {
+        let look = Quat::from_rotation_y(0.8);
+        let guard = advance_body_facing(Quat::IDENTITY, look, Vec3::X, SkeletonAction::Block, 1.0);
+        assert!((guard * Vec3::Z).abs_diff_eq(look * Vec3::NEG_Z, 0.0001));
+        let travel = advance_body_facing(Quat::IDENTITY, look, Vec3::X, SkeletonAction::None, 1.0);
+        assert!((travel * Vec3::Z).abs_diff_eq(Vec3::X, 0.0001));
     }
 
     #[test]

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -18,9 +18,10 @@ pub use avian3d;
 pub mod prelude {
     pub use crate::AdventureSimulatorCorePlugins;
     pub use crate::animation::{
-        AnimationEvaluation, AnimationPack, AnimationPackLibrary, AttackLine, Footwork, LeadFoot,
-        PackValidationError, PoseSample, PoseSampling, Posture, ResolvedPose, SemanticPose,
-        SkeletonAction, SkeletonLocomotionInput, SkeletonState, StrikeFamily,
+        AnimationEvaluation, AnimationPack, AnimationPackLibrary, AttackLine,
+        BODY_TURN_SPEED_RADIANS, Footwork, LeadFoot, PackValidationError, PoseSample, PoseSampling,
+        Posture, ResolvedPose, SemanticPose, SkeletonAction, SkeletonLocomotionInput,
+        SkeletonState, StrikeFamily, advance_body_facing, controller_yaw,
         project_skeleton_locomotion,
     };
     pub use crate::combat::{Attack, Dodge, HANDS_REACH, Parry, melee_interaction_range};
@@ -36,7 +37,7 @@ pub mod prelude {
     pub use adventuresim_core::prelude::*;
     pub use avian3d::prelude::*;
     pub use bevy_ahoy::{
-        CharacterController, CharacterControllerState, CharacterLook,
+        AhoySystems, CharacterController, CharacterControllerState, CharacterLook,
         camera::{CharacterControllerCamera, CharacterControllerCameraOf},
         input,
     };

--- a/crates/adventuresim-tactical-server/src/bot.rs
+++ b/crates/adventuresim-tactical-server/src/bot.rs
@@ -102,7 +102,8 @@ mod tests {
         let actor = world
             .spawn((
                 Player::default(),
-                Transform::from_translation(position),
+                Transform::from_translation(position)
+                    .with_rotation(Quat::from_rotation_y(std::f32::consts::PI)),
                 side,
                 CharacterLook::default(),
                 input::AccumulatedInput::default(),
@@ -139,7 +140,8 @@ mod tests {
         let actor = world
             .spawn((
                 Player::default(),
-                Transform::from_translation(position),
+                Transform::from_translation(position)
+                    .with_rotation(Quat::from_rotation_y(std::f32::consts::PI)),
                 side,
                 CharacterLook::default(),
                 input::AccumulatedInput::default(),
@@ -179,7 +181,8 @@ mod tests {
         world
             .spawn((
                 Player::default(),
-                Transform::from_translation(position),
+                Transform::from_translation(position)
+                    .with_rotation(Quat::from_rotation_y(std::f32::consts::PI)),
                 side,
                 CharacterLook::default(),
                 TacticalCombatState::default(),

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -122,7 +122,10 @@ fn main() {
         ),
     )
     .add_systems(OnEnter(ServerState::Running), on_server_started)
-    .add_systems(FixedPostUpdate, update_skeleton_locomotion)
+    .add_systems(
+        FixedPostUpdate,
+        update_skeleton_locomotion.after(AhoySystems::MoveCharacters),
+    )
     .add_observer(on_join_request)
     .add_observer(on_player_input)
     .add_observer(on_client_disconnected);

--- a/crates/adventuresim-tactical-server/src/player_projection.rs
+++ b/crates/adventuresim-tactical-server/src/player_projection.rs
@@ -305,7 +305,8 @@ fn spawn_connected_player(
         } else {
             TacticalCombatSide::Party
         },
-        Transform::from_xyz(spawn_position.x, spawn_height, spawn_position.y),
+        Transform::from_xyz(spawn_position.x, spawn_height, spawn_position.y)
+            .with_rotation(Quat::from_rotation_y(std::f32::consts::PI)),
         (
             player_collider.clone(),
             CollisionMargin(0.01),
@@ -474,6 +475,9 @@ pub(crate) fn on_player_input(
         With<Player>,
     >,
 ) {
+    let Some(validated) = validate_player_input(input.look, input.movement, input.jump) else {
+        return;
+    };
     let Some(entity) = input.client_id.entity() else {
         return;
     };
@@ -485,12 +489,37 @@ pub(crate) fn on_player_input(
         accumulated_input.jumped = None;
         return;
     }
-    look.yaw = input.look.x;
-    look.pitch = input.look.y.clamp(-1.5, 1.5);
-    accumulated_input.last_movement = input.movement.map(|m| m.clamp_length_max(1.0));
-    if input.jump {
+    look.yaw = validated.yaw;
+    look.pitch = validated.pitch;
+    accumulated_input.last_movement = validated.movement;
+    if validated.jump {
         accumulated_input.jumped = Some(Stopwatch::new());
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct ValidatedPlayerInput {
+    movement: Option<Vec2>,
+    yaw: f32,
+    pitch: f32,
+    jump: bool,
+}
+
+fn validate_player_input(
+    look: Vec2,
+    movement: Option<Vec2>,
+    jump: bool,
+) -> Option<ValidatedPlayerInput> {
+    if !look.is_finite() || movement.is_some_and(|movement| !movement.is_finite()) {
+        return None;
+    }
+    Some(ValidatedPlayerInput {
+        movement: movement.map(|movement| movement.clamp_length_max(1.0)),
+        yaw: (look.x + std::f32::consts::PI).rem_euclid(std::f32::consts::TAU)
+            - std::f32::consts::PI,
+        pitch: look.y.clamp(-1.5, 1.5),
+        jump,
+    })
 }
 
 /// Projects authoritative controller motion into the compact presentation
@@ -502,12 +531,20 @@ pub(crate) fn update_skeleton_locomotion(
             &CharacterControllerState,
             &LinearVelocity,
             &mut SkeletonState,
+            &mut Transform,
         ),
         With<Player>,
     >,
 ) {
-    for (controller, velocity, mut skeleton) in &mut players {
+    for (controller, velocity, mut skeleton, mut transform) in &mut players {
         let tick = (time.elapsed_secs_f64() * 64.0).round() as u64;
+        transform.rotation = advance_body_facing(
+            transform.rotation,
+            controller.orientation,
+            velocity.0,
+            skeleton.action,
+            time.delta_secs(),
+        );
         project_skeleton_locomotion(
             &mut skeleton,
             SkeletonLocomotionInput {
@@ -562,7 +599,8 @@ fn player_spawn_offset(collider: &Collider) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    use super::{mission_enemy_health_scale, mission_enemy_scale};
+    use super::{mission_enemy_health_scale, mission_enemy_scale, validate_player_input};
+    use bevy::prelude::*;
 
     #[test]
     fn same_durable_enemy_identity_projects_different_mission_strength() {
@@ -578,5 +616,42 @@ mod tests {
     fn zero_combat_scale_keeps_test_enemy_alive() {
         assert_eq!(mission_enemy_health_scale(0, 0.0), 1.0);
         assert_eq!(mission_enemy_health_scale(5_000, 0.5), 0.5);
+    }
+
+    #[test]
+    fn player_input_rejects_non_finite_look_or_movement_as_one_update() {
+        let mut controller_input = (Vec2::new(0.4, -0.2), Some(Vec2::new(0.25, 0.5)), false);
+        for (look, movement) in [
+            (Vec2::new(f32::NAN, 0.0), Some(Vec2::ZERO)),
+            (Vec2::new(0.0, f32::INFINITY), Some(Vec2::ZERO)),
+            (Vec2::ZERO, Some(Vec2::new(f32::NEG_INFINITY, 0.0))),
+            (Vec2::ZERO, Some(Vec2::new(0.0, f32::NAN))),
+        ] {
+            if let Some(validated) = validate_player_input(look, movement, true) {
+                controller_input = (
+                    Vec2::new(validated.yaw, validated.pitch),
+                    validated.movement,
+                    validated.jump,
+                );
+            }
+        }
+        assert_eq!(
+            controller_input,
+            (Vec2::new(0.4, -0.2), Some(Vec2::new(0.25, 0.5)), false)
+        );
+    }
+
+    #[test]
+    fn player_input_normalizes_finite_boundaries_before_controller_state() {
+        let validated = validate_player_input(
+            Vec2::new(std::f32::consts::TAU * 4.0 + 0.25, 99.0),
+            Some(Vec2::splat(10.0)),
+            true,
+        )
+        .unwrap();
+        assert!((validated.yaw - 0.25).abs() < 0.0001);
+        assert_eq!(validated.pitch, 1.5);
+        assert!(validated.movement.unwrap().length() <= 1.0001);
+        assert!(validated.yaw.is_finite() && validated.pitch.is_finite());
     }
 }

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -83,8 +83,8 @@ The animation evaluator consumes skeleton state in this order:
 4. Interpolate authored poses using continuous blend coordinates.
 5. Apply masked or additive layers such as directional ducking and impact
    flinches.
-6. Apply procedural facing, foot placement, hip correction, terrain IK,
-   hand/weapon constraints, and head/torso look.
+6. Apply foot placement, hip correction, terrain IK, hand/weapon constraints,
+   and head/torso look. Body facing is already present on the replicated root.
 7. Apply optional secondary animation.
 
 Overgrowth similarly supplies named blend coordinates such as movement speed,
@@ -440,7 +440,19 @@ rather than swapping bones discretely. Terrain leg IK preserves continuous
 support for walking, narrows support through the walk/run blend, and releases
 both feet during the authored run flight phase. During high support it also
 locks the stance foot horizontally in world space until release, preventing
-visible skating as the gameplay root advances. Arm and leg swing share the
+visible skating as the gameplay root advances. A footprint is acquired only
+near full contact and begins at the previous visible world-space foot target,
+so the foot cannot jump by one root step as it becomes loaded. During a body
+turn or at the edge of leg reach, shared virtual-time rate-bounded pelvis lowering absorbs
+the reach deficit first; the plant slides only as far as still required on its
+anatomical side corridor instead of dropping and reacquiring in one frame. A
+plant is released on a true discontinuity, support loss, or an
+airborne/non-upright transition. Left and right targets remain on separate
+pelvis-space tracks with a minimum separation. The solver keeps a 20-degree
+soft extension reserve and a forward, slightly outward anatomical bend
+hemisphere; invalid targets are constrained or released rather than
+reconstructing a knee through the straight-leg singularity. Release toward a
+sparse authored swing target is velocity-bounded in character space. Arm and leg swing share the
 same phase reconstruction before terrain IK; only the legs receive the final
 terrain solve. An explicit hand or weapon constraint can then override the
 reconstructed arm carriage.
@@ -461,17 +473,33 @@ for regression and visual review. It uses the gameplay player-spawn observer, ch
 camera, terrain presentation, authored animation evaluator, and procedural
 passes rather than maintaining parallel fixture implementations. Locomotion is
 projected and integrated continuously at the authoritative 64Hz fixed tick over
-seeded uneven terrain. For each logical tick the replay freezes simulation and
-captures one raw gameplay-camera image plus side and front diagnostic images of
-that exact pose. Its manifest records final world-space bones, support weights,
-continuity, planted-foot drift, and terrain-relative foot clearance; those
+seeded uneven terrain. A deterministic procedural clock prevents asynchronous
+screenshot rendering from advancing retained IK state more than once for the
+same logical tick, while the complete FK/IK pipeline still reevaluates each
+view. The replay captures one raw gameplay-camera image plus side and front
+diagnostic images of that exact pose. Its manifest records final world-space bones, support weights,
+continuity, planted-foot drift under a stable body, signed foot tracks and separation, knee flexion
+and bend hemisphere, desired body-forward alignment, bounded per-tick turning
+residual (including look-facing guards), and terrain-relative foot clearance; those
 signals locate suspect frames but do not replace review of the rendered mesh.
 The fixture supplies deterministic controller observations at the shared
 server projection boundary and follows rendered terrain height; it does not
 exercise physics contacts, replication, interpolation, or recorded live input.
 
-During ordinary travel the body turns toward its velocity, so forward walk and
-run also serve diagonal and lateral travel. During combat, the torso remains
+During ordinary travel the server advances the replicated body's authored +Z
+axis toward authoritative horizontal velocity at a bounded turn rate. Camera
+pitch is removed before planar gait projection. Camera yaw intentionally maps
+raw movement input into world movement, but it is not applied again by either
+the client root or authored-rig child. At idle, the last body yaw is retained;
+an exact reversal uses a deterministic turn side. Attack and block are the
+current guard boundary and retain look/aim facing while moving. This root is
+shared by local players, remote players, bots, fallback bodies, authored rigs,
+and the viewer, with the authored +Z/controller -Z half-turn represented once.
+The viewer additionally replays gradual turns, an exact reversal, planted
+guard rotation, camera pitch, and cross-slope terrain.
+
+During ordinary travel forward walk and run therefore also serve diagonal and
+lateral travel. During combat, the torso remains
 oriented toward the opponent and a procedural stance-step planner provides
 advancing, retreating, strafing, and diagonal movement without directional
 gait cycles. It maintains a world-space target for each planted foot, chooses


### PR DESCRIPTION
## Summary
- make ordinary locomotion face authoritative world-space movement while guard actions face controller look
- constrain terrain IK with anatomical foot tracks, knee flexion/hemisphere limits, continuous plants, pelvis reach correction, and bounded sparse swing targets
- expand the deterministic animation viewer with realistic gameplay-path scenarios and quantitative continuity/biomechanics checks
- validate replicated player input before it reaches controller or facing state

## Verification
- cargo fmt --all -- --check
- cargo test -p adventuresim-tactical-core
- cargo test -p adventuresim-tactical-server
- cargo test -p adventuresim-tactical-client --bin adventuresim-tactical-client
- cargo test -p adventuresim-tactical-client --bin animation-viewer
- cargo check -p adventuresim-tactical-server -p adventuresim-tactical-client
- git diff --check
- full 10-scenario 64 Hz animation capture report: locomotion-review-v46-final (all manifest gates pass)

## Stack
This draft is based on codex/tactical-supervised-play, the implementation of #398, so local tactical startup remains testable while this animation layer is reviewed.