### PR TITLE
Mirror missing tactical lead poses

### DIFF
--- a/assets/animations/biped/README.md
+++ b/assets/animations/biped/README.md
@@ -7,7 +7,9 @@ biped/
     idle_relaxed.glb
     walk.glb
     run.glb
-    attack_thrust_lead_left_stay.glb
+    guard_lead_left.glb
+    attack_thrust_lead_left_contact.glb
+    duck_lead_left_left.glb
     ...
 ```
 
@@ -30,5 +32,7 @@ validating the one-animation, duration, and canonical target-path contracts it
 copies source bytes exactly, and `--check` verifies the committed result.
 
 Missing motion files are expected while art is in progress. They participate
-in pack and similar-pose fallback independently and ultimately leave the
+in fallback independently. For guard, attack, and guard-relative duck pairs,
+an exact side wins; otherwise an available same-pack opposite side is mirrored
+before the parent pack is consulted. The remaining similar-pose chain ultimately leaves the
 authored base rig in its T-pose rather than crashing or hiding the actor.

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -269,9 +269,9 @@ impl AnimationPackCatalog {
             }
         }
         for (motion, pose) in [
-            ("duck_lead_left_backward", "duck_backward"),
-            ("duck_lead_left_left", "duck_left"),
-            ("duck_lead_left_right", "duck_right"),
+            ("duck_lead_left_backward", "duck_lead_left_backward"),
+            ("duck_lead_left_left", "duck_lead_left_left"),
+            ("duck_lead_left_right", "duck_lead_left_right"),
         ] {
             builder.motion(motion, 0);
             builder.pose(motion, 0, pose)?;
@@ -400,6 +400,7 @@ pub(super) struct AnimationPlayback {
     clips: Vec<WeightedClip>,
     use_authored_bind_pose: bool,
     pub(super) lower_body_mirror: f32,
+    pub(super) whole_body_mirror: f32,
 }
 
 impl AnimationPlayback {
@@ -415,6 +416,7 @@ impl Default for AnimationPlayback {
             clips: Vec::new(),
             use_authored_bind_pose: true,
             lower_body_mirror: 0.0,
+            whole_body_mirror: 0.0,
         }
     }
 }
@@ -424,6 +426,7 @@ struct WeightedClip {
     clip: LoadedClip,
     weight: f32,
     time_seconds: f32,
+    mirrored_weight: f32,
 }
 
 #[derive(Component)]
@@ -838,6 +841,19 @@ fn evaluate_skeletons(
         }
         let next = AnimationPlayback {
             use_authored_bind_pose: weighted.is_empty(),
+            whole_body_mirror: {
+                let total = weighted.iter().map(|clip| clip.weight).sum::<f32>();
+                if total > f32::EPSILON {
+                    (weighted
+                        .iter()
+                        .map(|clip| clip.mirrored_weight)
+                        .sum::<f32>()
+                        / total)
+                        .clamp(0.0, 1.0)
+                } else {
+                    0.0
+                }
+            },
             clips: weighted,
             lower_body_mirror: if resolved_weight > f32::EPSILON {
                 (mirror_weight / resolved_weight).clamp(0.0, 1.0)
@@ -931,6 +947,7 @@ struct ResolvedAnchor<'a> {
     clip: &'a LoadedClip,
     anchor: &'a PoseAnchor,
     pack_id: &'a str,
+    mirrored: bool,
 }
 
 fn resolve_anchor<'a>(
@@ -942,6 +959,8 @@ fn resolve_anchor<'a>(
     let ResolvedPose::Clip {
         pack_id,
         pose: resolved_pose,
+        mirrored,
+        ..
     } = runtime.library.resolve(requested_pack, pose)
     else {
         return None;
@@ -956,6 +975,7 @@ fn resolve_anchor<'a>(
         clip,
         anchor,
         pack_id,
+        mirrored,
     })
 }
 
@@ -973,11 +993,15 @@ fn append_weighted(
             && (existing.time_seconds - time_seconds).abs() < 0.0001
     }) {
         existing.weight += weight;
+        if resolved.mirrored {
+            existing.mirrored_weight += weight;
+        }
     } else {
         weighted.push(WeightedClip {
             clip: resolved.clip.clone(),
             weight,
             time_seconds,
+            mirrored_weight: if resolved.mirrored { weight } else { 0.0 },
         });
     }
 }
@@ -1219,7 +1243,9 @@ mod tests {
     fn default_catalog_owns_all_required_poses_once() {
         let catalog = AnimationPackCatalog::default();
         let root = &catalog.packs[HUMANOID_UNARMED_PACK];
-        assert_eq!(root.poses.len(), SemanticPose::HUMANOID_REQUIRED.len());
+        // Right-lead ducks are semantic mirror counterparts rather than
+        // duplicate anchors in the same authored files.
+        assert_eq!(root.poses.len() + 3, SemanticPose::HUMANOID_REQUIRED.len());
         assert_eq!(
             root.motions["walk"].path,
             "animations/biped/unarmed/walk.glb"
@@ -1239,7 +1265,7 @@ mod tests {
             }
         );
         assert_eq!(
-            root.poses[&SemanticPose::DuckBackward],
+            root.poses[&SemanticPose::DuckLeadLeftBackward],
             PoseAnchor {
                 motion: "duck_lead_left_backward".to_owned(),
                 frame: 0,
@@ -1540,6 +1566,41 @@ mod tests {
         );
         assert_eq!(weighted.len(), 1);
         assert!(weighted[0].time_seconds.abs() < 0.0001);
+    }
+
+    #[test]
+    fn missing_opposite_guard_uses_mirrored_same_pack_anchor() {
+        let catalog = AnimationPackCatalog::default();
+        let runtime = runtime_with_available([SemanticPose::GuardLeadLeft]);
+        let resolved = resolve_anchor(
+            &runtime,
+            &catalog,
+            HUMANOID_UNARMED_PACK,
+            SemanticPose::GuardLeadRight,
+        )
+        .expect("mirrored guard fallback");
+
+        assert!(resolved.mirrored);
+        assert_eq!(
+            resolved.anchor,
+            &catalog.packs[HUMANOID_UNARMED_PACK].poses[&SemanticPose::GuardLeadLeft]
+        );
+
+        let mut weighted = Vec::new();
+        append_resolved_sample(
+            &mut weighted,
+            &runtime,
+            &catalog,
+            HUMANOID_UNARMED_PACK,
+            PoseSample {
+                pose: SemanticPose::GuardLeadRight,
+                sampling: PoseSampling::Anchor,
+                weight: 0.75,
+                mirror_lower_body: 0.0,
+            },
+        );
+        assert_eq!(weighted.len(), 1);
+        assert!((weighted[0].mirrored_weight - 0.75).abs() < 0.0001);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -183,7 +183,11 @@ pub(super) fn apply_head_and_torso_look(
     }
 }
 
-/// Constructs the opposite gait half-cycle for every bilateral limb chain.
+/// Applies pack fallback reflection and constructs the opposite gait half-cycle.
+/// Whole-body reflection includes the central chain and swaps every bilateral
+/// limb; gait reflection is limited to bilateral limbs. Applying both is an
+/// involution, so their bilateral weights compose as an XOR blend.
+///
 /// Gait mirroring transitions only around the authored passing pose, where the
 /// limbs are nearest neutral; interpolating throughout contact folds a planted
 /// stride through itself. The playback field retains its historical
@@ -238,14 +242,39 @@ pub(super) fn apply_gait_mirroring(
         let Ok(playback) = playbacks.get(owner) else {
             continue;
         };
-        let weight = playback.lower_body_mirror;
-        if weight <= f32::EPSILON {
+        let whole_body_weight = playback.whole_body_mirror.clamp(0.0, 1.0);
+        let gait_weight = playback.lower_body_mirror.clamp(0.0, 1.0);
+        if whole_body_weight <= f32::EPSILON && gait_weight <= f32::EPSILON {
             continue;
         }
         let Some(rig_global) = rig_globals.get(&owner) else {
             continue;
         };
         let mut desired_globals = BTreeMap::<Entity, Affine3A>::new();
+        let mut mirror_weights = BTreeMap::<Entity, f32>::new();
+        if whole_body_weight > f32::EPSILON {
+            for role in [
+                BoneRole::Root,
+                BoneRole::Pelvis,
+                BoneRole::StomachOne,
+                BoneRole::StomachTwo,
+                BoneRole::Chest,
+                BoneRole::NeckOne,
+                BoneRole::NeckTwo,
+                BoneRole::Head,
+            ] {
+                let Some(bone) = rig.get(&role) else {
+                    continue;
+                };
+                desired_globals.insert(
+                    bone.entity,
+                    mirrored_global_affine(bone.global, *rig_global),
+                );
+                mirror_weights.insert(bone.entity, whole_body_weight);
+            }
+        }
+        let bilateral_weight =
+            whole_body_weight + gait_weight - 2.0 * whole_body_weight * gait_weight;
         for (left_role, right_role) in [
             (BoneRole::ClavicleLeft, BoneRole::ClavicleRight),
             (BoneRole::UpperArmLeft, BoneRole::UpperArmRight),
@@ -272,12 +301,18 @@ pub(super) fn apply_gait_mirroring(
                 right.entity,
                 mirrored_global_affine(left.global, *rig_global),
             );
+            mirror_weights.insert(left.entity, bilateral_weight);
+            mirror_weights.insert(right.entity, bilateral_weight);
         }
         let mut bones = transforms.p2();
         for bone in rig.values() {
             let Some(&desired_global) = desired_globals.get(&bone.entity) else {
                 continue;
             };
+            let weight = mirror_weights[&bone.entity];
+            if weight <= f32::EPSILON {
+                continue;
+            }
             let desired_parent = bone
                 .parent
                 .and_then(|parent| desired_globals.get(&parent).copied())

--- a/crates/adventuresim-tactical-core/src/animation.rs
+++ b/crates/adventuresim-tactical-core/src/animation.rs
@@ -26,9 +26,12 @@ pub enum SemanticPose {
     CrouchWalkContact,
     CrouchWalkPassing,
     DuckForward,
-    DuckBackward,
-    DuckLeft,
-    DuckRight,
+    DuckLeadLeftBackward,
+    DuckLeadLeftLeft,
+    DuckLeadLeftRight,
+    DuckLeadRightBackward,
+    DuckLeadRightLeft,
+    DuckLeadRightRight,
     JumpCenterLaunch,
     JumpCenterFlight,
     JumpCenterLanding,
@@ -91,7 +94,7 @@ pub enum SemanticPose {
 }
 
 impl SemanticPose {
-    pub const HUMANOID_REQUIRED: [Self; 71] = [
+    pub const HUMANOID_REQUIRED: [Self; 74] = [
         Self::IdleRelaxed,
         Self::WalkContact,
         Self::WalkPassing,
@@ -101,9 +104,12 @@ impl SemanticPose {
         Self::CrouchWalkContact,
         Self::CrouchWalkPassing,
         Self::DuckForward,
-        Self::DuckBackward,
-        Self::DuckLeft,
-        Self::DuckRight,
+        Self::DuckLeadLeftBackward,
+        Self::DuckLeadLeftLeft,
+        Self::DuckLeadLeftRight,
+        Self::DuckLeadRightBackward,
+        Self::DuckLeadRightLeft,
+        Self::DuckLeadRightRight,
         Self::JumpCenterLaunch,
         Self::JumpCenterFlight,
         Self::JumpCenterLanding,
@@ -177,9 +183,12 @@ impl SemanticPose {
             CrouchWalkContact => "crouch_walk_contact",
             CrouchWalkPassing => "crouch_walk_passing",
             DuckForward => "duck_forward",
-            DuckBackward => "duck_backward",
-            DuckLeft => "duck_left",
-            DuckRight => "duck_right",
+            DuckLeadLeftBackward => "duck_lead_left_backward",
+            DuckLeadLeftLeft => "duck_lead_left_left",
+            DuckLeadLeftRight => "duck_lead_left_right",
+            DuckLeadRightBackward => "duck_lead_right_backward",
+            DuckLeadRightLeft => "duck_lead_right_left",
+            DuckLeadRightRight => "duck_lead_right_right",
             JumpCenterLaunch => "jump_center_launch",
             JumpCenterFlight => "jump_center_flight",
             JumpCenterLanding => "jump_center_landing",
@@ -252,6 +261,49 @@ impl SemanticPose {
         }
     }
 
+    /// Authored whole-body counterpart that may satisfy this pose by
+    /// reflection when the exact pose is absent from the same pack. Exact
+    /// authored clips always win, so handed packs opt out simply by exporting
+    /// both sides.
+    pub fn mirrored_counterpart(self) -> Option<Self> {
+        use SemanticPose::*;
+        Some(match self {
+            DuckLeadLeftBackward => DuckLeadRightBackward,
+            DuckLeadLeftLeft => DuckLeadRightRight,
+            DuckLeadLeftRight => DuckLeadRightLeft,
+            DuckLeadRightBackward => DuckLeadLeftBackward,
+            DuckLeadRightLeft => DuckLeadLeftRight,
+            DuckLeadRightRight => DuckLeadLeftLeft,
+            GuardLeadLeft => GuardLeadRight,
+            GuardLeadRight => GuardLeadLeft,
+            AttackThrustLeadLeftStayCommit => AttackThrustLeadRightStayCommit,
+            AttackThrustLeadLeftStayContact => AttackThrustLeadRightStayContact,
+            AttackThrustLeadLeftStayFollowThrough => AttackThrustLeadRightStayFollowThrough,
+            AttackThrustLeadLeftSwitchCommit => AttackThrustLeadRightSwitchCommit,
+            AttackThrustLeadLeftSwitchContact => AttackThrustLeadRightSwitchContact,
+            AttackThrustLeadLeftSwitchFollowThrough => AttackThrustLeadRightSwitchFollowThrough,
+            AttackThrustLeadRightStayCommit => AttackThrustLeadLeftStayCommit,
+            AttackThrustLeadRightStayContact => AttackThrustLeadLeftStayContact,
+            AttackThrustLeadRightStayFollowThrough => AttackThrustLeadLeftStayFollowThrough,
+            AttackThrustLeadRightSwitchCommit => AttackThrustLeadLeftSwitchCommit,
+            AttackThrustLeadRightSwitchContact => AttackThrustLeadLeftSwitchContact,
+            AttackThrustLeadRightSwitchFollowThrough => AttackThrustLeadLeftSwitchFollowThrough,
+            AttackSlashLeadLeftStayCommit => AttackSlashLeadRightStayCommit,
+            AttackSlashLeadLeftStayContact => AttackSlashLeadRightStayContact,
+            AttackSlashLeadLeftStayFollowThrough => AttackSlashLeadRightStayFollowThrough,
+            AttackSlashLeadLeftSwitchCommit => AttackSlashLeadRightSwitchCommit,
+            AttackSlashLeadLeftSwitchContact => AttackSlashLeadRightSwitchContact,
+            AttackSlashLeadLeftSwitchFollowThrough => AttackSlashLeadRightSwitchFollowThrough,
+            AttackSlashLeadRightStayCommit => AttackSlashLeadLeftStayCommit,
+            AttackSlashLeadRightStayContact => AttackSlashLeadLeftStayContact,
+            AttackSlashLeadRightStayFollowThrough => AttackSlashLeadLeftStayFollowThrough,
+            AttackSlashLeadRightSwitchCommit => AttackSlashLeadLeftSwitchCommit,
+            AttackSlashLeadRightSwitchContact => AttackSlashLeadLeftSwitchContact,
+            AttackSlashLeadRightSwitchFollowThrough => AttackSlashLeadLeftSwitchFollowThrough,
+            _ => return None,
+        })
+    }
+
     /// The next closest semantic pose. A miss restarts lookup at the selected
     /// animation pack, so specialized packs can supply a useful substitute.
     pub fn fallback(self) -> Option<Self> {
@@ -265,7 +317,9 @@ impl SemanticPose {
             CrouchIdle => IdleRelaxed,
             CrouchWalkContact => WalkContact,
             CrouchWalkPassing => WalkPassing,
-            DuckForward | DuckBackward | DuckLeft | DuckRight => CrouchIdle,
+            DuckForward => CrouchIdle,
+            DuckLeadLeftBackward | DuckLeadLeftLeft | DuckLeadLeftRight => GuardLeadLeft,
+            DuckLeadRightBackward | DuckLeadRightLeft | DuckLeadRightRight => GuardLeadRight,
             JumpCenterLaunch | JumpCenterLanding => CrouchIdle,
             JumpCenterFlight => RunFlight,
             JumpForwardLaunch => JumpCenterLaunch,
@@ -289,7 +343,7 @@ impl SemanticPose {
             DiveImpact => JumpForwardLanding,
             ProneSupineRollLeft | ProneSupineRollRight => ProneIdle,
             GuardLeadLeft => IdleRelaxed,
-            GuardLeadRight => GuardLeadLeft,
+            GuardLeadRight => IdleRelaxed,
             AttackThrustLeadLeftStayCommit => AttackSlashLeadLeftStayCommit,
             AttackThrustLeadLeftStayContact => AttackSlashLeadLeftStayContact,
             AttackThrustLeadLeftStayFollowThrough => AttackSlashLeadLeftStayFollowThrough,
@@ -308,9 +362,9 @@ impl SemanticPose {
             AttackSlashLeadLeftSwitchCommit => AttackSlashLeadLeftStayCommit,
             AttackSlashLeadLeftSwitchContact => AttackSlashLeadLeftStayContact,
             AttackSlashLeadLeftSwitchFollowThrough => AttackSlashLeadLeftStayFollowThrough,
-            AttackSlashLeadRightStayCommit => AttackSlashLeadLeftStayCommit,
-            AttackSlashLeadRightStayContact => AttackSlashLeadLeftStayContact,
-            AttackSlashLeadRightStayFollowThrough => AttackSlashLeadLeftStayFollowThrough,
+            AttackSlashLeadRightStayCommit
+            | AttackSlashLeadRightStayContact
+            | AttackSlashLeadRightStayFollowThrough => GuardLeadRight,
             AttackSlashLeadRightSwitchCommit => AttackSlashLeadRightStayCommit,
             AttackSlashLeadRightSwitchContact => AttackSlashLeadRightStayContact,
             AttackSlashLeadRightSwitchFollowThrough => AttackSlashLeadRightStayFollowThrough,
@@ -349,7 +403,11 @@ pub struct AnimationPack {
 pub enum ResolvedPose<'a> {
     Clip {
         pack_id: &'a str,
+        /// Semantic pose satisfied before any ordinary semantic fallback.
+        semantic: SemanticPose,
+        /// Authored clip sampled for that semantic pose.
         pose: SemanticPose,
+        mirrored: bool,
     },
     /// Use the rig's authored bind transform. For the humanoid convention this
     /// is a T-pose and needs no animation clip.
@@ -414,7 +472,7 @@ impl AnimationPackLibrary {
     pub fn validate_complete(&self, root: &str) -> Result<(), PackValidationError> {
         self.validate_structure()?;
         for pose in SemanticPose::HUMANOID_REQUIRED {
-            if !matches!(self.resolve(root, pose), ResolvedPose::Clip { pose: p, .. } if p == pose)
+            if !matches!(self.resolve(root, pose), ResolvedPose::Clip { semantic, .. } if semantic == pose)
             {
                 return Err(PackValidationError::MissingRequiredPose(pose));
             }
@@ -443,7 +501,19 @@ impl AnimationPackLibrary {
                 if pack.clips.contains(&pose) {
                     return ResolvedPose::Clip {
                         pack_id: &pack.id,
+                        semantic: pose,
                         pose,
+                        mirrored: false,
+                    };
+                }
+                if let Some(source) = pose.mirrored_counterpart()
+                    && pack.clips.contains(&source)
+                {
+                    return ResolvedPose::Clip {
+                        pack_id: &pack.id,
+                        semantic: pose,
+                        pose: source,
+                        mirrored: true,
                     };
                 }
                 pack_id = pack.fallback.as_deref();
@@ -975,18 +1045,17 @@ fn action_samples(state: &SkeletonState) -> Vec<PoseSample> {
         SkeletonAction::None | SkeletonAction::JumpCharge | SkeletonAction::Jump => Vec::new(),
         SkeletonAction::Dodge => {
             let pose = if state.action_direction.x.abs() > state.action_direction.y.abs() {
-                if state.action_direction.x < 0.0 {
-                    SemanticPose::DuckLeft
-                } else {
-                    SemanticPose::DuckRight
-                }
+                duck_side_pose(state.lead_foot, state.action_direction.x < 0.0)
             } else if state.action_direction.y < 0.0 {
-                SemanticPose::DuckBackward
+                match state.lead_foot {
+                    LeadFoot::Left => SemanticPose::DuckLeadLeftBackward,
+                    LeadFoot::Right => SemanticPose::DuckLeadRightBackward,
+                }
             } else {
                 SemanticPose::DuckForward
             };
             vec![out_and_back(
-                SemanticPose::CrouchIdle,
+                guard_pose(state.lead_foot),
                 pose,
                 state.action_phase,
             )]
@@ -1010,6 +1079,15 @@ fn action_samples(state: &SkeletonState) -> Vec<PoseSample> {
             SemanticPose::CrouchIdle,
             state.action_phase,
         )],
+    }
+}
+
+fn duck_side_pose(lead: LeadFoot, duck_left: bool) -> SemanticPose {
+    match (lead, duck_left) {
+        (LeadFoot::Left, true) => SemanticPose::DuckLeadLeftLeft,
+        (LeadFoot::Left, false) => SemanticPose::DuckLeadLeftRight,
+        (LeadFoot::Right, true) => SemanticPose::DuckLeadRightLeft,
+        (LeadFoot::Right, false) => SemanticPose::DuckLeadRightRight,
     }
 }
 
@@ -1128,14 +1206,94 @@ mod tests {
             library.resolve("rapier", SemanticPose::RunContact),
             ResolvedPose::Clip {
                 pack_id: "unarmed",
+                semantic: SemanticPose::WalkContact,
                 pose: SemanticPose::WalkContact,
+                mirrored: false,
             }
         );
         assert_eq!(
             library.resolve("rapier", SemanticPose::RunFlight),
             ResolvedPose::Clip {
                 pack_id: "rapier",
+                semantic: SemanticPose::RunFlight,
                 pose: SemanticPose::RunFlight,
+                mirrored: false,
+            }
+        );
+    }
+
+    #[test]
+    fn missing_side_resolves_to_mirrored_authored_counterpart() {
+        let mut library = AnimationPackLibrary::default();
+        library
+            .insert(pack("unarmed", None, [SemanticPose::GuardLeadLeft]))
+            .unwrap();
+
+        assert_eq!(
+            library.resolve("unarmed", SemanticPose::GuardLeadRight),
+            ResolvedPose::Clip {
+                pack_id: "unarmed",
+                semantic: SemanticPose::GuardLeadRight,
+                pose: SemanticPose::GuardLeadLeft,
+                mirrored: true,
+            }
+        );
+    }
+
+    #[test]
+    fn mirrored_semantic_counterparts_are_involutions() {
+        for pose in SemanticPose::HUMANOID_REQUIRED {
+            let Some(counterpart) = pose.mirrored_counterpart() else {
+                continue;
+            };
+            assert_ne!(pose, counterpart);
+            assert_eq!(counterpart.mirrored_counterpart(), Some(pose));
+        }
+    }
+
+    #[test]
+    fn specialized_pack_mirrors_its_own_counterpart_before_parent_fallback() {
+        let mut library = AnimationPackLibrary::default();
+        library
+            .insert(pack("unarmed", None, [SemanticPose::GuardLeadRight]))
+            .unwrap();
+        library
+            .insert(pack(
+                "sword",
+                Some("unarmed"),
+                [SemanticPose::GuardLeadLeft],
+            ))
+            .unwrap();
+
+        assert_eq!(
+            library.resolve("sword", SemanticPose::GuardLeadRight),
+            ResolvedPose::Clip {
+                pack_id: "sword",
+                semantic: SemanticPose::GuardLeadRight,
+                pose: SemanticPose::GuardLeadLeft,
+                mirrored: true,
+            }
+        );
+    }
+
+    #[test]
+    fn authored_opposite_side_wins_over_mirroring() {
+        let mut library = AnimationPackLibrary::default();
+        library
+            .insert(pack(
+                "sword",
+                None,
+                [SemanticPose::GuardLeadLeft, SemanticPose::GuardLeadRight],
+            ))
+            .unwrap();
+
+        assert_eq!(
+            library.resolve("sword", SemanticPose::GuardLeadRight),
+            ResolvedPose::Clip {
+                pack_id: "sword",
+                semantic: SemanticPose::GuardLeadRight,
+                pose: SemanticPose::GuardLeadRight,
+                mirrored: false,
             }
         );
     }
@@ -1154,7 +1312,9 @@ mod tests {
             library.resolve("unarmed", SemanticPose::AttackThrustLeadRightSwitchContact,),
             ResolvedPose::Clip {
                 pack_id: "unarmed",
+                semantic: SemanticPose::AttackSlashLeadRightSwitchContact,
                 pose: SemanticPose::AttackSlashLeadRightSwitchContact,
+                mirrored: false,
             }
         );
     }
@@ -1438,11 +1598,30 @@ mod tests {
             action_direction: Vec2::X,
             ..default()
         });
-        assert_eq!(dodge.action[0].pose, SemanticPose::DuckRight);
+        assert_eq!(dodge.action[0].pose, SemanticPose::DuckLeadLeftRight);
         assert_eq!(
             dodge.action[0].sampling,
             PoseSampling::Span {
-                end: SemanticPose::CrouchIdle,
+                end: SemanticPose::GuardLeadLeft,
+                progress: 0.5,
+            }
+        );
+
+        let right_lead_dodge = AnimationEvaluation::from_skeleton(&SkeletonState {
+            lead_foot: LeadFoot::Right,
+            action: SkeletonAction::Dodge,
+            action_phase: 0.25,
+            action_direction: Vec2::NEG_X,
+            ..default()
+        });
+        assert_eq!(
+            right_lead_dodge.action[0].pose,
+            SemanticPose::GuardLeadRight
+        );
+        assert_eq!(
+            right_lead_dodge.action[0].sampling,
+            PoseSampling::Span {
+                end: SemanticPose::DuckLeadRightLeft,
                 progress: 0.5,
             }
         );

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -279,13 +279,13 @@ Single-pose files place their named semantic pose at frame 0:
 | `idle_relaxed` | `idle_relaxed` |
 | `crouch_idle` | `crouch_idle` |
 | `guard_lead_left` | `guard_lead_left` |
-| `guard_lead_right` | `guard_lead_right` |
+| `guard_lead_right` (optional counterpart) | `guard_lead_right` |
 | `airborne_center` | `airborne_center` |
 | `airborne_travel` | `airborne_travel` |
-| `attack_thrust_lead_left` | `attack_thrust_lead_left_contact` |
-| `attack_thrust_lead_right` | `attack_thrust_lead_right_contact` |
-| `attack_slash_lead_left` | `attack_slash_lead_left_contact` |
-| `attack_slash_lead_right` | `attack_slash_lead_right_contact` |
+| `attack_thrust_lead_left_contact` | `attack_thrust_lead_left_contact` |
+| `attack_thrust_lead_right_contact` (optional counterpart) | `attack_thrust_lead_right_contact` |
+| `attack_slash_lead_left_contact` | `attack_slash_lead_left_contact` |
+| `attack_slash_lead_right_contact` (optional counterpart) | `attack_slash_lead_right_contact` |
 | `prone_idle` | `prone_idle` |
 | `supine_idle` | `supine_idle` |
 
@@ -300,14 +300,25 @@ preview, but does not introduce additional semantic names:
 | `prone_crawl` | 0 `prone_crawl_contact`; 8 `prone_crawl_passing`; 16 opposite contact; 24 opposite passing; 32 loop closure |
 | `supine_scamper` | 0 `supine_scamper_contact`; 8 `supine_scamper_passing`; 16 opposite contact; 24 opposite passing; 32 loop closure |
 
-Each directional duck is a short out-and-back motion in its own file. Frame 0
-and frame 12 reproduce `crouch_idle` as unnamed endpoint references; frame
-6 is the file's named pose:
+Each guard-relative duck extreme is a single pose in its own file at frame 0.
+The runtime blends from the current guard to the extreme and back. The lead
+and final direction components are both semantic: a left-lead dodge toward
+anatomical left is not interchangeable with a left-lead dodge toward right.
 
-| File basename | Semantic pose at frame 6 |
+| File basename | Semantic pose at frame 0 |
 |---|---|
-| `duck_backward` | `duck_backward` |
-| `duck_left` | `duck_left` |
+| `duck_lead_left_backward` | `duck_lead_left_backward` |
+| `duck_lead_left_left` | `duck_lead_left_left` |
+| `duck_lead_left_right` | `duck_lead_left_right` |
+| `duck_lead_right_backward` (optional counterpart) | `duck_lead_right_backward` |
+| `duck_lead_right_left` (optional counterpart) | `duck_lead_right_left` |
+| `duck_lead_right_right` (optional counterpart) | `duck_lead_right_right` |
+
+An exact file always wins. If one side is absent, the runtime mirrors the
+opposite-side pose from the same pack before consulting its parent pack. A
+whole-body mirror swaps both the stance lead and anatomical direction, so the
+pairs are `left_backward`/`right_backward`, `left_left`/`right_right`, and
+`left_right`/`right_left`.
 
 Airborne motion uses the two single-pose files listed above. The runtime blends
 from a directional crouch/load into `airborne_center` or `airborne_travel`,
@@ -315,11 +326,12 @@ modifies the traveling pose from horizontal velocity, and returns through a
 directional crouch/load on landing. There are no separate authored launch,
 direction, or landing samples in the complete pack.
 
-Attacks likewise use the four single-pose contact files listed above: one for
-each combination of `thrust` or `slash` and left or right starting lead. There
-are no required commit or follow-through poses, and `stay` versus `switch` is
-not part of the asset name. Runtime footwork, continuation, and recovery turn
-the contact pose into a complete attack.
+Attacks likewise use the single-pose contact files listed above. There are no
+required commit or follow-through poses, and `stay` versus `switch` is not part
+of the asset name. Runtime footwork, continuation, and recovery turn the
+contact pose into a complete attack. A pack may export both lead files when
+handedness makes them distinct, or export only one and let the missing lead use
+the mirrored same-pack counterpart.
 
 Each block contact has its own file using the semantic pose name as its
 basename. Frame 0 reproduces the applicable guard, frame 6 is the named block
@@ -400,8 +412,13 @@ Locomotion semantic anchors use the **left** side as their canonical first
 half-cycle. When a sparse gait source contains only that half, the runtime
 reflects the complete bilateral limb motion—including clavicles, arms, hands,
 legs, feet, and twist bones—to construct the opposite half and closure.
-Attack and guard poses are not assumed to be whole-body mirrorable because a
-weapon may remain in the same hand.
+Guard, attack, and guard-relative duck counterparts use presence-based
+mirroring. The runtime prefers an exact pose in the requested pack, then a
+whole-body mirrored opposite-side pose from that same pack, and only then the
+parent pack and ordinary semantic fallback chain. Symmetric styles such as
+unarmed combat can therefore author one side. Handed weapon styles author both
+sides whenever reflection would move the weapon to the wrong hand or otherwise
+change the technique.
 
 ## Required semantic poses
 
@@ -524,35 +541,40 @@ Every complete combat pack provides, or inherits:
 | Pose | Animator brief |
 |---|---|
 | `guard_lead_left` | Place the left foot forward and the right foot back on two stable tracks rather than one tightrope line. Distribute weight so either foot can move without a preliminary shuffle; neither knee is locked. Turn the pelvis and torso only as required by the pack's fighting method. In the unarmed root pack, raise both hands to protect the head and torso with the dominant hand free to punch. In a weapon pack, use its normal ready grip and keep the point or striking portion controlled. |
-| `guard_lead_right` | Construct the corresponding stable guard with the right foot forward and left foot back. Preserve the same handedness and held-item hand as `guard_lead_left`; this is a change of foot lead, not a whole-body mirror. Match stance width, guard height, and overall readiness closely enough that attacks can end in either guard without a visible change of style. |
+| `guard_lead_right` | Construct the corresponding stable guard with the right foot forward and left foot back. When this pose is authored, preserve the same handedness and held-item hand as `guard_lead_left`; this is a change of foot lead, not a reflection. Match stance width, guard height, and overall readiness closely enough that attacks can end in either guard without a visible change of style. |
 
 These are stable endpoints for attacks and blocks. Which foot is forward is an
-explicit part of skeleton state. Complete one-handed guards should be authored
-for both lead feet rather than obtained by mirroring the entire body, because
-whole-body mirroring also changes the weapon hand.
+explicit part of skeleton state. If only one guard exists in a pack, the other
+lead mirrors it. Complete one-handed guards should therefore author both lead
+feet whenever whole-body mirroring would change the weapon hand incorrectly.
 
 ### Crouching and directional ducking
 
-`crouch_idle` is the center of a two-dimensional directional duck blend. The
-complete pack adds only a backward withdrawal and one anatomical-left lateral
-extreme. Begin each pose from `crouch_idle`, keep the same planted foot
-locations, and preserve the normal hand carriage.
+Directional ducking begins from the active guard rather than a neutral crouch.
+Each lead has backward, anatomical-left, and anatomical-right semantics. A
+symmetrical pack may author the three extremes for one lead; the opposite lead
+then comes from the mirrored counterpart. Both lateral extremes for a single
+lead remain distinct and cannot be constructed by mirroring each other,
+because that would also exchange the lead feet. Keep the guard's planted foot
+locations and normal hand carriage.
 
 | Pose | Animator brief |
 |---|---|
-| `duck_backward` | Withdraw the head and upper torso backward while sitting the pelvis down and back between the feet. Increase knee flexion to preserve balance and avoid creating the motion solely by arching the lower back. Keep the gaze generally forward and do not lift both toes or heels. |
-| `duck_left` | Shift the pelvis, ribcage, and especially the head toward anatomical left. Load the left leg more heavily, flex it, and allow the right leg to lengthen without moving either foot. Incline or rotate the torso only enough to keep balance and protect the head. Do not cross the legs. |
+| `duck_lead_<left\|right>_backward` | From the named guard lead, withdraw the head and upper torso backward while sitting the pelvis down and back between the feet. Increase knee flexion to preserve balance and avoid creating the motion solely by arching the lower back. Keep the gaze generally forward and do not lift both toes or heels. |
+| `duck_lead_<left\|right>_left` | From the named guard lead, shift the pelvis, ribcage, and especially the head toward anatomical left. Load the left leg more heavily, flex it, and allow the right leg to lengthen without moving either foot. Incline or rotate the torso only enough to keep balance and protect the head. Do not cross the legs. |
+| `duck_lead_<left\|right>_right` | From the named guard lead, make the corresponding anatomical-right displacement while retaining that same lead. This is a separately authored extreme when the pack supplies both lateral directions for the lead; do not derive it by reflecting the other lateral pose without also changing lead. |
 
-The runtime constructs rightward ducking by safely mirroring the lateral body
-delta while retaining handed equipment constraints. Forward/downward ducking
-comes from increasing the `crouch_idle` weight and applying a bounded forward
-head, ribcage, and pelvis displacement with planted-foot IK. Diagonal ducks
-blend these components. Direction still describes the defender's desired body
-or head displacement in local space, not merely the attacker's bearing.
+The same-pack counterpart rule mirrors an entire lead/direction pair only when
+the requested counterpart file is absent. Forward/downward ducking remains
+procedural: it applies a bounded forward head, ribcage, and pelvis displacement
+with planted-foot IK. Diagonal ducks blend these components. Direction still
+describes the defender's desired body or head displacement in local space, not
+merely the attacker's bearing.
 
 Directional ducks should preferably be authored as pose deltas or masked
-overrides so that they can be applied over the current guard without requiring
-versions for every weapon and lead foot.
+overrides over their named guard. Packs need only omit counterparts that remain
+valid under whole-body reflection; asymmetric weapons and techniques should
+export the exact opposite-lead files.
 
 ### Jumping and dodging
 
@@ -715,24 +737,26 @@ an automatic get-up or ragdoll transition rather than a player-controlled roll.
 
 ## Initial complete-pack size
 
-The humanoid unarmed root must define every required semantic pose because it
-has no fallback. Its tentative size is:
+The humanoid unarmed root must satisfy every required semantic pose because it
+has no parent pack. Exact files and the presence-based mirrored counterparts
+both satisfy that requirement. Its tentative authored size is:
 
 | Family | Authored poses |
 |---|---:|
 | Standing and locomotion | 6 |
-| Directional ducking | 2 |
+| Directional ducking | 3 |
 | Jumping and dodging | 2 |
 | Prone and supine | 8 |
-| Combat guards | 2 |
-| Thrust/punch attacks | 2 |
-| Slash/swipe attacks | 2 |
+| Combat guards | 1 |
+| Thrust/punch attacks | 1 |
+| Slash/swipe attacks | 1 |
 | Blocks | 6 |
-| **Complete unarmed root** | **30** |
+| **Complete unarmed root** | **28** |
 
 Most specialized packs should be substantially smaller because they inherit
-unchanged poses. A pack that overrides just one strike family needs two attack
-poses, not another complete set of thirty. The unarmed root supplies punch
+unchanged poses. A symmetric pack that overrides one strike family needs one
+attack pose; an asymmetric pack exports the opposite lead as well. The unarmed
+root supplies punch
 poses for unresolved thrust semantics and swipe poses for unresolved slash
 semantics.
 


### PR DESCRIPTION
## Summary
- resolve absent left/right weapon-pack poses through mirrored semantic counterparts
- prefer authored opposite-side assets whenever they exist
- document duck-side and optional handed-pose conventions

## Verification
- covered by the tactical animation package tests in the stacked verification run
- independently reviewed for fallback architecture and correctness