### PR TITLE
Add procedural raised-guard footwork

### DIFF
--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -113,9 +113,10 @@ When support is high, terrain IK retains the foot's world-space horizontal
 plant until support releases; this prevents the character-following camera
 from concealing conveyor-belt foot skating.
 
-In debug builds, press `F8` to toggle only the final terrain leg-IK pass. The
-HUD reports whether it is on or off; authored FK, gait mirroring, and torso
-stabilization remain active for a useful before/after comparison.
+Terrain conformity starts off. In debug builds, press `F8` to opt into its
+height, slope, and pelvis corrections. The HUD reports whether it is on or off;
+authored FK, gait mirroring, torso stabilization, and flat-ground procedural
+guard stepping remain active for a useful before/after comparison.
 
 The procedural humanoid pass recognizes these case-sensitive bone names:
 

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -19,7 +19,7 @@ mod procedural;
 #[allow(unused_imports)]
 pub(crate) use procedural::{
     BoneRole, HandIkTarget, HandSide, HeldWeaponConstraint, HumanoidBone, HumanoidIkTargets,
-    ProceduralAnimationClock, ProceduralIkState, locomotion_support_weights,
+    ProceduralAnimationClock, ProceduralIkState, RaisedFootworkState, locomotion_support_weights,
 };
 const HUMANOID_UNARMED_PACK: &str = "humanoid_unarmed";
 const BIPED_BASE_GLB: &str = "animations/biped/unarmed/base.glb";
@@ -91,14 +91,15 @@ impl Plugin for TacticalAnimationPlugin {
     }
 }
 
-/// Runtime switch for the final terrain leg-IK pass. It defaults on in every
-/// build; the debug plugin exposes an F8 toggle without changing authored FK.
+/// Runtime switch for terrain height, slope, and pelvis conformity. Flat-ground
+/// procedural guard footwork remains active while this is disabled. Debug
+/// builds expose F8 as an explicit opt-in toggle.
 #[derive(Resource, Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TerrainIkEnabled(pub bool);
 
 impl Default for TerrainIkEnabled {
     fn default() -> Self {
-        Self(true)
+        Self(false)
     }
 }
 
@@ -1552,6 +1553,11 @@ pub fn spawn_fallback_t_pose(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn terrain_ik_defaults_off() {
+        assert!(!TerrainIkEnabled::default().0);
+    }
 
     fn spawn_test_t_pose(
         In(owner): In<Entity>,

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -463,6 +463,7 @@ struct PoleMemory {
     left_arm: Option<Vec3>,
     right_arm: Option<Vec3>,
     pelvis_shift: f32,
+    raised_pelvis_shift: f32,
     evaluation_tick: Option<u64>,
 }
 
@@ -485,6 +486,10 @@ impl ProceduralAnimationClock {
 }
 
 const MIN_INTER_FOOT_SEPARATION: f32 = 0.16;
+// Cascadeur's final ankle bones sit about 15 mm inside analytic targets after
+// the complete hierarchy solve. Keep a measured planning allowance so the
+// rendered bones, not merely abstract targets, retain the 0.16 m contract.
+const GUARD_TARGET_INTER_FOOT_SEPARATION: f32 = MIN_INTER_FOOT_SEPARATION + 0.04;
 const FOOT_TRACK_INNER: f32 = MIN_INTER_FOOT_SEPARATION * 0.5;
 const FOOT_TRACK_OUTER: f32 = 0.55;
 const MAX_PLANT_DISCONTINUITY: f32 = 2.0;
@@ -493,13 +498,52 @@ const MAX_FOOT_TARGET_STEP: f32 = 0.2;
 const PELVIS_CORRECTION_SPEED: f32 = 1.6;
 const MAX_PELVIS_CORRECTION_STEP: f32 = 0.05;
 const MIN_KNEE_FLEXION: f32 = 20.0_f32.to_radians();
+const RAISED_GUARD_PELVIS_DROP: f32 = 0.14;
 
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub(crate) struct ProceduralIkState(PoleMemory);
 
-impl ProceduralIkState {
-    pub(crate) fn reset(&mut self) {
-        self.0 = PoleMemory::default();
+/// Client-only world-space plants for combat-stance locomotion. The replicated
+/// skeleton chooses cadence and direction; exact feet remain presentation
+/// state so they never become tactical authority.
+#[derive(Component, Debug, Clone, Copy)]
+pub(crate) struct RaisedFootworkState {
+    initialized: bool,
+    half_step: u8,
+    lead: LeadFoot,
+    swing_left: bool,
+    step_origin: Vec3,
+    step_rotation: Quat,
+    swing_stance_local: Vec3,
+    swing_start: Vec3,
+    swing_end: Vec3,
+    left_plant: Vec3,
+    right_plant: Vec3,
+    evaluation_tick: Option<u64>,
+    step_sequence: u32,
+    pub(crate) left_solve_target: Option<Vec3>,
+    pub(crate) right_solve_target: Option<Vec3>,
+}
+
+impl Default for RaisedFootworkState {
+    fn default() -> Self {
+        Self {
+            initialized: false,
+            half_step: 0,
+            lead: LeadFoot::Left,
+            swing_left: false,
+            step_origin: Vec3::ZERO,
+            step_rotation: Quat::IDENTITY,
+            swing_stance_local: Vec3::ZERO,
+            swing_start: Vec3::ZERO,
+            swing_end: Vec3::ZERO,
+            left_plant: Vec3::ZERO,
+            right_plant: Vec3::ZERO,
+            evaluation_tick: None,
+            step_sequence: 0,
+            left_solve_target: None,
+            right_solve_target: None,
+        }
     }
 }
 
@@ -547,20 +591,11 @@ pub(super) fn apply_terrain_leg_ik(
     bones: Query<(Entity, &HumanoidBone, Option<&SoleUpAxis>)>,
     parents: Query<&ChildOf>,
     mut ik_states: Query<&mut ProceduralIkState>,
+    mut raised_states: Query<&mut RaisedFootworkState>,
     mut transforms: ParamSet<(TransformHelper, Query<&mut Transform>)>,
     mut commands: Commands,
 ) {
-    if !enabled.0 {
-        // Discard plant targets while disabled so re-enabling IK starts from
-        // the current authored pose instead of snapping to a stale footprint.
-        for mut state in &mut ik_states {
-            state.0 = PoleMemory::default();
-        }
-        return;
-    }
-    let Some(terrain) = terrain.iter().next() else {
-        return;
-    };
+    let terrain = terrain.iter().next();
     let mut rigs = BTreeMap::<Entity, BTreeMap<BoneRole, Entity>>::new();
     let mut sole_axes = BTreeMap::<Entity, Vec3>::new();
     {
@@ -578,9 +613,12 @@ pub(super) fn apply_terrain_leg_ik(
         let Ok(skeleton) = owners.get(owner) else {
             continue;
         };
-        if !skeleton.grounded || skeleton.posture != Posture::Upright {
+        if !raised_footwork_posture_is_valid(skeleton) {
             if let Ok(mut state) = ik_states.get_mut(owner) {
                 state.0 = PoleMemory::default();
+            }
+            if let Ok(mut state) = raised_states.get_mut(owner) {
+                *state = RaisedFootworkState::default();
             }
             continue;
         }
@@ -589,14 +627,10 @@ pub(super) fn apply_terrain_leg_ik(
         let raised_guard_follower = skeleton.weapon_guard == WeaponGuardState::Raised
             && skeleton.action == SkeletonAction::None
             && skeleton.raised_locomotion.active;
-        let (left_weight, right_weight) = if raised_guard_follower {
-            // Fixed-lead guard poses already provide safe authored XZ tracks.
-            // Follow both feet vertically over terrain, but never turn their
-            // current authored positions into alternating world-space plants.
-            (1.0, 1.0)
-        } else {
-            gait_support_weights(phase, ground_speed)
-        };
+        if !raised_guard_follower && let Ok(mut raised) = raised_states.get_mut(owner) {
+            *raised = RaisedFootworkState::default();
+        }
+        let (left_weight, right_weight) = gait_support_weights(phase, ground_speed);
         let legs = [
             (
                 BoneRole::ThighLeft,
@@ -617,10 +651,6 @@ pub(super) fn apply_terrain_leg_ik(
             .get_mut(owner)
             .map(|state| state.0)
             .unwrap_or_default();
-        if raised_guard_follower {
-            memory.left_foot_plant = None;
-            memory.right_foot_plant = None;
-        }
         let state_delta_seconds = match clock.fixed_tick {
             Some((tick, _)) if memory.evaluation_tick == Some(tick) => 0.0,
             Some((tick, delta_seconds)) => {
@@ -629,6 +659,42 @@ pub(super) fn apply_terrain_leg_ik(
             }
             None => time.delta_secs(),
         };
+        let desired_raised_pelvis_shift = if raised_guard_follower {
+            -RAISED_GUARD_PELVIS_DROP
+        } else {
+            0.0
+        };
+        if state_delta_seconds > 0.0 {
+            memory.raised_pelvis_shift = advance_pelvis_shift(
+                memory.raised_pelvis_shift,
+                desired_raised_pelvis_shift,
+                state_delta_seconds,
+            );
+        }
+        let raised_pelvis_shift = memory.raised_pelvis_shift;
+        if raised_pelvis_shift < -0.001
+            && let Some(&pelvis) = rig.get(&BoneRole::Pelvis)
+        {
+            let local_delta = parents
+                .get(pelvis)
+                .ok()
+                .and_then(|parent| {
+                    transforms
+                        .p0()
+                        .compute_global_transform(parent.parent())
+                        .ok()
+                })
+                .map(|parent| {
+                    parent
+                        .affine()
+                        .inverse()
+                        .transform_vector3(Vec3::Y * raised_pelvis_shift)
+                })
+                .unwrap_or(Vec3::Y * raised_pelvis_shift);
+            if let Ok(mut transform) = transforms.p1().get_mut(pelvis) {
+                transform.translation += local_delta;
+            }
+        }
         // Pole, plant, and pelvis reach all belong to the server-owned
         // authored-body frame. The child rig carries no locomotion yaw.
         let (rig_origin, rig_rotation) = rig_scenes
@@ -637,6 +703,332 @@ pub(super) fn apply_terrain_leg_ik(
             .and_then(|(entity, _)| transforms.p0().compute_global_transform(entity).ok())
             .map(|global| (global.translation(), global.rotation()))
             .unwrap_or((Vec3::ZERO, Quat::IDENTITY));
+
+        if raised_guard_follower {
+            // The authored guard is nearly straight-legged. Smoothly lower its
+            // pelvis so a world-planted support foot remains within physical
+            // reach without a one-frame stance-height snap at starts or stops.
+            let left = (
+                rig.get(&BoneRole::ThighLeft),
+                rig.get(&BoneRole::ShinLeft),
+                rig.get(&BoneRole::FootLeft),
+            );
+            let right = (
+                rig.get(&BoneRole::ThighRight),
+                rig.get(&BoneRole::ShinRight),
+                rig.get(&BoneRole::FootRight),
+            );
+            let (Some(&left_upper), Some(&left_lower), Some(&left_foot)) = left else {
+                continue;
+            };
+            let (Some(&right_upper), Some(&right_lower), Some(&right_foot)) = right else {
+                continue;
+            };
+            let Some((_, _, left_foot_snapshot)) = snapshot_chain(
+                left_upper,
+                left_lower,
+                left_foot,
+                &parents,
+                &transforms.p0(),
+            ) else {
+                continue;
+            };
+            let Some((_, _, right_foot_snapshot)) = snapshot_chain(
+                right_upper,
+                right_lower,
+                right_foot,
+                &parents,
+                &transforms.p0(),
+            ) else {
+                continue;
+            };
+            let mut footwork = raised_states
+                .get_mut(owner)
+                .map(|state| *state)
+                .unwrap_or_default();
+            let tick = clock.fixed_tick.map(|(tick, _)| tick);
+            let advances = match tick {
+                Some(tick) => footwork.evaluation_tick != Some(tick),
+                None => state_delta_seconds > 0.0,
+            };
+            if let Some(tick) = tick {
+                footwork.evaluation_tick = Some(tick);
+            }
+            let phase = skeleton.gait_phase.rem_euclid(1.0);
+            let half_step = (phase >= 0.5) as u8;
+            let swing_left = skeleton.raised_locomotion.swing_foot == LeadFoot::Left;
+            // Pelvis lowering must not lower the semantic movement plane.
+            // Recover the pre-drop authored ankle positions for persistent
+            // flat plants; the analytic solve bends the lowered legs to them.
+            let left_authored =
+                left_foot_snapshot.global.translation() + Vec3::Y * -raised_pelvis_shift;
+            let right_authored =
+                right_foot_snapshot.global.translation() + Vec3::Y * -raised_pelvis_shift;
+            let visible_left = memory.left_foot_world_target.unwrap_or(left_authored);
+            let visible_right = memory.right_foot_world_target.unwrap_or(right_authored);
+            let discontinuous =
+                footwork.initialized && rig_origin.distance_squared(footwork.step_origin) > 4.0;
+            let sequence_delta = guard_step_sequence_delta(
+                footwork.step_sequence,
+                skeleton.raised_locomotion.step_sequence,
+            );
+            let skipped_handoff = footwork.initialized && sequence_delta > 1;
+            if !footwork.initialized
+                || footwork.lead != skeleton.lead_foot
+                || discontinuous
+                || skipped_handoff
+            {
+                footwork = RaisedFootworkState {
+                    initialized: true,
+                    half_step,
+                    lead: skeleton.lead_foot,
+                    swing_left,
+                    step_origin: rig_origin,
+                    step_rotation: rig_rotation,
+                    swing_stance_local: rig_rotation.inverse()
+                        * ((if swing_left {
+                            left_authored
+                        } else {
+                            right_authored
+                        }) - rig_origin),
+                    swing_start: if swing_left {
+                        visible_left
+                    } else {
+                        visible_right
+                    },
+                    swing_end: if swing_left {
+                        left_authored
+                    } else {
+                        right_authored
+                    },
+                    left_plant: visible_left,
+                    right_plant: visible_right,
+                    evaluation_tick: tick,
+                    step_sequence: skeleton.raised_locomotion.step_sequence,
+                    left_solve_target: None,
+                    right_solve_target: None,
+                };
+            } else if advances && sequence_delta == 1 {
+                if footwork.swing_left {
+                    footwork.left_plant = footwork.left_solve_target.unwrap_or(footwork.swing_end);
+                } else {
+                    footwork.right_plant =
+                        footwork.right_solve_target.unwrap_or(footwork.swing_end);
+                }
+                footwork.half_step = half_step;
+                footwork.step_sequence = skeleton.raised_locomotion.step_sequence;
+                footwork.swing_left = swing_left;
+                footwork.step_origin = rig_origin;
+                footwork.step_rotation = rig_rotation;
+                footwork.swing_stance_local = rig_rotation.inverse()
+                    * ((if swing_left {
+                        left_authored
+                    } else {
+                        right_authored
+                    }) - rig_origin);
+                footwork.swing_start = if swing_left {
+                    footwork.left_plant
+                } else {
+                    footwork.right_plant
+                };
+            }
+            let local_direction = skeleton
+                .raised_locomotion
+                .local_direction
+                .normalize_or_zero();
+            // Semantic controller axes are opposite the authored rig's X/Z
+            // axes. The owner carries the single 180-degree body conversion.
+            let rig_local_direction = -local_direction;
+            let step_length = guard_step_length(skeleton.raised_locomotion.speed);
+            let opposite_plant = if footwork.swing_left {
+                footwork.right_plant
+            } else {
+                footwork.left_plant
+            };
+            footwork.swing_end = plan_guard_step_endpoint(
+                footwork.step_origin,
+                footwork.step_rotation,
+                footwork.swing_stance_local,
+                rig_local_direction,
+                step_length,
+                footwork.swing_left,
+                opposite_plant,
+            );
+            let step_progress = (phase * 2.0).fract();
+            let horizontal_progress = smoothstep(0.0, 1.0, step_progress);
+            let mut swing_target = footwork
+                .swing_start
+                .lerp(footwork.swing_end, horizontal_progress);
+            let mut left_target = footwork.left_plant;
+            let mut right_target = footwork.right_plant;
+            let support_target = if footwork.swing_left {
+                right_target
+            } else {
+                left_target
+            };
+            swing_target = constrain_guard_swing_to_live_corridor(
+                swing_target,
+                support_target,
+                rig_origin,
+                rig_rotation,
+                footwork.swing_stance_local.x.signum(),
+            );
+            let mut terrain_swing_end = footwork.swing_end;
+            if enabled.0
+                && let Some(terrain) = terrain
+            {
+                left_target = terrain_conformed_guard_target(
+                    left_target,
+                    terrain.height_at(left_target.xz()),
+                );
+                right_target = terrain_conformed_guard_target(
+                    right_target,
+                    terrain.height_at(right_target.xz()),
+                );
+                terrain_swing_end = terrain_conformed_guard_target(
+                    terrain_swing_end,
+                    terrain.height_at(terrain_swing_end.xz()),
+                );
+                swing_target.y = footwork
+                    .swing_start
+                    .y
+                    .lerp(terrain_swing_end.y, horizontal_progress);
+            }
+            swing_target.y += (std::f32::consts::PI * step_progress).sin() * 0.10;
+            if footwork.swing_left {
+                left_target = swing_target;
+            } else {
+                right_target = swing_target;
+            }
+
+            for (upper, lower, foot, target, left, support) in [
+                (
+                    left_upper,
+                    left_lower,
+                    left_foot,
+                    left_target,
+                    true,
+                    !footwork.swing_left,
+                ),
+                (
+                    right_upper,
+                    right_lower,
+                    right_foot,
+                    right_target,
+                    false,
+                    footwork.swing_left,
+                ),
+            ] {
+                let Some((upper_snapshot, lower_snapshot, foot_snapshot)) =
+                    snapshot_chain(upper, lower, foot, &parents, &transforms.p0())
+                else {
+                    continue;
+                };
+                let upper_length = upper_snapshot
+                    .global
+                    .translation()
+                    .distance(lower_snapshot.global.translation());
+                let lower_length = lower_snapshot
+                    .global
+                    .translation()
+                    .distance(foot_snapshot.global.translation());
+                let side = anatomical_side(
+                    rig_rotation,
+                    rig_origin,
+                    upper_snapshot.global.translation(),
+                    left,
+                );
+                let remembered = if left {
+                    memory.left_leg
+                } else {
+                    memory.right_leg
+                };
+                let canonical_pole = canonical_knee_pole(side);
+                let remembered = remembered.filter(|pole| pole.dot(canonical_pole) > 0.2);
+                let pole = pole_to_world(rig_rotation, remembered.unwrap_or(canonical_pole));
+                if let Some(solution) = solve_two_bone_with_reach(
+                    upper_snapshot.global.translation(),
+                    lower_snapshot.global.translation(),
+                    foot_snapshot.global.translation(),
+                    target,
+                    upper_length,
+                    lower_length,
+                    pole,
+                    (upper_length + lower_length) * 0.999,
+                ) {
+                    apply_two_bone_solution(
+                        upper,
+                        lower,
+                        foot,
+                        solution,
+                        &parents,
+                        &mut transforms,
+                    );
+                    let bend = (solution.knee - upper_snapshot.global.translation())
+                        .reject_from_normalized(solution.end_direction);
+                    if let Some(valid) = bend.try_normalize() {
+                        if left {
+                            memory.left_leg = Some(pole_to_owner(rig_rotation, valid));
+                        } else {
+                            memory.right_leg = Some(pole_to_owner(rig_rotation, valid));
+                        }
+                    }
+                }
+                if enabled.0
+                    && support
+                    && let Some(terrain) = terrain
+                    && let Some(normal) = terrain.normal_at(target.xz())
+                    && let Some(&sole_axis) = sole_axes.get(&foot)
+                {
+                    align_foot_to_slope(foot, sole_axis, normal, 1.0, &parents, &mut transforms);
+                }
+                if left {
+                    footwork.left_solve_target = Some(target);
+                    memory.left_foot_world_target = Some(target);
+                    memory.left_support_weight = Some(support as u8 as f32);
+                } else {
+                    footwork.right_solve_target = Some(target);
+                    memory.right_foot_world_target = Some(target);
+                    memory.right_support_weight = Some(support as u8 as f32);
+                }
+            }
+            if let Ok(mut state) = raised_states.get_mut(owner) {
+                *state = footwork;
+            } else {
+                commands.entity(owner).insert(footwork);
+            }
+            if let Ok(mut state) = ik_states.get_mut(owner) {
+                state.0 = memory;
+            } else {
+                commands.entity(owner).insert(ProceduralIkState(memory));
+            }
+            continue;
+        }
+
+        if !enabled.0 {
+            // Terrain IK is opt-in. Clear only leg targets so enabling it later
+            // cannot resurrect stale plants; arm pole continuity is unrelated.
+            memory.left_foot_plant = None;
+            memory.right_foot_plant = None;
+            memory.left_foot_target = None;
+            memory.right_foot_target = None;
+            memory.left_foot_world_target = None;
+            memory.right_foot_world_target = None;
+            memory.left_support_weight = None;
+            memory.right_support_weight = None;
+            memory.left_release_active = false;
+            memory.right_release_active = false;
+            memory.pelvis_shift = 0.0;
+            if let Ok(mut state) = ik_states.get_mut(owner) {
+                state.0 = memory;
+            } else {
+                commands.entity(owner).insert(ProceduralIkState(memory));
+            }
+            continue;
+        }
+        let Some(terrain) = terrain else {
+            continue;
+        };
         let mut desired_hip_shift = 0.0_f32;
         for (upper_role, lower_role, foot_role, weight, left) in legs {
             let (Some(&upper), Some(&lower), Some(&foot)) = (
@@ -923,6 +1315,10 @@ pub(super) fn apply_terrain_leg_ik(
     }
 }
 
+fn raised_footwork_posture_is_valid(skeleton: &SkeletonState) -> bool {
+    skeleton.grounded && skeleton.posture == Posture::Upright
+}
+
 fn locomotion_run_weight(speed: f32) -> f32 {
     ((speed - 2.0) / (5.5 - 2.0)).clamp(0.0, 1.0)
 }
@@ -937,16 +1333,15 @@ pub(crate) fn gait_support_weights(phase: f32, speed: f32) -> (f32, f32) {
     )
 }
 
-/// World-space plant confidence used by diagnostics. Raised guard movement
-/// follows authored foot XZ positions instead of alternating retained plants,
-/// so neither side is reported as pinned even though both receive full terrain
-/// height/reach correction inside the IK solver.
+/// World-space plant confidence used by diagnostics. Procedural guard movement
+/// has exactly one support foot while the other follows its clearance arc.
 pub(crate) fn locomotion_support_weights(skeleton: &SkeletonState) -> (f32, f32) {
     if skeleton.weapon_guard == WeaponGuardState::Raised
         && skeleton.action == SkeletonAction::None
         && skeleton.raised_locomotion.active
     {
-        (0.0, 0.0)
+        let swing_left = skeleton.raised_locomotion.swing_foot == LeadFoot::Left;
+        ((!swing_left) as u8 as f32, swing_left as u8 as f32)
     } else {
         gait_support_weights(skeleton.gait_phase, skeleton.local_velocity.xz().length())
     }
@@ -999,6 +1394,79 @@ fn constrain_foot_to_track(world: Vec3, rig_origin: Vec3, rig_rotation: Quat, si
     let signed_x = (local.x * side).clamp(FOOT_TRACK_INNER, FOOT_TRACK_OUTER);
     local.x = signed_x * side;
     rig_origin + rig_rotation * local
+}
+
+fn plan_guard_step_endpoint(
+    step_origin: Vec3,
+    step_rotation: Quat,
+    mut stance_local: Vec3,
+    local_direction: Vec2,
+    step_length: f32,
+    left: bool,
+    opposite_plant: Vec3,
+) -> Vec3 {
+    // Cascadeur's authored lateral axis is opposite the conventional Bevy
+    // anatomical assumption. Derive the corridor from the actual pose rather
+    // than assigning a sign from the semantic bone name.
+    let side = if stance_local.x.abs() > 0.001 {
+        stance_local.x.signum()
+    } else if left {
+        -1.0
+    } else {
+        1.0
+    };
+    let lateral_travel = local_direction.x * step_length;
+    let authored_track = (stance_local.x * side)
+        .abs()
+        .clamp(FOOT_TRACK_INNER, FOOT_TRACK_OUTER);
+    let moving_toward_side = lateral_travel * side > 0.001;
+    let mut track = if lateral_travel.abs() <= 0.001 {
+        authored_track
+    } else if moving_toward_side {
+        (lateral_travel.abs() + FOOT_TRACK_INNER).min(FOOT_TRACK_OUTER)
+    } else {
+        FOOT_TRACK_INNER
+    };
+    let future_origin = step_origin
+        + step_rotation * Vec3::new(local_direction.x, 0.0, local_direction.y) * step_length;
+    let opposite_local = step_rotation.inverse() * (opposite_plant - future_origin);
+    // Separation is an anatomical lateral-track contract. Fore/aft spacing
+    // must not be credited toward it or feet can converge onto one tightrope.
+    let separation_track = opposite_local.x * side + GUARD_TARGET_INTER_FOOT_SEPARATION;
+    track = track
+        .max(separation_track)
+        .clamp(FOOT_TRACK_INNER, FOOT_TRACK_OUTER);
+    stance_local.x = track * side;
+    future_origin + step_rotation * stance_local
+}
+
+fn guard_step_sequence_delta(previous: u32, current: u32) -> u32 {
+    current.wrapping_sub(previous)
+}
+
+fn constrain_guard_swing_to_live_corridor(
+    target: Vec3,
+    support: Vec3,
+    rig_origin: Vec3,
+    rig_rotation: Quat,
+    side: f32,
+) -> Vec3 {
+    let mut local = rig_rotation.inverse() * (target - rig_origin);
+    let support_local = rig_rotation.inverse() * (support - rig_origin);
+    let required_track = support_local.x * side + GUARD_TARGET_INTER_FOOT_SEPARATION;
+    let signed_track = (local.x * side)
+        .max(FOOT_TRACK_INNER)
+        .max(required_track)
+        .min(FOOT_TRACK_OUTER);
+    local.x = signed_track * side;
+    rig_origin + rig_rotation * local
+}
+
+fn terrain_conformed_guard_target(mut flat_target: Vec3, terrain_height: Option<f32>) -> Vec3 {
+    if let Some(height) = terrain_height {
+        flat_target.y = height + 0.085;
+    }
+    flat_target
 }
 
 fn maximum_reach(upper_length: f32, lower_length: f32) -> f32 {
@@ -1063,6 +1531,53 @@ fn solve_two_bone(
     lower_length: f32,
     pole_direction: Vec3,
 ) -> Option<TwoBoneSolution> {
+    solve_two_bone_internal(
+        root,
+        current_knee,
+        current_end,
+        target,
+        upper_length,
+        lower_length,
+        pole_direction,
+        maximum_reach(upper_length, lower_length),
+        true,
+    )
+}
+
+fn solve_two_bone_with_reach(
+    root: Vec3,
+    current_knee: Vec3,
+    current_end: Vec3,
+    target: Vec3,
+    upper_length: f32,
+    lower_length: f32,
+    pole_direction: Vec3,
+    maximum_target_reach: f32,
+) -> Option<TwoBoneSolution> {
+    solve_two_bone_internal(
+        root,
+        current_knee,
+        current_end,
+        target,
+        upper_length,
+        lower_length,
+        pole_direction,
+        maximum_target_reach,
+        false,
+    )
+}
+
+fn solve_two_bone_internal(
+    root: Vec3,
+    current_knee: Vec3,
+    current_end: Vec3,
+    target: Vec3,
+    upper_length: f32,
+    lower_length: f32,
+    pole_direction: Vec3,
+    maximum_target_reach: f32,
+    preserve_authored_bend: bool,
+) -> Option<TwoBoneSolution> {
     if !root.is_finite() || !target.is_finite() || upper_length <= 0.0001 || lower_length <= 0.0001
     {
         return None;
@@ -1074,7 +1589,7 @@ fn solve_two_bone(
         .unwrap_or(Vec3::NEG_Y);
     let distance = target_offset.length().clamp(
         (upper_length - lower_length).abs() + 0.0001,
-        maximum_reach(upper_length, lower_length),
+        maximum_target_reach.min(upper_length + lower_length - 0.0001),
     );
     let end = root + target_direction * distance;
     let along = (upper_length * upper_length - lower_length * lower_length + distance * distance)
@@ -1091,18 +1606,22 @@ fn solve_two_bone(
     // Preserve authored continuity only while it remains in the anatomical
     // hemisphere. Never flip a valid authored bend through a straight-leg
     // singularity merely to satisfy a pole chosen on the opposite side.
-    let stabilized_authored_bend = authored_bend.zip(pole_bend).and_then(|(authored, pole)| {
-        let alignment = authored.dot(pole);
-        (alignment > 0.05)
-            .then(|| {
-                pole.lerp(authored, smoothstep(0.05, 0.5, alignment))
-                    .try_normalize()
-            })
-            .flatten()
-    });
+    let stabilized_authored_bend = preserve_authored_bend
+        .then_some(authored_bend)
+        .flatten()
+        .zip(pole_bend)
+        .and_then(|(authored, pole)| {
+            let alignment = authored.dot(pole);
+            (alignment > 0.05)
+                .then(|| {
+                    pole.lerp(authored, smoothstep(0.05, 0.5, alignment))
+                        .try_normalize()
+                })
+                .flatten()
+        });
     let bend = stabilized_authored_bend
         .or(pole_bend)
-        .or(authored_bend)
+        .or(preserve_authored_bend.then_some(authored_bend).flatten())
         .or_else(|| target_direction.any_orthonormal_vector().try_normalize())?;
     let knee = root + target_direction * along + bend * height;
     (knee.is_finite() && end.is_finite()).then_some(TwoBoneSolution {
@@ -1639,7 +2158,7 @@ mod tests {
     }
 
     #[test]
-    fn raised_guard_movement_never_reports_alternating_world_plants() {
+    fn raised_guard_movement_reports_exactly_one_procedural_support_foot() {
         for (lead, phase) in [
             (LeadFoot::Left, 0.0),
             (LeadFoot::Left, 0.5),
@@ -1655,10 +2174,16 @@ mod tests {
                     active: true,
                     local_direction: Vec2::NEG_Y,
                     speed: 2.0,
+                    swing_foot: lead,
+                    step_sequence: 0,
                 },
                 ..default()
             };
-            assert_eq!(locomotion_support_weights(&skeleton), (0.0, 0.0));
+            let (left, right) = locomotion_support_weights(&skeleton);
+            assert_eq!(left + right, 1.0);
+            let expected_swing_left = lead == LeadFoot::Left;
+            assert_eq!(left, (!expected_swing_left) as u8 as f32);
+            assert_eq!(right, expected_swing_left as u8 as f32);
         }
         let idle = SkeletonState {
             weapon_guard: WeaponGuardState::Raised,
@@ -1666,6 +2191,98 @@ mod tests {
             ..default()
         };
         assert_eq!(locomotion_support_weights(&idle), (1.0, 1.0));
+    }
+
+    #[test]
+    fn analog_guard_speed_scales_step_reach_without_unbounded_strides() {
+        assert!(guard_step_length(1.0) < guard_step_length(2.0));
+        assert_eq!(guard_step_length(0.0), 0.28);
+        assert_eq!(guard_step_length(100.0), 0.42);
+    }
+
+    #[test]
+    fn guard_step_planner_preserves_tracks_and_separation_in_all_directions() {
+        let origin = Vec3::ZERO;
+        let rotation = Quat::IDENTITY;
+        let step = guard_step_length(2.0);
+        for direction in [
+            Vec2::X,
+            Vec2::NEG_X,
+            Vec2::Y,
+            Vec2::NEG_Y,
+            Vec2::ONE.normalize(),
+            Vec2::new(-1.0, -1.0).normalize(),
+        ] {
+            for left in [true, false] {
+                let side = if left { -1.0 } else { 1.0 };
+                let stance = Vec3::new(0.12 * side, -0.85, if left { -0.2 } else { 0.2 });
+                let opposite = Vec3::new(-0.12 * side, -0.85, -stance.z);
+                let target = plan_guard_step_endpoint(
+                    origin, rotation, stance, direction, step, left, opposite,
+                );
+                let future_origin = Vec3::new(direction.x, 0.0, direction.y) * step;
+                let local = rotation.inverse() * (target - future_origin);
+                assert!(local.x * side >= FOOT_TRACK_INNER - 0.0001);
+                assert!(local.x * side <= FOOT_TRACK_OUTER + 0.0001);
+                let separation = target.xz().distance(opposite.xz());
+                assert!(
+                    separation >= GUARD_TARGET_INTER_FOOT_SEPARATION - 0.0001,
+                    "direction={direction:?} left={left} target={target:?} opposite={opposite:?} separation={separation}"
+                );
+                assert!(
+                    (target.x - opposite.x).abs() >= GUARD_TARGET_INTER_FOOT_SEPARATION - 0.0001
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn live_swing_corridor_preserves_separation_between_handoffs() {
+        let root = Vec3::new(-0.2, 2.8, 0.0);
+        let rotation = Quat::from_rotation_y(std::f32::consts::PI);
+        let support = Vec3::new(0.21, 1.95, 0.02);
+        let unconstrained = Vec3::new(0.18, 2.02, 0.02);
+        let constrained =
+            constrain_guard_swing_to_live_corridor(unconstrained, support, root, rotation, 1.0);
+        let local = rotation.inverse() * (constrained - root);
+        assert!(local.x >= FOOT_TRACK_INNER);
+        assert!(
+            constrained.xz().distance(support.xz()) >= GUARD_TARGET_INTER_FOOT_SEPARATION - 0.0001
+        );
+        assert!((constrained.x - support.x).abs() >= GUARD_TARGET_INTER_FOOT_SEPARATION - 0.0001);
+    }
+
+    #[test]
+    fn skipped_full_cycle_has_distinct_semantic_step_identity() {
+        assert_eq!(guard_step_sequence_delta(41, 42), 1);
+        assert_eq!(guard_step_sequence_delta(41, 43), 2);
+        assert_eq!(guard_step_sequence_delta(u32::MAX, 0), 1);
+    }
+
+    #[test]
+    fn terrain_height_is_transient_during_an_active_guard_step() {
+        let flat = Vec3::new(0.2, -0.85, 0.3);
+        let elevated = terrain_conformed_guard_target(flat, Some(1.25));
+        assert_eq!(elevated.y, 1.335);
+        assert_eq!(terrain_conformed_guard_target(flat, None), flat);
+        assert_eq!(flat.y, -0.85);
+    }
+
+    #[test]
+    fn inactive_postures_require_raised_footwork_reset() {
+        for (grounded, posture) in [
+            (false, Posture::Airborne),
+            (true, Posture::Crouched),
+            (true, Posture::Prone),
+        ] {
+            let skeleton = SkeletonState {
+                grounded,
+                posture,
+                weapon_guard: WeaponGuardState::Raised,
+                ..default()
+            };
+            assert!(!raised_footwork_posture_is_valid(&skeleton));
+        }
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 
 use crate::animation::{
     AnimationPlayback, BoneRole, HumanoidBone, ProceduralAnimationClock, ProceduralIkState,
-    TacticalAnimationPlugin, locomotion_support_weights,
+    RaisedFootworkState, TacticalAnimationPlugin, TerrainIkEnabled, locomotion_support_weights,
 };
 use crate::{
     camera::{CameraMode, TacticalCameraPlugin, TacticalCameraSet, third_person_offset},
@@ -32,6 +32,8 @@ use crate::{
 const SAMPLE_HZ: f32 = 64.0;
 const CAPTURE_ROOT_GROUND_OFFSET_METRES: f32 = 0.95;
 const FULL_PLANT_SUPPORT_WEIGHT: f32 = 0.99;
+const RAISED_MINIMUM_INTER_FOOT_SEPARATION_METRES: f32 = 0.16;
+const RAISED_MAXIMUM_PELVIS_VERTICAL_STEP_METRES: f32 = 0.05;
 const ORDINARY_VERTICAL_RANGE_LIMIT_METRES: f32 = 0.20;
 const RAISED_GUARD_VERTICAL_RANGE_LIMIT_METRES: f32 = 0.30;
 const VIEWS: [CaptureView; 3] = [CaptureView::Gameplay, CaptureView::Side, CaptureView::Front];
@@ -107,6 +109,9 @@ pub(crate) fn run(
         .insert_resource(CameraMode { third_person: true })
         .insert_resource(WeaponGuardInputState::default())
         .insert_resource(Time::<Fixed>::from_hz(SAMPLE_HZ as f64))
+        // Deterministic captures explicitly validate the optional terrain
+        // pass; live clients and the playground keep its default-off setting.
+        .insert_resource(TerrainIkEnabled(true))
         .insert_resource(ClearColor(Color::srgb(0.08, 0.1, 0.13)))
         .insert_resource(CaptureSequence::new(output, settle_frames, scenario))
         .add_systems(Startup, setup_viewer)
@@ -160,6 +165,7 @@ struct PlannedFrame {
     camera_pitch: f32,
     action: SkeletonAction,
     weapon_guard: WeaponGuardState,
+    lead_foot: LeadFoot,
 }
 
 #[derive(Resource)]
@@ -269,6 +275,7 @@ struct ScenarioMetrics {
     loop_seam_position_metres: Option<f32>,
     loop_seam_rotation_degrees: Option<f32>,
     pelvis_vertical_range_metres: f32,
+    maximum_pelvis_vertical_step_metres: f32,
     head_vertical_range_metres: f32,
     foot_terrain_relief_metres: f32,
     minimum_knee_forward_bend_metres: f32,
@@ -311,6 +318,8 @@ struct FrameSample {
     guard_action: bool,
     left_support_weight: f32,
     right_support_weight: f32,
+    desired_left_foot_target: Option<[f32; 3]>,
+    desired_right_foot_target: Option<[f32; 3]>,
     screenshots: BTreeMap<String, String>,
     bones: BTreeMap<String, BoneSample>,
 }
@@ -336,7 +345,7 @@ fn steady_scenario_in_direction(
     cycles: f32,
     local_direction: Vec2,
 ) -> Vec<PlannedFrame> {
-    let cycle_duration = stride_length(speed) / speed;
+    let cycle_duration = stride_length(speed) * 2.0 / speed;
     let duration = cycles * cycle_duration;
     // Include the first authoritative tick after the requested final cycle.
     // Fixed-rate sampling rarely lands on the mathematical wrap exactly; the
@@ -354,6 +363,7 @@ fn steady_scenario_in_direction(
             camera_pitch: 0.0,
             action: SkeletonAction::None,
             weapon_guard: WeaponGuardState::Lowered,
+            lead_foot: LeadFoot::Left,
         })
         .collect()
 }
@@ -387,6 +397,7 @@ fn transition_scenario() -> Vec<PlannedFrame> {
                 camera_pitch: 0.0,
                 action: SkeletonAction::None,
                 weapon_guard: WeaponGuardState::Lowered,
+                lead_foot: LeadFoot::Left,
             }
         })
         .collect()
@@ -415,8 +426,40 @@ fn capture_plan() -> Vec<PlannedFrame> {
         raised_guard_scenario("raised-guard-forward-right", Vec2::new(1.0, -1.0)),
         raised_guard_scenario("raised-guard-backward-left", Vec2::new(-1.0, 1.0)),
         raised_guard_scenario("raised-guard-backward-right", Vec2::ONE),
+        raised_guard_steady_scenario("raised-guard-half-speed", 1.0, 1.0, Vec2::X),
+        raised_guard_acceleration_scenario(),
         raised_guard_release_scenario(),
         raised_guard_reversal_scenario(),
+        raised_guard_steady_scenario_with_lead(
+            "raised-guard-right-lead-left",
+            2.0,
+            1.0,
+            Vec2::NEG_X,
+            LeadFoot::Right,
+        ),
+        raised_guard_steady_scenario_with_lead(
+            "raised-guard-right-lead-right",
+            2.0,
+            1.0,
+            Vec2::X,
+            LeadFoot::Right,
+        ),
+        raised_guard_steady_scenario_with_lead(
+            "raised-guard-right-lead-forward-right",
+            2.0,
+            1.0,
+            Vec2::new(1.0, -1.0),
+            LeadFoot::Right,
+        ),
+        raised_guard_acceleration_scenario_with_lead(
+            "raised-guard-right-lead-accelerate",
+            LeadFoot::Right,
+        ),
+        raised_guard_release_scenario_with_lead("raised-guard-right-lead-release", LeadFoot::Right),
+        raised_guard_reversal_scenario_with_lead(
+            "raised-guard-right-lead-reversal",
+            LeadFoot::Right,
+        ),
         raised_guard_transition_scenario(),
         steady_scenario_in_direction("cross-slope-walk", 2.0, 1.0, Vec2::X),
         transition_scenario(),
@@ -446,6 +489,7 @@ fn turning_scenario(name: &'static str, reversal: bool) -> Vec<PlannedFrame> {
                 camera_pitch: 0.55 * progress,
                 action: SkeletonAction::None,
                 weapon_guard: WeaponGuardState::Lowered,
+                lead_foot: LeadFoot::Left,
             }
         })
         .collect()
@@ -465,6 +509,7 @@ fn guard_plant_turn_scenario() -> Vec<PlannedFrame> {
                 camera_pitch: 0.0,
                 action: SkeletonAction::Block,
                 weapon_guard: WeaponGuardState::Lowered,
+                lead_foot: LeadFoot::Left,
             }
         })
         .collect()
@@ -472,11 +517,69 @@ fn guard_plant_turn_scenario() -> Vec<PlannedFrame> {
 
 fn raised_guard_scenario(name: &'static str, direction: Vec2) -> Vec<PlannedFrame> {
     let direction = direction.normalize_or_zero();
-    steady_scenario_in_direction(name, 2.0, 1.0, direction)
-        .into_iter()
-        .map(|mut frame| {
-            frame.weapon_guard = WeaponGuardState::Raised;
-            frame
+    raised_guard_steady_scenario(name, 2.0, 1.0, direction)
+}
+
+fn raised_guard_steady_scenario(
+    name: &'static str,
+    speed: f32,
+    cycles: f32,
+    direction: Vec2,
+) -> Vec<PlannedFrame> {
+    raised_guard_steady_scenario_with_lead(name, speed, cycles, direction, LeadFoot::Left)
+}
+
+fn raised_guard_steady_scenario_with_lead(
+    name: &'static str,
+    speed: f32,
+    cycles: f32,
+    direction: Vec2,
+    lead_foot: LeadFoot,
+) -> Vec<PlannedFrame> {
+    let duration = cycles * guard_step_length(speed) * 2.0 / speed;
+    let last_frame = (duration * SAMPLE_HZ).ceil() as usize + 1;
+    (0..=last_frame)
+        .map(|scenario_frame| PlannedFrame {
+            scenario: name,
+            scenario_frame,
+            speed,
+            time_seconds: scenario_frame as f32 / SAMPLE_HZ,
+            local_direction: direction.normalize_or_zero(),
+            camera_yaw: 0.0,
+            camera_pitch: 0.0,
+            action: SkeletonAction::None,
+            weapon_guard: WeaponGuardState::Raised,
+            lead_foot,
+        })
+        .collect()
+}
+
+fn raised_guard_acceleration_scenario() -> Vec<PlannedFrame> {
+    raised_guard_acceleration_scenario_with_lead(
+        "raised-guard-accelerate-from-rest",
+        LeadFoot::Left,
+    )
+}
+
+fn raised_guard_acceleration_scenario_with_lead(
+    name: &'static str,
+    lead_foot: LeadFoot,
+) -> Vec<PlannedFrame> {
+    (0..=96)
+        .map(|scenario_frame| {
+            let time_seconds = scenario_frame as f32 / SAMPLE_HZ;
+            PlannedFrame {
+                scenario: name,
+                scenario_frame,
+                speed: (time_seconds / 0.5).clamp(0.0, 1.0) * 2.0,
+                time_seconds,
+                local_direction: Vec2::X,
+                camera_yaw: 0.0,
+                camera_pitch: 0.0,
+                action: SkeletonAction::None,
+                weapon_guard: WeaponGuardState::Raised,
+                lead_foot,
+            }
         })
         .collect()
 }
@@ -497,14 +600,22 @@ fn raised_guard_transition_scenario() -> Vec<PlannedFrame> {
             } else {
                 WeaponGuardState::Raised
             },
+            lead_foot: LeadFoot::Left,
         })
         .collect()
 }
 
 fn raised_guard_release_scenario() -> Vec<PlannedFrame> {
+    raised_guard_release_scenario_with_lead("raised-guard-release-at-peak", LeadFoot::Left)
+}
+
+fn raised_guard_release_scenario_with_lead(
+    name: &'static str,
+    lead_foot: LeadFoot,
+) -> Vec<PlannedFrame> {
     (0..=64)
         .map(|scenario_frame| PlannedFrame {
-            scenario: "raised-guard-release-at-peak",
+            scenario: name,
             scenario_frame,
             speed: if scenario_frame <= 20 { 2.0 } else { 0.0 },
             time_seconds: scenario_frame as f32 / SAMPLE_HZ,
@@ -513,14 +624,22 @@ fn raised_guard_release_scenario() -> Vec<PlannedFrame> {
             camera_pitch: 0.0,
             action: SkeletonAction::None,
             weapon_guard: WeaponGuardState::Raised,
+            lead_foot,
         })
         .collect()
 }
 
 fn raised_guard_reversal_scenario() -> Vec<PlannedFrame> {
+    raised_guard_reversal_scenario_with_lead("raised-guard-left-right-reversal", LeadFoot::Left)
+}
+
+fn raised_guard_reversal_scenario_with_lead(
+    name: &'static str,
+    lead_foot: LeadFoot,
+) -> Vec<PlannedFrame> {
     (0..=64)
         .map(|scenario_frame| PlannedFrame {
-            scenario: "raised-guard-left-right-reversal",
+            scenario: name,
             scenario_frame,
             speed: 2.0,
             time_seconds: scenario_frame as f32 / SAMPLE_HZ,
@@ -533,6 +652,7 @@ fn raised_guard_reversal_scenario() -> Vec<PlannedFrame> {
             camera_pitch: 0.0,
             action: SkeletonAction::None,
             weapon_guard: WeaponGuardState::Raised,
+            lead_foot,
         })
         .collect()
 }
@@ -590,6 +710,7 @@ fn drive_sequence(
             &mut CharacterLook,
             Option<&AnimationPlayback>,
             Option<&mut ProceduralIkState>,
+            Option<&mut RaisedFootworkState>,
         ),
         With<CaptureSubject>,
     >,
@@ -600,7 +721,9 @@ fn drive_sequence(
     }
     let frame = sequence.plan[sequence.index].clone();
     let mut gait_phase = 0.0;
-    for (mut skeleton, mut transform, mut look, playback, ik_state) in &mut subjects {
+    for (mut skeleton, mut transform, mut look, playback, ik_state, raised_footwork) in
+        &mut subjects
+    {
         let Some(playback) = playback else {
             return;
         };
@@ -615,7 +738,10 @@ fn drive_sequence(
             *skeleton = SkeletonState::default();
             *guard_input = WeaponGuardInputState::default();
             if let Some(mut ik_state) = ik_state {
-                ik_state.reset();
+                *ik_state = ProceduralIkState::default();
+            }
+            if let Some(mut raised_footwork) = raised_footwork {
+                *raised_footwork = RaisedFootworkState::default();
             }
             let ground = terrain.height_at(Vec2::ZERO).unwrap_or_default();
             transform.translation = Vec3::new(0.0, ground + CAPTURE_ROOT_GROUND_OFFSET_METRES, 0.0);
@@ -630,6 +756,7 @@ fn drive_sequence(
             WeaponGuardState::Raised => 1.0,
             WeaponGuardState::Lowered => -1.0,
         };
+        skeleton.lead_foot = frame.lead_foot;
         guard_input.apply_controls(wheel, false);
         set_weapon_guard(&mut skeleton, guard_input.desired);
         let local_velocity =
@@ -817,6 +944,7 @@ fn capture_frame(
             &SkeletonState,
             &GlobalTransform,
             Option<&AnimationPlayback>,
+            Option<&RaisedFootworkState>,
         ),
         With<CaptureSubject>,
     >,
@@ -827,7 +955,8 @@ fn capture_frame(
     if !sequence.applied || sequence.capture_in_flight {
         return;
     }
-    let Ok((subject, skeleton, subject_global, playback)) = subjects.single() else {
+    let Ok((subject, skeleton, subject_global, playback, raised_footwork)) = subjects.single()
+    else {
         wait_or_fail(&mut sequence, "capture subject is missing", &mut exit);
         return;
     };
@@ -873,6 +1002,9 @@ fn capture_frame(
     if sequence.view_index == 0 {
         let (left_support_weight, right_support_weight) = locomotion_support_weights(skeleton);
         let root_distance_metres = sequence.scenario_distance;
+        let (desired_left_foot_target, desired_right_foot_target) = raised_footwork
+            .map(|state| (state.left_solve_target, state.right_solve_target))
+            .unwrap_or_default();
         sequence.samples.push(FrameSample {
             scenario: frame.scenario.to_owned(),
             scenario_frame: frame.scenario_frame,
@@ -903,6 +1035,8 @@ fn capture_frame(
                 || matches!(frame.action, SkeletonAction::Attack | SkeletonAction::Block),
             left_support_weight,
             right_support_weight,
+            desired_left_foot_target: desired_left_foot_target.map(|value| value.to_array()),
+            desired_right_foot_target: desired_right_foot_target.map(|value| value.to_array()),
             screenshots: VIEWS
                 .into_iter()
                 .map(|view| {
@@ -1062,6 +1196,9 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
     let continuity_within_review_bounds = scenarios.iter().all(|metrics| {
         metrics.maximum_root_relative_step_metres <= 0.20
             && metrics.maximum_bone_rotation_step_degrees <= 60.0
+            && (!metrics.scenario.starts_with("raised-guard")
+                || metrics.maximum_pelvis_vertical_step_metres
+                    <= RAISED_MAXIMUM_PELVIS_VERTICAL_STEP_METRES)
     });
     let no_ground_penetration = scenarios
         .iter()
@@ -1080,9 +1217,10 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         let vertical_range_limit =
             vertical_range_limit(&metrics.scenario, metrics.foot_terrain_relief_metres);
         metrics.maximum_supported_foot_slip_metres_per_frame <= 0.035
-            && metrics.maximum_planted_foot_drift_metres <= 0.035
+            && metrics.maximum_planted_foot_drift_metres <= planted_drift_limit(&metrics.scenario)
             && metrics.minimum_signed_foot_track_metres >= -0.01
-            && metrics.minimum_inter_foot_separation_metres >= 0.08
+            && metrics.minimum_inter_foot_separation_metres
+                >= inter_foot_separation_limit(&metrics.scenario)
             && metrics.minimum_knee_flexion_degrees >= 4.0
             && metrics.minimum_knee_hemisphere_dot >= 0.0
             && metrics.maximum_facing_tracking_excess_degrees <= 0.2
@@ -1149,6 +1287,22 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         )
         .unwrap_or_else(|error| panic!("failed to write {failure_path:?}: {error}"));
         exit.write(AppExit::Error(1.try_into().expect("one is non-zero")));
+    }
+}
+
+fn planted_drift_limit(scenario: &str) -> f32 {
+    if scenario.starts_with("raised-guard") {
+        0.01
+    } else {
+        0.035
+    }
+}
+
+fn inter_foot_separation_limit(scenario: &str) -> f32 {
+    if scenario.starts_with("raised-guard") {
+        RAISED_MINIMUM_INTER_FOOT_SEPARATION_METRES
+    } else {
+        0.08
     }
 }
 
@@ -1253,6 +1407,7 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
                 loop_seam_position_metres: loop_position,
                 loop_seam_rotation_degrees: loop_rotation,
                 pelvis_vertical_range_metres: root_relative_vertical_range(&frames, "pelvis"),
+                maximum_pelvis_vertical_step_metres: root_relative_vertical_step(&frames, "pelvis"),
                 head_vertical_range_metres: root_relative_vertical_range(&frames, "head"),
                 foot_terrain_relief_metres: foot_terrain_relief(&frames),
                 minimum_knee_forward_bend_metres: minimum_knee_bend(&frames),
@@ -1273,6 +1428,12 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
 }
 
 fn expects_loop_seam(scenario: &str) -> bool {
+    if scenario.contains("-release")
+        || scenario.contains("-reversal")
+        || scenario.contains("accelerate")
+    {
+        return false;
+    }
     !matches!(
         scenario,
         "start-stop-transition"
@@ -1481,6 +1642,17 @@ fn root_relative_vertical_range(frames: &[&FrameSample], bone: &str) -> f32 {
     } else {
         0.0
     }
+}
+
+fn root_relative_vertical_step(frames: &[&FrameSample], bone: &str) -> f32 {
+    frames
+        .windows(2)
+        .filter_map(|pair| {
+            let previous = pair[0].bones.get(bone)?.position[1] - pair[0].root_position_metres[1];
+            let current = pair[1].bones.get(bone)?.position[1] - pair[1].root_position_metres[1];
+            Some((current - previous).abs())
+        })
+        .fold(0.0, f32::max)
 }
 
 /// Terrain height variation under the two sampled feet relative to the
@@ -1711,6 +1883,8 @@ mod tests {
             guard_action: false,
             left_support_weight: 1.0,
             right_support_weight: 1.0,
+            desired_left_foot_target: None,
+            desired_right_foot_target: None,
             screenshots,
             bones: BTreeMap::new(),
         };
@@ -1783,10 +1957,41 @@ mod tests {
                 .iter()
                 .any(|frame| { frame.weapon_guard == WeaponGuardState::Raised })
         );
+        for scenario in [
+            "raised-guard-right-lead-left",
+            "raised-guard-right-lead-right",
+            "raised-guard-right-lead-forward-right",
+            "raised-guard-right-lead-accelerate",
+            "raised-guard-right-lead-release",
+            "raised-guard-right-lead-reversal",
+        ] {
+            assert!(plan.iter().any(|frame| {
+                frame.scenario == scenario
+                    && frame.weapon_guard == WeaponGuardState::Raised
+                    && frame.lead_foot == LeadFoot::Right
+            }));
+        }
     }
 
     #[test]
-    fn raised_guard_viewer_scenarios_cover_guard_peak_return_with_fixed_lead() {
+    fn raised_guard_uses_strict_plant_and_separation_gates() {
+        assert_eq!(planted_drift_limit("raised-guard-right"), 0.01);
+        assert_eq!(inter_foot_separation_limit("raised-guard-right"), 0.16);
+        assert_eq!(planted_drift_limit("steady-walk-2.0"), 0.035);
+        assert_eq!(inter_foot_separation_limit("steady-walk-2.0"), 0.08);
+        for transition in [
+            "raised-guard-release-at-peak",
+            "raised-guard-right-lead-release",
+            "raised-guard-left-right-reversal",
+            "raised-guard-right-lead-reversal",
+            "raised-guard-accelerate-from-rest",
+        ] {
+            assert!(!expects_loop_seam(transition));
+        }
+    }
+
+    #[test]
+    fn raised_guard_viewer_scenarios_cross_complete_step_cycle_with_fixed_lead() {
         for scenario in [
             "raised-guard-forward",
             "raised-guard-backward",
@@ -1799,7 +2004,7 @@ mod tests {
         ] {
             let mut skeleton = SkeletonState::default();
             set_weapon_guard(&mut skeleton, WeaponGuardState::Raised);
-            let mut movement_progress = Vec::new();
+            let mut phases = Vec::new();
             for frame in capture_plan()
                 .into_iter()
                 .filter(|frame| frame.scenario == scenario)
@@ -1823,32 +2028,20 @@ mod tests {
                         tick: frame.scenario_frame as u64,
                     },
                 );
-                assert_eq!(skeleton.lead_foot, LeadFoot::Left);
-                movement_progress.extend(
-                    AnimationEvaluation::from_skeleton(&skeleton)
-                        .base
-                        .into_iter()
-                        .filter_map(|sample| match sample.sampling {
-                            PoseSampling::Span { progress, .. } => Some(progress),
-                            _ => None,
-                        }),
-                );
+                assert_eq!(skeleton.lead_foot, frame.lead_foot);
+                let evaluation = AnimationEvaluation::from_skeleton(&skeleton);
+                assert_eq!(evaluation.base.len(), 1);
+                assert_eq!(evaluation.base[0].pose, SemanticPose::GuardLeadLeft);
+                assert_eq!(evaluation.base[0].sampling, PoseSampling::Anchor);
+                phases.push(skeleton.gait_phase);
             }
-            assert!(movement_progress.iter().any(|&progress| progress <= 0.001));
-            let peak = movement_progress
-                .iter()
-                .position(|&progress| progress >= 0.99)
-                .expect("raised scenario reaches its directional extreme");
-            assert!(
-                movement_progress[peak + 1..]
-                    .iter()
-                    .any(|&progress| progress <= 0.05)
-            );
+            assert!(phases.windows(2).any(|pair| pair[1] < pair[0]));
+            assert!(phases.iter().any(|&phase| phase >= 0.5));
         }
     }
 
     #[test]
-    fn raised_guard_viewer_latches_release_and_reversal_until_guard_seam() {
+    fn raised_guard_viewer_finishes_release_and_reverses_at_foot_handoff() {
         let replay = |scenario: &str| {
             let mut skeleton = SkeletonState::default();
             set_weapon_guard(&mut skeleton, WeaponGuardState::Raised);
@@ -1895,14 +2088,12 @@ mod tests {
         assert_eq!(release.last().unwrap().1, 0.0);
 
         let reversal = replay("raised-guard-left-right-reversal");
-        assert!(
-            reversal.iter().any(|(frame, _, intent)| {
-                *frame >= 16 && intent.local_direction == Vec2::NEG_X
-            })
-        );
-        assert!(reversal.iter().any(|(frame, phase, intent)| {
-            *frame > 16 && *phase < 0.2 && intent.local_direction == Vec2::X
-        }));
+        let changed = reversal
+            .iter()
+            .find(|(_, _, intent)| intent.local_direction == Vec2::X)
+            .expect("reversal is accepted at a foot handoff");
+        assert!(changed.0 >= 16);
+        assert!(changed.1 < 0.08 || (0.5..0.58).contains(&changed.1));
     }
 
     #[test]
@@ -1951,6 +2142,8 @@ mod tests {
             guard_action: false,
             left_support_weight: 1.0,
             right_support_weight: 1.0,
+            desired_left_foot_target: None,
+            desired_right_foot_target: None,
             screenshots: BTreeMap::new(),
             bones,
         };
@@ -1997,6 +2190,8 @@ mod tests {
             guard_action: false,
             left_support_weight,
             right_support_weight: 0.0,
+            desired_left_foot_target: None,
+            desired_right_foot_target: None,
             screenshots: BTreeMap::new(),
             bones: BTreeMap::from([
                 ("left_foot".into(), foot(left_x, left_terrain_height)),
@@ -2027,6 +2222,21 @@ mod tests {
             ORDINARY_VERTICAL_RANGE_LIMIT_METRES
         );
         assert!((vertical_range_limit("cross-slope-walk", 0.08) - 0.28).abs() < 0.0001);
+    }
+
+    #[test]
+    fn pelvis_vertical_step_detects_a_one_frame_guard_height_snap() {
+        let mut first = foot_metric_frame(0, 0.0, 1.0, 0.0, 0.0);
+        let mut second = foot_metric_frame(1, 0.0, 1.0, 0.0, 0.0);
+        let pelvis = |height: f32| BoneSample {
+            position: Vec3::new(0.0, height, 0.0).to_array(),
+            rotation_xyzw: Quat::IDENTITY.to_array(),
+            terrain_clearance_metres: None,
+        };
+        first.bones.insert("pelvis".into(), pelvis(1.0));
+        second.bones.insert("pelvis".into(), pelvis(0.86));
+
+        assert!((root_relative_vertical_step(&[&first, &second], "pelvis") - 0.14).abs() < 0.0001);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/debug.rs
+++ b/crates/adventuresim-tactical-client/src/debug.rs
@@ -192,7 +192,7 @@ mod tests {
             .resource_mut::<ButtonInput<KeyCode>>()
             .press(KeyCode::F8);
         app.update();
-        assert!(!app.world().resource::<TerrainIkEnabled>().0);
+        assert!(app.world().resource::<TerrainIkEnabled>().0);
 
         {
             let mut keyboard = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
@@ -202,6 +202,6 @@ mod tests {
             keyboard.press(KeyCode::F8);
         }
         app.update();
-        assert!(app.world().resource::<TerrainIkEnabled>().0);
+        assert!(!app.world().resource::<TerrainIkEnabled>().0);
     }
 }

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -181,7 +181,7 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                         "DEBUG: F2 to toggle body | F3 to toggle hitbox | F4 to toggle hitscan"
                     ),
                     (GameSpeedDebugSpan, TextSpan::new(" | F7 game speed: 1x")),
-                    (TerrainIkDebugSpan, TextSpan::new(" | F8 terrain IK: ON"))
+                    (TerrainIkDebugSpan, TextSpan::new(" | F8 terrain IK: OFF"))
                 ],
             ),
             (

--- a/crates/adventuresim-tactical-core/src/animation.rs
+++ b/crates/adventuresim-tactical-core/src/animation.rs
@@ -577,13 +577,21 @@ pub enum WeaponGuardState {
     Raised,
 }
 
-/// Direction and cadence held for one complete raised-guard movement pulse.
-/// New controller input is observed only when the pulse returns to guard.
+/// Compact authoritative input for client-side raised-guard foot placement.
+/// Speed follows the controller continuously so acceleration changes cadence
+/// during the current step. Ordinary turns wait for the next foot handoff;
+/// material opposite-direction reversals perform an immediate safe semantic
+/// handoff so the support side agrees with the already-reversed gameplay root.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize, Deserialize, Reflect)]
 pub struct RaisedLocomotionIntent {
     pub active: bool,
     pub local_direction: Vec2,
     pub speed: f32,
+    /// Swing-side state is independent from the fixed guard lead.
+    pub swing_foot: LeadFoot,
+    /// Monotonic semantic handoff identity. Clients use this to detect
+    /// coalesced updates without treating gait-phase parity as step identity.
+    pub step_sequence: u32,
 }
 
 impl RaisedLocomotionIntent {
@@ -691,8 +699,8 @@ pub fn set_weapon_guard(skeleton: &mut SkeletonState, weapon_guard: WeaponGuardS
 }
 
 impl SkeletonState {
-    /// Presentation motion remains latched through a raised-guard pulse even
-    /// when gameplay velocity has already stopped or changed direction.
+    /// Presentation motion finishes an in-flight raised-guard step after
+    /// gameplay velocity stops. Speed otherwise follows authoritative motion.
     pub fn animation_local_velocity(&self) -> Vec3 {
         if self.weapon_guard == WeaponGuardState::Raised && self.raised_locomotion.active {
             self.raised_locomotion.local_velocity()
@@ -854,30 +862,104 @@ fn advance_raised_locomotion_intent(
         local_direction: Vec2::new(observed_local_velocity.x, observed_local_velocity.z)
             .normalize_or_zero(),
         speed: observed_speed,
+        swing_foot: skeleton.lead_foot,
+        step_sequence: skeleton.raised_locomotion.step_sequence,
     });
     if !skeleton.raised_locomotion.active {
         let Some(observed) = observed else {
             skeleton.gait_phase = 0.0;
             return;
         };
-        skeleton.raised_locomotion = observed;
+        skeleton.raised_locomotion = RaisedLocomotionIntent {
+            swing_foot: initial_guard_swing_foot(observed.local_direction, skeleton.lead_foot),
+            ..observed
+        };
         skeleton.gait_phase = 0.0;
-    }
-
-    let speed = skeleton.raised_locomotion.speed;
-    let next_phase = skeleton.gait_phase + gait_cycle_phase_delta(speed, delta_seconds.max(0.0));
-    if next_phase < 1.0 {
-        skeleton.gait_phase = next_phase;
-        return;
     }
 
     if let Some(observed) = observed {
-        skeleton.raised_locomotion = observed;
-        skeleton.gait_phase = next_phase.rem_euclid(1.0);
-    } else {
-        skeleton.raised_locomotion = RaisedLocomotionIntent::default();
-        skeleton.gait_phase = 0.0;
+        // Do not latch the tiny velocity from the first acceleration tick for
+        // a complete pulse. Cadence and reach adapt immediately; only a hard
+        // direction change waits until the current swing foot lands.
+        skeleton.raised_locomotion.speed = observed.speed;
+        if skeleton
+            .raised_locomotion
+            .local_direction
+            .dot(observed.local_direction)
+            < -0.5
+        {
+            // Gameplay root velocity reverses immediately. Hand support off
+            // immediately too, rather than dragging the old world plant
+            // across its anatomical corridor until the scheduled seam.
+            skeleton.raised_locomotion.local_direction = observed.local_direction;
+            skeleton.raised_locomotion.swing_foot = match skeleton.raised_locomotion.swing_foot {
+                LeadFoot::Left => LeadFoot::Right,
+                LeadFoot::Right => LeadFoot::Left,
+            };
+            skeleton.raised_locomotion.step_sequence =
+                skeleton.raised_locomotion.step_sequence.wrapping_add(1);
+            skeleton.gait_phase = if skeleton.gait_phase < 0.5 { 0.5 } else { 0.0 };
+            return;
+        }
     }
+    let speed = skeleton.raised_locomotion.speed;
+    let phase = skeleton.gait_phase.rem_euclid(1.0);
+    let next_phase = phase + guard_step_phase_delta(speed, delta_seconds.max(0.0));
+    let handoffs = ((next_phase * 2.0).floor() - (phase * 2.0).floor()).max(0.0) as u32;
+    let crossed_handoff = handoffs > 0;
+
+    if observed.is_none() && crossed_handoff {
+        let step_sequence = skeleton.raised_locomotion.step_sequence.wrapping_add(1);
+        skeleton.raised_locomotion = RaisedLocomotionIntent {
+            step_sequence,
+            ..default()
+        };
+        skeleton.gait_phase = if phase < 0.5 { 0.5 } else { 0.0 };
+        return;
+    }
+
+    skeleton.gait_phase = next_phase.rem_euclid(1.0);
+    if crossed_handoff && let Some(observed) = observed {
+        if handoffs % 2 == 1 {
+            skeleton.raised_locomotion.swing_foot = match skeleton.raised_locomotion.swing_foot {
+                LeadFoot::Left => LeadFoot::Right,
+                LeadFoot::Right => LeadFoot::Left,
+            };
+        }
+        skeleton.raised_locomotion.step_sequence = skeleton
+            .raised_locomotion
+            .step_sequence
+            .wrapping_add(handoffs);
+        skeleton.raised_locomotion.local_direction = observed.local_direction;
+    }
+}
+
+fn initial_guard_swing_foot(direction: Vec2, lead: LeadFoot) -> LeadFoot {
+    if direction.x.abs() >= direction.y.abs() {
+        if direction.x.is_sign_negative() {
+            LeadFoot::Left
+        } else {
+            LeadFoot::Right
+        }
+    } else if direction.y.is_sign_positive() {
+        // Retreat begins with the forward foot; advance begins with the rear.
+        lead
+    } else {
+        match lead {
+            LeadFoot::Left => LeadFoot::Right,
+            LeadFoot::Right => LeadFoot::Left,
+        }
+    }
+}
+
+/// Ground distance covered by one procedural combat-stance step. Raised
+/// movement uses compact shuffles rather than ordinary walking strides.
+pub fn guard_step_length(speed: f32) -> f32 {
+    (0.26 + speed.max(0.0) * 0.06).clamp(0.28, 0.42)
+}
+
+fn guard_step_phase_delta(speed: f32, delta_seconds: f32) -> f32 {
+    speed.max(0.0) * delta_seconds.max(0.0) / (guard_step_length(speed) * 2.0)
 }
 
 /// Advances a complete left-right gait cycle. `stride_length` describes one
@@ -976,64 +1058,16 @@ impl AnimationEvaluation {
 }
 
 fn raised_guard_locomotion_samples(
-    local_velocity: Vec3,
-    phase: f32,
+    _local_velocity: Vec3,
+    _phase: f32,
     lead: LeadFoot,
 ) -> Vec<PoseSample> {
-    let forward = -local_velocity.z;
-    let lateral = local_velocity.x;
-    let magnitude = forward.abs() + lateral.abs();
-    if magnitude <= 0.05 {
-        return vec![PoseSample {
-            pose: guard_pose(lead),
-            sampling: PoseSampling::Anchor,
-            weight: 1.0,
-            mirror_lower_body: 0.0,
-        }];
-    }
-    let mut samples = Vec::with_capacity(2);
-    let movement_progress = 1.0 - guard_shuttle_guard_weight(phase);
-    let forward_weight = forward.abs() / magnitude;
-    if forward_weight > f32::EPSILON {
-        samples.push(PoseSample {
-            pose: guard_pose(lead),
-            sampling: PoseSampling::Span {
-                end: match lead {
-                    LeadFoot::Left => SemanticPose::GuardWalkLeadLeft,
-                    LeadFoot::Right => SemanticPose::GuardWalkLeadRight,
-                },
-                progress: movement_progress,
-            },
-            weight: forward_weight,
-            mirror_lower_body: 0.0,
-        });
-    }
-    let lateral_weight = lateral.abs() / magnitude;
-    if lateral_weight > f32::EPSILON {
-        samples.push(PoseSample {
-            pose: guard_pose(lead),
-            sampling: PoseSampling::Span {
-                end: match (lead, lateral.is_sign_negative()) {
-                    (LeadFoot::Left, true) => SemanticPose::GuardStrafeLeadLeftLeft,
-                    (LeadFoot::Left, false) => SemanticPose::GuardStrafeLeadLeftRight,
-                    (LeadFoot::Right, true) => SemanticPose::GuardStrafeLeadRightLeft,
-                    (LeadFoot::Right, false) => SemanticPose::GuardStrafeLeadRightRight,
-                },
-                progress: movement_progress,
-            },
-            weight: lateral_weight,
-            mirror_lower_body: 0.0,
-        });
-    }
-    samples
-}
-
-/// Weight of the static guard endpoint in the fixed-lead movement shuttle.
-/// Phase zero is deliberately the guard so entering Raised can start without
-/// sampling a directional movement extreme.
-pub fn guard_shuttle_guard_weight(phase: f32) -> f32 {
-    let movement = (std::f32::consts::PI * phase.rem_euclid(1.0)).sin().powi(2);
-    1.0 - movement
+    vec![PoseSample {
+        pose: guard_pose(lead),
+        sampling: PoseSampling::Anchor,
+        weight: 1.0,
+        mirror_lower_body: 0.0,
+    }]
 }
 
 fn gait_or_idle(
@@ -1388,6 +1422,8 @@ mod tests {
             active: speed > 0.05,
             local_direction: Vec2::new(local_velocity.x, local_velocity.z).normalize_or_zero(),
             speed,
+            swing_foot: LeadFoot::Left,
+            step_sequence: 0,
         }
     }
 
@@ -1793,7 +1829,7 @@ mod tests {
     }
 
     #[test]
-    fn raised_guard_idle_and_cardinal_locomotion_use_frozen_lead_contracts() {
+    fn raised_guard_locomotion_uses_static_lead_guard_for_procedural_legs() {
         let evaluate = |velocity| {
             AnimationEvaluation::from_skeleton(&SkeletonState {
                 weapon_guard: WeaponGuardState::Raised,
@@ -1808,35 +1844,16 @@ mod tests {
         assert_eq!(idle.base[0].pose, SemanticPose::GuardLeadLeft);
         assert_eq!(idle.base[0].sampling, PoseSampling::Anchor);
 
-        for velocity in [Vec3::NEG_Z, Vec3::Z] {
-            let sample = evaluate(velocity).base[0];
-            assert_eq!(sample.pose, SemanticPose::GuardLeadLeft);
-            assert_eq!(
-                sample.sampling,
-                PoseSampling::Span {
-                    end: SemanticPose::GuardWalkLeadLeft,
-                    progress: 0.5,
-                }
-            );
+        for velocity in [Vec3::NEG_Z, Vec3::Z, Vec3::NEG_X, Vec3::X] {
+            let evaluation = evaluate(velocity);
+            assert_eq!(evaluation.base.len(), 1);
+            assert_eq!(evaluation.base[0].pose, SemanticPose::GuardLeadLeft);
+            assert_eq!(evaluation.base[0].sampling, PoseSampling::Anchor);
         }
-        assert_eq!(
-            evaluate(Vec3::NEG_X).base[0].sampling,
-            PoseSampling::Span {
-                end: SemanticPose::GuardStrafeLeadLeftLeft,
-                progress: 0.5,
-            }
-        );
-        assert_eq!(
-            evaluate(Vec3::X).base[0].sampling,
-            PoseSampling::Span {
-                end: SemanticPose::GuardStrafeLeadLeftRight,
-                progress: 0.5,
-            }
-        );
     }
 
     #[test]
-    fn raised_guard_diagonal_blend_is_l1_normalized_and_phase_synchronized() {
+    fn raised_guard_diagonal_keeps_static_guard_and_fixed_lead() {
         let evaluation = AnimationEvaluation::from_skeleton(&SkeletonState {
             weapon_guard: WeaponGuardState::Raised,
             lead_foot: LeadFoot::Right,
@@ -1845,44 +1862,14 @@ mod tests {
             gait_phase: 0.75,
             ..default()
         });
-        assert_eq!(evaluation.base.len(), 2);
+        assert_eq!(evaluation.base.len(), 1);
         assert_eq!(evaluation.base[0].pose, SemanticPose::GuardLeadRight);
-        assert_eq!(evaluation.base[0].weight, 0.25);
-        assert_eq!(
-            evaluation.base[0].sampling,
-            PoseSampling::Span {
-                end: SemanticPose::GuardWalkLeadRight,
-                progress: 0.5,
-            }
-        );
-        assert_eq!(
-            evaluation.base[1].sampling,
-            PoseSampling::Span {
-                end: SemanticPose::GuardStrafeLeadRightLeft,
-                progress: 0.5,
-            }
-        );
-        assert_eq!(evaluation.base[1].weight, 0.75);
-        assert!(evaluation.base.iter().all(|sample| {
-            sample.pose == SemanticPose::GuardLeadRight && sample.mirror_lower_body == 0.0
-        }));
-        assert_eq!(
-            evaluation
-                .base
-                .iter()
-                .map(|sample| sample.weight)
-                .sum::<f32>(),
-            1.0
-        );
+        assert_eq!(evaluation.base[0].sampling, PoseSampling::Anchor);
+        assert_eq!(evaluation.base[0].weight, 1.0);
     }
 
     #[test]
-    fn raised_guard_shuttle_starts_and_closes_at_guard_without_switching_lead() {
-        for (phase, expected) in [(0.0, 1.0), (0.25, 0.5), (0.5, 0.0), (0.75, 0.5)] {
-            assert!((guard_shuttle_guard_weight(phase) - expected).abs() < 0.0001);
-        }
-        assert!((guard_shuttle_guard_weight(0.999) - 1.0).abs() < 0.0001);
-
+    fn raised_guard_fk_stays_at_guard_through_both_procedural_steps() {
         for phase in [0.0, 0.5, 0.999] {
             let evaluation = AnimationEvaluation::from_skeleton(&SkeletonState {
                 weapon_guard: WeaponGuardState::Raised,
@@ -1893,13 +1880,7 @@ mod tests {
                 ..default()
             });
             assert_eq!(evaluation.base[0].pose, SemanticPose::GuardLeadRight);
-            assert_eq!(
-                evaluation.base[0].sampling,
-                PoseSampling::Span {
-                    end: SemanticPose::GuardWalkLeadRight,
-                    progress: 1.0 - guard_shuttle_guard_weight(phase),
-                }
-            );
+            assert_eq!(evaluation.base[0].sampling, PoseSampling::Anchor);
         }
     }
 
@@ -1922,7 +1903,7 @@ mod tests {
     }
 
     #[test]
-    fn raised_guard_release_at_peak_completes_return_before_idling() {
+    fn raised_guard_release_finishes_only_the_in_flight_step() {
         let mut state = SkeletonState::default();
         set_weapon_guard(&mut state, WeaponGuardState::Raised);
         let input = |velocity, delta_seconds| SkeletonLocomotionInput {
@@ -1933,20 +1914,20 @@ mod tests {
             delta_seconds,
             tick: 1,
         };
-        project_skeleton_locomotion(&mut state, input(Vec3::NEG_Z * 2.0, 0.61));
+        project_skeleton_locomotion(&mut state, input(Vec3::NEG_Z * 2.0, 0.095));
         assert!(state.raised_locomotion.active);
-        assert!((state.gait_phase - 0.5).abs() < 0.001);
+        assert!((state.gait_phase - 0.25).abs() < 0.001);
 
-        project_skeleton_locomotion(&mut state, input(Vec3::ZERO, 0.3));
+        project_skeleton_locomotion(&mut state, input(Vec3::ZERO, 0.08));
         assert!(state.raised_locomotion.active);
         assert_eq!(state.raised_locomotion.local_direction, Vec2::NEG_Y);
-        project_skeleton_locomotion(&mut state, input(Vec3::ZERO, 0.31));
+        project_skeleton_locomotion(&mut state, input(Vec3::ZERO, 0.02));
         assert!(!state.raised_locomotion.active);
-        assert_eq!(state.gait_phase, 0.0);
+        assert_eq!(state.gait_phase, 0.5);
     }
 
     #[test]
-    fn raised_guard_direction_change_is_latched_only_at_guard_seam() {
+    fn raised_guard_direction_change_waits_only_for_foot_handoff() {
         let mut state = SkeletonState::default();
         set_weapon_guard(&mut state, WeaponGuardState::Raised);
         let input = |velocity, delta_seconds| SkeletonLocomotionInput {
@@ -1957,14 +1938,91 @@ mod tests {
             delta_seconds,
             tick: 1,
         };
-        project_skeleton_locomotion(&mut state, input(Vec3::NEG_X * 2.0, 0.2));
-        project_skeleton_locomotion(&mut state, input(Vec3::X * 2.0, 0.2));
+        project_skeleton_locomotion(&mut state, input(Vec3::NEG_X * 2.0, 0.05));
+        project_skeleton_locomotion(&mut state, input(Vec3::NEG_Z * 2.0, 0.05));
         assert_eq!(state.raised_locomotion.local_direction, Vec2::NEG_X);
 
-        project_skeleton_locomotion(&mut state, input(Vec3::X * 2.0, 0.85));
-        assert_eq!(state.raised_locomotion.local_direction, Vec2::X);
-        assert!(state.gait_phase < 0.15);
+        project_skeleton_locomotion(&mut state, input(Vec3::NEG_Z * 2.0, 0.15));
+        assert_eq!(state.raised_locomotion.local_direction, Vec2::NEG_Y);
+        assert!(state.gait_phase > 0.5);
         assert_eq!(state.lead_foot, LeadFoot::Left);
+    }
+
+    #[test]
+    fn raised_guard_reversal_hands_support_off_immediately() {
+        let mut state = SkeletonState::default();
+        set_weapon_guard(&mut state, WeaponGuardState::Raised);
+        let input = |velocity| SkeletonLocomotionInput {
+            orientation: Quat::IDENTITY,
+            linear_velocity: velocity,
+            grounded: true,
+            crouching: false,
+            delta_seconds: 0.05,
+            tick: 1,
+        };
+        project_skeleton_locomotion(&mut state, input(Vec3::NEG_X * 2.0));
+        let sequence = state.raised_locomotion.step_sequence;
+        let swing = state.raised_locomotion.swing_foot;
+        project_skeleton_locomotion(&mut state, input(Vec3::X * 2.0));
+        assert_eq!(state.raised_locomotion.local_direction, Vec2::X);
+        assert_eq!(state.raised_locomotion.step_sequence, sequence + 1);
+        assert_ne!(state.raised_locomotion.swing_foot, swing);
+        assert!(state.gait_phase == 0.0 || state.gait_phase == 0.5);
+    }
+
+    #[test]
+    fn raised_guard_cadence_adapts_during_first_acceleration_step() {
+        let mut state = SkeletonState::default();
+        set_weapon_guard(&mut state, WeaponGuardState::Raised);
+        let input = |velocity| SkeletonLocomotionInput {
+            orientation: Quat::IDENTITY,
+            linear_velocity: velocity,
+            grounded: true,
+            crouching: false,
+            delta_seconds: 0.05,
+            tick: 1,
+        };
+        project_skeleton_locomotion(&mut state, input(Vec3::NEG_Z * 0.1));
+        let slow_delta = state.gait_phase;
+        project_skeleton_locomotion(&mut state, input(Vec3::NEG_Z * 2.0));
+        let fast_delta = state.gait_phase - slow_delta;
+        assert_eq!(state.raised_locomotion.speed, 2.0);
+        assert!(fast_delta > slow_delta * 5.0);
+    }
+
+    #[test]
+    fn raised_guard_sequence_counts_coalesced_handoffs_beyond_phase_parity() {
+        let mut state = SkeletonState::default();
+        set_weapon_guard(&mut state, WeaponGuardState::Raised);
+        project_skeleton_locomotion(
+            &mut state,
+            SkeletonLocomotionInput {
+                orientation: Quat::IDENTITY,
+                linear_velocity: Vec3::NEG_Z * 2.0,
+                grounded: true,
+                crouching: false,
+                // At 2 m/s a full two-step cycle is 0.38 seconds.
+                delta_seconds: guard_step_length(2.0) * 2.0 / 2.0,
+                tick: 1,
+            },
+        );
+        assert_eq!(state.raised_locomotion.step_sequence, 2);
+        assert_eq!(state.raised_locomotion.swing_foot, LeadFoot::Right);
+        assert!(state.gait_phase < 0.0001);
+    }
+
+    #[test]
+    fn diagonal_guard_steps_begin_with_the_outward_lateral_foot() {
+        for lead in [LeadFoot::Left, LeadFoot::Right] {
+            assert_eq!(
+                initial_guard_swing_foot(Vec2::new(-1.0, -1.0).normalize(), lead),
+                LeadFoot::Left
+            );
+            assert_eq!(
+                initial_guard_swing_foot(Vec2::new(1.0, 1.0).normalize(), lead),
+                LeadFoot::Right
+            );
+        }
     }
 
     #[test]

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -22,8 +22,8 @@ pub mod prelude {
         BODY_TURN_SPEED_RADIANS, Footwork, LeadFoot, PackValidationError, PoseSample, PoseSampling,
         Posture, RaisedLocomotionIntent, ResolvedPose, SemanticPose, SkeletonAction,
         SkeletonLocomotionInput, SkeletonState, StrikeFamily, WeaponGuardState,
-        advance_body_facing, controller_yaw, guard_shuttle_guard_weight,
-        project_skeleton_locomotion, set_weapon_guard,
+        advance_body_facing, controller_yaw, guard_step_length, project_skeleton_locomotion,
+        set_weapon_guard,
     };
     pub use crate::combat::{Attack, Dodge, HANDS_REACH, Parry, melee_interaction_range};
     pub use crate::inventory::{

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -68,13 +68,13 @@ guard only in transient tactical `SkeletonState`, and replicates it with the
 rest of that state. It is never persisted to SpacetimeDB. Incapacitation
 forces the authoritative state back to `lowered`.
 
-Raised upright locomotion also carries a transient latched direction and
-cadence. Once a guard shuttle leaves its static endpoint, the authority keeps
-that intent until it returns to guard even if gameplay velocity stops or
-changes. Input observed during the pulse is accepted only at that seam. This
-prevents release or reversal from replacing a movement extreme halfway through
-the blend. Lowering, incapacitation, crouching, or leaving the ground clears
-the latch.
+Raised upright locomotion also carries transient procedural step intent and
+cadence. Speed follows the controller throughout a step. Ordinary turns are
+accepted at the next foot handoff, while a material opposite-direction reversal
+performs an immediate safe semantic handoff so the support foot agrees with the
+already-reversed gameplay root. Releasing movement completes only the active
+half-step. Lowering, incapacitation, crouching, or leaving the ground clears the
+intent.
 
 A discrete raised/lowered change is presentation-crossfaded from the currently
 displayed effective pose over 0.18 seconds. This includes resolved fallback
@@ -534,9 +534,12 @@ Locomotion also bounds root, pelvis, torso, neck, and head excursions around
 bind before look and final IK, then restores a bounded vertical lift at each
 run flight beat.
 
-Debug clients expose `F8` as a runtime terrain leg-IK toggle. Disabling it
-leaves authored FK, gait mirroring, and torso stabilization intact and clears
-stored foot plants so re-enabling IK cannot snap to an obsolete target.
+Terrain conformity defaults off while its uneven-ground behavior is being
+refined. Debug clients expose `F8` as an explicit runtime opt-in. Disabling it
+leaves authored FK, gait mirroring, torso stabilization, flat-ground combat
+foot placement, and the analytic leg solve intact. Only terrain height/normal
+sampling and pelvis conformity are gated, and stale ordinary terrain plants
+are cleared without resetting unrelated arm-pole continuity.
 Debug clients also expose `F7` to toggle the connected local tactical mission
 between normal and quarter-speed game time. Both client presentation and the
 authoritative server clock change together, so movement, physics, combat, and
@@ -568,6 +571,9 @@ bob without weakening the flat-ground check. Cumulative planted-foot drift is
 measured while support is effectively pinned (at least 0.99). The separate
 per-frame slip gate continues through the blended release interval (at least
 0.9 support), where the IK target intentionally yields back to authored FK.
+Raised-guard scenarios additionally require no more than 0.01 m cumulative
+support drift and at least 0.16 m inter-foot separation; ordinary gait retains
+its legacy 0.035 m drift and 0.08 m separation regression bounds.
 Loop-seam gates apply only to repeatable cycles. Start/stop, facing-turn, and
 raised-guard release-at-peak scenarios are transition probes whose final
 simulation state intentionally differs from the state that initiated them;
@@ -586,29 +592,41 @@ shared by local players, remote players, bots, fallback bodies, authored rigs,
 and the viewer, with the authored +Z/controller -Z half-turn represented once.
 The viewer additionally replays gradual turns, an exact reversal, planted
 guard rotation, camera pitch, cross-slope terrain, every raised cardinal and
-diagonal direction, release at the directional peak, and a mid-pulse lateral
+diagonal direction, release during a step, and a mid-step lateral
 reversal.
 
 During lowered travel, forward walk and run continue to serve diagonal and
-lateral travel. Raised upright grounded movement instead freezes the current
-lead and evaluates a synchronized fixed-lead shuttle. Phase zero is the static
-guard, phase one-half is the directional authored extreme, and the pulse then
-returns smoothly to guard with zero velocity at both endpoints. Forward and
-backward magnitude select the same-lead guard-walk pose; signed lateral
-magnitude selects the corresponding same-lead strafe. Diagonals blend those
-contributions with L1-normalized weights, so forward/back and lateral weights
-always sum to one and sample the same pulse. Neither retreat nor the return
-half swaps lead, mirrors the lower body, or constructs an opposite-foot step.
-Direction and speed are latched for the whole out-and-back pulse. Releasing at
-the extreme therefore completes the return to guard; changing direction waits
-until that guard seam before starting the next pulse.
+lateral travel. Raised upright grounded movement freezes the current lead and
+samples only its static guard pose. A client-only procedural lower-body pass
+alternates one swing foot with exactly one world-space support foot. Each
+compact step projects authoritative local velocity from the step origin,
+retains the authored guard's separated stance tracks, interpolates horizontally
+with a smooth curve, and adds a sine clearance arc. Step reach scales with
+analogue speed and is bounded to combat-shuffle distances.
 
-Ordinary alternating world-space foot plants are disabled while a moving
-raised guard follows the authored pose. Both feet retain their authored XZ
-tracks while terrain IK follows their current positions vertically and keeps
-the existing reach, knee-pole, and minimum-separation constraints. This avoids
-turning the fixed-lead shuttle back into a crossing gait. Raised grounded idle
-may plant both feet in its static guard. Raised crouched and airborne
+Cadence follows current authoritative speed throughout the first step, so a
+small acceleration sample cannot slow a complete cycle. Ordinary turns are
+accepted at the next foot handoff. A material opposite-direction reversal
+performs an immediate safe semantic handoff; releasing movement finishes only
+the active half-step rather than freezing a foot in the air or completing an
+entire two-step pulse. The guard lead never doubles as swing-side state and
+remains fixed across forward, backward, lateral, and diagonal motion. Authored
+guard walk and strafe files remain available for comparison but are not sampled
+by continuous raised locomotion.
+
+Semantic intent carries a wrapping step sequence and a swing side separate
+from guard lead. The sequence increments at every handoff, allowing a client
+that receives coalesced updates to reset safely even when normalized phase
+returns to the same parity after a skipped full cycle. World-space targets
+remain client-only.
+
+Procedural guard plants and targets stay entirely client-side. Replicated
+`SkeletonState` carries only semantic direction, speed, phase, swing side, and
+step identity; it never
+carries bones or world foot positions. Flat-ground placement works with
+terrain IK disabled. When terrain conformity is explicitly enabled, the same
+targets additionally follow height and slope without replacing their planted
+XZ positions. Raised grounded idle uses the static guard. Raised crouched and airborne
 characters retain the existing crouch and airborne posture rules; specialized
 raised variants can be added later.
 


### PR DESCRIPTION
## Summary
- keep terrain IK disabled by default with F8 as an opt-in toggle
- replace authored raised-guard locomotion shuttles with procedural all-direction stepping over the static lead guard pose
- preserve analog movement speed and cadence, fixed lead semantics, planted support, safe direction handoffs, and smooth start/stop pelvis height
- expand the deterministic animation viewer with both-lead acceleration, release, reversal, drift, separation, and vertical-transition gates
- update tactical client and animation documentation

## Verification
- cargo test -p adventuresim-tactical-core animation::tests (35 passed)
- cargo test -p adventuresim-tactical-client animation (56 client + 70 viewer passed)
- cargo fmt --all -- --check
- git diff --check
- deterministic executable capture matrix for all raised-guard directions plus both-lead acceleration, release, and reversal; all validation gates passed

## Stack
Base: codex/tactical-locomotion-input-polish

## Follow-up
Terrain IK remains opt-in until its uneven-ground behavior is improved in a later PR.