### PR TITLE
Add deterministic locomotion dynamics

### DIFF
--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -58,9 +58,10 @@ right retain their lateral spacing while exchanging gait roles. Authored
 upper-body carriage remains intact; explicit hand targets and weapon
 constraints apply only when gameplay supplies them. Root, pelvis, spine, neck,
 and head motion is clamped around the authored bind pose before look and final
-IK. During active locomotion, authored root/pelvis Y is normalized, then one
-phase-owned `sin²` curve supplies two contact minima and two passing/flight
-peaks per cycle without moving the gameplay controller. Idle poses blend back
+IK. During active locomotion, authored root/pelvis Y is normalized, then the
+shared gait profile supplies grounded bounce or a gravity-shaped run flight
+arc with two phase-aligned peaks per cycle without moving the gameplay
+controller. Idle poses blend back
 to their authored central-bone transforms. The 33mm hierarchy compensation is
 measured for upright, lowered-guard `humanoid_unarmed` locomotion only;
 crouching, guard movement, and specialized packs receive no inferred
@@ -119,6 +120,25 @@ blends toward run, support narrows around each foot contact. At 5.5m/s the
 quarter-cycle run flight unloads both legs for roughly 90-110ms and presents
 at least 0.10m of sole clearance. When terrain IK is explicitly enabled, high
 support retains the foot's world-space horizontal plant until release.
+
+The replicated skeleton also carries the shared 64 Hz locomotion sample tick,
+observed world velocity/acceleration, alternating contact sequence, and landing
+sequence/impact. The client transforms acceleration through the current body
+frame and advances retained lean only once per authoritative tick, including
+bounded coalesced gaps. A hard stop retains the effective authored locomotion
+pose and releases it to exact idle over a fixed-tick 0.18-second crossfade,
+preventing the sparse run/idle clips from switching in one frame. Landing
+response compresses once on a real airborne
+landing, retains both pre-compression world foot plants through recovery, and
+solves the actual hip/knee chains back to them; it never translates or stretches thigh roots. Stationary and
+stopping ordinary locomotion blends both feet back to full support.
+
+Contact and landing messages are deduplicated presentation hooks for future
+audio/VFX. Plausible contact gaps reconstruct at most eight ordered alternating
+contacts; resets, backward sequences, and larger gaps resynchronize silently.
+Missed landing updates collapse to the latest observation rather than bursting.
+An event's sample tick is the tick where its replicated sequence was observed,
+not an invented historical contact timestamp.
 
 Terrain conformity starts off. In debug builds, press `F8` to opt into its
 height, slope, and pelvis corrections. The HUD reports whether it is on or off;

--- a/crates/adventuresim-tactical-client/src/animation.rs
+++ b/crates/adventuresim-tactical-client/src/animation.rs
@@ -19,13 +19,13 @@ mod procedural;
 #[allow(unused_imports)]
 pub(crate) use procedural::{
     BoneRole, HandIkTarget, HandSide, HeldWeaponConstraint, HumanoidBone, HumanoidIkTargets,
-    LocomotionHeightState, ProceduralAnimationClock, ProceduralIkState, RaisedFootworkState,
-    locomotion_support_weights,
+    LocomotionBodyResponseState, LocomotionHeightState, ProceduralAnimationClock,
+    ProceduralIkState, RaisedFootworkState, locomotion_support_weights,
 };
 const HUMANOID_UNARMED_PACK: &str = "humanoid_unarmed";
 const BIPED_BASE_GLB: &str = "animations/biped/unarmed/base.glb";
 const ANIMATION_FPS: f32 = 30.0;
-const GUARD_PRESENTATION_CROSSFADE_SECONDS: f32 = 0.18;
+const PRESENTATION_CROSSFADE_SECONDS: f32 = 0.18;
 // Player transforms sit at the center of the 1.9 m server collider, while
 // authored rigs use a floor-level origin. Keep visual feet on the collider's
 // lower face so the first-person camera lands at the authored head.
@@ -44,12 +44,74 @@ fn animation_asset_path(path: &str) -> String {
 
 pub struct TacticalAnimationPlugin;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocomotionPresentationEventKind {
+    Contact(LeadFoot),
+    Landing,
+}
+
+#[derive(Message, Debug, Clone, Copy)]
+pub(crate) struct LocomotionPresentationEvent {
+    pub owner: Entity,
+    pub sequence: u64,
+    /// Authoritative sample tick when this sequence state was observed. For a
+    /// coalesced gap this is not a reconstructed historical contact time.
+    pub sample_tick: u64,
+    pub kind: LocomotionPresentationEventKind,
+}
+
+const MAX_COALESCED_PRESENTATION_EVENTS: u64 = 8;
+
+fn bounded_forward_sequence_delta(previous: u64, current: u64) -> Option<u64> {
+    current
+        .checked_sub(previous)
+        .filter(|delta| *delta <= MAX_COALESCED_PRESENTATION_EVENTS)
+}
+
+fn latest_coalesced_landing(previous: u64, current: u64) -> Option<u64> {
+    bounded_forward_sequence_delta(previous, current)
+        .filter(|delta| *delta > 0)
+        .map(|_| current)
+}
+
+fn coalesced_contacts(
+    previous: u64,
+    current: u64,
+    latest_foot: LeadFoot,
+) -> Option<Vec<(u64, LeadFoot)>> {
+    let delta = bounded_forward_sequence_delta(previous, current)?;
+    Some(
+        (0..delta)
+            .rev()
+            .map(|offset| {
+                let foot = if offset % 2 == 0 {
+                    latest_foot
+                } else {
+                    match latest_foot {
+                        LeadFoot::Left => LeadFoot::Right,
+                        LeadFoot::Right => LeadFoot::Left,
+                    }
+                };
+                (current - offset, foot)
+            })
+            .collect(),
+    )
+}
+
+#[derive(Component, Debug, Clone, Copy, Default)]
+struct LocomotionEventCursor {
+    initialized: bool,
+    contact_sequence: u64,
+    landing_sequence: u64,
+}
+
 impl Plugin for TacticalAnimationPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<AnimationPackCatalog>()
             .init_resource::<AnimationRuntime>()
             .init_resource::<TerrainIkEnabled>()
             .init_resource::<ProceduralAnimationClock>()
+            .add_message::<LocomotionPresentationEvent>()
             .add_systems(Startup, request_animation_packs)
             .add_observer(on_successful_attack)
             .add_systems(
@@ -67,6 +129,8 @@ impl Plugin for TacticalAnimationPlugin {
                     sync_animation_graphs,
                     drive_fk_players,
                     update_rig_visibility,
+                    emit_locomotion_presentation_events,
+                    trace_locomotion_presentation_events,
                 )
                     .chain(),
             )
@@ -80,6 +144,8 @@ impl Plugin for TacticalAnimationPlugin {
                     restore_authored_bind_pose,
                     procedural::apply_gait_mirroring,
                     procedural::stabilize_locomotion_torso,
+                    procedural::apply_landing_leg_compression,
+                    procedural::apply_locomotion_body_response,
                     procedural::apply_head_and_torso_look,
                     procedural::apply_impact_reaction,
                     procedural::apply_terrain_leg_ik,
@@ -89,6 +155,65 @@ impl Plugin for TacticalAnimationPlugin {
                     .after(AnimationSystems)
                     .before(TransformSystems::Propagate),
             );
+    }
+}
+
+fn trace_locomotion_presentation_events(mut messages: MessageReader<LocomotionPresentationEvent>) {
+    for message in messages.read() {
+        trace!(
+            owner = ?message.owner,
+            sequence = message.sequence,
+            sample_tick = message.sample_tick,
+            kind = ?message.kind,
+            "locomotion presentation event"
+        );
+    }
+}
+
+fn emit_locomotion_presentation_events(
+    mut commands: Commands,
+    mut messages: MessageWriter<LocomotionPresentationEvent>,
+    mut skeletons: Query<(Entity, &SkeletonState, Option<&mut LocomotionEventCursor>)>,
+) {
+    for (owner, skeleton, cursor) in &mut skeletons {
+        let mut next = cursor.as_deref().copied().unwrap_or_default();
+        if !next.initialized {
+            next.initialized = true;
+            next.contact_sequence = skeleton.contact_sequence;
+            next.landing_sequence = skeleton.landing_sequence;
+        } else {
+            if let Some(contacts) = coalesced_contacts(
+                next.contact_sequence,
+                skeleton.contact_sequence,
+                skeleton.contact_foot,
+            ) {
+                for (sequence, foot) in contacts {
+                    messages.write(LocomotionPresentationEvent {
+                        owner,
+                        sequence,
+                        sample_tick: skeleton.locomotion_sample_tick,
+                        kind: LocomotionPresentationEventKind::Contact(foot),
+                    });
+                }
+            }
+            if let Some(sequence) =
+                latest_coalesced_landing(next.landing_sequence, skeleton.landing_sequence)
+            {
+                messages.write(LocomotionPresentationEvent {
+                    owner,
+                    sequence,
+                    sample_tick: skeleton.locomotion_sample_tick,
+                    kind: LocomotionPresentationEventKind::Landing,
+                });
+            }
+            next.contact_sequence = skeleton.contact_sequence;
+            next.landing_sequence = skeleton.landing_sequence;
+        }
+        if let Some(mut cursor) = cursor {
+            *cursor = next;
+        } else {
+            commands.entity(owner).insert(next);
+        }
     }
 }
 
@@ -417,7 +542,8 @@ pub(super) struct AnimationPlayback {
     pub(super) lower_body_mirror: f32,
     pub(super) whole_body_mirror: f32,
     weapon_guard: WeaponGuardState,
-    guard_transition: Option<GuardPlaybackTransition>,
+    ordinary_locomotion_active: bool,
+    presentation_transition: Option<PlaybackTransition>,
     evaluation_tick: Option<u64>,
 }
 
@@ -436,7 +562,8 @@ impl Default for AnimationPlayback {
             lower_body_mirror: 0.0,
             whole_body_mirror: 0.0,
             weapon_guard: WeaponGuardState::Lowered,
-            guard_transition: None,
+            ordinary_locomotion_active: false,
+            presentation_transition: None,
             evaluation_tick: None,
         }
     }
@@ -459,7 +586,7 @@ struct PlaybackPose {
 }
 
 #[derive(Debug, Clone)]
-struct GuardPlaybackTransition {
+struct PlaybackTransition {
     from: PlaybackPose,
     elapsed_seconds: f32,
 }
@@ -926,11 +1053,16 @@ fn evaluate_skeletons(
                 0.0
             },
         };
+        let ordinary_locomotion_active = skeleton.grounded
+            && skeleton.action == SkeletonAction::None
+            && skeleton.weapon_guard == WeaponGuardState::Lowered
+            && skeleton.animation_speed() > 0.05;
         if let Some(mut playback) = playback {
-            update_guard_crossfade(
+            update_presentation_crossfade(
                 &mut playback,
                 target,
                 skeleton.weapon_guard,
+                ordinary_locomotion_active,
                 &procedural_clock,
                 time.delta_secs(),
             );
@@ -941,17 +1073,19 @@ fn evaluate_skeletons(
                 lower_body_mirror: target.lower_body_mirror,
                 whole_body_mirror: target.whole_body_mirror,
                 weapon_guard: skeleton.weapon_guard,
-                guard_transition: None,
+                ordinary_locomotion_active,
+                presentation_transition: None,
                 evaluation_tick: procedural_clock.fixed_step().map(|(tick, _)| tick),
             });
         }
     }
 }
 
-fn update_guard_crossfade(
+fn update_presentation_crossfade(
     playback: &mut AnimationPlayback,
     target: PlaybackPose,
     weapon_guard: WeaponGuardState,
+    ordinary_locomotion_active: bool,
     procedural_clock: &ProceduralAnimationClock,
     render_delta_seconds: f32,
 ) {
@@ -964,24 +1098,29 @@ fn update_guard_crossfade(
         None => render_delta_seconds.max(0.0),
     };
     let guard_changed = playback.weapon_guard != weapon_guard;
-    if guard_changed {
-        playback.guard_transition = Some(GuardPlaybackTransition {
+    let locomotion_released =
+        playback.ordinary_locomotion_active && !ordinary_locomotion_active && !guard_changed;
+    let transition_started = guard_changed || locomotion_released;
+    if transition_started {
+        playback.presentation_transition = Some(PlaybackTransition {
             from: playback_pose(playback),
             elapsed_seconds: 0.0,
         });
         playback.weapon_guard = weapon_guard;
     }
+    playback.ordinary_locomotion_active = ordinary_locomotion_active;
 
     let mut transition_complete = false;
-    let resolved = if let Some(transition) = playback.guard_transition.as_mut() {
+    let resolved = if let Some(transition) = playback.presentation_transition.as_mut() {
         // The state change is first presented at the exact old pose. Time
         // begins accumulating on the next simulation/render observation, so
-        // a replicated guard edge cannot consume the preceding frame's dt.
-        if !guard_changed {
+        // a replicated guard or locomotion edge cannot consume the preceding
+        // frame's dt.
+        if !transition_started {
             transition.elapsed_seconds += delta_seconds;
         }
         let progress =
-            (transition.elapsed_seconds / GUARD_PRESENTATION_CROSSFADE_SECONDS).clamp(0.0, 1.0);
+            (transition.elapsed_seconds / PRESENTATION_CROSSFADE_SECONDS).clamp(0.0, 1.0);
         let pose = blend_playback_poses(&transition.from, &target, progress);
         transition_complete = progress >= 1.0;
         pose
@@ -989,7 +1128,7 @@ fn update_guard_crossfade(
         target
     };
     if transition_complete {
-        playback.guard_transition = None;
+        playback.presentation_transition = None;
     }
     apply_playback_pose(playback, resolved);
 }
@@ -2289,15 +2428,16 @@ mod tests {
         let mut clock = ProceduralAnimationClock::default();
         clock.set_fixed_tick(10, 0.1);
 
-        update_guard_crossfade(
+        update_presentation_crossfade(
             &mut playback,
             mirror_test_pose(0.2),
             WeaponGuardState::Raised,
+            false,
             &clock,
             0.0,
         );
 
-        assert!(playback.guard_transition.is_some());
+        assert!(playback.presentation_transition.is_some());
         assert!((playback.lower_body_mirror - 0.8).abs() < 0.0001);
         assert!((playback.whole_body_mirror - 0.8).abs() < 0.0001);
     }
@@ -2311,25 +2451,72 @@ mod tests {
         };
         let mut clock = ProceduralAnimationClock::default();
         clock.set_fixed_tick(10, 0.1);
-        update_guard_crossfade(
+        update_presentation_crossfade(
             &mut playback,
             mirror_test_pose(0.2),
             WeaponGuardState::Raised,
+            false,
             &clock,
             0.0,
         );
-        clock.set_fixed_tick(11, GUARD_PRESENTATION_CROSSFADE_SECONDS);
-        update_guard_crossfade(
+        clock.set_fixed_tick(11, PRESENTATION_CROSSFADE_SECONDS);
+        update_presentation_crossfade(
             &mut playback,
             mirror_test_pose(0.2),
             WeaponGuardState::Raised,
+            false,
             &clock,
             0.0,
         );
 
-        assert!(playback.guard_transition.is_none());
+        assert!(playback.presentation_transition.is_none());
         assert!((playback.lower_body_mirror - 0.2).abs() < 0.0001);
         assert!((playback.whole_body_mirror - 0.2).abs() < 0.0001);
+    }
+
+    #[test]
+    fn hard_stop_retains_then_releases_the_effective_locomotion_pose() {
+        let mut playback = AnimationPlayback {
+            lower_body_mirror: 0.8,
+            whole_body_mirror: 0.8,
+            ordinary_locomotion_active: true,
+            ..default()
+        };
+        let mut clock = ProceduralAnimationClock::default();
+        clock.set_fixed_tick(10, 1.0 / LOCOMOTION_SAMPLE_HZ);
+        update_presentation_crossfade(
+            &mut playback,
+            mirror_test_pose(0.0),
+            WeaponGuardState::Lowered,
+            false,
+            &clock,
+            0.0,
+        );
+        assert!(playback.presentation_transition.is_some());
+        assert!((playback.lower_body_mirror - 0.8).abs() < 0.0001);
+
+        update_presentation_crossfade(
+            &mut playback,
+            mirror_test_pose(0.0),
+            WeaponGuardState::Lowered,
+            false,
+            &clock,
+            1.0,
+        );
+        assert!((playback.lower_body_mirror - 0.8).abs() < 0.0001);
+
+        clock.set_fixed_tick(11, PRESENTATION_CROSSFADE_SECONDS);
+        update_presentation_crossfade(
+            &mut playback,
+            mirror_test_pose(0.0),
+            WeaponGuardState::Lowered,
+            false,
+            &clock,
+            0.0,
+        );
+        assert!(playback.presentation_transition.is_none());
+        assert!(playback.lower_body_mirror.abs() < 0.0001);
+        assert!(playback.whole_body_mirror.abs() < 0.0001);
     }
 
     #[test]
@@ -2341,33 +2528,36 @@ mod tests {
         };
         let mut clock = ProceduralAnimationClock::default();
         clock.set_fixed_tick(10, 0.09);
-        update_guard_crossfade(
+        update_presentation_crossfade(
             &mut playback,
             mirror_test_pose(0.2),
             WeaponGuardState::Raised,
+            false,
             &clock,
             0.0,
         );
         clock.set_fixed_tick(11, 0.09);
-        update_guard_crossfade(
+        update_presentation_crossfade(
             &mut playback,
             mirror_test_pose(0.2),
             WeaponGuardState::Raised,
+            false,
             &clock,
             0.0,
         );
         let before_reversal = playback.lower_body_mirror;
 
         clock.set_fixed_tick(12, 0.09);
-        update_guard_crossfade(
+        update_presentation_crossfade(
             &mut playback,
             mirror_test_pose(0.8),
             WeaponGuardState::Lowered,
+            false,
             &clock,
             0.0,
         );
 
-        let transition = playback.guard_transition.as_ref().unwrap();
+        let transition = playback.presentation_transition.as_ref().unwrap();
         assert!((playback.lower_body_mirror - before_reversal).abs() < 0.0001);
         assert!((transition.from.lower_body_mirror - before_reversal).abs() < 0.0001);
     }
@@ -2383,5 +2573,25 @@ mod tests {
             secondary_grip_local: None,
         };
         assert_eq!(constraint.primary_hand, HandSide::Right);
+    }
+
+    #[test]
+    fn presentation_sequence_gaps_are_bounded_ordered_and_reset_safe() {
+        assert_eq!(
+            coalesced_contacts(10, 13, LeadFoot::Right),
+            Some(vec![
+                (11, LeadFoot::Right),
+                (12, LeadFoot::Left),
+                (13, LeadFoot::Right),
+            ])
+        );
+        assert_eq!(coalesced_contacts(13, 13, LeadFoot::Right), Some(vec![]));
+        assert_eq!(coalesced_contacts(13, 2, LeadFoot::Left), None);
+        assert_eq!(coalesced_contacts(2, 20, LeadFoot::Left), None);
+        assert_eq!(bounded_forward_sequence_delta(7, 9), Some(2));
+        assert_eq!(bounded_forward_sequence_delta(9, 7), None);
+        assert_eq!(latest_coalesced_landing(7, 9), Some(9));
+        assert_eq!(latest_coalesced_landing(9, 7), None);
+        assert_eq!(latest_coalesced_landing(2, 20), None);
     }
 }

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -331,11 +331,8 @@ pub(super) fn apply_gait_mirroring(
     }
 }
 
-const WALK_HEIGHT_AMPLITUDE_METRES: f32 = 0.04;
-const RUN_HEIGHT_AMPLITUDE_METRES: f32 = 0.18;
-const GUARD_HEIGHT_AMPLITUDE_METRES: f32 = 0.03;
-const CROUCH_HEIGHT_AMPLITUDE_METRES: f32 = 0.025;
 const HEIGHT_TRANSITION_SPEED_METRES_PER_SECOND: f32 = 0.4;
+const LOCOMOTION_STOP_HEIGHT_SPEED_METRES_PER_SECOND: f32 = 0.8;
 const NORMALIZATION_TRANSITION_PER_SECOND: f32 = 8.0;
 // The upright lowered-guard humanoid_unarmed root/pelvis rotations lift its
 // pelvis by about 33 mm at passing even after local Y is normalized. This is a
@@ -350,6 +347,14 @@ pub(crate) struct LocomotionHeightState {
     displayed_wave: f32,
     wave_transition_offset: f32,
     normalization_weight: f32,
+    pub(crate) landing_compression: f32,
+    landing_recovery_metres_per_second: f32,
+    landing_left_foot_target: Option<Vec3>,
+    landing_right_foot_target: Option<Vec3>,
+    landing_plant_owner_position: Option<Vec3>,
+    landing_plant_tick: Option<u64>,
+    landing_plant_resync_tick: Option<u64>,
+    last_landing_sequence: u64,
     last_guard: Option<WeaponGuardState>,
     last_posture: Option<Posture>,
     last_action: Option<SkeletonAction>,
@@ -360,12 +365,24 @@ pub(crate) struct LocomotionHeightState {
 /// One phase-owned vertical waveform with contacts at 0/.5 and passing or
 /// flight peaks at .25/.75. This is presentation-only and is never applied to
 /// the authoritative owner/controller transform.
-pub(crate) fn locomotion_height_wave(phase: f32, amplitude: f32) -> f32 {
+fn grounded_height_wave(phase: f32, amplitude: f32) -> f32 {
     let sine = (phase.rem_euclid(1.0) * std::f32::consts::TAU).sin();
     amplitude * sine * sine
 }
 
-fn locomotion_height_amplitude(skeleton: &SkeletonState) -> f32 {
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub(crate) struct LocomotionBodyResponseState {
+    pub(crate) pitch_radians: f32,
+    pub(crate) roll_radians: f32,
+    target_pitch_radians: f32,
+    target_roll_radians: f32,
+    last_tick: Option<u64>,
+    last_posture: Option<Posture>,
+    last_action: Option<SkeletonAction>,
+    last_grounded: Option<bool>,
+}
+
+pub(crate) fn locomotion_height_wave(skeleton: &SkeletonState) -> f32 {
     if !skeleton.grounded || skeleton.action != SkeletonAction::None {
         return 0.0;
     }
@@ -373,15 +390,15 @@ fn locomotion_height_amplitude(skeleton: &SkeletonState) -> f32 {
     if speed <= 0.05 {
         return 0.0;
     }
+    let profile = locomotion_profile(skeleton);
     let moving_weight = smoothstep(0.05, 0.75, speed);
-    let amplitude = if skeleton.posture == Posture::Crouched {
-        CROUCH_HEIGHT_AMPLITUDE_METRES
-    } else if skeleton.weapon_guard == WeaponGuardState::Raised {
-        GUARD_HEIGHT_AMPLITUDE_METRES
-    } else {
-        WALK_HEIGHT_AMPLITUDE_METRES.lerp(RUN_HEIGHT_AMPLITUDE_METRES, locomotion_run_weight(speed))
-    };
-    amplitude * moving_weight
+    let grounded = grounded_height_wave(skeleton.gait_phase, profile.bounce_metres);
+    if profile.flight_apex_metres <= f32::EPSILON {
+        return grounded * moving_weight;
+    }
+    let half_step = (skeleton.gait_phase.rem_euclid(0.5) * 2.0).clamp(0.0, 1.0);
+    let flight = 4.0 * half_step * (1.0 - half_step) * profile.flight_apex_metres;
+    (grounded + flight) * moving_weight
 }
 
 fn authored_height_compensation(skeleton: &SkeletonState) -> f32 {
@@ -407,59 +424,109 @@ fn advance_towards(current: f32, target: f32, maximum_delta: f32) -> f32 {
     current + (target - current).clamp(-maximum_delta.max(0.0), maximum_delta.max(0.0))
 }
 
+fn landing_compression_for_impact(profile: LocomotionProfile, impact_speed: f32) -> f32 {
+    if impact_speed < 1.0 {
+        0.0
+    } else {
+        (impact_speed * profile.landing.compression_per_metre_per_second).clamp(
+            profile.landing.minimum_compression_metres,
+            profile.landing.maximum_compression_metres,
+        )
+    }
+}
+
 /// Normalizes authored root/pelvis height before applying the single gait
 /// waveform. XZ translation, rotations, and all authored limb transforms are
 /// retained. Action and airborne transitions blend back to authored central Y.
 pub(super) fn stabilize_locomotion_torso(
     mut commands: Commands,
-    time: Res<Time>,
-    clock: Res<ProceduralAnimationClock>,
     mut owners: Query<(Entity, &SkeletonState, Option<&mut LocomotionHeightState>)>,
     mut bones: Query<(&HumanoidBone, &AuthoredBindTransform, &mut Transform)>,
 ) {
     let mut heights = BTreeMap::new();
     for (owner, skeleton, state) in &mut owners {
-        let target_amplitude = locomotion_height_amplitude(skeleton);
+        let target_wave = locomotion_height_wave(skeleton);
         let target_authored_compensation = authored_height_compensation(skeleton);
         let target_normalization = locomotion_normalization_target(skeleton);
         let mut next = state.as_deref().copied().unwrap_or_default();
         if !next.initialized {
             next.initialized = true;
-            next.amplitude = target_amplitude;
+            next.amplitude = target_wave;
             next.authored_rise_compensation = target_authored_compensation;
             next.normalization_weight = target_normalization;
             next.last_guard = Some(skeleton.weapon_guard);
             next.last_posture = Some(skeleton.posture);
             next.last_action = Some(skeleton.action);
             next.last_grounded = Some(skeleton.grounded);
+            next.last_landing_sequence = skeleton.landing_sequence;
         }
-        let delta_seconds = match clock.fixed_step() {
-            Some((tick, _)) if next.evaluation_tick == Some(tick) => 0.0,
-            Some((tick, delta_seconds)) => {
-                next.evaluation_tick = Some(tick);
-                delta_seconds
-            }
-            None => time.delta_secs(),
+        let tick_delta =
+            presentation_tick_delta(next.evaluation_tick, skeleton.locomotion_sample_tick)
+                .unwrap_or_default();
+        next.evaluation_tick = Some(skeleton.locomotion_sample_tick);
+        let delta_seconds = tick_delta as f32 / LOCOMOTION_SAMPLE_HZ;
+        let ordinary_stop = skeleton.grounded
+            && skeleton.action == SkeletonAction::None
+            && matches!(skeleton.posture, Posture::Upright | Posture::Crouched)
+            && skeleton.animation_speed() <= 0.05;
+        next.amplitude = if ordinary_stop {
+            advance_towards(
+                next.amplitude,
+                0.0,
+                LOCOMOTION_STOP_HEIGHT_SPEED_METRES_PER_SECOND * delta_seconds,
+            )
+        } else {
+            target_wave
         };
-        next.amplitude = advance_towards(
-            next.amplitude,
-            target_amplitude,
-            HEIGHT_TRANSITION_SPEED_METRES_PER_SECOND * delta_seconds,
-        );
         next.authored_rise_compensation = advance_towards(
             next.authored_rise_compensation,
             target_authored_compensation,
             HEIGHT_TRANSITION_SPEED_METRES_PER_SECOND * delta_seconds,
         );
+        let retained_normalization =
+            target_normalization.max((next.amplitude.abs() > 0.001) as u8 as f32);
         next.normalization_weight = advance_towards(
             next.normalization_weight,
-            target_normalization,
+            retained_normalization,
             NORMALIZATION_TRANSITION_PER_SECOND * delta_seconds,
         );
-        let raw_wave = locomotion_height_wave(
-            skeleton.gait_phase,
-            next.amplitude - next.authored_rise_compensation,
-        );
+        let landing_delta = skeleton
+            .landing_sequence
+            .checked_sub(next.last_landing_sequence)
+            .filter(|delta| *delta <= 8);
+        let landed = landing_delta.is_some_and(|delta| delta > 0);
+        if skeleton.landing_sequence != next.last_landing_sequence {
+            next.last_landing_sequence = skeleton.landing_sequence;
+        }
+        if landed {
+            next.landing_compression = landing_compression_for_impact(
+                locomotion_profile(skeleton),
+                skeleton.landing_impact_speed,
+            );
+            next.landing_recovery_metres_per_second =
+                next.landing_compression / locomotion_profile(skeleton).landing.recovery_seconds;
+            next.landing_left_foot_target = None;
+            next.landing_right_foot_target = None;
+            next.landing_plant_owner_position = None;
+            next.landing_plant_tick = None;
+            next.landing_plant_resync_tick = None;
+        }
+        if !landed {
+            next.landing_compression = advance_towards(
+                next.landing_compression,
+                0.0,
+                next.landing_recovery_metres_per_second * delta_seconds,
+            );
+        }
+        if !skeleton.grounded
+            || skeleton.action != SkeletonAction::None
+            || next.landing_compression <= 0.001
+        {
+            clear_landing_foot_plants(&mut next);
+        }
+        let compensation =
+            grounded_height_wave(skeleton.gait_phase, next.authored_rise_compensation);
+        let raw_wave = next.amplitude - compensation;
         let state_changed = next.last_guard != Some(skeleton.weapon_guard)
             || next.last_posture != Some(skeleton.posture)
             || next.last_action != Some(skeleton.action)
@@ -490,7 +557,10 @@ pub(super) fn stabilize_locomotion_torso(
         let Some(&height) = heights.get(&bone.owner) else {
             continue;
         };
-        if height.normalization_weight <= f32::EPSILON && height.amplitude <= f32::EPSILON {
+        if height.normalization_weight <= f32::EPSILON
+            && height.amplitude <= f32::EPSILON
+            && height.landing_compression <= f32::EPSILON
+        {
             continue;
         }
         let (translation_limit, rotation_limit) = match bone.role {
@@ -529,6 +599,168 @@ pub(super) fn stabilize_locomotion_torso(
             height.normalization_weight.clamp(0.0, 1.0),
         );
     }
+}
+
+/// Preserves both world-space feet during the short landing-only pelvis
+/// compression by flexing the actual hip/knee chains. This is independent of
+/// the opt-in terrain solver and never translates or stretches thigh roots.
+pub(super) fn apply_landing_leg_compression(
+    mut owners: Query<
+        (&SkeletonState, &mut LocomotionHeightState, &GlobalTransform),
+        Without<HumanoidBone>,
+    >,
+    bones: Query<(Entity, &HumanoidBone, &GlobalTransform)>,
+    parents: Query<&ChildOf>,
+    mut transforms: ParamSet<(TransformHelper, Query<&mut Transform>)>,
+) {
+    let mut rigs = BTreeMap::<Entity, BTreeMap<BoneRole, Entity>>::new();
+    let mut previous_world_positions = BTreeMap::<Entity, Vec3>::new();
+    for (entity, bone, global) in &bones {
+        rigs.entry(bone.owner)
+            .or_default()
+            .insert(bone.role, entity);
+        previous_world_positions.insert(entity, global.translation());
+    }
+    for (owner, rig) in rigs {
+        let Ok((skeleton, mut height, owner_transform)) = owners.get_mut(owner) else {
+            continue;
+        };
+        if !skeleton.grounded
+            || skeleton.action != SkeletonAction::None
+            || height.landing_compression <= 0.001
+        {
+            clear_landing_foot_plants(&mut height);
+            continue;
+        }
+        let owner_position = owner_transform.translation();
+        if height.landing_plant_resync_tick == Some(skeleton.locomotion_sample_tick) {
+            continue;
+        }
+        height.landing_plant_resync_tick = None;
+        let discontinuous = landing_plant_is_discontinuous(
+            height.landing_plant_tick,
+            skeleton.locomotion_sample_tick,
+            height.landing_plant_owner_position,
+            owner_position,
+        );
+        if discontinuous {
+            clear_landing_foot_plants(&mut height);
+            height.landing_plant_resync_tick = Some(skeleton.locomotion_sample_tick);
+            continue;
+        }
+        height.landing_plant_tick = Some(skeleton.locomotion_sample_tick);
+        height.landing_plant_owner_position = Some(owner_position);
+        let landing_compression = height.landing_compression;
+        if let Some(&pelvis) = rig.get(&BoneRole::Pelvis) {
+            let local_delta = parents
+                .get(pelvis)
+                .ok()
+                .and_then(|parent| {
+                    transforms
+                        .p0()
+                        .compute_global_transform(parent.parent())
+                        .ok()
+                })
+                .map(|parent| {
+                    parent
+                        .affine()
+                        .inverse()
+                        .transform_vector3(Vec3::NEG_Y * landing_compression)
+                })
+                .unwrap_or(Vec3::NEG_Y * landing_compression);
+            if local_delta.is_finite()
+                && let Ok(mut transform) = transforms.p1().get_mut(pelvis)
+            {
+                transform.translation += local_delta;
+            }
+        }
+        for (upper_role, lower_role, foot_role, left) in [
+            (
+                BoneRole::ThighLeft,
+                BoneRole::ShinLeft,
+                BoneRole::FootLeft,
+                true,
+            ),
+            (
+                BoneRole::ThighRight,
+                BoneRole::ShinRight,
+                BoneRole::FootRight,
+                false,
+            ),
+        ] {
+            let (Some(&upper), Some(&lower), Some(&foot)) = (
+                rig.get(&upper_role),
+                rig.get(&lower_role),
+                rig.get(&foot_role),
+            ) else {
+                continue;
+            };
+            let Some((upper_snapshot, lower_snapshot, foot_snapshot)) =
+                snapshot_chain(upper, lower, foot, &parents, &transforms.p0())
+            else {
+                continue;
+            };
+            let upper_length = upper_snapshot
+                .global
+                .translation()
+                .distance(lower_snapshot.global.translation());
+            let lower_length = lower_snapshot
+                .global
+                .translation()
+                .distance(foot_snapshot.global.translation());
+            let target = if left {
+                retain_landing_foot_target(
+                    &mut height.landing_left_foot_target,
+                    previous_world_positions[&foot],
+                )
+            } else {
+                retain_landing_foot_target(
+                    &mut height.landing_right_foot_target,
+                    previous_world_positions[&foot],
+                )
+            };
+            let side = if left { -1.0 } else { 1.0 };
+            let pole = owner_transform.rotation() * canonical_knee_pole(side);
+            if let Some(solution) = solve_landing_two_bone(
+                upper_snapshot.global.translation(),
+                lower_snapshot.global.translation(),
+                foot_snapshot.global.translation(),
+                target,
+                upper_length,
+                lower_length,
+                pole,
+                landing_compression,
+            ) {
+                apply_two_bone_solution(upper, lower, foot, solution, &parents, &mut transforms);
+            }
+        }
+    }
+}
+
+fn retain_landing_foot_target(
+    retained: &mut Option<Vec3>,
+    pre_landing_foot_position: Vec3,
+) -> Vec3 {
+    *retained.get_or_insert(pre_landing_foot_position)
+}
+
+fn landing_plant_is_discontinuous(
+    previous_tick: Option<u64>,
+    current_tick: u64,
+    previous_owner_position: Option<Vec3>,
+    current_owner_position: Vec3,
+) -> bool {
+    presentation_tick_delta(previous_tick, current_tick).is_none()
+        || previous_owner_position
+            .is_some_and(|previous| previous.distance_squared(current_owner_position) > 4.0)
+}
+
+fn clear_landing_foot_plants(height: &mut LocomotionHeightState) {
+    height.landing_left_foot_target = None;
+    height.landing_right_foot_target = None;
+    height.landing_plant_owner_position = None;
+    height.landing_plant_tick = None;
+    height.landing_plant_resync_tick = None;
 }
 
 fn clamp_rotation_from_bind(bind: Quat, animated: Quat, maximum_angle: f32) -> Quat {
@@ -653,6 +885,12 @@ const MAX_FOOT_TARGET_STEP: f32 = 0.2;
 const PELVIS_CORRECTION_SPEED: f32 = 1.6;
 const MAX_PELVIS_CORRECTION_STEP: f32 = 0.05;
 const MIN_KNEE_FLEXION: f32 = 20.0_f32.to_radians();
+// Keep the normal knee reserve while a landing visibly carries weight, then
+// release it before the pelvis reaches the authored height. The released
+// reach remains capped at the authored leg extension, preventing a final
+// recovery-frame foot lift or snap without introducing a straight-leg target.
+const LANDING_KNEE_RESERVE_RELEASE_COMPRESSION: f32 = 0.012;
+const LANDING_KNEE_RESERVE_FULL_COMPRESSION: f32 = 0.04;
 const RAISED_GUARD_PELVIS_DROP: f32 = 0.14;
 
 #[derive(Component, Debug, Clone, Copy, Default)]
@@ -777,15 +1015,13 @@ pub(super) fn apply_terrain_leg_ik(
             }
             continue;
         }
-        let phase = skeleton.gait_phase.rem_euclid(1.0);
-        let ground_speed = skeleton.animation_speed();
         let raised_guard_follower = skeleton.weapon_guard == WeaponGuardState::Raised
             && skeleton.action == SkeletonAction::None
             && skeleton.raised_locomotion.active;
         if !raised_guard_follower && let Ok(mut raised) = raised_states.get_mut(owner) {
             *raised = RaisedFootworkState::default();
         }
-        let (left_weight, right_weight) = gait_support_weights(phase, ground_speed);
+        let (left_weight, right_weight) = locomotion_support_weights(skeleton);
         let legs = [
             (
                 BoneRole::ThighLeft,
@@ -1474,23 +1710,13 @@ fn raised_footwork_posture_is_valid(skeleton: &SkeletonState) -> bool {
     skeleton.grounded && skeleton.posture == Posture::Upright
 }
 
-fn locomotion_run_weight(speed: f32) -> f32 {
-    ((speed - 2.0) / (5.5 - 2.0)).clamp(0.0, 1.0)
-}
-
-pub(crate) fn gait_support_weights(phase: f32, speed: f32) -> (f32, f32) {
-    let run_weight = locomotion_run_weight(speed);
-    let locomotion = smoothstep(0.0, 0.75, speed);
-    let gait = |phase| foot_support_weight(phase, true, run_weight);
-    (
-        1.0_f32.lerp(gait(phase.rem_euclid(1.0)), locomotion),
-        1.0_f32.lerp(gait((phase + 0.5).rem_euclid(1.0)), locomotion),
-    )
-}
-
 /// World-space plant confidence used by diagnostics. Procedural guard movement
 /// has exactly one support foot while the other follows its clearance arc.
 pub(crate) fn locomotion_support_weights(skeleton: &SkeletonState) -> (f32, f32) {
+    let speed = skeleton.animation_speed();
+    if speed <= 0.05 || !skeleton.grounded || skeleton.action != SkeletonAction::None {
+        return (1.0, 1.0);
+    }
     if skeleton.weapon_guard == WeaponGuardState::Raised
         && skeleton.action == SkeletonAction::None
         && skeleton.raised_locomotion.active
@@ -1498,32 +1724,133 @@ pub(crate) fn locomotion_support_weights(skeleton: &SkeletonState) -> (f32, f32)
         let swing_left = skeleton.raised_locomotion.swing_foot == LeadFoot::Left;
         ((!swing_left) as u8 as f32, swing_left as u8 as f32)
     } else {
-        gait_support_weights(skeleton.gait_phase, skeleton.local_velocity.xz().length())
+        let (left, right) = gait_support_weights(locomotion_profile(skeleton), skeleton.gait_phase);
+        let moving = smoothstep(0.05, 0.75, speed);
+        (1.0 - (1.0 - left) * moving, 1.0 - (1.0 - right) * moving)
     }
 }
 
-fn foot_support_weight(phase: f32, moving: bool, run_weight: f32) -> f32 {
-    if !moving {
-        return 1.0;
-    }
-    let run_weight = run_weight.clamp(0.0, 1.0);
-    // The canonical leg owns support from contact through passing, then hands
-    // off to its mirrored counterpart. This keeps the passing swing foot free
-    // instead of constraining both feet to a misleading 0.6 weight.
-    // Release over a substantial part of late stance. A four-frame release at
-    // ordinary walk speed makes the analytic knee visibly snap straight even
-    // when the foot target itself remains continuous.
-    let walk_support = (1.0 - smoothstep(0.28, 0.50, phase)).max(smoothstep(0.78, 1.0, phase));
+const MAX_PRESENTATION_SAMPLE_GAP: u64 = 32;
 
-    // A running foot supports only a compact interval around its contact.
-    // In particular, both legs must be free during the quarter-cycle flight
-    // phases; forcing a minimum IK weight there turns the authored swing into
-    // a visible kick/pop.
-    let distance_to_contact = phase.min(1.0 - phase);
-    // At 5.5 m/s fixed-rate sampling observes about 90-110 ms with both feet
-    // unloaded around each quarter-cycle flight beat.
-    let run_support = 1.0 - smoothstep(0.06, 0.16, distance_to_contact);
-    walk_support.lerp(run_support, run_weight).clamp(0.0, 1.0)
+fn presentation_tick_delta(previous: Option<u64>, current: u64) -> Option<u64> {
+    match previous {
+        None => Some(0),
+        Some(previous) if current >= previous => {
+            let delta = current - previous;
+            (delta <= MAX_PRESENTATION_SAMPLE_GAP).then_some(delta)
+        }
+        Some(_) => None,
+    }
+}
+
+/// Adds bounded inertial body response from server-observed world
+/// acceleration transformed through the current presentation body frame.
+/// Retained angles are client presentation only.
+pub(super) fn apply_locomotion_body_response(
+    mut commands: Commands,
+    mut owners: Query<
+        (
+            Entity,
+            &SkeletonState,
+            &Transform,
+            Option<&mut LocomotionBodyResponseState>,
+        ),
+        Without<HumanoidBone>,
+    >,
+    mut bones: Query<(&HumanoidBone, &mut Transform), Without<SkeletonState>>,
+) {
+    let mut responses = BTreeMap::new();
+    for (owner, skeleton, owner_transform, state) in &mut owners {
+        let mut next = state.as_deref().copied().unwrap_or_default();
+        let tick = skeleton.locomotion_sample_tick;
+        let tick_delta = presentation_tick_delta(next.last_tick, tick);
+        let discontinuous = tick_delta.is_none()
+            || next
+                .last_posture
+                .is_some_and(|value| value != skeleton.posture)
+            || next
+                .last_action
+                .is_some_and(|value| value != skeleton.action)
+            || next
+                .last_grounded
+                .is_some_and(|value| value != skeleton.grounded);
+        if discontinuous || !skeleton.grounded || skeleton.action != SkeletonAction::None {
+            next.pitch_radians = 0.0;
+            next.roll_radians = 0.0;
+            next.target_pitch_radians = 0.0;
+            next.target_roll_radians = 0.0;
+        } else if let Some(tick_delta @ 1..) = tick_delta {
+            let delta_seconds = tick_delta as f32 / LOCOMOTION_SAMPLE_HZ;
+            let body_acceleration =
+                owner_transform.rotation.inverse() * skeleton.world_acceleration;
+            if body_acceleration.xz().length() > 0.5 {
+                let combined = body_response_target(body_acceleration);
+                next.target_pitch_radians = combined.x;
+                next.target_roll_radians = combined.y;
+            } else {
+                let target_decay = 10.0_f32.to_radians() / 0.4 * delta_seconds;
+                next.target_pitch_radians =
+                    advance_towards(next.target_pitch_radians, 0.0, target_decay);
+                next.target_roll_radians =
+                    advance_towards(next.target_roll_radians, 0.0, target_decay);
+            }
+            let maximum_step = 2.0_f32.to_radians() * tick_delta as f32;
+            let current = Vec2::new(next.pitch_radians, next.roll_radians);
+            let target = Vec2::new(next.target_pitch_radians, next.target_roll_radians);
+            let advanced = current + (target - current).clamp_length_max(maximum_step);
+            next.pitch_radians = advanced.x;
+            next.roll_radians = advanced.y;
+        }
+        next.last_tick = Some(tick);
+        next.last_posture = Some(skeleton.posture);
+        next.last_action = Some(skeleton.action);
+        next.last_grounded = Some(skeleton.grounded);
+        responses.insert(owner, next);
+        if let Some(mut state) = state {
+            *state = next;
+        } else {
+            commands.entity(owner).insert(next);
+        }
+    }
+    for (bone, mut transform) in &mut bones {
+        let Some(response) = responses.get(&bone.owner) else {
+            continue;
+        };
+        let weight = match bone.role {
+            BoneRole::Pelvis => 0.20,
+            BoneRole::StomachOne => 0.25,
+            BoneRole::StomachTwo => 0.25,
+            BoneRole::Chest => 0.30,
+            _ => continue,
+        };
+        transform.rotation *= Quat::from_euler(
+            EulerRot::XYZ,
+            response.pitch_radians * weight,
+            0.0,
+            response.roll_radians * weight,
+        );
+    }
+}
+
+fn body_response_target(acceleration: Vec3) -> Vec2 {
+    // Tactical body forward is local +Z (the authored rig carries its own
+    // facing correction), so positive Z acceleration pitches into travel.
+    let pitch = if acceleration.z > 0.0 {
+        (-acceleration.z / 12.0 * 10.0_f32.to_radians()).clamp(-12.0_f32.to_radians(), 0.0)
+    } else {
+        (-acceleration.z / 12.0 * 8.0_f32.to_radians()).clamp(0.0, 10.0_f32.to_radians())
+    };
+    let roll = (-acceleration.x / 10.0 * 8.0_f32.to_radians())
+        .clamp(-10.0_f32.to_radians(), 10.0_f32.to_radians());
+    let response = Vec2::new(pitch, roll);
+    // Leave a sub-milliradian numerical margin so degree conversion cannot
+    // report a value microscopically above the documented 15-degree cap.
+    let maximum_response = 15.0_f32.to_radians() - 0.000001;
+    if response.length_squared() > maximum_response * maximum_response {
+        response.normalize_or_zero() * maximum_response
+    } else {
+        response
+    }
 }
 
 fn smoothstep(edge0: f32, edge1: f32, value: f32) -> f32 {
@@ -1633,6 +1960,23 @@ fn maximum_reach(upper_length: f32, lower_length: f32) -> f32 {
     .sqrt()
 }
 
+fn landing_maximum_reach(
+    upper_length: f32,
+    lower_length: f32,
+    authored_reach: f32,
+    compression: f32,
+) -> f32 {
+    let reserved_reach = maximum_reach(upper_length, lower_length);
+    let full_reach = upper_length + lower_length - 0.0001;
+    let released_reach = authored_reach.clamp(reserved_reach, full_reach);
+    let reserve_weight = smoothstep(
+        LANDING_KNEE_RESERVE_RELEASE_COMPRESSION,
+        LANDING_KNEE_RESERVE_FULL_COMPRESSION,
+        compression,
+    );
+    released_reach.lerp(reserved_reach, reserve_weight)
+}
+
 fn constrain_target_to_reach(target: Vec3, root: Vec3, maximum_reach: f32) -> Vec3 {
     let vertical = target.y - root.y;
     let maximum_horizontal = (maximum_reach * maximum_reach - vertical * vertical)
@@ -1697,6 +2041,34 @@ fn solve_two_bone(
         lower_length,
         pole_direction,
         maximum_reach(upper_length, lower_length),
+        true,
+    )
+}
+
+fn solve_landing_two_bone(
+    root: Vec3,
+    current_knee: Vec3,
+    current_end: Vec3,
+    target: Vec3,
+    upper_length: f32,
+    lower_length: f32,
+    pole_direction: Vec3,
+    compression: f32,
+) -> Option<TwoBoneSolution> {
+    solve_two_bone_internal(
+        root,
+        current_knee,
+        current_end,
+        target,
+        upper_length,
+        lower_length,
+        pole_direction,
+        landing_maximum_reach(
+            upper_length,
+            lower_length,
+            root.distance(current_end),
+            compression,
+        ),
         true,
     )
 }
@@ -2293,32 +2665,20 @@ mod tests {
     }
 
     #[test]
-    fn idle_plants_both_feet_and_gait_weight_is_continuous() {
-        assert_eq!(foot_support_weight(0.25, false, 1.0), 1.0);
-        assert_eq!(foot_support_weight(0.75, false, 1.0), 1.0);
-        let before = foot_support_weight(0.5 - 0.0001, true, 0.0);
-        let after = foot_support_weight(0.5 + 0.0001, true, 0.0);
-        assert!((before - after).abs() < 0.001);
-    }
-
-    #[test]
     fn run_has_unconstrained_flight_but_walk_retains_support() {
         for phase in [0.25, 0.75] {
-            assert_eq!(foot_support_weight(phase, true, 1.0), 0.0);
-            let (left, right) = gait_support_weights(phase, 2.0);
-            assert!((left.max(right) - 1.0).abs() < 0.0001);
-            assert!(left.min(right) <= 0.0001);
+            let (run_left, run_right) = gait_support_weights(RUN_LOCOMOTION_PROFILE, phase);
+            assert_eq!((run_left, run_right), (0.0, 0.0));
+            let (walk_left, walk_right) = gait_support_weights(WALK_LOCOMOTION_PROFILE, phase);
+            assert!(walk_left + walk_right > 0.0);
         }
-        assert_eq!(foot_support_weight(0.0, true, 1.0), 1.0);
-        assert_eq!(locomotion_run_weight(2.0), 0.0);
-        assert_eq!(locomotion_run_weight(5.5), 1.0);
 
-        let phase_step = 5.5 / ((0.9 + 5.5 * 0.16) * 2.0) / 64.0;
+        let phase_step = gait_cycle_phase_delta(RUN_LOCOMOTION_PROFILE, 5.5, 1.0 / 64.0);
         let mut longest = 0_u32;
         let mut current = 0_u32;
         for frame in 0..=64 {
             let phase = frame as f32 * phase_step;
-            let (left, right) = gait_support_weights(phase, 5.5);
+            let (left, right) = gait_support_weights(RUN_LOCOMOTION_PROFILE, phase);
             if left <= 0.001 && right <= 0.001 {
                 current += 1;
                 longest = longest.max(current);
@@ -2332,16 +2692,24 @@ mod tests {
 
     #[test]
     fn phase_owned_height_has_two_contact_minima_and_two_equal_peaks() {
-        for amplitude in [
-            WALK_HEIGHT_AMPLITUDE_METRES,
-            RUN_HEIGHT_AMPLITUDE_METRES,
-            GUARD_HEIGHT_AMPLITUDE_METRES,
-            CROUCH_HEIGHT_AMPLITUDE_METRES,
-        ] {
-            assert!(locomotion_height_wave(0.0, amplitude).abs() < 0.0001);
-            assert!(locomotion_height_wave(0.5, amplitude).abs() < 0.0001);
-            assert!((locomotion_height_wave(0.25, amplitude) - amplitude).abs() < 0.0001);
-            assert!((locomotion_height_wave(0.75, amplitude) - amplitude).abs() < 0.0001);
+        for phase in [0.0, 0.5] {
+            let state = SkeletonState {
+                local_velocity: Vec3::NEG_Z * 5.5,
+                gait_phase: phase,
+                ..default()
+            };
+            assert!(locomotion_height_wave(&state).abs() < 0.0001);
+        }
+        for phase in [0.25, 0.75] {
+            let state = SkeletonState {
+                local_velocity: Vec3::NEG_Z * 5.5,
+                gait_phase: phase,
+                ..default()
+            };
+            assert!(
+                (locomotion_height_wave(&state) - RUN_LOCOMOTION_PROFILE.flight_apex_metres).abs()
+                    < 0.0001
+            );
         }
     }
 
@@ -2360,36 +2728,34 @@ mod tests {
             ..default()
         };
         assert!(
-            (locomotion_height_amplitude(&moving(
-                2.0,
-                Posture::Upright,
-                WeaponGuardState::Lowered,
-            )) - WALK_HEIGHT_AMPLITUDE_METRES)
+            (locomotion_height_wave(&SkeletonState {
+                gait_phase: 0.25,
+                ..moving(2.0, Posture::Upright, WeaponGuardState::Lowered,)
+            }) - WALK_LOCOMOTION_PROFILE.bounce_metres)
                 .abs()
                 < 0.0001
         );
         assert!(
-            (locomotion_height_amplitude(&moving(
-                5.5,
-                Posture::Upright,
-                WeaponGuardState::Lowered,
-            )) - RUN_HEIGHT_AMPLITUDE_METRES)
+            (locomotion_height_wave(&SkeletonState {
+                gait_phase: 0.25,
+                ..moving(5.5, Posture::Upright, WeaponGuardState::Lowered,)
+            }) - RUN_LOCOMOTION_PROFILE.flight_apex_metres)
                 .abs()
                 < 0.0001
         );
         assert!(
-            (locomotion_height_amplitude(
-                &moving(2.0, Posture::Upright, WeaponGuardState::Raised,)
-            ) - GUARD_HEIGHT_AMPLITUDE_METRES)
+            (locomotion_height_wave(&SkeletonState {
+                gait_phase: 0.25,
+                ..moving(2.0, Posture::Upright, WeaponGuardState::Raised)
+            }) - RAISED_GUARD_LOCOMOTION_PROFILE.bounce_metres)
                 .abs()
                 < 0.0001
         );
         assert!(
-            (locomotion_height_amplitude(&moving(
-                1.5,
-                Posture::Crouched,
-                WeaponGuardState::Lowered,
-            )) - CROUCH_HEIGHT_AMPLITUDE_METRES)
+            (locomotion_height_wave(&SkeletonState {
+                gait_phase: 0.25,
+                ..moving(1.5, Posture::Crouched, WeaponGuardState::Lowered,)
+            }) - CROUCH_LOCOMOTION_PROFILE.bounce_metres)
                 .abs()
                 < 0.0001
         );
@@ -2440,6 +2806,137 @@ mod tests {
     }
 
     #[test]
+    fn body_response_and_landing_compression_are_bounded() {
+        let forward = body_response_target(Vec3::Z * 12.0);
+        let braking = body_response_target(Vec3::NEG_Z * 12.0);
+        let lateral = body_response_target(Vec3::X * 12.0);
+        assert!((-12.0..=-8.0).contains(&forward.x.to_degrees()));
+        assert!((6.0..=10.0).contains(&braking.x.to_degrees()));
+        assert!((6.0..=10.0).contains(&lateral.y.abs().to_degrees()));
+        assert!(
+            body_response_target(Vec3::new(40.0, 0.0, 40.0))
+                .length()
+                .to_degrees()
+                <= 15.0
+        );
+        assert_eq!(
+            landing_compression_for_impact(WALK_LOCOMOTION_PROFILE, 0.5),
+            0.0
+        );
+        assert!((0.04..=0.08).contains(&landing_compression_for_impact(
+            WALK_LOCOMOTION_PROFILE,
+            4.5,
+        )));
+        assert_eq!(presentation_tick_delta(Some(10), 10), Some(0));
+        assert_eq!(presentation_tick_delta(Some(10), 14), Some(4));
+        assert_eq!(presentation_tick_delta(Some(14), 2), None);
+        assert_eq!(presentation_tick_delta(Some(2), 40), None);
+    }
+
+    #[test]
+    fn landing_leg_solve_preserves_the_foot_with_real_knee_flexion() {
+        let root = Vec3::new(0.0, 1.75, 0.0);
+        let knee = Vec3::new(0.0, 0.85, 0.08);
+        let compressed_foot = Vec3::new(0.0, -0.05, 0.0);
+        let target = compressed_foot + Vec3::Y * 0.05;
+        let upper = root.distance(knee);
+        let lower = knee.distance(compressed_foot);
+        let solution = solve_two_bone(root, knee, compressed_foot, target, upper, lower, Vec3::Z)
+            .expect("compressed leg should reach its pre-compression foot");
+        let flexion = 180.0
+            - (root - solution.knee)
+                .angle_between(solution.end - solution.knee)
+                .to_degrees();
+        assert!(solution.end.distance(target) <= 0.0001);
+        assert!(flexion >= 10.0);
+
+        let mut retained = None;
+        let first = retain_landing_foot_target(&mut retained, target);
+        let recovered_frame =
+            retain_landing_foot_target(&mut retained, Vec3::new(0.0, -0.02, 0.03));
+        assert_eq!(first, target);
+        assert_eq!(recovered_frame, first);
+        assert!(!landing_plant_is_discontinuous(
+            Some(10),
+            10,
+            Some(Vec3::ZERO),
+            Vec3::ZERO,
+        ));
+        assert!(landing_plant_is_discontinuous(
+            Some(10),
+            9,
+            Some(Vec3::ZERO),
+            Vec3::ZERO,
+        ));
+        assert!(landing_plant_is_discontinuous(
+            Some(10),
+            11,
+            Some(Vec3::ZERO),
+            Vec3::X * 3.0,
+        ));
+
+        let mut height = LocomotionHeightState {
+            landing_left_foot_target: retained,
+            landing_right_foot_target: Some(first),
+            landing_plant_owner_position: Some(Vec3::ZERO),
+            landing_plant_tick: Some(10),
+            landing_plant_resync_tick: Some(10),
+            ..default()
+        };
+        clear_landing_foot_plants(&mut height);
+        assert!(height.landing_left_foot_target.is_none());
+        assert!(height.landing_right_foot_target.is_none());
+        assert!(height.landing_plant_owner_position.is_none());
+        assert!(height.landing_plant_tick.is_none());
+        assert!(height.landing_plant_resync_tick.is_none());
+    }
+
+    #[test]
+    fn landing_knee_reserve_releases_smoothly_for_late_recovery_reach() {
+        let upper = 0.9;
+        let lower = 0.9;
+        let authored_reach = 1.79;
+        let reserved_reach = maximum_reach(upper, lower);
+
+        let peak_reach = landing_maximum_reach(upper, lower, authored_reach, 0.04);
+        assert!((peak_reach - reserved_reach).abs() <= f32::EPSILON);
+        let peak_flexion = 180.0
+            - ((upper * upper + lower * lower - peak_reach * peak_reach) / (2.0 * upper * lower))
+                .clamp(-1.0, 1.0)
+                .acos()
+                .to_degrees();
+        assert!(peak_flexion >= 10.0);
+
+        let release_samples = [0.04, 0.033, 0.026, 0.019, 0.012];
+        let reaches = release_samples
+            .map(|compression| landing_maximum_reach(upper, lower, authored_reach, compression));
+        for pair in reaches.windows(2) {
+            assert!(pair[1] >= pair[0]);
+            assert!(pair[1] - pair[0] < 0.01);
+        }
+        assert!((reaches[4] - authored_reach).abs() <= 0.0001);
+
+        let target = Vec3::ZERO;
+        let current_knee = Vec3::new(0.0, 0.89, 0.1);
+        for compression in [0.012, 0.008, 0.004, 0.001] {
+            let root = Vec3::Y * (authored_reach - compression);
+            let current_end = Vec3::NEG_Y * compression;
+            let solution = solve_landing_two_bone(
+                root,
+                current_knee,
+                current_end,
+                target,
+                upper,
+                lower,
+                Vec3::Z,
+                compression,
+            )
+            .expect("late landing recovery should remain solvable");
+            assert!(solution.end.distance(target) <= 0.0001);
+        }
+    }
+
+    #[test]
     fn raised_guard_movement_reports_exactly_one_procedural_support_foot() {
         for (lead, phase) in [
             (LeadFoot::Left, 0.0),
@@ -2473,6 +2970,26 @@ mod tests {
             ..default()
         };
         assert_eq!(locomotion_support_weights(&idle), (1.0, 1.0));
+    }
+
+    #[test]
+    fn ordinary_idle_and_stopping_restore_symmetric_terrain_support() {
+        let idle = SkeletonState {
+            gait_phase: 0.25,
+            ..default()
+        };
+        assert_eq!(locomotion_support_weights(&idle), (1.0, 1.0));
+
+        let stopping = SkeletonState {
+            gait_phase: 0.25,
+            local_velocity: Vec3::NEG_Z * 0.2,
+            ..default()
+        };
+        let (left, right) = locomotion_support_weights(&stopping);
+        let (raw_left, raw_right) =
+            gait_support_weights(locomotion_profile(&stopping), stopping.gait_phase);
+        assert!(left > raw_left && right > raw_right);
+        assert!(left > 0.5 && right > 0.5);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -20,7 +20,8 @@ use bevy::{
 use serde::Serialize;
 
 use crate::animation::{
-    AnimationPlayback, BoneRole, HumanoidBone, LocomotionHeightState, ProceduralAnimationClock,
+    AnimationPlayback, BoneRole, HumanoidBone, LocomotionBodyResponseState, LocomotionHeightState,
+    LocomotionPresentationEvent, LocomotionPresentationEventKind, ProceduralAnimationClock,
     ProceduralIkState, RaisedFootworkState, TacticalAnimationPlugin, TerrainIkEnabled,
     locomotion_support_weights,
 };
@@ -30,7 +31,7 @@ use crate::{
     presentation::TacticalPresentationPlugin,
 };
 
-const SAMPLE_HZ: f32 = 64.0;
+const SAMPLE_HZ: f32 = LOCOMOTION_SAMPLE_HZ;
 const CAPTURE_ROOT_GROUND_OFFSET_METRES: f32 = 0.95;
 const FULL_PLANT_SUPPORT_WEIGHT: f32 = 0.99;
 const RAISED_MINIMUM_INTER_FOOT_SEPARATION_METRES: f32 = 0.16;
@@ -63,6 +64,64 @@ const TRACKED_BONE_NAMES: [&str; 15] = [
     "left_foot",
     "right_foot",
 ];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScenarioKind {
+    Ordinary,
+    RaisedGuard,
+    Terrain,
+    Transition,
+    Landing,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScenarioMetadata {
+    kind: ScenarioKind,
+    repeatable: bool,
+    procedural_solver: bool,
+}
+
+fn scenario_metadata(name: &str) -> ScenarioMetadata {
+    if name == "cross-slope-walk" {
+        ScenarioMetadata {
+            kind: ScenarioKind::Terrain,
+            repeatable: true,
+            procedural_solver: true,
+        }
+    } else if name.starts_with("raised-guard") {
+        ScenarioMetadata {
+            kind: ScenarioKind::RaisedGuard,
+            repeatable: !name.contains("release")
+                && !name.contains("reversal")
+                && !name.contains("accelerate")
+                && name != "raised-guard-transition",
+            procedural_solver: true,
+        }
+    } else if name == "airborne-landing" {
+        ScenarioMetadata {
+            kind: ScenarioKind::Landing,
+            repeatable: false,
+            procedural_solver: false,
+        }
+    } else if name.contains("transition")
+        || name.contains("enter-exit")
+        || name.contains("hard-stop")
+        || name.contains("ramp")
+        || name.contains("turn")
+    {
+        ScenarioMetadata {
+            kind: ScenarioKind::Transition,
+            repeatable: false,
+            procedural_solver: false,
+        }
+    } else {
+        ScenarioMetadata {
+            kind: ScenarioKind::Ordinary,
+            repeatable: true,
+            procedural_solver: false,
+        }
+    }
+}
 
 pub(crate) fn run(
     output: PathBuf,
@@ -135,7 +194,10 @@ pub(crate) fn run(
             PostUpdate,
             draw_skeleton_overlay.after(TransformSystems::Propagate),
         )
-        .add_systems(Last, capture_frame)
+        .add_systems(
+            Last,
+            (collect_locomotion_presentation_events, capture_frame).chain(),
+        )
         .run()
 }
 
@@ -192,6 +254,9 @@ struct CaptureSequence {
     view_fingerprints: Vec<u64>,
     duplicate_view_frames: Vec<String>,
     samples: Vec<FrameSample>,
+    presentation_events: Vec<PresentationEventSample>,
+    repeated_evaluation_baseline: Option<RepeatedEvaluationSnapshot>,
+    repeated_evaluation_valid: bool,
     active_scenario: Option<&'static str>,
     simulation_tick: u64,
     scenario_distance: f32,
@@ -220,11 +285,23 @@ impl CaptureSequence {
             view_fingerprints: Vec::with_capacity(VIEWS.len()),
             duplicate_view_frames: Vec::new(),
             samples: Vec::new(),
+            presentation_events: Vec::new(),
+            repeated_evaluation_baseline: None,
+            repeated_evaluation_valid: true,
             active_scenario: None,
             simulation_tick: 0,
             scenario_distance: 0.0,
         }
     }
+}
+
+struct RepeatedEvaluationSnapshot {
+    scenario: &'static str,
+    scenario_frame: usize,
+    bones: BTreeMap<String, BoneSample>,
+    contact_sequence: u64,
+    landing_sequence: u64,
+    event_count: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -235,6 +312,17 @@ struct CaptureManifest {
     validation: CaptureValidation,
     scenarios: Vec<ScenarioMetrics>,
     frames: Vec<FrameSample>,
+    presentation_events: Vec<PresentationEventSample>,
+}
+
+#[derive(Debug, Serialize)]
+struct PresentationEventSample {
+    scenario: String,
+    scenario_frame: usize,
+    owner: String,
+    sequence: u64,
+    sample_tick: u64,
+    kind: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -249,6 +337,16 @@ struct CaptureValidation {
     flat_controller_height_stable: bool,
     phase_owned_height_valid: bool,
     run_flight_valid: bool,
+    body_response_valid: bool,
+    speed_ramp_phase_continuity_valid: bool,
+    contact_sequences_valid: bool,
+    cadence_contact_valid: bool,
+    event_stream_valid: bool,
+    landing_response_valid: bool,
+    landing_foot_preservation_valid: bool,
+    hard_stop_maximum_pelvis_step_metres: Option<f32>,
+    hard_stop_height_continuity_valid: bool,
+    repeated_evaluation_valid: bool,
     views_are_distinct: bool,
     duplicate_view_frames: Vec<String>,
     note: &'static str,
@@ -327,6 +425,16 @@ struct FrameSample {
     time_seconds: f32,
     speed_metres_per_second: f32,
     gait_phase: f32,
+    locomotion_sample_tick: u64,
+    body_acceleration: [f32; 3],
+    world_acceleration: [f32; 3],
+    contact_sequence: u64,
+    contact_foot: LeadFoot,
+    landing_sequence: u64,
+    landing_impact_speed: f32,
+    body_lean_pitch_degrees: f32,
+    body_lean_roll_degrees: f32,
+    landing_compression_metres: f32,
     root_distance_metres: f32,
     root_position_metres: [f32; 3],
     world_travel_direction: [f32; 3],
@@ -351,10 +459,6 @@ struct BoneSample {
     terrain_clearance_metres: Option<f32>,
 }
 
-fn stride_length(speed: f32) -> f32 {
-    (0.9 + speed * 0.16).clamp(0.9, 1.8)
-}
-
 fn steady_scenario(name: &'static str, speed: f32, cycles: f32) -> Vec<PlannedFrame> {
     steady_scenario_in_direction(name, speed, cycles, Vec2::NEG_Y)
 }
@@ -365,7 +469,7 @@ fn steady_scenario_in_direction(
     cycles: f32,
     local_direction: Vec2,
 ) -> Vec<PlannedFrame> {
-    let cycle_duration = stride_length(speed) * 2.0 / speed;
+    let cycle_duration = ordinary_step_distance(speed) * 2.0 / speed;
     let duration = cycles * cycle_duration;
     // Include the first authoritative tick after the requested final cycle.
     // Fixed-rate sampling rarely lands on the mathematical wrap exactly; the
@@ -451,6 +555,55 @@ fn crouch_transition_scenario() -> Vec<PlannedFrame> {
         .collect()
 }
 
+fn dynamics_speed_scenario(name: &'static str, hard_stop: bool) -> Vec<PlannedFrame> {
+    (0..=256)
+        .map(|scenario_frame| {
+            let speed = if hard_stop {
+                if scenario_frame < 96 { 5.5 } else { 0.0 }
+            } else if scenario_frame < 32 {
+                5.5 * scenario_frame as f32 / 32.0
+            } else if scenario_frame < 128 {
+                5.5
+            } else if scenario_frame < 160 {
+                5.5 * (160 - scenario_frame) as f32 / 32.0
+            } else {
+                0.0
+            };
+            PlannedFrame {
+                scenario: name,
+                scenario_frame,
+                speed,
+                time_seconds: scenario_frame as f32 / SAMPLE_HZ,
+                local_direction: Vec2::NEG_Y,
+                camera_yaw: 0.0,
+                camera_pitch: 0.0,
+                crouching: false,
+                action: SkeletonAction::None,
+                weapon_guard: WeaponGuardState::Lowered,
+                lead_foot: LeadFoot::Left,
+            }
+        })
+        .collect()
+}
+
+fn airborne_landing_scenario() -> Vec<PlannedFrame> {
+    (0..=96)
+        .map(|scenario_frame| PlannedFrame {
+            scenario: "airborne-landing",
+            scenario_frame,
+            speed: 0.0,
+            time_seconds: scenario_frame as f32 / SAMPLE_HZ,
+            local_direction: Vec2::ZERO,
+            camera_yaw: 0.0,
+            camera_pitch: 0.0,
+            crouching: false,
+            action: SkeletonAction::None,
+            weapon_guard: WeaponGuardState::Lowered,
+            lead_foot: LeadFoot::Left,
+        })
+        .collect()
+}
+
 fn smoothstep01(value: f32) -> f32 {
     let value = value.clamp(0.0, 1.0);
     value * value * (3.0 - 2.0 * value)
@@ -511,6 +664,12 @@ fn capture_plan() -> Vec<PlannedFrame> {
         ),
         raised_guard_transition_scenario(),
         crouch_transition_scenario(),
+        dynamics_speed_scenario("speed-ramp-up-down", false),
+        dynamics_speed_scenario("hard-stop", true),
+        dynamics_turn_scenario("dynamics-turn-90", std::f32::consts::FRAC_PI_2),
+        dynamics_turn_scenario("dynamics-turn-180", std::f32::consts::PI),
+        airborne_landing_scenario(),
+        steady_scenario("cadence-contact", 2.0, 2.0),
         steady_scenario_in_direction("cross-slope-walk", 2.0, 1.0, Vec2::X),
         transition_scenario(),
     ]
@@ -537,6 +696,27 @@ fn turning_scenario(name: &'static str, reversal: bool) -> Vec<PlannedFrame> {
                     std::f32::consts::FRAC_PI_2 * progress
                 },
                 camera_pitch: 0.55 * progress,
+                crouching: false,
+                action: SkeletonAction::None,
+                weapon_guard: WeaponGuardState::Lowered,
+                lead_foot: LeadFoot::Left,
+            }
+        })
+        .collect()
+}
+
+fn dynamics_turn_scenario(name: &'static str, angle_radians: f32) -> Vec<PlannedFrame> {
+    (0..=64)
+        .map(|frame| {
+            let progress = frame as f32 / 64.0;
+            PlannedFrame {
+                scenario: name,
+                scenario_frame: frame,
+                speed: 5.5,
+                time_seconds: progress,
+                local_direction: Vec2::NEG_Y,
+                camera_yaw: angle_radians * progress,
+                camera_pitch: 0.0,
                 crouching: false,
                 action: SkeletonAction::None,
                 weapon_guard: WeaponGuardState::Lowered,
@@ -770,6 +950,7 @@ fn drive_sequence(
             Option<&mut ProceduralIkState>,
             Option<&mut RaisedFootworkState>,
             Option<&mut LocomotionHeightState>,
+            Option<&mut LocomotionBodyResponseState>,
         ),
         With<CaptureSubject>,
     >,
@@ -779,6 +960,7 @@ fn drive_sequence(
         return;
     }
     let frame = sequence.plan[sequence.index].clone();
+    let metadata = scenario_metadata(frame.scenario);
     let mut gait_phase = 0.0;
     for (
         mut skeleton,
@@ -788,6 +970,7 @@ fn drive_sequence(
         ik_state,
         raised_footwork,
         height_state,
+        body_response,
     ) in &mut subjects
     {
         let Some(playback) = playback else {
@@ -812,6 +995,9 @@ fn drive_sequence(
             if let Some(mut height_state) = height_state {
                 *height_state = LocomotionHeightState::default();
             }
+            if let Some(mut body_response) = body_response {
+                *body_response = LocomotionBodyResponseState::default();
+            }
             let ground = terrain.height_at(Vec2::ZERO).unwrap_or_default();
             transform.translation = Vec3::new(0.0, ground + CAPTURE_ROOT_GROUND_OFFSET_METRES, 0.0);
             transform.rotation = Quat::from_rotation_y(std::f32::consts::PI);
@@ -826,11 +1012,20 @@ fn drive_sequence(
             WeaponGuardState::Lowered => -1.0,
         };
         skeleton.lead_foot = frame.lead_foot;
-        terrain_ik.0 = frame.scenario == "cross-slope-walk";
+        terrain_ik.0 = metadata.kind == ScenarioKind::Terrain;
         guard_input.apply_controls(wheel, false);
         set_weapon_guard(&mut skeleton, guard_input.desired);
-        let local_velocity =
-            Vec3::new(frame.local_direction.x, 0.0, frame.local_direction.y) * frame.speed;
+        let grounded = metadata.kind != ScenarioKind::Landing || frame.scenario_frame >= 32;
+        let vertical_velocity = if metadata.kind == ScenarioKind::Landing && !grounded {
+            -4.5
+        } else {
+            0.0
+        };
+        let local_velocity = Vec3::new(
+            frame.local_direction.x * frame.speed,
+            vertical_velocity,
+            frame.local_direction.y * frame.speed,
+        );
         let world_velocity = controller_yaw(orientation) * local_velocity;
         let delta_seconds = if frame.scenario_frame == 0 {
             0.0
@@ -867,7 +1062,7 @@ fn drive_sequence(
             SkeletonLocomotionInput {
                 orientation,
                 linear_velocity: world_velocity,
-                grounded: true,
+                grounded,
                 crouching: frame.crouching,
                 delta_seconds,
                 tick: sequence.simulation_tick,
@@ -1005,6 +1200,32 @@ fn draw_skeleton_overlay(
     }
 }
 
+fn collect_locomotion_presentation_events(
+    mut events: MessageReader<LocomotionPresentationEvent>,
+    mut sequence: ResMut<CaptureSequence>,
+) {
+    if sequence.index >= sequence.plan.len() {
+        return;
+    }
+    let scenario = sequence.plan[sequence.index].scenario.to_owned();
+    let scenario_frame = sequence.plan[sequence.index].scenario_frame;
+    sequence
+        .presentation_events
+        .extend(events.read().map(move |event| PresentationEventSample {
+            scenario: scenario.clone(),
+            scenario_frame,
+            owner: format!("{:?}", event.owner),
+            sequence: event.sequence,
+            sample_tick: event.sample_tick,
+            kind: match event.kind {
+                LocomotionPresentationEventKind::Contact(foot) => {
+                    format!("contact_{foot:?}").to_lowercase()
+                }
+                LocomotionPresentationEventKind::Landing => "landing".to_owned(),
+            },
+        }));
+}
+
 fn capture_frame(
     mut commands: Commands,
     mut sequence: ResMut<CaptureSequence>,
@@ -1016,6 +1237,8 @@ fn capture_frame(
             &GlobalTransform,
             Option<&AnimationPlayback>,
             Option<&RaisedFootworkState>,
+            Option<&LocomotionBodyResponseState>,
+            Option<&LocomotionHeightState>,
         ),
         With<CaptureSubject>,
     >,
@@ -1026,7 +1249,15 @@ fn capture_frame(
     if !sequence.applied || sequence.capture_in_flight {
         return;
     }
-    let Ok((subject, skeleton, subject_global, playback, raised_footwork)) = subjects.single()
+    let Ok((
+        subject,
+        skeleton,
+        subject_global,
+        playback,
+        raised_footwork,
+        body_response,
+        height_state,
+    )) = subjects.single()
     else {
         wait_or_fail(&mut sequence, "capture subject is missing", &mut exit);
         return;
@@ -1070,6 +1301,41 @@ fn capture_frame(
         view.slug()
     );
     let path = sequence.output.join(&file_name);
+    let evaluation_bones = collect_bones(
+        subject,
+        &bones,
+        &terrain,
+        (!terrain_ik.0)
+            .then_some(subject_global.translation().y - CAPTURE_ROOT_GROUND_OFFSET_METRES),
+    );
+    if sequence.view_index == 0 {
+        sequence.repeated_evaluation_baseline = Some(RepeatedEvaluationSnapshot {
+            scenario: frame.scenario,
+            scenario_frame: frame.scenario_frame,
+            bones: evaluation_bones.clone(),
+            contact_sequence: skeleton.contact_sequence,
+            landing_sequence: skeleton.landing_sequence,
+            event_count: sequence.presentation_events.len(),
+        });
+    } else if let Some(baseline) = &sequence.repeated_evaluation_baseline {
+        let bones_match = baseline.bones.iter().all(|(name, expected)| {
+            evaluation_bones.get(name).is_some_and(|actual| {
+                Vec3::from_array(expected.position).distance(Vec3::from_array(actual.position))
+                    <= 0.0005
+                    && Quat::from_array(expected.rotation_xyzw)
+                        .angle_between(Quat::from_array(actual.rotation_xyzw))
+                        .to_degrees()
+                        <= 0.1
+            })
+        });
+        let repeated_evaluation_matches = baseline.scenario == frame.scenario
+            && baseline.scenario_frame == frame.scenario_frame
+            && bones_match
+            && baseline.contact_sequence == skeleton.contact_sequence
+            && baseline.landing_sequence == skeleton.landing_sequence
+            && baseline.event_count == sequence.presentation_events.len();
+        sequence.repeated_evaluation_valid &= repeated_evaluation_matches;
+    }
     if sequence.view_index == 0 {
         let (left_support_weight, right_support_weight) = locomotion_support_weights(skeleton);
         let root_distance_metres = sequence.scenario_distance;
@@ -1082,6 +1348,19 @@ fn capture_frame(
             time_seconds: frame.time_seconds,
             speed_metres_per_second: frame.speed,
             gait_phase: skeleton.gait_phase,
+            locomotion_sample_tick: skeleton.locomotion_sample_tick,
+            body_acceleration: (subject_global.rotation().inverse() * skeleton.world_acceleration)
+                .to_array(),
+            world_acceleration: skeleton.world_acceleration.to_array(),
+            contact_sequence: skeleton.contact_sequence,
+            contact_foot: skeleton.contact_foot,
+            landing_sequence: skeleton.landing_sequence,
+            landing_impact_speed: skeleton.landing_impact_speed,
+            body_lean_pitch_degrees: body_response
+                .map_or(0.0, |state| state.pitch_radians.to_degrees()),
+            body_lean_roll_degrees: body_response
+                .map_or(0.0, |state| state.roll_radians.to_degrees()),
+            landing_compression_metres: height_state.map_or(0.0, |state| state.landing_compression),
             root_distance_metres,
             root_position_metres: subject_global.translation().to_array(),
             world_travel_direction: (controller_yaw(Quat::from_rotation_y(frame.camera_yaw))
@@ -1122,13 +1401,7 @@ fn capture_frame(
                     )
                 })
                 .collect(),
-            bones: collect_bones(
-                subject,
-                &bones,
-                &terrain,
-                (!terrain_ik.0)
-                    .then_some(subject_global.translation().y - CAPTURE_ROOT_GROUND_OFFSET_METRES),
-            ),
+            bones: evaluation_bones,
         });
     }
     sequence.capture_in_flight = true;
@@ -1255,6 +1528,7 @@ fn wait_or_fail(sequence: &mut CaptureSequence, reason: &str, exit: &mut Message
 
 fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppExit>) {
     let frames = std::mem::take(&mut sequence.samples);
+    let presentation_events = std::mem::take(&mut sequence.presentation_events);
     let scenarios = scenario_metrics(&frames);
     let finite_transforms = frames.iter().all(|frame| {
         frame.bones.values().all(|bone| {
@@ -1321,6 +1595,206 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
             true
         }
     });
+    let contact_sequences_valid = frames.windows(2).all(|pair| {
+        if pair[0].scenario != pair[1].scenario {
+            return true;
+        }
+        let delta = pair[1]
+            .contact_sequence
+            .wrapping_sub(pair[0].contact_sequence);
+        delta <= 1
+            && (delta == 0 || pair[1].contact_foot != pair[0].contact_foot)
+            && !(pair[0].speed_metres_per_second <= 0.05
+                && pair[1].speed_metres_per_second <= 0.05
+                && delta != 0)
+    });
+    let cadence_frames = frames
+        .iter()
+        .filter(|frame| frame.scenario == "cadence-contact")
+        .collect::<Vec<_>>();
+    let cadence_contacts = cadence_frames
+        .windows(2)
+        .filter_map(|pair| {
+            (pair[1].contact_sequence == pair[0].contact_sequence + 1).then_some(pair[1])
+        })
+        .collect::<Vec<_>>();
+    let cadence_step_distance = ordinary_step_distance(2.0);
+    let adjusted_contact_distances = cadence_contacts
+        .iter()
+        .map(|frame| {
+            let contact_phase = match frame.contact_foot {
+                LeadFoot::Left => 0.0,
+                LeadFoot::Right => 0.5,
+            };
+            let phase_since_contact = (frame.gait_phase - contact_phase).rem_euclid(1.0);
+            frame.root_distance_metres - phase_since_contact * cadence_step_distance * 2.0
+        })
+        .collect::<Vec<_>>();
+    let cadence_tolerance = (cadence_step_distance * 0.01).max(0.005);
+    let cadence_contact_valid = cadence_frames.is_empty()
+        || (cadence_contacts.len() == 4
+            && cadence_contacts.windows(2).all(|pair| {
+                pair[1].contact_sequence == pair[0].contact_sequence + 1
+                    && pair[1].contact_foot != pair[0].contact_foot
+            })
+            && adjusted_contact_distances.windows(2).all(|pair| {
+                ((pair[1] - pair[0]) - cadence_step_distance).abs() <= cadence_tolerance
+            })
+            && adjusted_contact_distances.windows(3).all(|window| {
+                ((window[2] - window[0]) - cadence_step_distance * 2.0).abs() <= cadence_tolerance
+            }));
+    let event_stream_valid = presentation_events.windows(2).all(|pair| {
+        let same_stream = (pair[0].kind.starts_with("contact")
+            && pair[1].kind.starts_with("contact"))
+            || (pair[0].kind == "landing" && pair[1].kind == "landing");
+        pair[0].scenario != pair[1].scenario
+            || !same_stream
+            || (pair[1].sequence > pair[0].sequence && pair[1].sample_tick >= pair[0].sample_tick)
+    }) && presentation_events
+        .iter()
+        .enumerate()
+        .all(|(index, event)| {
+            !presentation_events[..index].iter().any(|previous| {
+                previous.owner == event.owner
+                    && previous.scenario == event.scenario
+                    && previous.kind == event.kind
+                    && previous.sequence == event.sequence
+            })
+        })
+        && (cadence_frames.is_empty()
+            || presentation_events
+                .iter()
+                .filter(|event| {
+                    event.scenario == "cadence-contact" && event.kind.starts_with("contact")
+                })
+                .count()
+                == 4)
+        && (!frames
+            .iter()
+            .any(|frame| frame.scenario == "airborne-landing")
+            || presentation_events
+                .iter()
+                .filter(|event| event.scenario == "airborne-landing" && event.kind == "landing")
+                .count()
+                == 1);
+    let speed_ramp_phase_continuity_valid = frames.windows(2).all(|pair| {
+        if pair[0].scenario != "speed-ramp-up-down" || pair[1].scenario != "speed-ramp-up-down" {
+            return true;
+        }
+        let phase_delta = pair[1].gait_phase - pair[0].gait_phase;
+        phase_delta >= -0.001
+            || (phase_delta < -0.5
+                && pair[1]
+                    .contact_sequence
+                    .wrapping_sub(pair[0].contact_sequence)
+                    == 1)
+    });
+    let lean_range = |scenario: &str, select: fn(&FrameSample) -> f32| {
+        frames
+            .iter()
+            .filter(|frame| frame.scenario == scenario)
+            .map(select)
+            .fold(
+                (f32::INFINITY, f32::NEG_INFINITY),
+                |(minimum, maximum), value| (minimum.min(value), maximum.max(value)),
+            )
+    };
+    let (ramp_pitch_minimum, ramp_pitch_maximum) =
+        lean_range("speed-ramp-up-down", |frame| frame.body_lean_pitch_degrees);
+    let (_, hard_stop_pitch_maximum) =
+        lean_range("hard-stop", |frame| frame.body_lean_pitch_degrees);
+    let turn_90_roll = lean_range("dynamics-turn-90", |frame| {
+        frame.body_lean_roll_degrees.abs()
+    });
+    let turn_180_roll = lean_range("dynamics-turn-180", |frame| {
+        frame.body_lean_roll_degrees.abs()
+    });
+    let lean_step_valid = frames.windows(2).all(|pair| {
+        pair[0].scenario != pair[1].scenario
+            || Vec2::new(
+                pair[1].body_lean_pitch_degrees - pair[0].body_lean_pitch_degrees,
+                pair[1].body_lean_roll_degrees - pair[0].body_lean_roll_degrees,
+            )
+            .length()
+                <= 2.01
+    });
+    let has_scenario = |name: &str| frames.iter().any(|frame| frame.scenario == name);
+    let body_response_valid = (!has_scenario("speed-ramp-up-down")
+        || ((-12.0..=-8.0).contains(&ramp_pitch_minimum)
+            && (6.0..=10.0).contains(&ramp_pitch_maximum)))
+        && (!has_scenario("hard-stop") || (6.0..=10.0).contains(&hard_stop_pitch_maximum))
+        && (!has_scenario("dynamics-turn-90") || (6.0..=10.0).contains(&turn_90_roll.1))
+        && (!has_scenario("dynamics-turn-180") || (6.0..=10.0).contains(&turn_180_roll.1))
+        && lean_step_valid
+        && ["speed-ramp-up-down", "hard-stop"]
+            .iter()
+            .filter(|scenario| has_scenario(scenario))
+            .all(|scenario| {
+                frames
+                    .iter()
+                    .rev()
+                    .find(|frame| frame.scenario == *scenario)
+                    .is_some_and(|frame| {
+                        Vec2::new(frame.body_lean_pitch_degrees, frame.body_lean_roll_degrees)
+                            .length()
+                            <= 0.5
+                    })
+            });
+    let landing_frames = frames
+        .iter()
+        .filter(|frame| scenario_metadata(&frame.scenario).kind == ScenarioKind::Landing)
+        .collect::<Vec<_>>();
+    let landing_response_valid = landing_frames.is_empty()
+        || (landing_frames
+            .last()
+            .zip(landing_frames.first())
+            .is_some_and(|(last, first)| {
+                last.landing_sequence.wrapping_sub(first.landing_sequence) == 1
+            })
+            && (0.04..=0.08).contains(
+                &landing_frames
+                    .iter()
+                    .map(|frame| frame.landing_compression_metres)
+                    .fold(0.0, f32::max),
+            )
+            && landing_frames
+                .last()
+                .is_some_and(|frame| frame.landing_compression_metres <= 0.005)
+            && landing_frames
+                .iter()
+                .max_by(|left, right| {
+                    left.landing_compression_metres
+                        .total_cmp(&right.landing_compression_metres)
+                })
+                .is_some_and(|frame| frame_minimum_knee_flexion(frame) >= 10.0));
+    let landing_grounded_frames = landing_frames
+        .iter()
+        .copied()
+        .filter(|frame| frame.scenario_frame >= 32)
+        .collect::<Vec<_>>();
+    let landing_foot_preservation_valid = landing_frames.is_empty()
+        || landing_grounded_frames.last().is_some_and(|reference| {
+            ["left_foot", "right_foot"].iter().all(|name| {
+                let Some(reference_position) = reference
+                    .bones
+                    .get(*name)
+                    .map(|bone| Vec3::from_array(bone.position))
+                else {
+                    return false;
+                };
+                landing_grounded_frames.iter().all(|frame| {
+                    frame.bones.get(*name).is_some_and(|bone| {
+                        Vec3::from_array(bone.position).distance(reference_position) <= 0.01
+                            && bone
+                                .terrain_clearance_metres
+                                .is_some_and(|height| height >= -0.01)
+                    })
+                })
+            })
+        });
+    let hard_stop_maximum_pelvis_step_metres = hard_stop_pelvis_vertical_step(&frames);
+    let hard_stop_height_continuity_valid =
+        hard_stop_maximum_pelvis_step_metres.is_none_or(|maximum_step| maximum_step <= 0.02);
     let biomechanics_within_review_bounds = scenarios.iter().all(|metrics| {
         // Raised guard deliberately adds a little vertical readiness through
         // the pelvis and torso. Keep the stricter ordinary-locomotion gate,
@@ -1358,6 +1832,7 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
             }
     });
     let views_are_distinct = sequence.duplicate_view_frames.is_empty();
+    let repeated_evaluation_valid = sequence.repeated_evaluation_valid;
     let manifest = CaptureManifest {
         sample_hz: SAMPLE_HZ,
         pipeline: "shared tactical player, scene, camera, authoritative locomotion projection, authored FK, and final procedural passes",
@@ -1373,12 +1848,23 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
             flat_controller_height_stable,
             phase_owned_height_valid,
             run_flight_valid,
+            body_response_valid,
+            speed_ramp_phase_continuity_valid,
+            contact_sequences_valid,
+            cadence_contact_valid,
+            event_stream_valid,
+            landing_response_valid,
+            landing_foot_preservation_valid,
+            hard_stop_maximum_pelvis_step_metres,
+            hard_stop_height_continuity_valid,
+            repeated_evaluation_valid,
             views_are_distinct,
             duplicate_view_frames: sequence.duplicate_view_frames.clone(),
             note: "Continuity metrics are regression signals, not biomechanical proof; review index.html at normal and slow speed.",
         },
         scenarios,
         frames,
+        presentation_events,
     };
     let manifest_path = sequence.output.join("manifest.json");
     fs::write(
@@ -1400,6 +1886,15 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         && flat_controller_height_stable
         && phase_owned_height_valid
         && run_flight_valid
+        && body_response_valid
+        && speed_ramp_phase_continuity_valid
+        && contact_sequences_valid
+        && cadence_contact_valid
+        && event_stream_valid
+        && landing_response_valid
+        && landing_foot_preservation_valid
+        && hard_stop_height_continuity_valid
+        && repeated_evaluation_valid
         && views_are_distinct
     {
         exit.write(AppExit::Success);
@@ -1423,7 +1918,7 @@ fn planted_drift_limit(scenario: &str) -> f32 {
 }
 
 fn procedural_leg_solver_gates_apply(scenario: &str) -> bool {
-    scenario == "cross-slope-walk" || scenario.starts_with("raised-guard")
+    scenario_metadata(scenario).procedural_solver
 }
 
 fn inter_foot_separation_limit(scenario: &str) -> f32 {
@@ -1445,7 +1940,8 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
             // Terrain conformity calibrates retained pelvis/plant state during
             // its first cycle. Judge its steady gait after that deterministic
             // warmup, matching the phase-height validation window.
-            let metric_frames = if scenario == "cross-slope-walk" {
+            let metadata = scenario_metadata(scenario);
+            let metric_frames = if metadata.kind == ScenarioKind::Terrain {
                 phase_validation_frames(&frames)
             } else {
                 frames.clone()
@@ -1453,7 +1949,7 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
             let procedural_frames = metric_frames
                 .iter()
                 .copied()
-                .filter(|frame| scenario == "cross-slope-walk" || frame.guard_action)
+                .filter(|frame| metadata.kind == ScenarioKind::Terrain || frame.guard_action)
                 .collect::<Vec<_>>();
             let mut maximum_step = 0.0_f32;
             let mut maximum_rotation = 0.0_f32;
@@ -1507,7 +2003,7 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
                     // A body turn deliberately slides an old world plant onto
                     // its new anatomical side corridor. Treat that bounded
                     // adaptation separately from skating under a stable body.
-                    let procedural_plant_active = scenario == "cross-slope-walk"
+                    let procedural_plant_active = metadata.kind == ScenarioKind::Terrain
                         || (before.guard_action && after.guard_action);
                     if procedural_plant_active
                         && support >= 0.9
@@ -1591,26 +2087,16 @@ fn scenario_metrics(frames: &[FrameSample]) -> Vec<ScenarioMetrics> {
 }
 
 fn expects_loop_seam(scenario: &str) -> bool {
-    if scenario.contains("-release")
-        || scenario.contains("-reversal")
-        || scenario.contains("accelerate")
-    {
-        return false;
-    }
-    !matches!(
-        scenario,
-        "start-stop-transition"
-            | "gradual-camera-turn"
-            | "half-turn-reversal"
-            | "planted-guard-turn"
-            | "crouch-enter-exit"
-            | "raised-guard-release-at-peak"
-    )
+    scenario_metadata(scenario).repeatable
 }
 
 fn vertical_range_limit(scenario: &str, foot_terrain_relief_metres: f32) -> f32 {
     if scenario.starts_with("raised-guard-") {
         RAISED_GUARD_VERTICAL_RANGE_LIMIT_METRES
+    } else if scenario == "hard-stop" {
+        // The scenario intentionally spans the run apex and exact final idle.
+        // Per-frame release continuity is enforced separately at 2 cm.
+        ORDINARY_VERTICAL_RANGE_LIMIT_METRES + 0.01
     } else if scenario == "cross-slope-walk" {
         ORDINARY_VERTICAL_RANGE_LIMIT_METRES + foot_terrain_relief_metres.max(0.0)
     } else {
@@ -1666,23 +2152,27 @@ fn minimum_inter_foot_separation(frames: &[&FrameSample]) -> f32 {
 fn minimum_knee_flexion(frames: &[&FrameSample]) -> f32 {
     frames
         .iter()
-        .flat_map(|frame| {
-            [
-                ("left_hip", "left_knee", "left_foot"),
-                ("right_hip", "right_knee", "right_foot"),
-            ]
-            .map(|(hip, knee, foot)| {
-                let (Some(hip), Some(knee), Some(foot)) = (
-                    body_local(frame, hip),
-                    body_local(frame, knee),
-                    body_local(frame, foot),
-                ) else {
-                    return f32::INFINITY;
-                };
-                180.0 - (hip - knee).angle_between(foot - knee).to_degrees()
-            })
-        })
+        .map(|frame| frame_minimum_knee_flexion(frame))
         .fold(f32::INFINITY, f32::min)
+}
+
+fn frame_minimum_knee_flexion(frame: &FrameSample) -> f32 {
+    [
+        ("left_hip", "left_knee", "left_foot"),
+        ("right_hip", "right_knee", "right_foot"),
+    ]
+    .into_iter()
+    .map(|(hip, knee, foot)| {
+        let (Some(hip), Some(knee), Some(foot)) = (
+            body_local(frame, hip),
+            body_local(frame, knee),
+            body_local(frame, foot),
+        ) else {
+            return f32::INFINITY;
+        };
+        180.0 - (hip - knee).angle_between(foot - knee).to_degrees()
+    })
+    .fold(f32::INFINITY, f32::min)
 }
 
 fn minimum_knee_hemisphere(frames: &[&FrameSample]) -> f32 {
@@ -1827,6 +2317,27 @@ fn root_relative_vertical_step(frames: &[&FrameSample], bone: &str) -> f32 {
             Some((current - previous).abs())
         })
         .fold(0.0, f32::max)
+}
+
+fn hard_stop_pelvis_vertical_step(frames: &[FrameSample]) -> Option<f32> {
+    let hard_stop = frames
+        .iter()
+        .filter(|frame| frame.scenario == "hard-stop")
+        .collect::<Vec<_>>();
+    if hard_stop.is_empty() {
+        return None;
+    }
+    let Some(first_stopped) = hard_stop
+        .iter()
+        .position(|frame| frame.speed_metres_per_second <= 0.05)
+    else {
+        return Some(f32::INFINITY);
+    };
+    let transition_start = first_stopped.saturating_sub(1);
+    Some(root_relative_vertical_step(
+        &hard_stop[transition_start..],
+        "pelvis",
+    ))
 }
 
 fn controller_vertical_range(frames: &[&FrameSample]) -> f32 {
@@ -2225,6 +2736,16 @@ mod tests {
             time_seconds: 0.0,
             speed_metres_per_second: 0.0,
             gait_phase: 0.0,
+            locomotion_sample_tick: 0,
+            body_acceleration: Vec3::ZERO.to_array(),
+            world_acceleration: Vec3::ZERO.to_array(),
+            contact_sequence: 0,
+            contact_foot: LeadFoot::Left,
+            landing_sequence: 0,
+            landing_impact_speed: 0.0,
+            body_lean_pitch_degrees: 0.0,
+            body_lean_roll_degrees: 0.0,
+            landing_compression_metres: 0.0,
             root_distance_metres: 0.0,
             root_position_metres: Vec3::ZERO.to_array(),
             world_travel_direction: Vec3::Z.to_array(),
@@ -2507,6 +3028,16 @@ mod tests {
             time_seconds: 0.0,
             speed_metres_per_second: 2.0,
             gait_phase: 0.0,
+            locomotion_sample_tick: 0,
+            body_acceleration: Vec3::ZERO.to_array(),
+            world_acceleration: Vec3::ZERO.to_array(),
+            contact_sequence: 0,
+            contact_foot: LeadFoot::Left,
+            landing_sequence: 0,
+            landing_impact_speed: 0.0,
+            body_lean_pitch_degrees: 0.0,
+            body_lean_roll_degrees: 0.0,
+            landing_compression_metres: 0.0,
             root_distance_metres: 0.0,
             root_position_metres: Vec3::ZERO.to_array(),
             world_travel_direction: Vec3::NEG_Z.to_array(),
@@ -2537,6 +3068,38 @@ mod tests {
         assert!(maximum_guard_facing_error(&[&frame]) > 179.0);
     }
 
+    #[test]
+    fn hard_stop_height_gate_measures_only_the_transition_and_settle_window() {
+        let frame = |scenario_frame: usize, speed: f32, pelvis_y: f32| {
+            let mut frame = foot_metric_frame(scenario_frame, -0.1, 1.0, 0.0, 0.0);
+            frame.scenario = "hard-stop".into();
+            frame.speed_metres_per_second = speed;
+            frame.bones.insert(
+                "pelvis".into(),
+                BoneSample {
+                    position: (Vec3::Y * pelvis_y).to_array(),
+                    rotation_xyzw: Quat::IDENTITY.to_array(),
+                    terrain_clearance_metres: None,
+                },
+            );
+            frame
+        };
+        let frames = vec![
+            frame(0, 5.5, 0.0),
+            frame(1, 5.5, 0.03),
+            frame(2, 5.5, 0.04),
+            frame(3, 0.0, 0.055),
+            frame(4, 0.0, 0.065),
+        ];
+        assert!(
+            (root_relative_vertical_step(&frames.iter().collect::<Vec<_>>(), "pelvis") - 0.03)
+                .abs()
+                < 0.0001
+        );
+        assert!((hard_stop_pelvis_vertical_step(&frames).unwrap() - 0.015).abs() < 0.0001);
+        assert_eq!(hard_stop_pelvis_vertical_step(&[]), None);
+    }
+
     fn foot_metric_frame(
         scenario_frame: usize,
         left_x: f32,
@@ -2555,6 +3118,16 @@ mod tests {
             time_seconds: scenario_frame as f32 / SAMPLE_HZ,
             speed_metres_per_second: 2.0,
             gait_phase: 0.0,
+            locomotion_sample_tick: scenario_frame as u64,
+            body_acceleration: Vec3::ZERO.to_array(),
+            world_acceleration: Vec3::ZERO.to_array(),
+            contact_sequence: 0,
+            contact_foot: LeadFoot::Left,
+            landing_sequence: 0,
+            landing_impact_speed: 0.0,
+            body_lean_pitch_degrees: 0.0,
+            body_lean_roll_degrees: 0.0,
+            landing_compression_metres: 0.0,
             root_distance_metres: 0.0,
             root_position_metres: Vec3::new(0.0, CAPTURE_ROOT_GROUND_OFFSET_METRES, 0.0).to_array(),
             world_travel_direction: Vec3::NEG_Z.to_array(),

--- a/crates/adventuresim-tactical-core/src/animation.rs
+++ b/crates/adventuresim-tactical-core/src/animation.rs
@@ -628,6 +628,167 @@ pub enum Footwork {
     Switch,
 }
 
+/// Typed locomotion families shared by authoritative cadence projection and
+/// client-only presentation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Reflect)]
+pub enum LocomotionGait {
+    #[default]
+    Walk,
+    Run,
+    Crouch,
+    RaisedGuard,
+}
+
+/// Compact gait dynamics metadata. Phase 0..1 is one complete left/right
+/// cycle; contact phases are 0 and 0.5.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect)]
+pub struct LocomotionProfile {
+    pub gait: LocomotionGait,
+    pub reference_speed: f32,
+    pub step_distance: f32,
+    /// Radius around each contact phase that can carry support.
+    pub support_phase_radius: f32,
+    /// Visual grounded bounce, in metres.
+    pub bounce_metres: f32,
+    /// Visual unsupported apex, in metres. Zero means a grounded curve.
+    pub flight_apex_metres: f32,
+    pub landing: LandingProfile,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect)]
+pub struct LandingProfile {
+    pub compression_per_metre_per_second: f32,
+    pub minimum_compression_metres: f32,
+    pub maximum_compression_metres: f32,
+    pub recovery_seconds: f32,
+}
+
+pub const HUMANOID_LANDING_PROFILE: LandingProfile = LandingProfile {
+    compression_per_metre_per_second: 0.012,
+    minimum_compression_metres: 0.04,
+    maximum_compression_metres: 0.08,
+    recovery_seconds: 0.16,
+};
+
+pub const LOCOMOTION_SAMPLE_HZ: f32 = 64.0;
+
+pub const WALK_LOCOMOTION_PROFILE: LocomotionProfile = LocomotionProfile {
+    gait: LocomotionGait::Walk,
+    reference_speed: 2.0,
+    step_distance: 1.22,
+    support_phase_radius: 0.28,
+    bounce_metres: 0.04,
+    flight_apex_metres: 0.0,
+    landing: HUMANOID_LANDING_PROFILE,
+};
+pub const RUN_LOCOMOTION_PROFILE: LocomotionProfile = LocomotionProfile {
+    gait: LocomotionGait::Run,
+    reference_speed: 5.5,
+    step_distance: 1.78,
+    support_phase_radius: 0.175,
+    bounce_metres: 0.0,
+    flight_apex_metres: 0.16,
+    landing: HUMANOID_LANDING_PROFILE,
+};
+pub const CROUCH_LOCOMOTION_PROFILE: LocomotionProfile = LocomotionProfile {
+    gait: LocomotionGait::Crouch,
+    reference_speed: 1.5,
+    step_distance: 1.14,
+    support_phase_radius: 0.30,
+    bounce_metres: 0.025,
+    flight_apex_metres: 0.0,
+    landing: HUMANOID_LANDING_PROFILE,
+};
+pub const RAISED_GUARD_LOCOMOTION_PROFILE: LocomotionProfile = LocomotionProfile {
+    gait: LocomotionGait::RaisedGuard,
+    reference_speed: 2.0,
+    step_distance: 0.38,
+    support_phase_radius: 0.25,
+    bounce_metres: 0.03,
+    flight_apex_metres: 0.0,
+    landing: HUMANOID_LANDING_PROFILE,
+};
+
+pub fn locomotion_profile(state: &SkeletonState) -> LocomotionProfile {
+    let speed = state.animation_speed();
+    if state.posture == Posture::Crouched {
+        return CROUCH_LOCOMOTION_PROFILE;
+    }
+    if state.weapon_guard == WeaponGuardState::Raised {
+        return LocomotionProfile {
+            step_distance: guard_step_length(speed),
+            ..RAISED_GUARD_LOCOMOTION_PROFILE
+        };
+    }
+    let run = ((speed - WALK_LOCOMOTION_PROFILE.reference_speed)
+        / (RUN_LOCOMOTION_PROFILE.reference_speed - WALK_LOCOMOTION_PROFILE.reference_speed))
+        .clamp(0.0, 1.0);
+    LocomotionProfile {
+        gait: if run >= 0.5 {
+            LocomotionGait::Run
+        } else {
+            LocomotionGait::Walk
+        },
+        reference_speed: WALK_LOCOMOTION_PROFILE
+            .reference_speed
+            .lerp(RUN_LOCOMOTION_PROFILE.reference_speed, run),
+        step_distance: ordinary_step_distance(speed),
+        support_phase_radius: WALK_LOCOMOTION_PROFILE
+            .support_phase_radius
+            .lerp(RUN_LOCOMOTION_PROFILE.support_phase_radius, run),
+        bounce_metres: WALK_LOCOMOTION_PROFILE.bounce_metres * (1.0 - run),
+        flight_apex_metres: RUN_LOCOMOTION_PROFILE.flight_apex_metres * run,
+        landing: HUMANOID_LANDING_PROFILE,
+    }
+}
+
+/// Shared distance model through authored walk/run reference points. This
+/// replaces duplicated cadence arithmetic without changing current timing.
+pub fn ordinary_step_distance(speed: f32) -> f32 {
+    let speed = speed.max(0.0);
+    if speed <= WALK_LOCOMOTION_PROFILE.reference_speed {
+        0.9_f32.lerp(
+            WALK_LOCOMOTION_PROFILE.step_distance,
+            speed / WALK_LOCOMOTION_PROFILE.reference_speed,
+        )
+    } else {
+        let blend = ((speed - WALK_LOCOMOTION_PROFILE.reference_speed)
+            / (RUN_LOCOMOTION_PROFILE.reference_speed - WALK_LOCOMOTION_PROFILE.reference_speed))
+            .clamp(0.0, 1.0);
+        WALK_LOCOMOTION_PROFILE
+            .step_distance
+            .lerp(RUN_LOCOMOTION_PROFILE.step_distance, blend)
+    }
+}
+
+pub fn gait_cycle_phase_delta(profile: LocomotionProfile, speed: f32, delta_seconds: f32) -> f32 {
+    speed.max(0.0) * delta_seconds.max(0.0) / (profile.step_distance.max(0.01) * 2.0)
+}
+
+pub fn gait_support_weights(profile: LocomotionProfile, phase: f32) -> (f32, f32) {
+    if profile.gait == LocomotionGait::RaisedGuard {
+        return (1.0, 1.0);
+    }
+    let support = |contact: f32| {
+        let distance = {
+            let delta = (phase - contact).abs();
+            delta.min(1.0 - delta)
+        };
+        (1.0 - smoothstep(
+            profile.support_phase_radius * 0.45,
+            profile.support_phase_radius,
+            distance,
+        ))
+        .clamp(0.0, 1.0)
+    };
+    (support(0.0), support(0.5))
+}
+
+fn smoothstep(edge0: f32, edge1: f32, value: f32) -> f32 {
+    let t = ((value - edge0) / (edge1 - edge0).max(f32::EPSILON)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Reflect)]
 pub enum AttackLine {
     #[default]
@@ -642,8 +803,15 @@ pub enum AttackLine {
 pub struct SkeletonState {
     pub posture: Posture,
     pub local_velocity: Vec3,
+    pub world_velocity: Vec3,
     pub grounded: bool,
     pub gait_phase: f32,
+    pub locomotion_sample_tick: u64,
+    pub world_acceleration: Vec3,
+    pub contact_sequence: u64,
+    pub contact_foot: LeadFoot,
+    pub landing_sequence: u64,
+    pub landing_impact_speed: f32,
     pub lead_foot: LeadFoot,
     pub weapon_guard: WeaponGuardState,
     pub raised_locomotion: RaisedLocomotionIntent,
@@ -664,8 +832,15 @@ impl Default for SkeletonState {
         Self {
             posture: Posture::Upright,
             local_velocity: Vec3::ZERO,
+            world_velocity: Vec3::ZERO,
             grounded: true,
             gait_phase: 0.0,
+            locomotion_sample_tick: 0,
+            world_acceleration: Vec3::ZERO,
+            contact_sequence: 0,
+            contact_foot: LeadFoot::Left,
+            landing_sequence: 0,
+            landing_impact_speed: 0.0,
             lead_foot: LeadFoot::Left,
             weapon_guard: WeaponGuardState::Lowered,
             raised_locomotion: RaisedLocomotionIntent::default(),
@@ -818,9 +993,29 @@ fn body_yaw(rotation: Quat) -> f32 {
 /// Bone evaluation remains client-only; this is the shared server seam that
 /// keeps deterministic captures on the same stride and posture rules.
 pub fn project_skeleton_locomotion(skeleton: &mut SkeletonState, input: SkeletonLocomotionInput) {
+    let previous_world_velocity = skeleton.world_velocity;
+    let was_grounded = skeleton.grounded;
+    let previous_guard_sequence = skeleton.raised_locomotion.step_sequence;
+    let previous_guard_swing = skeleton
+        .raised_locomotion
+        .active
+        .then_some(skeleton.raised_locomotion.swing_foot);
     let local_velocity = controller_yaw(input.orientation).inverse() * input.linear_velocity;
+    let contiguous_sample = input.tick == skeleton.locomotion_sample_tick.wrapping_add(1);
+    skeleton.world_acceleration = if contiguous_sample {
+        ((input.linear_velocity - previous_world_velocity) * LOCOMOTION_SAMPLE_HZ)
+            .clamp_length_max(80.0)
+    } else {
+        Vec3::ZERO
+    };
     skeleton.local_velocity = local_velocity;
+    skeleton.world_velocity = input.linear_velocity;
     skeleton.grounded = input.grounded;
+    skeleton.locomotion_sample_tick = input.tick;
+    if !was_grounded && input.grounded {
+        skeleton.landing_sequence = skeleton.landing_sequence.wrapping_add(1);
+        skeleton.landing_impact_speed = (-previous_world_velocity.y).max(0.0);
+    }
     skeleton.posture = if input.grounded {
         if input.crouching {
             Posture::Crouched
@@ -834,11 +1029,21 @@ pub fn project_skeleton_locomotion(skeleton: &mut SkeletonState, input: Skeleton
     let ground_speed = local_velocity.xz().length();
     if skeleton.weapon_guard == WeaponGuardState::Raised && skeleton.posture == Posture::Upright {
         advance_raised_locomotion_intent(skeleton, local_velocity, input.delta_seconds);
+        let handoffs = skeleton
+            .raised_locomotion
+            .step_sequence
+            .wrapping_sub(previous_guard_sequence);
+        advance_contact_identity(skeleton, handoffs, previous_guard_swing);
     } else {
         skeleton.raised_locomotion = RaisedLocomotionIntent::default();
         if input.grounded && ground_speed > 0.05 {
-            let phase_delta = gait_cycle_phase_delta(ground_speed, input.delta_seconds);
-            skeleton.gait_phase = (skeleton.gait_phase + phase_delta).rem_euclid(1.0);
+            let profile = locomotion_profile(skeleton);
+            let phase = skeleton.gait_phase.rem_euclid(1.0);
+            let next_phase =
+                phase + gait_cycle_phase_delta(profile, ground_speed, input.delta_seconds);
+            let handoffs = ((next_phase * 2.0).floor() - (phase * 2.0).floor()).max(0.0) as u32;
+            skeleton.gait_phase = next_phase.rem_euclid(1.0);
+            advance_contact_identity(skeleton, handoffs, None);
             if skeleton.weapon_guard == WeaponGuardState::Lowered {
                 skeleton.lead_foot = if skeleton.gait_phase < 0.5 {
                     LeadFoot::Left
@@ -849,6 +1054,28 @@ pub fn project_skeleton_locomotion(skeleton: &mut SkeletonState, input: Skeleton
         }
     }
     skeleton.advance_action(input.tick);
+}
+
+fn advance_contact_identity(
+    skeleton: &mut SkeletonState,
+    handoffs: u32,
+    first_contact: Option<LeadFoot>,
+) {
+    for handoff in 0..handoffs {
+        skeleton.contact_sequence = skeleton.contact_sequence.wrapping_add(1);
+        skeleton.contact_foot = if handoff == 0 {
+            first_contact.unwrap_or_else(|| opposite_foot(skeleton.contact_foot))
+        } else {
+            opposite_foot(skeleton.contact_foot)
+        };
+    }
+}
+
+fn opposite_foot(foot: LeadFoot) -> LeadFoot {
+    match foot {
+        LeadFoot::Left => LeadFoot::Right,
+        LeadFoot::Right => LeadFoot::Left,
+    }
 }
 
 fn advance_raised_locomotion_intent(
@@ -904,7 +1131,11 @@ fn advance_raised_locomotion_intent(
     }
     let speed = skeleton.raised_locomotion.speed;
     let phase = skeleton.gait_phase.rem_euclid(1.0);
-    let next_phase = phase + guard_step_phase_delta(speed, delta_seconds.max(0.0));
+    let profile = LocomotionProfile {
+        step_distance: guard_step_length(speed),
+        ..RAISED_GUARD_LOCOMOTION_PROFILE
+    };
+    let next_phase = phase + gait_cycle_phase_delta(profile, speed, delta_seconds.max(0.0));
     let handoffs = ((next_phase * 2.0).floor() - (phase * 2.0).floor()).max(0.0) as u32;
     let crossed_handoff = handoffs > 0;
 
@@ -956,17 +1187,6 @@ fn initial_guard_swing_foot(direction: Vec2, lead: LeadFoot) -> LeadFoot {
 /// movement uses compact shuffles rather than ordinary walking strides.
 pub fn guard_step_length(speed: f32) -> f32 {
     (0.26 + speed.max(0.0) * 0.06).clamp(0.28, 0.42)
-}
-
-fn guard_step_phase_delta(speed: f32, delta_seconds: f32) -> f32 {
-    speed.max(0.0) * delta_seconds.max(0.0) / (guard_step_length(speed) * 2.0)
-}
-
-/// Advances a complete left-right gait cycle. `stride_length` describes one
-/// step, while phase 0..1 contains both the left and right step.
-fn gait_cycle_phase_delta(speed: f32, delta_seconds: f32) -> f32 {
-    let stride_length = (0.9 + speed * 0.16).clamp(0.9, 1.8);
-    speed * delta_seconds.max(0.0) / (stride_length * 2.0)
 }
 
 /// One weighted authored pose contributing to the FK result.
@@ -1673,8 +1893,96 @@ mod tests {
         assert!(state.grounded);
         assert_eq!(state.posture, Posture::Upright);
         assert!((state.local_velocity - local_velocity).length() < 0.0001);
-        assert!((state.gait_phase - 2.0 / (0.9 + 2.0 * 0.16) / 2.0 / 64.0).abs() < 0.0001);
+        assert!(
+            (state.gait_phase - gait_cycle_phase_delta(WALK_LOCOMOTION_PROFILE, 2.0, 1.0 / 64.0))
+                .abs()
+                < 0.0001
+        );
         assert_eq!(state.lead_foot, LeadFoot::Left);
+    }
+
+    #[test]
+    fn shared_profiles_own_cadence_support_and_flight() {
+        assert!(
+            (ordinary_step_distance(2.0) - WALK_LOCOMOTION_PROFILE.step_distance).abs() < 0.0001
+        );
+        assert!(
+            (ordinary_step_distance(5.5) - RUN_LOCOMOTION_PROFILE.step_distance).abs() < 0.0001
+        );
+        let (walk_left, walk_right) = gait_support_weights(WALK_LOCOMOTION_PROFILE, 0.25);
+        assert!(walk_left + walk_right > 0.0);
+        assert_eq!(
+            gait_support_weights(RUN_LOCOMOTION_PROFILE, 0.25),
+            (0.0, 0.0)
+        );
+        assert_eq!(RUN_LOCOMOTION_PROFILE.flight_apex_metres, 0.16);
+    }
+
+    #[test]
+    fn projector_sequences_contacts_acceleration_and_one_landing_edge() {
+        let mut state = SkeletonState {
+            gait_phase: 0.49,
+            locomotion_sample_tick: 1,
+            local_velocity: Vec3::new(0.0, -4.0, -1.0),
+            world_velocity: Vec3::new(0.0, -4.0, -1.0),
+            grounded: false,
+            ..default()
+        };
+        project_skeleton_locomotion(
+            &mut state,
+            SkeletonLocomotionInput {
+                orientation: Quat::IDENTITY,
+                linear_velocity: Vec3::NEG_Z * 2.0,
+                grounded: true,
+                crouching: false,
+                delta_seconds: 0.1,
+                tick: 2,
+            },
+        );
+        assert_eq!(state.contact_sequence, 1);
+        assert_eq!(state.contact_foot, LeadFoot::Right);
+        assert_eq!(state.landing_sequence, 1);
+        assert_eq!(state.landing_impact_speed, 4.0);
+        assert!(state.world_acceleration.length() > 0.0);
+        project_skeleton_locomotion(
+            &mut state,
+            SkeletonLocomotionInput {
+                orientation: Quat::IDENTITY,
+                linear_velocity: Vec3::NEG_Z * 2.0,
+                grounded: true,
+                crouching: false,
+                delta_seconds: 0.1,
+                tick: 3,
+            },
+        );
+        assert_eq!(state.landing_sequence, 1);
+    }
+
+    #[test]
+    fn turning_acceleration_is_differenced_in_one_world_frame() {
+        let previous_velocity = Vec3::NEG_Z * 5.5;
+        let orientation = Quat::from_rotation_y(std::f32::consts::FRAC_PI_2);
+        let current_velocity = controller_yaw(orientation) * Vec3::NEG_Z * 5.5;
+        let mut state = SkeletonState {
+            locomotion_sample_tick: 4,
+            local_velocity: Vec3::NEG_Z * 5.5,
+            world_velocity: previous_velocity,
+            ..default()
+        };
+        project_skeleton_locomotion(
+            &mut state,
+            SkeletonLocomotionInput {
+                orientation,
+                linear_velocity: current_velocity,
+                grounded: true,
+                crouching: false,
+                delta_seconds: 1.0 / LOCOMOTION_SAMPLE_HZ,
+                tick: 5,
+            },
+        );
+        let expected =
+            ((current_velocity - previous_velocity) * LOCOMOTION_SAMPLE_HZ).clamp_length_max(80.0);
+        assert!(state.world_acceleration.abs_diff_eq(expected, 0.0001));
     }
 
     #[test]
@@ -1823,9 +2131,11 @@ mod tests {
     #[test]
     fn gait_phase_spans_two_steps_at_run_speed() {
         let speed = 5.5;
-        let stride_length = 0.9 + speed * 0.16;
-        let cycle_seconds = stride_length * 2.0 / speed;
-        assert!((gait_cycle_phase_delta(speed, cycle_seconds) - 1.0).abs() < 0.0001);
+        let cycle_seconds = RUN_LOCOMOTION_PROFILE.step_distance * 2.0 / speed;
+        assert!(
+            (gait_cycle_phase_delta(RUN_LOCOMOTION_PROFILE, speed, cycle_seconds) - 1.0).abs()
+                < 0.0001
+        );
     }
 
     #[test]

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -19,11 +19,14 @@ pub mod prelude {
     pub use crate::AdventureSimulatorCorePlugins;
     pub use crate::animation::{
         AnimationEvaluation, AnimationPack, AnimationPackLibrary, AttackLine,
-        BODY_TURN_SPEED_RADIANS, Footwork, LeadFoot, PackValidationError, PoseSample, PoseSampling,
-        Posture, RaisedLocomotionIntent, ResolvedPose, SemanticPose, SkeletonAction,
-        SkeletonLocomotionInput, SkeletonState, StrikeFamily, WeaponGuardState,
-        advance_body_facing, controller_yaw, guard_step_length, project_skeleton_locomotion,
-        set_weapon_guard,
+        BODY_TURN_SPEED_RADIANS, CROUCH_LOCOMOTION_PROFILE, Footwork, HUMANOID_LANDING_PROFILE,
+        LOCOMOTION_SAMPLE_HZ, LandingProfile, LeadFoot, LocomotionGait, LocomotionProfile,
+        PackValidationError, PoseSample, PoseSampling, Posture, RAISED_GUARD_LOCOMOTION_PROFILE,
+        RUN_LOCOMOTION_PROFILE, RaisedLocomotionIntent, ResolvedPose, SemanticPose, SkeletonAction,
+        SkeletonLocomotionInput, SkeletonState, StrikeFamily, WALK_LOCOMOTION_PROFILE,
+        WeaponGuardState, advance_body_facing, controller_yaw, gait_cycle_phase_delta,
+        gait_support_weights, guard_step_length, locomotion_profile, ordinary_step_distance,
+        project_skeleton_locomotion, set_weapon_guard,
     };
     pub use crate::combat::{Attack, Dodge, HANDS_REACH, Parry, melee_interaction_range};
     pub use crate::inventory::{

--- a/crates/adventuresim-tactical-server/src/player_projection.rs
+++ b/crates/adventuresim-tactical-server/src/player_projection.rs
@@ -568,7 +568,7 @@ pub(crate) fn update_skeleton_locomotion(
             let lowered = authoritative_weapon_guard(skeleton.weapon_guard, true);
             set_weapon_guard(&mut skeleton, lowered);
         }
-        let tick = (time.elapsed_secs_f64() * 64.0).round() as u64;
+        let tick = (time.elapsed_secs_f64() * LOCOMOTION_SAMPLE_HZ as f64).round() as u64;
         transform.rotation = advance_body_facing(
             transform.rotation,
             controller.orientation,

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -504,9 +504,11 @@ input preserves its radial magnitude, so half stick deflection requests 2.75
 m/s lowered or 1.0 m/s raised. Radial clamping prevents diagonal overspeed,
 generic controllers without skeleton state use the lowered cap, and Ahoy still
 applies its existing crouch multiplier and acceleration/deceleration. Gait phase 0 through 1 is
-one complete left-right cycle rather than one step; phase frequency therefore
-uses twice the estimated single-step stride length. This keeps the authored
-walk/run cadence tied to ground distance without double-speed footfalls.
+one complete left-right cycle rather than one step. Shared typed walk, run,
+crouch, and raised-guard profiles own reference speed, step distance, support,
+flight, bounce, and compression metadata used by both authoritative projection
+and client presentation. This keeps cadence tied to actual post-physics ground
+distance without duplicated timing formulas or double-speed footfalls.
 
 Contact and passing/flight anchors are authoritative sparse gait inputs. The
 evaluator constructs four smooth quarters: contact to passing, passing to the
@@ -532,16 +534,45 @@ stopping blends central bones back to the authored idle. XZ, rotations, and
 authored limb silhouettes remain intact. The measured 0.033 m hierarchy-rise
 compensation applies only to upright, lowered-guard `humanoid_unarmed`
 locomotion; crouching, guard movement, and specialized packs receive zero
-compensation until measured independently. One visual-only
-`sin²(TAU * phase)` curve owns height: contacts at phase 0 and 0.5 are minima,
-and passing/flight at 0.25 and 0.75 are maxima. Starting amplitudes are 0.04 m
-walk, 0.18 m run, 0.03 m raised guard, and 0.025 m crouch, continuously blended
+compensation until measured independently. One visual-only profile evaluation
+owns height: contacts at phase 0 and 0.5 are minima, grounded gaits use smooth
+compression/recovery curves, and running uses a gravity-shaped parabolic arc
+across each full contact-to-contact half-step so the sole is already elevated
+when shared support releases. Its 0.16 m run apex and 0.04 m walk,
+0.03 m raised-guard, and 0.025 m crouch bounce are continuously blended
 across speed and state changes. The curve never changes authoritative owner Y,
 grounded state, or posture. Guard's separate reach correction remains an
 additive baseline concern rather than a gait wave.
 When guard, crouch, grounded, or action state changes, a decaying visual offset
 preserves the previously displayed height across the edge; the new phase curve
 then resumes without resetting or delaying authoritative gait phase.
+
+The authoritative projector derives world velocity/acceleration, alternating
+contact identity, landing identity/impact, and the shared 64 Hz sample tick from
+consecutive post-physics observations. The client transforms acceleration into
+the current body frame and advances retained response only once per logical
+sample: acceleration leans forward, braking leans back, lateral acceleration
+rolls inward, and steady motion decays to neutral. Bounded skipped-tick gaps use
+their authoritative tick duration; repeated renders of one tick do not advance.
+A hard stop retains the effective authored locomotion pose, then releases it to
+exact idle through the same deterministic 0.18-second presentation crossfade
+used for guard edges instead of switching sparse clips in one frame.
+A real airborne-to-grounded sequence triggers one 0.04-0.08 m, roughly 0.16
+second landing compression. A landing-only analytic solve flexes the actual
+hips/knees back to retained pre-compression world foot plants throughout recovery.
+Its knee-flexion reserve eases toward the authored leg extension during the final
+12 mm of compression release so the feet do not lift or snap on the last frame,
+without translating thigh roots or enabling general terrain IK. The plants
+resynchronize after tick/teleport discontinuities and clear on air, action, or
+completion. At rest and while stopping, ordinary
+support blends symmetrically back to full support on both feet.
+
+Monotonic contact and landing sequences drive deduplicated client presentation
+messages for future audio/VFX only. Up to eight plausible missed contacts are
+reconstructed in alternating order. A backward/reset or larger delta silently
+resynchronizes instead of producing a phantom burst; missed landing changes
+collapse to one latest observation. `sample_tick` is the observation tick of
+the replicated sequence state, not a reconstructed historical event time.
 
 Terrain conformity defaults off while its uneven-ground behavior is being
 refined. Debug clients expose `F8` as an explicit runtime opt-in. Disabling it
@@ -568,13 +599,25 @@ diagnostic images of that exact pose. Its manifest records final world-space bon
 continuity, planted-foot drift under a stable body, signed foot tracks and separation, knee flexion
 and bend hemisphere, desired body-forward alignment, bounded per-tick turning
 residual (including look-facing guards), terrain-relative foot clearance,
-phase-indexed height extrema and peak count, controller vertical range, and run
-flight duration/sole clearance; those
+phase-indexed height extrema and peak count, controller vertical range, run
+flight duration/sole clearance, authoritative acceleration, retained lean,
+landing compression, contact identity, landing identity, and fixed tick; those
 signals locate suspect frames but do not replace review of the rendered mesh.
 For steady height scenarios, every complete cycle after warmup must contain
 exactly two prominent peaks in the phase 0.25 and 0.75 passing windows. A
 0.003 m prominence threshold filters sampling jitter while still rejecting an
 extra visible beat.
+Typed scenario metadata distinguishes ordinary, transition, terrain,
+raised-guard, and landing gates. The suite includes a speed ramp, an
+apex-adjacent hard stop, real forward-input camera/controller turns through 90
+and 180 degrees, airborne landing, and a two-cycle cadence/contact fixture.
+Every logical sample is evaluated repeatedly across the three review views;
+the gate compares bones within 0.5 mm/0.1 degrees and requires unchanged
+contact/landing sequences and event counts. Success also gates lean and phase
+continuity, hard-stop pelvis continuity from the moving-to-zero edge through
+settling, two ordered contacts per cycle and
+shared step distance, event order/count/deduplication, landing knee flex, foot
+preservation within 1 cm, and landing penetration no lower than -1 cm.
 The fixture supplies deterministic controller observations at the shared
 server projection boundary and follows rendered terrain height only in the
 cross-slope probe; it does not


### PR DESCRIPTION
Implements the next stacked locomotion-dynamics pass: shared gait profiles and cadence/contact sequencing, run flight and movement bob, stable-frame acceleration lean, fixed-tick retained response, deterministic presentation events, smooth hard stops, and planted-foot landing compression with real knee flexion. Extends the animation viewer with speed-ramp, stop, camera-yaw turn, cadence/contact, landing, event-order, and repeated-evaluation gates. Updates tactical animation documentation. Verified with focused core/client tests, server and viewer checks, formatting/diff checks, independent correctness and maintainability reviews, and passing targeted render captures for speed ramp, hard stop, 180-degree turn, cadence/contact, and airborne landing.