### PR TITLE
Unify strategic presence checks

### DIFF
--- a/crates/adventuresim-core/src/lib.rs
+++ b/crates/adventuresim-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod strategic_currency;
 pub mod strategic_economy;
 pub mod strategic_inventory;
 pub mod strategic_place;
+pub mod strategic_presence;
 pub mod strategic_schedule;
 pub mod strategic_state;
 pub mod strategic_time;
@@ -92,6 +93,7 @@ pub mod prelude {
     pub use crate::social::*;
     pub use crate::strategic_economy::*;
     pub use crate::strategic_place::*;
+    pub use crate::strategic_presence::*;
     pub use crate::strategic_schedule::*;
     pub use crate::strategic_time::*;
     pub use crate::survival::*;

--- a/crates/adventuresim-core/src/strategic_presence.rs
+++ b/crates/adventuresim-core/src/strategic_presence.rs
@@ -1,0 +1,443 @@
+//! Typed strategic presence and co-presence rules.
+//!
+//! Domain owners supply validated facts; this module prevents those facts from
+//! being joined through feature-specific strings or upgraded from a coarse
+//! settlement to an exact venue without explicit evidence.
+
+use crate::strategic_place::{PlaceIdentityError, StrategicPlaceId};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResidencePresenceRole {
+    OwnerOccupant,
+    HouseholdOccupant,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PresenceBasis {
+    SettlementMembership,
+    ValidatedVenueSelection,
+    ScheduledResident,
+    ResidenceOccupancy(ResidencePresenceRole),
+}
+
+/// One character's presence projected at an explicit observer frontier.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StrategicPresence {
+    character_id: u64,
+    place: StrategicPlaceId,
+    frontier: PresenceFrontier,
+    basis: PresenceBasis,
+}
+
+/// The observer whose personal chronology authorizes a presence projection.
+/// Target characters' clocks are intentionally neither read nor compared for
+/// pairwise-soft interactions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PresenceFrontier {
+    pub observer_character_id: u64,
+    pub personal_minute: u64,
+}
+
+impl StrategicPresence {
+    pub fn settlement_membership(
+        character_id: u64,
+        settlement_id: impl Into<String>,
+        frontier: PresenceFrontier,
+    ) -> Result<Self, PresenceError> {
+        Ok(Self {
+            character_id,
+            place: StrategicPlaceId::settlement(settlement_id)?,
+            frontier,
+            basis: PresenceBasis::SettlementMembership,
+        })
+    }
+
+    /// Refines coarse settlement membership after the server validates an
+    /// instantaneous venue selection against current settlement navigation.
+    pub fn validated_venue_selection(
+        settlement_presence: &Self,
+        place: StrategicPlaceId,
+    ) -> Result<Self, PresenceError> {
+        let StrategicPlaceId::Settlement {
+            settlement_id: coarse_settlement,
+        } = &settlement_presence.place
+        else {
+            return Err(PresenceError::CoarseSettlementRequired);
+        };
+        if settlement_presence.basis != PresenceBasis::SettlementMembership {
+            return Err(PresenceError::CoarseSettlementRequired);
+        }
+        if !matches!(
+            &place,
+            StrategicPlaceId::SettlementVenue { .. } | StrategicPlaceId::ChapterVenue { .. }
+        ) || place.settlement_id() != Some(coarse_settlement.as_str())
+        {
+            return Err(PresenceError::PlaceMismatch);
+        }
+        Ok(Self {
+            character_id: settlement_presence.character_id,
+            place,
+            frontier: settlement_presence.frontier,
+            basis: PresenceBasis::ValidatedVenueSelection,
+        })
+    }
+
+    pub fn scheduled_resident(
+        character_id: u64,
+        place: StrategicPlaceId,
+        frontier: PresenceFrontier,
+        schedule: DailyPresenceWindow,
+        alive: bool,
+        context_suppressed: bool,
+        health_suppressed: bool,
+    ) -> Result<ScheduledStrategicPresence, PresenceError> {
+        if !matches!(
+            &place,
+            StrategicPlaceId::SettlementVenue { .. } | StrategicPlaceId::ChapterVenue { .. }
+        ) {
+            return Err(PresenceError::ExactVenueRequired);
+        }
+        if !alive {
+            return Err(PresenceError::Unavailable);
+        }
+        let remaining_minutes = schedule.remaining_minutes(
+            frontier.personal_minute,
+            context_suppressed,
+            health_suppressed,
+        )?;
+        Ok(ScheduledStrategicPresence {
+            presence: Self {
+                character_id,
+                place,
+                frontier,
+                basis: PresenceBasis::ScheduledResident,
+            },
+            remaining_minutes,
+        })
+    }
+
+    /// Exact residence presence requires an effective occupancy edge. Legal
+    /// ownership alone deliberately has no constructor.
+    pub fn residence_occupancy(
+        character_id: u64,
+        place: StrategicPlaceId,
+        owner_character_id: u64,
+        admitted_minute: u64,
+        frontier: PresenceFrontier,
+        holding_active: bool,
+    ) -> Result<Self, PresenceError> {
+        if !matches!(&place, StrategicPlaceId::Residence { .. }) {
+            return Err(PresenceError::ResidenceRequired);
+        }
+        if admitted_minute > frontier.personal_minute {
+            return Err(PresenceError::FutureEvidence);
+        }
+        if !holding_active {
+            return Err(PresenceError::Unavailable);
+        }
+        let role = if character_id == owner_character_id {
+            ResidencePresenceRole::OwnerOccupant
+        } else {
+            ResidencePresenceRole::HouseholdOccupant
+        };
+        Ok(Self {
+            character_id,
+            place,
+            frontier,
+            basis: PresenceBasis::ResidenceOccupancy(role),
+        })
+    }
+
+    pub fn character_id(&self) -> u64 {
+        self.character_id
+    }
+
+    pub fn place(&self) -> &StrategicPlaceId {
+        &self.place
+    }
+
+    pub fn frontier(&self) -> PresenceFrontier {
+        self.frontier
+    }
+
+    pub fn basis(&self) -> PresenceBasis {
+        self.basis
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ScheduledStrategicPresence {
+    presence: StrategicPresence,
+    remaining_minutes: u64,
+}
+
+impl ScheduledStrategicPresence {
+    pub fn presence(&self) -> &StrategicPresence {
+        &self.presence
+    }
+
+    pub fn remaining_minutes(&self) -> u64 {
+        self.remaining_minutes
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DailyPresenceWindow {
+    pub start_minute: u16,
+    pub end_minute: u16,
+}
+
+/// Historical suppression contributed by one outbreak infection course.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PresenceSuppression {
+    pub context_suppressed: bool,
+    pub health_suppressed: bool,
+}
+
+/// Computes patient suppression solely from facts effective at the observer's
+/// minute. A later recovery, death, or source remediation cannot rewrite an
+/// earlier projection.
+pub fn outbreak_patient_suppression_at(
+    contracted_minute: u64,
+    recovery_minute: u64,
+    remediation_minute: Option<u64>,
+    observer_minute: u64,
+    alive_at_observer: bool,
+) -> Result<PresenceSuppression, PresenceError> {
+    if recovery_minute < contracted_minute {
+        return Err(PresenceError::InvalidChronology);
+    }
+    if !alive_at_observer {
+        return Ok(PresenceSuppression {
+            context_suppressed: false,
+            health_suppressed: true,
+        });
+    }
+    let infection_active =
+        contracted_minute <= observer_minute && observer_minute < recovery_minute;
+    Ok(PresenceSuppression {
+        context_suppressed: infection_active
+            && remediation_minute.is_none_or(|minute| minute > observer_minute),
+        health_suppressed: infection_active,
+    })
+}
+
+impl DailyPresenceWindow {
+    pub fn remaining_minutes(
+        self,
+        personal_minute: u64,
+        context_suppressed: bool,
+        health_suppressed: bool,
+    ) -> Result<u64, PresenceError> {
+        if self.start_minute > 1_440 || self.end_minute > 1_440 {
+            return Err(PresenceError::InvalidSchedule);
+        }
+        if context_suppressed || health_suppressed {
+            return Err(PresenceError::Suppressed);
+        }
+        let minute = personal_minute % 1_440;
+        let start = u64::from(self.start_minute);
+        let end = u64::from(self.end_minute);
+        if start == end {
+            return Err(PresenceError::OutsideSchedule);
+        }
+        let remaining = if start < end {
+            if start <= minute && minute < end {
+                Some(end - minute)
+            } else {
+                None
+            }
+        } else if minute >= start {
+            Some((1_440 - minute) + end)
+        } else if minute < end {
+            Some(end - minute)
+        } else {
+            None
+        };
+        remaining.ok_or(PresenceError::OutsideSchedule)
+    }
+}
+
+/// Co-presence is equality of canonical place at the same projected personal
+/// observer frontier. A settlement shell never equals an exact venue, and
+/// facts projected for different observers/frontiers never silently join.
+pub fn are_co_present(left: &StrategicPresence, right: &StrategicPresence) -> bool {
+    left.frontier == right.frontier && left.place == right.place
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PresenceError {
+    InvalidPlaceIdentity,
+    CoarseSettlementRequired,
+    ExactVenueRequired,
+    ResidenceRequired,
+    PlaceMismatch,
+    InvalidSchedule,
+    OutsideSchedule,
+    Suppressed,
+    FutureEvidence,
+    InvalidChronology,
+    Unavailable,
+}
+
+impl From<PlaceIdentityError> for PresenceError {
+    fn from(_: PlaceIdentityError) -> Self {
+        Self::InvalidPlaceIdentity
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::strategic_place::SettlementVenueKind;
+
+    fn frontier(observer_character_id: u64, personal_minute: u64) -> PresenceFrontier {
+        PresenceFrontier {
+            observer_character_id,
+            personal_minute,
+        }
+    }
+
+    #[test]
+    fn settlement_membership_does_not_equal_exact_venue_presence() {
+        let coarse =
+            StrategicPresence::settlement_membership(1, "lubeck", frontier(1, 720)).unwrap();
+        let inn = StrategicPlaceId::settlement_venue("lubeck", SettlementVenueKind::Inn).unwrap();
+        let exact = StrategicPresence::validated_venue_selection(&coarse, inn).unwrap();
+
+        assert!(!are_co_present(&coarse, &exact));
+        assert_eq!(exact.basis(), PresenceBasis::ValidatedVenueSelection);
+    }
+
+    #[test]
+    fn chapter_representative_can_share_an_effective_service_venue() {
+        let observer_frontier = frontier(1, 720);
+        let coarse =
+            StrategicPresence::settlement_membership(1, "lubeck", observer_frontier).unwrap();
+        let inn = StrategicPlaceId::settlement_venue("lubeck", SettlementVenueKind::Inn).unwrap();
+        let actor = StrategicPresence::validated_venue_selection(&coarse, inn.clone()).unwrap();
+        let representative = StrategicPresence::scheduled_resident(
+            2,
+            inn,
+            observer_frontier,
+            DailyPresenceWindow {
+                start_minute: 0,
+                end_minute: 1_440,
+            },
+            true,
+            false,
+            false,
+        )
+        .unwrap();
+
+        assert!(are_co_present(&actor, representative.presence()));
+    }
+
+    #[test]
+    fn residence_presence_distinguishes_owner_occupant_from_household_occupant() {
+        let home =
+            StrategicPlaceId::residence("lubeck", "residence-holding:1:lubeck:cheap:0").unwrap();
+        let observer_frontier = frontier(1, 200);
+        let owner = StrategicPresence::residence_occupancy(
+            1,
+            home.clone(),
+            1,
+            100,
+            observer_frontier,
+            true,
+        )
+        .unwrap();
+        let guest =
+            StrategicPresence::residence_occupancy(2, home, 1, 150, observer_frontier, true)
+                .unwrap();
+
+        assert_eq!(
+            owner.basis(),
+            PresenceBasis::ResidenceOccupancy(ResidencePresenceRole::OwnerOccupant)
+        );
+        assert_eq!(
+            guest.basis(),
+            PresenceBasis::ResidenceOccupancy(ResidencePresenceRole::HouseholdOccupant)
+        );
+        assert!(are_co_present(&owner, &guest));
+    }
+
+    #[test]
+    fn schedule_suppression_and_future_occupancy_fail_closed() {
+        let inn = StrategicPlaceId::settlement_venue("lubeck", SettlementVenueKind::Inn).unwrap();
+        let window = DailyPresenceWindow {
+            start_minute: 480,
+            end_minute: 1_020,
+        };
+        assert_eq!(
+            StrategicPresence::scheduled_resident(
+                2,
+                inn,
+                frontier(1, 720),
+                window,
+                true,
+                true,
+                false
+            ),
+            Err(PresenceError::Suppressed)
+        );
+        assert_eq!(
+            window.remaining_minutes(1_100, false, false),
+            Err(PresenceError::OutsideSchedule)
+        );
+
+        let home = StrategicPlaceId::residence("lubeck", "holding-1").unwrap();
+        assert_eq!(
+            StrategicPresence::residence_occupancy(2, home, 1, 800, frontier(1, 720), true),
+            Err(PresenceError::FutureEvidence)
+        );
+    }
+
+    #[test]
+    fn co_presence_rejects_different_places_and_personal_frontiers() {
+        let lubeck =
+            StrategicPresence::settlement_membership(1, "lubeck", frontier(1, 720)).unwrap();
+        let hamburg =
+            StrategicPresence::settlement_membership(2, "hamburg", frontier(1, 720)).unwrap();
+        let future =
+            StrategicPresence::settlement_membership(2, "lubeck", frontier(1, 721)).unwrap();
+        let other_observer =
+            StrategicPresence::settlement_membership(2, "lubeck", frontier(2, 720)).unwrap();
+
+        assert!(!are_co_present(&lubeck, &hamburg));
+        assert!(!are_co_present(&lubeck, &future));
+        assert!(!are_co_present(&lubeck, &other_observer));
+    }
+
+    #[test]
+    fn outbreak_suppression_is_projected_at_the_observer_frontier() {
+        assert_eq!(
+            outbreak_patient_suppression_at(100, 300, Some(250), 200, true).unwrap(),
+            PresenceSuppression {
+                context_suppressed: true,
+                health_suppressed: true,
+            }
+        );
+        assert_eq!(
+            outbreak_patient_suppression_at(100, 300, Some(250), 260, true).unwrap(),
+            PresenceSuppression {
+                context_suppressed: false,
+                health_suppressed: true,
+            }
+        );
+        assert_eq!(
+            outbreak_patient_suppression_at(100, 300, Some(250), 300, true).unwrap(),
+            PresenceSuppression {
+                context_suppressed: false,
+                health_suppressed: false,
+            }
+        );
+        assert_eq!(
+            outbreak_patient_suppression_at(100, 300, None, 200, false).unwrap(),
+            PresenceSuppression {
+                context_suppressed: false,
+                health_suppressed: true,
+            }
+        );
+    }
+}

--- a/crates/adventuresim-stdb-module/src/outbreak.rs
+++ b/crates/adventuresim-stdb-module/src/outbreak.rs
@@ -669,6 +669,56 @@ fn deactivate_outbreak_patient_contexts(ctx: &ReducerContext, case_id: &str) {
     }
 }
 
+/// Reconstructs settlement-presence suppression at an observer-relative
+/// historical minute. Mutable materialized patient flags describe only the
+/// latest world state and must never be read for a lagging observer.
+pub(crate) fn patient_presence_suppression_at(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minute: u64,
+) -> Option<adventuresim_core::strategic_presence::PresenceSuppression> {
+    let alive_at_observer = crate::relationship::character_alive_at(ctx, character_id, minute);
+    let mut aggregate = adventuresim_core::strategic_presence::PresenceSuppression {
+        context_suppressed: false,
+        health_suppressed: !alive_at_observer,
+    };
+    for patient in ctx
+        .db
+        .outbreak_patient_authority()
+        .patient_character_id()
+        .filter(character_id)
+    {
+        let episode = ctx.db.infection_episode().id().find(patient.episode_id)?;
+        let authority = ctx
+            .db
+            .outbreak_authority()
+            .case_id()
+            .find(&patient.case_id)?;
+        if episode.character_id != character_id || episode.disease_id != authority.disease_id {
+            return None;
+        }
+        let disease_id = crate::disease::parse_id(&episode.disease_id).ok()?;
+        let definition = adventuresim_core::disease::definition(disease_id);
+        let recovery_minute = episode
+            .contracted_at
+            .checked_add(definition.incubation_minutes)?
+            .checked_add(definition.rise_minutes)?
+            .checked_add(definition.peak_minutes)?
+            .checked_add(definition.recovery_minutes)?;
+        let suppression = adventuresim_core::strategic_presence::outbreak_patient_suppression_at(
+            episode.contracted_at,
+            recovery_minute,
+            authority.remediated_at,
+            minute,
+            alive_at_observer,
+        )
+        .ok()?;
+        aggregate.context_suppressed |= suppression.context_suppressed;
+        aggregate.health_suppressed |= suppression.health_suppressed;
+    }
+    Some(aggregate)
+}
+
 /// Release a recovered or dead patient from case-site presentation whenever
 /// their ordinary Character clock advances past the standard episode course.
 pub(crate) fn refresh_patient_context_after_time_write(

--- a/crates/adventuresim-stdb-module/src/residence.rs
+++ b/crates/adventuresim-stdb-module/src/residence.rs
@@ -9,6 +9,8 @@ use adventuresim_core::courtship::{
     RefreshableMorale, refresh_bounded_leisure_morale, residence_leisure_bonus_milli,
     residence_period_charge,
 };
+use adventuresim_core::strategic_place::StrategicPlaceId;
+use adventuresim_core::strategic_presence::{PresenceFrontier, StrategicPresence, are_co_present};
 use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, reducer, table, view};
 
 use crate::character::character;
@@ -507,13 +509,40 @@ pub fn active_residence_for_occupant(
     character_id: u64,
     settlement_id: &str,
 ) -> Option<ResidenceHolding> {
+    active_residence_presence(ctx, character_id, settlement_id).map(|(holding, _)| holding)
+}
+
+/// Private typed projection of residence access. Exact presence comes from
+/// chronological occupancy; ownership without occupancy is insufficient.
+pub(crate) fn active_residence_presence(
+    ctx: &ReducerContext,
+    character_id: u64,
+    settlement_id: &str,
+) -> Option<(ResidenceHolding, StrategicPresence)> {
     let minute = residence_now(ctx, character_id).ok()?;
-    let holding_id = occupant_holding_id_at(ctx, character_id, minute)?;
-    ctx.db
+    let (holding_id, admitted_minute) = occupant_holding_at(ctx, character_id, minute)?;
+    let holding = ctx
+        .db
         .residence_holding()
         .id()
         .find(&holding_id)
-        .filter(|row| holding_active_at(ctx, &row.id, minute) && row.settlement_id == settlement_id)
+        .filter(|row| {
+            holding_active_at(ctx, &row.id, minute) && row.settlement_id == settlement_id
+        })?;
+    let place = StrategicPlaceId::residence(&holding.settlement_id, &holding.id).ok()?;
+    let presence = StrategicPresence::residence_occupancy(
+        character_id,
+        place,
+        holding.owner_character_id,
+        admitted_minute,
+        PresenceFrontier {
+            observer_character_id: character_id,
+            personal_minute: minute,
+        },
+        true,
+    )
+    .ok()?;
+    Some((holding, presence))
 }
 
 /// Whether a holding was usable at an effective personal minute. Current
@@ -562,6 +591,14 @@ pub(crate) fn occupant_holding_id_at(
     character_id: u64,
     minute: u64,
 ) -> Option<String> {
+    occupant_holding_at(ctx, character_id, minute).map(|(holding_id, _)| holding_id)
+}
+
+fn occupant_holding_at(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minute: u64,
+) -> Option<(String, u64)> {
     let mut transitions = ctx
         .db
         .residence_transition()
@@ -585,14 +622,17 @@ pub(crate) fn occupant_holding_id_at(
     });
     transitions
         .into_iter()
-        .fold(None, |holding_id, transition| match transition.kind {
-            ResidenceTransitionKind::OccupantAdmitted => Some(transition.holding_id),
+        .fold(None, |occupancy, transition| match transition.kind {
+            ResidenceTransitionKind::OccupantAdmitted => {
+                Some((transition.holding_id, transition.minute))
+            }
             ResidenceTransitionKind::OccupantRemoved
-                if holding_id.as_deref() == Some(transition.holding_id.as_str()) =>
+                if occupancy.as_ref().map(|(id, _)| id.as_str())
+                    == Some(transition.holding_id.as_str()) =>
             {
                 None
             }
-            _ => holding_id,
+            _ => occupancy,
         })
 }
 
@@ -820,8 +860,34 @@ fn validate_public_admission(
         Some(occupant_id),
         crate::relationship::TemporalScope::PairwiseSoft,
     )?;
-    if owner.current_settlement_id.as_deref() != Some(&holding.settlement_id)
-        || occupant.current_settlement_id.as_deref() != Some(&holding.settlement_id)
+    let frontier = PresenceFrontier {
+        observer_character_id: holding.owner_character_id,
+        personal_minute: actor_minute,
+    };
+    let owner_presence = owner
+        .current_settlement_id
+        .as_deref()
+        .and_then(|settlement_id| {
+            StrategicPresence::settlement_membership(owner.id, settlement_id, frontier).ok()
+        });
+    let occupant_presence = occupant
+        .current_settlement_id
+        .as_deref()
+        .and_then(|settlement_id| {
+            StrategicPresence::settlement_membership(occupant.id, settlement_id, frontier).ok()
+        });
+    let expected_place = StrategicPlaceId::settlement(&holding.settlement_id)
+        .map_err(|_| "Residence settlement identity is invalid")?;
+    if !owner_presence
+        .as_ref()
+        .is_some_and(|presence| presence.place() == &expected_place)
+        || !occupant_presence
+            .as_ref()
+            .is_some_and(|presence| presence.place() == &expected_place)
+        || !owner_presence
+            .as_ref()
+            .zip(occupant_presence.as_ref())
+            .is_some_and(|(owner, occupant)| are_co_present(owner, occupant))
     {
         return Err("Residence admission requires both characters to be co-located".into());
     }

--- a/crates/adventuresim-stdb-module/src/settlement_population.rs
+++ b/crates/adventuresim-stdb-module/src/settlement_population.rs
@@ -4,11 +4,14 @@ use crate::{
     personality::{Presentation, character_personality, character_personality__view},
     relationship::{NpcPolicy, npc_policy},
     strategic::{settlement, strategic_gateway_authority__view},
-    time::world_clock,
 };
 use adventuresim_core::settlement_population::{
     self as population, AgeBand, GenerationInput, LocationContext, PresenceBridge, Profession,
     Schedule,
+};
+use adventuresim_core::strategic_place::{SettlementVenueKind, StrategicPlaceId};
+use adventuresim_core::strategic_presence::{
+    DailyPresenceWindow, PresenceFrontier, ScheduledStrategicPresence, StrategicPresence,
 };
 use serde::{Deserialize, Serialize};
 use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, table, view};
@@ -747,36 +750,70 @@ pub fn npc_is_present(
     npc_presence_remaining_minutes_at(ctx, presence, minute).is_some()
 }
 
-/// Authoritative availability projection shared by every service, dialogue,
-/// investigation, and social consumer. This catches episode completion even
-/// when the patient has been idle since outbreak materialization.
+/// Canonical exact place behind an authoritative settlement NPC location.
+/// The `overview` route is the presentation alias for the public square.
+pub fn canonical_npc_place(settlement_id: &str, location_id: &str) -> Option<StrategicPlaceId> {
+    let venue = if matches!(location_id, "overview" | "public-square") {
+        Some(SettlementVenueKind::PublicSquare)
+    } else {
+        SettlementVenueKind::from_id(location_id)
+    };
+    if let Some(kind) = venue {
+        return StrategicPlaceId::settlement_venue(settlement_id, kind).ok();
+    }
+    let (organization, chapter) =
+        adventuresim_core::organization::organization_chapter_at(settlement_id, location_id)?;
+    StrategicPlaceId::chapter_venue(settlement_id, &organization.id, &chapter.location_id).ok()
+}
+
+/// Typed scheduled presence at the actor-relative personal minute. Historical
+/// outbreak state is reconstructed without mutating or reading future state.
+pub fn npc_strategic_presence_at(
+    ctx: &ReducerContext,
+    presence: &SettlementResidentPresence,
+    observer_character_id: u64,
+    minute: u64,
+) -> Option<ScheduledStrategicPresence> {
+    let suppression =
+        crate::outbreak::patient_presence_suppression_at(ctx, presence.character_id, minute)?;
+    let alive = crate::relationship::character_alive_at(ctx, presence.character_id, minute);
+    StrategicPresence::scheduled_resident(
+        presence.character_id,
+        canonical_npc_place(&presence.settlement_id, &presence.location_id)?,
+        PresenceFrontier {
+            observer_character_id,
+            personal_minute: minute,
+        },
+        DailyPresenceWindow {
+            start_minute: presence.start_minute,
+            end_minute: presence.end_minute,
+        },
+        alive,
+        suppression.context_suppressed,
+        suppression.health_suppressed,
+    )
+    .ok()
+}
+
+/// Compatibility projection for consumers that only need schedule duration.
+/// It deliberately does not fabricate a typed observer frontier.
 pub fn npc_presence_remaining_minutes_at(
     ctx: &ReducerContext,
     presence: &SettlementResidentPresence,
     minute: u64,
 ) -> Option<u64> {
-    let frontier = ctx
-        .db
-        .world_clock()
-        .id()
-        .find(0)
-        .map_or(minute, |clock| clock.official_minutes.max(minute));
-    crate::outbreak::refresh_patient_context_after_time_write(ctx, presence.character_id, frontier);
-    let effective_presence = ctx
-        .db
-        .settlement_resident_presence()
-        .character_id()
-        .find(presence.character_id)
-        .unwrap_or_else(|| presence.clone());
-    let alive = ctx
-        .db
-        .character()
-        .id()
-        .find(presence.character_id)
-        .is_some_and(|character| character.alive);
-    alive
-        .then(|| npc_presence_remaining_minutes(&effective_presence, minute))
-        .flatten()
+    let suppression =
+        crate::outbreak::patient_presence_suppression_at(ctx, presence.character_id, minute)?;
+    DailyPresenceWindow {
+        start_minute: presence.start_minute,
+        end_minute: presence.end_minute,
+    }
+    .remaining_minutes(
+        minute,
+        suppression.context_suppressed,
+        suppression.health_suppressed,
+    )
+    .ok()
 }
 
 /// Remaining contiguous minutes in the NPC's current daily presence window.
@@ -785,27 +822,32 @@ pub fn npc_presence_remaining_minutes(
     presence: &SettlementResidentPresence,
     minute: u64,
 ) -> Option<u64> {
-    if presence.context_suppressed || presence.health_suppressed {
-        return None;
+    DailyPresenceWindow {
+        start_minute: presence.start_minute,
+        end_minute: presence.end_minute,
     }
-    let minute = minute % 1_440;
-    let start = u64::from(presence.start_minute);
-    let end = u64::from(presence.end_minute);
-    if start == end {
-        return None;
-    }
-    if start < end {
-        (start <= minute && minute < end).then_some(end - minute)
-    } else if minute >= start {
-        Some((1_440 - minute) + end)
-    } else {
-        (minute < end).then_some(end - minute)
-    }
+    .remaining_minutes(
+        minute,
+        presence.context_suppressed,
+        presence.health_suppressed,
+    )
+    .ok()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_npc_places_use_physical_venue_identity() {
+        let overview = canonical_npc_place("lubeck", "overview").unwrap();
+        let square = canonical_npc_place("lubeck", "public-square").unwrap();
+        let inn = canonical_npc_place("lubeck", "inn").unwrap();
+
+        assert_eq!(overview, square);
+        assert_ne!(overview, inn);
+        assert!(canonical_npc_place("lubeck", "unknown-route-value").is_none());
+    }
 
     fn settlement_resident_profile() -> SettlementResidentProfile {
         SettlementResidentProfile {
@@ -960,15 +1002,29 @@ mod tests {
     }
 
     #[test]
-    fn authoritative_presence_refreshes_idle_outbreak_health_before_service_use() {
+    fn authoritative_presence_reconstructs_historical_outbreak_state_without_mutation() {
         let source = include_str!("settlement_population.rs");
+        let typed_projection = source
+            .split("pub fn npc_strategic_presence_at")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("pub fn npc_presence_remaining_minutes_at")
+                    .next()
+            })
+            .expect("typed historical presence projection");
+        assert!(typed_projection.contains("patient_presence_suppression_at"));
+        assert!(typed_projection.contains("character_alive_at"));
+        assert!(!typed_projection.contains("world_clock"));
+        assert!(!typed_projection.contains("refresh_patient_context_after_time_write"));
+        assert!(!typed_projection.contains("character.alive"));
+
         let projection = source
             .split("pub fn npc_presence_remaining_minutes_at")
             .nth(1)
             .and_then(|tail| tail.split("pub fn npc_presence_remaining_minutes").next())
             .expect("authoritative presence projection");
-        assert!(projection.contains("world_clock"));
-        assert!(projection.contains("refresh_patient_context_after_time_write"));
-        assert!(projection.contains("character.alive"));
+        assert!(projection.contains("patient_presence_suppression_at"));
+        assert!(!projection.contains("PresenceFrontier"));
+        assert!(!projection.contains("refresh_patient_context_after_time_write"));
     }
 }

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_effects.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_effects.rs
@@ -223,14 +223,24 @@ pub(crate) fn exact_organization_representative(
     let organization = adventuresim_core::organization::organization(&npc.organization_id)?;
     let chapter = organization.chapter(settlement_id)?;
     let settlement = ctx.db.settlement().id().find(&settlement_id.to_owned())?;
-    if adventuresim_core::organization::chapter_effective_location_id(
+    let observed_place =
+        crate::settlement_population::canonical_npc_place(settlement_id, location_id)?;
+    let effective_location = adventuresim_core::organization::chapter_effective_location_id(
         organization,
         chapter,
         &settlement.economy,
-    ) != location_id
-    {
+    );
+    let effective_place =
+        crate::settlement_population::canonical_npc_place(settlement_id, effective_location)?;
+    if observed_place != effective_place {
         return None;
     }
+    adventuresim_core::strategic_place::StrategicFixtureId::chapter(
+        observed_place,
+        &organization.id,
+        &chapter.location_id,
+    )
+    .ok()?;
     let expected_id = adventuresim_core::organization::organization_representative_id(
         settlement_id,
         &organization.id,

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_schema.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_schema.rs
@@ -485,7 +485,8 @@ fn require_live_dialogue_presence(
     session: &DialogueSession,
     character_id: u64,
 ) -> Result<crate::settlement_population::SettlementResidentProfile, String> {
-    require_navigable_npc_location(ctx, &session.settlement_id, &session.location_id)?;
+    let exact_place =
+        require_navigable_npc_place(ctx, &session.settlement_id, &session.location_id)?;
     let character = ctx
         .db
         .character()
@@ -513,7 +514,24 @@ fn require_live_dialogue_presence(
         .character_time()
         .character_id()
         .find(character_id)
-        .map_or(720, |time| time.minutes);
+        .map(|time| time.minutes)
+        .ok_or("Dialogue participant has no personal time authority")?;
+    let actor_settlement_presence =
+        adventuresim_core::strategic_presence::StrategicPresence::settlement_membership(
+            character_id,
+            session.settlement_id.clone(),
+            adventuresim_core::strategic_presence::PresenceFrontier {
+                observer_character_id: character_id,
+                personal_minute: minute,
+            },
+        )
+        .map_err(|_| "Dialogue settlement identity is invalid")?;
+    let actor_presence =
+        adventuresim_core::strategic_presence::StrategicPresence::validated_venue_selection(
+            &actor_settlement_presence,
+            exact_place,
+        )
+        .map_err(|_| "Dialogue location is not in the actor's settlement")?;
     let mut primary = None;
     for participant in npc_participants {
         let npc_character_id = participant
@@ -532,10 +550,18 @@ fn require_live_dialogue_presence(
             .character_id()
             .find(npc.character_id)
             .ok_or("Dialogue NPC has no authoritative presence")?;
+        let npc_presence = crate::settlement_population::npc_strategic_presence_at(
+            ctx,
+            &presence,
+            character_id,
+            minute,
+        )
+        .ok_or("Dialogue NPC is not present at the session location and time")?;
         if npc.home_settlement_id != session.settlement_id
-            || presence.settlement_id != session.settlement_id
-            || presence.location_id != session.location_id
-            || !crate::settlement_population::npc_is_present(ctx, &presence, minute)
+            || !adventuresim_core::strategic_presence::are_co_present(
+                &actor_presence,
+                npc_presence.presence(),
+            )
         {
             return Err("Dialogue NPC is not present at the session location and time".into());
         }
@@ -581,4 +607,14 @@ fn require_navigable_npc_location(
     } else {
         Err("NPC location is not available in this settlement".into())
     }
+}
+
+fn require_navigable_npc_place(
+    ctx: &ReducerContext,
+    settlement_id: &str,
+    location_id: &str,
+) -> Result<adventuresim_core::strategic_place::StrategicPlaceId, String> {
+    require_navigable_npc_location(ctx, settlement_id, location_id)?;
+    crate::settlement_population::canonical_npc_place(settlement_id, location_id)
+        .ok_or_else(|| "NPC location has no canonical strategic place".into())
 }

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_sessions.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_sessions.rs
@@ -24,16 +24,34 @@ pub fn start_dialogue(
     let settlement_id = character
         .current_settlement_id
         .ok_or("Dialogue requires a settlement")?;
-    require_navigable_npc_location(ctx, &settlement_id, &location_id)?;
+    // The route value selects a candidate only; server-side settlement
+    // navigability must resolve it before it becomes exact actor context.
+    let exact_place = require_navigable_npc_place(ctx, &settlement_id, &location_id)?;
     let npc_character_id = npc_actor_id
         .parse::<u64>()
         .map_err(|_| "Dialogue NPC identity is invalid")?;
-    crate::relationship::enforce_temporal_scope(
+    let minute = crate::relationship::enforce_temporal_scope(
         ctx,
         character_id,
         Some(npc_character_id),
         crate::relationship::TemporalScope::PairwiseSoft,
     )?;
+    let actor_settlement_presence =
+        adventuresim_core::strategic_presence::StrategicPresence::settlement_membership(
+            character_id,
+            settlement_id.clone(),
+            adventuresim_core::strategic_presence::PresenceFrontier {
+                observer_character_id: character_id,
+                personal_minute: minute,
+            },
+        )
+        .map_err(|_| "Dialogue settlement identity is invalid")?;
+    let actor_presence =
+        adventuresim_core::strategic_presence::StrategicPresence::validated_venue_selection(
+            &actor_settlement_presence,
+            exact_place,
+        )
+        .map_err(|_| "Dialogue location is not in the actor's settlement")?;
     let npc = crate::settlement_population::resolve_settlement_resident(ctx, npc_character_id)
         .ok_or("Dialogue actor is not a persistent settlement NPC")?;
     if npc.home_settlement_id != settlement_id {
@@ -51,16 +69,17 @@ pub fn start_dialogue(
         .character_id()
         .find(npc_character_id)
         .ok_or("Dialogue actor has no authoritative presence")?;
-    let minute = ctx
-        .db
-        .character_time()
-        .character_id()
-        .find(character_id)
-        .map_or(720, |time| time.minutes);
-    if presence.settlement_id != settlement_id
-        || presence.location_id != location_id
-        || !crate::settlement_population::npc_is_present(ctx, &presence, minute)
-    {
+    let npc_presence = crate::settlement_population::npc_strategic_presence_at(
+        ctx,
+        &presence,
+        character_id,
+        minute,
+    )
+    .ok_or("Dialogue actor is not present at this time")?;
+    if !adventuresim_core::strategic_presence::are_co_present(
+        &actor_presence,
+        npc_presence.presence(),
+    ) {
         return Err("Dialogue actor is not present at this time".into());
     }
     if conversation_id != npc.conversation_id {
@@ -129,8 +148,18 @@ pub fn start_dialogue(
         .settlement_id()
         .filter(&settlement_id)
         .filter(|candidate| {
-            candidate.location_id == location_id
-                && crate::settlement_population::npc_is_present(ctx, candidate, minute)
+            crate::settlement_population::npc_strategic_presence_at(
+                ctx,
+                candidate,
+                character_id,
+                minute,
+            )
+                .is_some_and(|candidate_presence| {
+                    adventuresim_core::strategic_presence::are_co_present(
+                        &actor_presence,
+                        candidate_presence.presence(),
+                    )
+                })
         })
         .filter_map(|presence| {
             crate::settlement_population::resolve_settlement_resident(ctx, presence.character_id)

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -2364,12 +2364,16 @@ fn require_character_residence_rest(ctx: &ReducerContext, character_id: u64) -> 
         .current_settlement_id
         .as_deref()
         .ok_or("Settlement rest requires the character to be at a settlement")?;
-    let residence =
-        crate::residence::active_residence_for_occupant(ctx, character_id, settlement_id)
+    let (residence, presence) =
+        crate::residence::active_residence_presence(ctx, character_id, settlement_id)
             .ok_or("You do not have a residence")?;
     debug_assert!(
         residence.status == crate::residence::ResidenceHoldingStatus::Active
             && residence.settlement_id == settlement_id
+            && matches!(
+                presence.place(),
+                adventuresim_core::strategic_place::StrategicPlaceId::Residence { .. }
+            )
     );
     Ok(())
 }

--- a/wiki/reference/dialogue.md
+++ b/wiki/reference/dialogue.md
@@ -104,6 +104,18 @@ addressed portrait changes the actor while the character remains at that locatio
 Service providers retain their service conversation, while ordinary residents use the
 compiled `local-resident` conversation and cannot receive service-only topics.
 
+The route location is only a candidate. The server first proves that it is a
+navigable location in the actor's current settlement, resolves its canonical
+place, and then projects the actor and every NPC at the actor's personal-time
+frontier through the shared strategic presence contract. The game does not yet
+persist within-settlement travel: a dialogue reducer may instantaneously select
+any server-validated, currently navigable venue in that settlement. The client
+cannot bypass settlement, navigability, schedule, health, or NPC checks, and the
+selection does not create navigation state. Historical death, infection-course,
+and remediation facts determine NPC suppression at the observer frontier. A service-linked chapter
+representative may share the service venue; the chapter fixture and exact
+representative fields still authorize organization business separately.
+
 The public NPC row contains only visible identity and presentation: name, age band,
 presentation, height, build, hair/facial hair, complexion, visible features, clothing,
 profession, household, and local role. Private demographic sex, the internal projection

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1720)
+## Files (1721)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -138,6 +138,7 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-core/src/strategic_economy.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/strategic_inventory.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/strategic_place.rs` — Rust source module for this component.
+- `crates/adventuresim-core/src/strategic_presence.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/strategic_schedule.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/strategic_state.rs` — Rust source module for this component.
 - `crates/adventuresim-core/src/strategic_time.rs` — Rust source module for this component.

--- a/wiki/reference/strategic-places.md
+++ b/wiki/reference/strategic-places.md
@@ -51,6 +51,35 @@ settlement service availability remains an economy-profile fact, and private
 case/outbreak sites remain undiscoverable until their existing knowledge and
 gateway rules expose them.
 
+## Presence and co-presence
+
+`adventuresim-core::strategic_presence` is the shared fail-closed projection
+contract. Each presence names a Character, a canonical `StrategicPlaceId`, the
+authorized observer's personal-time frontier, and one closed evidence basis:
+coarse settlement membership, validated instantaneous venue selection, scheduled
+resident presence, or chronological residence occupancy. Co-presence requires
+the same canonical place projected for the same observer frontier. It does not
+require the observed Character's independent clock to equal the observer's;
+pairwise-soft consumers continue to inspect only the actor's chronology.
+
+A coarse settlement membership never equals an exact venue. The strategic
+layer does not currently persist within-settlement travel or interior position.
+A reducer request may therefore select any currently navigable venue inside the
+actor's authoritative current settlement. A browser route or location parameter
+is only that candidate: server-side navigability must resolve its canonical venue
+before the selection becomes exact actor presence. This preserves instantaneous
+venue selection without inventing durable navigation state. NPC presence then
+applies historical alive, schedule, health, and context-suppression authority at
+that actor-relative minute. Service-linked
+chapter representatives therefore share the ordinary service place, while a
+standalone chapter retains its authored chapter place.
+
+Residence access projects an exact residence place only from an effective
+occupancy transition and active holding at the occupant's personal frontier.
+The typed basis distinguishes an owner who also occupies the home from a
+household occupant; ownership alone is neither presence nor occupancy. Private
+holding, household, and role facts remain inside the residence owner module.
+
 The current SpacetimeDB investigation module still owns its serialized
 `CaseSiteId` wrapper and generated client shape. The schema-adapter PR in this
 stack must validate that value into `StrategicPlaceId::CaseSite`, convert the

--- a/wiki/strategic/residences.md
+++ b/wiki/strategic/residences.md
@@ -68,6 +68,12 @@ so spouses and dependent children receive the same tier benefit without
 pretending to own the home. Public admission requires living co-located
 characters and an active shared household or spouse/parent/child relationship;
 an existing place in another home is rejected rather than silently stolen.
+Residence rest and comfort resolve the same chronological occupancy through
+the shared strategic presence contract. The resulting exact-place basis marks
+the legal owner only when that owner is also an occupant; ownership without an
+occupancy transition does not establish presence or access. Public admission
+continues to require only coarse same-settlement co-location and never upgrades
+that fact into presence at the target residence.
 Wedding and birth settlement use a private atomic move after establishing the
 new household or kinship. Both resolve holding activity, household membership,
 and occupancy at the ceremony or due minute, so a parent whose personal clock


### PR DESCRIPTION
## What changed

Add canonical strategic presence questions and temporal frontiers on top of the shared place identity model.

## Why

This is layer 2 of 14 for issue #414. It establishes one reviewable portion of the shared strategic-world foundation while preserving existing gameplay behavior and privacy boundaries.

## Stack

- Base: `agent/414-places-core`
- Head: `agent/414-presence-core`
- Review and merge in numeric stack order.

## Validation

Focused strategic-presence tests; workspace checks; formatting and diff checks.

Implementation used isolated worktrees and independent correctness/security review. The final layer supplies the composed simulator and live browser proof for the complete stack.