### PR TITLE
Unify case-site presence identities

### DIFF
--- a/crates/adventuresim-core/src/strategic_place.rs
+++ b/crates/adventuresim-core/src/strategic_place.rs
@@ -235,6 +235,14 @@ impl StrategicPlaceId {
             Self::CaseSite { .. } | Self::JourneyCamp { .. } => None,
         }
     }
+
+    /// Opaque case-site component when this is an exact case-site place.
+    pub fn case_site_id(&self) -> Option<&str> {
+        match self {
+            Self::CaseSite { site_id } => Some(site_id.as_str()),
+            _ => None,
+        }
+    }
 }
 
 /// One existing environmental or institutional fixture at an exact place.
@@ -329,6 +337,13 @@ impl StrategicFixtureId {
             | Self::Chapter { place, .. }
             | Self::OutbreakSource { place, .. }
             | Self::Fireplace { place } => place,
+        }
+    }
+
+    pub fn outbreak_id(&self) -> Option<&str> {
+        match self {
+            Self::OutbreakSource { outbreak_id, .. } => Some(outbreak_id.as_str()),
+            _ => None,
         }
     }
 }

--- a/crates/adventuresim-core/src/strategic_presence.rs
+++ b/crates/adventuresim-core/src/strategic_presence.rs
@@ -18,6 +18,8 @@ pub enum PresenceBasis {
     ValidatedVenueSelection,
     ScheduledResident,
     ResidenceOccupancy(ResidencePresenceRole),
+    CaseSiteOccupancy,
+    CaseContextMembership,
 }
 
 /// One character's presence projected at an explicit observer frontier.
@@ -148,6 +150,61 @@ impl StrategicPresence {
         })
     }
 
+    /// Physical party/Character occupancy at an exact case site. Observer
+    /// discovery remains the adapter's responsibility.
+    pub fn case_site_occupancy(
+        character_id: u64,
+        place: StrategicPlaceId,
+        frontier: PresenceFrontier,
+        occupied: bool,
+        alive_at_frontier: bool,
+    ) -> Result<Self, PresenceError> {
+        if !matches!(&place, StrategicPlaceId::CaseSite { .. }) {
+            return Err(PresenceError::CaseSiteRequired);
+        }
+        if !occupied || !alive_at_frontier {
+            return Err(PresenceError::Unavailable);
+        }
+        Ok(Self {
+            character_id,
+            place,
+            frontier,
+            basis: PresenceBasis::CaseSiteOccupancy,
+        })
+    }
+
+    /// Presence granted by one live contextual membership at a case site.
+    /// The expected revision prevents a stale projected context from joining.
+    pub fn case_context_membership(
+        character_id: u64,
+        place: StrategicPlaceId,
+        frontier: PresenceFrontier,
+        active: bool,
+        expected_context_id: &str,
+        actual_context_id: &str,
+        expected_revision: u32,
+        actual_revision: u32,
+        alive_at_frontier: bool,
+    ) -> Result<Self, PresenceError> {
+        if !matches!(&place, StrategicPlaceId::CaseSite { .. }) {
+            return Err(PresenceError::CaseSiteRequired);
+        }
+        if !active
+            || expected_context_id.is_empty()
+            || expected_context_id != actual_context_id
+            || expected_revision != actual_revision
+            || !alive_at_frontier
+        {
+            return Err(PresenceError::Unavailable);
+        }
+        Ok(Self {
+            character_id,
+            place,
+            frontier,
+            basis: PresenceBasis::CaseContextMembership,
+        })
+    }
+
     pub fn character_id(&self) -> u64 {
         self.character_id
     }
@@ -271,6 +328,7 @@ pub enum PresenceError {
     CoarseSettlementRequired,
     ExactVenueRequired,
     ResidenceRequired,
+    CaseSiteRequired,
     PlaceMismatch,
     InvalidSchedule,
     OutsideSchedule,
@@ -439,5 +497,77 @@ mod tests {
                 health_suppressed: true,
             }
         );
+    }
+
+    #[test]
+    fn case_occupant_and_current_context_actor_are_co_present() {
+        let frontier = frontier(1, 500);
+        let site = StrategicPlaceId::case_site("outbreak:site:well").unwrap();
+        let actor =
+            StrategicPresence::case_site_occupancy(1, site.clone(), frontier, true, true).unwrap();
+        let patient = StrategicPresence::case_context_membership(
+            2,
+            site,
+            frontier,
+            true,
+            "membership:2",
+            "membership:2",
+            4,
+            4,
+            true,
+        )
+        .unwrap();
+        assert!(are_co_present(&actor, &patient));
+    }
+
+    #[test]
+    fn case_context_rejects_mismatch_staleness_and_malformed_identity() {
+        let frontier = frontier(1, 500);
+        let first = StrategicPlaceId::case_site("case:one").unwrap();
+        let second = StrategicPlaceId::case_site("case:two").unwrap();
+        let actor =
+            StrategicPresence::case_site_occupancy(1, first.clone(), frontier, true, true).unwrap();
+        let elsewhere = StrategicPresence::case_context_membership(
+            2,
+            second,
+            frontier,
+            true,
+            "membership:2",
+            "membership:2",
+            1,
+            1,
+            true,
+        )
+        .unwrap();
+        assert!(!are_co_present(&actor, &elsewhere));
+        assert_eq!(
+            StrategicPresence::case_context_membership(
+                2,
+                first.clone(),
+                frontier,
+                true,
+                "membership:2",
+                "membership:2",
+                1,
+                2,
+                true,
+            ),
+            Err(PresenceError::Unavailable)
+        );
+        assert_eq!(
+            StrategicPresence::case_context_membership(
+                2,
+                first,
+                frontier,
+                true,
+                "membership:stale",
+                "membership:2",
+                2,
+                2,
+                true,
+            ),
+            Err(PresenceError::Unavailable)
+        );
+        assert!(StrategicPlaceId::case_site("bad site id").is_err());
     }
 }

--- a/crates/adventuresim-stdb-client/src/character_case_site_occupancy_type.rs
+++ b/crates/adventuresim-stdb-client/src/character_case_site_occupancy_type.rs
@@ -9,9 +9,12 @@ use super::case_site_id_type::CaseSiteId;
 #[derive(__lib::ser::Serialize, __lib::de::Deserialize, Clone, PartialEq, Debug)]
 #[sats(crate = __lib)]
 pub struct CharacterCaseSiteOccupancy {
+    pub id: String,
     pub character_id: u64,
     pub gateway_bucket: u8,
     pub case_site_id: CaseSiteId,
+    pub entered_at: u64,
+    pub left_at: Option<u64>,
 }
 
 impl __sdk::InModule for CharacterCaseSiteOccupancy {
@@ -22,18 +25,24 @@ impl __sdk::InModule for CharacterCaseSiteOccupancy {
 ///
 /// Provides typed access to columns for query building.
 pub struct CharacterCaseSiteOccupancyCols {
+    pub id: __sdk::__query_builder::Col<CharacterCaseSiteOccupancy, String>,
     pub character_id: __sdk::__query_builder::Col<CharacterCaseSiteOccupancy, u64>,
     pub gateway_bucket: __sdk::__query_builder::Col<CharacterCaseSiteOccupancy, u8>,
     pub case_site_id: __sdk::__query_builder::Col<CharacterCaseSiteOccupancy, CaseSiteId>,
+    pub entered_at: __sdk::__query_builder::Col<CharacterCaseSiteOccupancy, u64>,
+    pub left_at: __sdk::__query_builder::Col<CharacterCaseSiteOccupancy, Option<u64>>,
 }
 
 impl __sdk::__query_builder::HasCols for CharacterCaseSiteOccupancy {
     type Cols = CharacterCaseSiteOccupancyCols;
     fn cols(table_name: &'static str) -> Self::Cols {
         CharacterCaseSiteOccupancyCols {
+            id: __sdk::__query_builder::Col::new(table_name, "id"),
             character_id: __sdk::__query_builder::Col::new(table_name, "character_id"),
             gateway_bucket: __sdk::__query_builder::Col::new(table_name, "gateway_bucket"),
             case_site_id: __sdk::__query_builder::Col::new(table_name, "case_site_id"),
+            entered_at: __sdk::__query_builder::Col::new(table_name, "entered_at"),
+            left_at: __sdk::__query_builder::Col::new(table_name, "left_at"),
         }
     }
 }
@@ -44,6 +53,7 @@ impl __sdk::__query_builder::HasCols for CharacterCaseSiteOccupancy {
 pub struct CharacterCaseSiteOccupancyIxCols {
     pub character_id: __sdk::__query_builder::IxCol<CharacterCaseSiteOccupancy, u64>,
     pub gateway_bucket: __sdk::__query_builder::IxCol<CharacterCaseSiteOccupancy, u8>,
+    pub id: __sdk::__query_builder::IxCol<CharacterCaseSiteOccupancy, String>,
 }
 
 impl __sdk::__query_builder::HasIxCols for CharacterCaseSiteOccupancy {
@@ -52,6 +62,7 @@ impl __sdk::__query_builder::HasIxCols for CharacterCaseSiteOccupancy {
         CharacterCaseSiteOccupancyIxCols {
             character_id: __sdk::__query_builder::IxCol::new(table_name, "character_id"),
             gateway_bucket: __sdk::__query_builder::IxCol::new(table_name, "gateway_bucket"),
+            id: __sdk::__query_builder::IxCol::new(table_name, "id"),
         }
     }
 }

--- a/crates/adventuresim-stdb-client/src/character_context_membership_type.rs
+++ b/crates/adventuresim-stdb-client/src/character_context_membership_type.rs
@@ -18,6 +18,8 @@ pub struct CharacterContextMembership {
     pub role: CharacterContextRole,
     pub ordinal: u16,
     pub active: bool,
+    pub entered_at: u64,
+    pub left_at: Option<u64>,
     pub revision: u32,
     pub treatment_consent: bool,
 }
@@ -38,6 +40,8 @@ pub struct CharacterContextMembershipCols {
     pub role: __sdk::__query_builder::Col<CharacterContextMembership, CharacterContextRole>,
     pub ordinal: __sdk::__query_builder::Col<CharacterContextMembership, u16>,
     pub active: __sdk::__query_builder::Col<CharacterContextMembership, bool>,
+    pub entered_at: __sdk::__query_builder::Col<CharacterContextMembership, u64>,
+    pub left_at: __sdk::__query_builder::Col<CharacterContextMembership, Option<u64>>,
     pub revision: __sdk::__query_builder::Col<CharacterContextMembership, u32>,
     pub treatment_consent: __sdk::__query_builder::Col<CharacterContextMembership, bool>,
 }
@@ -54,6 +58,8 @@ impl __sdk::__query_builder::HasCols for CharacterContextMembership {
             role: __sdk::__query_builder::Col::new(table_name, "role"),
             ordinal: __sdk::__query_builder::Col::new(table_name, "ordinal"),
             active: __sdk::__query_builder::Col::new(table_name, "active"),
+            entered_at: __sdk::__query_builder::Col::new(table_name, "entered_at"),
+            left_at: __sdk::__query_builder::Col::new(table_name, "left_at"),
             revision: __sdk::__query_builder::Col::new(table_name, "revision"),
             treatment_consent: __sdk::__query_builder::Col::new(table_name, "treatment_consent"),
         }

--- a/crates/adventuresim-stdb-client/src/outbreak_authority_type.rs
+++ b/crates/adventuresim-stdb-client/src/outbreak_authority_type.rs
@@ -14,8 +14,8 @@ pub struct OutbreakAuthority {
     pub transmission_route: String,
     pub source_kind: String,
     pub source_json: String,
-    pub physical_source_site_id: String,
-    pub patient_presentation_site_id: String,
+    pub physical_source_fixture_id: String,
+    pub patient_presentation_place_id: String,
     pub responsible_resident_character_id: Option<u64>,
     pub culpability: Option<String>,
     pub carrier_threat_id: Option<String>,
@@ -42,8 +42,8 @@ pub struct OutbreakAuthorityCols {
     pub transmission_route: __sdk::__query_builder::Col<OutbreakAuthority, String>,
     pub source_kind: __sdk::__query_builder::Col<OutbreakAuthority, String>,
     pub source_json: __sdk::__query_builder::Col<OutbreakAuthority, String>,
-    pub physical_source_site_id: __sdk::__query_builder::Col<OutbreakAuthority, String>,
-    pub patient_presentation_site_id: __sdk::__query_builder::Col<OutbreakAuthority, String>,
+    pub physical_source_fixture_id: __sdk::__query_builder::Col<OutbreakAuthority, String>,
+    pub patient_presentation_place_id: __sdk::__query_builder::Col<OutbreakAuthority, String>,
     pub responsible_resident_character_id:
         __sdk::__query_builder::Col<OutbreakAuthority, Option<u64>>,
     pub culpability: __sdk::__query_builder::Col<OutbreakAuthority, Option<String>>,
@@ -67,13 +67,13 @@ impl __sdk::__query_builder::HasCols for OutbreakAuthority {
             transmission_route: __sdk::__query_builder::Col::new(table_name, "transmission_route"),
             source_kind: __sdk::__query_builder::Col::new(table_name, "source_kind"),
             source_json: __sdk::__query_builder::Col::new(table_name, "source_json"),
-            physical_source_site_id: __sdk::__query_builder::Col::new(
+            physical_source_fixture_id: __sdk::__query_builder::Col::new(
                 table_name,
-                "physical_source_site_id",
+                "physical_source_fixture_id",
             ),
-            patient_presentation_site_id: __sdk::__query_builder::Col::new(
+            patient_presentation_place_id: __sdk::__query_builder::Col::new(
                 table_name,
-                "patient_presentation_site_id",
+                "patient_presentation_place_id",
             ),
             responsible_resident_character_id: __sdk::__query_builder::Col::new(
                 table_name,

--- a/crates/adventuresim-stdb-client/src/outbreak_source_presence_span_type.rs
+++ b/crates/adventuresim-stdb-client/src/outbreak_source_presence_span_type.rs
@@ -9,7 +9,7 @@ use spacetimedb_sdk::__codegen::{self as __sdk, __lib, __sats, __ws};
 pub struct OutbreakSourcePresenceSpan {
     pub id: String,
     pub character_id: u64,
-    pub source_site_id: String,
+    pub source_place_id: String,
     pub started_at: u64,
     pub ended_at: Option<u64>,
 }
@@ -24,7 +24,7 @@ impl __sdk::InModule for OutbreakSourcePresenceSpan {
 pub struct OutbreakSourcePresenceSpanCols {
     pub id: __sdk::__query_builder::Col<OutbreakSourcePresenceSpan, String>,
     pub character_id: __sdk::__query_builder::Col<OutbreakSourcePresenceSpan, u64>,
-    pub source_site_id: __sdk::__query_builder::Col<OutbreakSourcePresenceSpan, String>,
+    pub source_place_id: __sdk::__query_builder::Col<OutbreakSourcePresenceSpan, String>,
     pub started_at: __sdk::__query_builder::Col<OutbreakSourcePresenceSpan, u64>,
     pub ended_at: __sdk::__query_builder::Col<OutbreakSourcePresenceSpan, Option<u64>>,
 }
@@ -35,7 +35,7 @@ impl __sdk::__query_builder::HasCols for OutbreakSourcePresenceSpan {
         OutbreakSourcePresenceSpanCols {
             id: __sdk::__query_builder::Col::new(table_name, "id"),
             character_id: __sdk::__query_builder::Col::new(table_name, "character_id"),
-            source_site_id: __sdk::__query_builder::Col::new(table_name, "source_site_id"),
+            source_place_id: __sdk::__query_builder::Col::new(table_name, "source_place_id"),
             started_at: __sdk::__query_builder::Col::new(table_name, "started_at"),
             ended_at: __sdk::__query_builder::Col::new(table_name, "ended_at"),
         }
@@ -48,7 +48,7 @@ impl __sdk::__query_builder::HasCols for OutbreakSourcePresenceSpan {
 pub struct OutbreakSourcePresenceSpanIxCols {
     pub character_id: __sdk::__query_builder::IxCol<OutbreakSourcePresenceSpan, u64>,
     pub id: __sdk::__query_builder::IxCol<OutbreakSourcePresenceSpan, String>,
-    pub source_site_id: __sdk::__query_builder::IxCol<OutbreakSourcePresenceSpan, String>,
+    pub source_place_id: __sdk::__query_builder::IxCol<OutbreakSourcePresenceSpan, String>,
 }
 
 impl __sdk::__query_builder::HasIxCols for OutbreakSourcePresenceSpan {
@@ -57,7 +57,7 @@ impl __sdk::__query_builder::HasIxCols for OutbreakSourcePresenceSpan {
         OutbreakSourcePresenceSpanIxCols {
             character_id: __sdk::__query_builder::IxCol::new(table_name, "character_id"),
             id: __sdk::__query_builder::IxCol::new(table_name, "id"),
-            source_site_id: __sdk::__query_builder::IxCol::new(table_name, "source_site_id"),
+            source_place_id: __sdk::__query_builder::IxCol::new(table_name, "source_place_id"),
         }
     }
 }

--- a/crates/adventuresim-stdb-module/src/corpse.rs
+++ b/crates/adventuresim-stdb-module/src/corpse.rs
@@ -19,7 +19,6 @@ use crate::{
         character, character__view, character_attributes, character_limbs, character_skills,
     },
     condition::character_condition,
-    investigation::character_case_site_occupancy,
     item::inventory_item,
     outbreak::outbreak_patient_authority,
     settlement_population::{SettlementResidentProfile, settlement_resident_profile},
@@ -279,11 +278,7 @@ fn require_corpse_access(
         corpse.buried,
         corpse.exhumed,
     );
-    let actor_site = ctx
-        .db
-        .character_case_site_occupancy()
-        .character_id()
-        .find(actor_id)
+    let actor_site = crate::investigation::current_character_case_site_occupancy(ctx, actor_id)
         .map(|row| row.case_site_id.value);
     let together = match location {
         CorpseLocation::Scene => actor_site.as_deref() == Some(corpse.case_site_id.as_str()),

--- a/crates/adventuresim-stdb-module/src/disease.rs
+++ b/crates/adventuresim-stdb-module/src/disease.rs
@@ -2153,18 +2153,10 @@ pub(crate) fn require_intervention_relationship(
     if actor_id == patient_id {
         return Ok(());
     }
-    let actor_site = crate::investigation::character_case_site_id(ctx, actor.id);
-    let patient_site = crate::investigation::character_case_site_id(ctx, patient.id);
-    let ordinary_relationship = physiology::intervention_relationship_allowed(
-        actor.id,
-        patient.id,
-        actor.party_id.as_deref(),
-        patient.party_id.as_deref(),
-        actor.current_settlement_id.as_deref(),
-        patient.current_settlement_id.as_deref(),
-        actor_site.as_deref(),
-        patient_site.as_deref(),
-    );
+    let ordinary_relationship = actor.party_id.is_some()
+        && actor.party_id == patient.party_id
+        && actor.current_settlement_id.is_some()
+        && actor.current_settlement_id == patient.current_settlement_id;
     let contextual_relationship =
         crate::world_actor::contextual_interaction_is_authorized(ctx, actor_id, patient_id, true);
     let has_active_patient_context = ctx

--- a/crates/adventuresim-stdb-module/src/investigation/claims.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/claims.rs
@@ -1551,11 +1551,9 @@ pub fn discover_investigation_lead(
 }
 
 fn same_place(ctx: &ReducerContext, left: &crate::Character, right: &crate::Character) -> bool {
-    let left_site = character_case_site_id(ctx, left.id);
-    let right_site = character_case_site_id(ctx, right.id);
     (left.current_settlement_id.is_some()
         && left.current_settlement_id == right.current_settlement_id)
-        || (left_site.is_some() && left_site == right_site)
+        || crate::world_actor::characters_are_contextually_present(ctx, left.id, right.id)
 }
 
 #[reducer]

--- a/crates/adventuresim-stdb-module/src/investigation/model.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/model.rs
@@ -32,21 +32,43 @@ use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 const MAX_TEXT: usize = 512;
 
+/// SpacetimeDB transport for the opaque component of a canonical
+/// `StrategicPlaceId::CaseSite`. It has no independent identity semantics;
+/// consumers must cross the centralized conversion boundary below.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, SpacetimeType)]
 pub struct CaseSiteId {
     pub value: String,
 }
 
 impl CaseSiteId {
+    pub fn try_new(value: impl Into<String>) -> Result<Self, String> {
+        let value = value.into();
+        adventuresim_core::strategic_place::StrategicPlaceId::case_site(value.clone())
+            .map_err(|_| "Case-site identity is malformed")?;
+        Ok(Self { value })
+    }
+
     pub fn as_str(&self) -> &str {
         &self.value
+    }
+
+    pub(crate) fn to_place(
+        &self,
+    ) -> Option<adventuresim_core::strategic_place::StrategicPlaceId> {
+        adventuresim_core::strategic_place::StrategicPlaceId::case_site(self.value.clone()).ok()
     }
 }
 
 impl From<String> for CaseSiteId {
     fn from(value: String) -> Self {
-        Self { value }
+        Self::try_new(value).expect("server-authored case-site component must be canonical")
     }
+}
+
+pub(crate) fn canonical_case_site_place(
+    value: &str,
+) -> Option<adventuresim_core::strategic_place::StrategicPlaceId> {
+    CaseSiteId::try_new(value.to_owned()).ok()?.to_place()
 }
 
 impl std::ops::Deref for CaseSiteId {
@@ -1047,27 +1069,88 @@ pub struct PartyCaseSiteTracking {
 #[table(accessor = character_case_site_occupancy)]
 pub struct CharacterCaseSiteOccupancy {
     #[primary_key]
+    pub id: String,
+    #[index(btree)]
     pub character_id: u64,
     #[index(btree)]
     pub gateway_bucket: u8,
     pub case_site_id: CaseSiteId,
+    pub entered_at: u64,
+    pub left_at: Option<u64>,
+}
+
+pub(crate) fn current_character_case_site_occupancy(
+    ctx: &ReducerContext,
+    character_id: u64,
+) -> Option<CharacterCaseSiteOccupancy> {
+    let mut rows = ctx
+        .db
+        .character_case_site_occupancy()
+        .character_id()
+        .filter(character_id)
+        .filter(|row| row.left_at.is_none());
+    let row = rows.next()?;
+    rows.next().is_none().then_some(row)
+}
+
+pub(crate) fn character_case_site_occupancy_at(
+    ctx: &ReducerContext,
+    character_id: u64,
+    minute: u64,
+) -> Option<CharacterCaseSiteOccupancy> {
+    let mut rows = ctx
+        .db
+        .character_case_site_occupancy()
+        .character_id()
+        .filter(character_id)
+        .filter(|row| {
+            row.entered_at <= minute && row.left_at.is_none_or(|left_at| left_at > minute)
+        });
+    let row = rows.next()?;
+    rows.next().is_none().then_some(row)
 }
 
 pub(crate) fn character_case_site_id(ctx: &ReducerContext, character_id: u64) -> Option<String> {
-    ctx.db
-        .character_case_site_occupancy()
-        .character_id()
-        .find(character_id)
-        .map(|row| row.case_site_id.value)
+    current_character_case_site_occupancy(ctx, character_id).map(|row| row.case_site_id.value)
 }
 
 pub(crate) fn set_character_case_site(
     ctx: &ReducerContext,
     character_id: u64,
     case_site_id: Option<String>,
-) {
-    let previous_site = character_case_site_id(ctx, character_id);
-    if previous_site.as_deref() != case_site_id.as_deref()
+) -> Result<(), String> {
+    let case_site_id = match case_site_id {
+        Some(value) => match CaseSiteId::try_new(value) {
+            Ok(value) => Some(value),
+            Err(error) => return Err(error),
+        },
+        None => None,
+    };
+    let minute = ctx
+        .db
+        .character_time()
+        .character_id()
+        .find(character_id)
+        .map(|row| row.minutes)
+        .ok_or("Case-site transition requires CharacterTime authority")?;
+    let mut current_rows = ctx
+        .db
+        .character_case_site_occupancy()
+        .character_id()
+        .filter(character_id)
+        .filter(|row| row.left_at.is_none())
+        .collect::<Vec<_>>();
+    if current_rows.len() > 1 {
+        return Err("Character has conflicting active case-site occupancy".into());
+    }
+    let current = current_rows.pop();
+    let previous_site = current
+        .as_ref()
+        .map(|row| row.case_site_id.value.clone());
+    if previous_site.as_deref() == case_site_id.as_ref().map(CaseSiteId::as_str) {
+        return Ok(());
+    }
+    if previous_site.as_deref() != case_site_id.as_ref().map(CaseSiteId::as_str)
         && let Some(previous_site) = previous_site.as_deref()
     {
         for membership in ctx
@@ -1087,29 +1170,28 @@ pub(crate) fn set_character_case_site(
     crate::outbreak::record_case_site_presence_transition(
         ctx,
         character_id,
-        case_site_id.as_deref(),
+        case_site_id.as_ref().map(CaseSiteId::as_str),
     );
-    if ctx
-        .db
-        .character_case_site_occupancy()
-        .character_id()
-        .find(character_id)
-        .is_some()
-    {
-        ctx.db
-            .character_case_site_occupancy()
-            .character_id()
-            .delete(character_id);
+    if let Some(mut current) = current {
+        current.left_at = Some(minute);
+        ctx.db.character_case_site_occupancy().id().update(current);
     }
-    if let Some(value) = case_site_id {
+    if let Some(case_site_id) = case_site_id {
         ctx.db
             .character_case_site_occupancy()
             .insert(CharacterCaseSiteOccupancy {
+                id: format!(
+                    "case-occupancy:{character_id}:{minute}:{}",
+                    case_site_id.as_str()
+                ),
                 character_id,
                 gateway_bucket: 0,
-                case_site_id: CaseSiteId { value },
+                case_site_id,
+                entered_at: minute,
+                left_at: None,
             });
     }
+    Ok(())
 }
 
 #[derive(Clone, Debug)]

--- a/crates/adventuresim-stdb-module/src/investigation/projections.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/projections.rs
@@ -1546,7 +1546,9 @@ fn action_unavailable_reason_view(
             .id()
             .find(&party_id)
             .and_then(|party| party.current_case_site_id)
-            .is_some_and(|site| site.value == required_case_site_id);
+            .and_then(|site| site.to_place())
+            .zip(canonical_case_site_place(required_case_site_id))
+            .is_some_and(|(occupied, required)| occupied == required);
     let temporal_wait_minutes = projected_party_activity_minute(ctx, &party_id)
         .map_or(0, |started_at| {
             projected_night_window_wait_minutes(ctx, capability, started_at)

--- a/crates/adventuresim-stdb-module/src/investigation/sites.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/sites.rs
@@ -120,7 +120,11 @@ fn case_site_presentation_view(
         .manifest
         .sites
         .iter()
-        .find(|generated_site| generated_site.id.0 == site.id.value)?;
+        .find(|generated_site| {
+            canonical_case_site_place(&generated_site.id.0)
+                .zip(site.id.to_place())
+                .is_some_and(|(generated, persisted)| generated == persisted)
+        })?;
     if generated_site.safe_label != site.name {
         return None;
     }
@@ -204,7 +208,9 @@ fn lead_projects_exact_case_site_pin(
         )
         && (lead.case_id == site.case_id
             || generated_public_case_id.is_some_and(|public| lead.case_id == public))
-        && lead.exact_location_id == site.id.value
+        && canonical_case_site_place(&lead.exact_location_id)
+            .zip(site.id.to_place())
+            .is_some_and(|(lead_place, site_place)| lead_place == site_place)
         && lead.latitude_e7 == site.latitude_e7
         && lead.longitude_e7 == site.longitude_e7
 }
@@ -238,7 +244,7 @@ fn validated_case_site_aliases(
     }
 }
 
-fn case_site_provenance_view(
+pub(crate) fn case_site_provenance_view(
     ctx: &ViewContext,
     site: &CaseSiteAuthority,
 ) -> Option<Option<(String, String)>> {
@@ -307,6 +313,7 @@ pub fn backend_character_case_site_locations(
         .character_case_site_occupancy()
         .gateway_bucket()
         .filter(0u8)
+        .filter(|row| row.left_at.is_none())
         .map(|row| BackendCharacterCaseSiteLocation {
             character_id: row.character_id,
             case_site_id: row.case_site_id,
@@ -362,31 +369,138 @@ pub(crate) fn exact_case_site_for_observer(
     observer_character_id: u64,
     case_site_id: &str,
 ) -> Option<(CaseSiteAuthority, InvestigationLead)> {
+    exact_case_site_for_observer_at(ctx, observer_character_id, case_site_id, u64::MAX)
+}
+
+fn lead_temporally_live(recorded_at: u64, correction_recorded_at: Option<u64>, minute: u64) -> bool {
+    recorded_at <= minute && correction_recorded_at.is_none_or(|corrected_at| corrected_at > minute)
+}
+
+fn lead_is_live_at(ctx: &ReducerContext, lead: &InvestigationLead, minute: u64) -> bool {
+    if lead.corrected_by.is_empty() {
+        return lead_temporally_live(lead.recorded_at, None, minute);
+    }
+    let correction_recorded_at = ctx.db
+        .investigation_lead()
+        .id()
+        .find(&lead.corrected_by)
+        .filter(|correction| correction.owner_character_id == lead.owner_character_id)
+        .map(|correction| correction.recorded_at);
+    correction_recorded_at.is_some()
+        && lead_temporally_live(lead.recorded_at, correction_recorded_at, minute)
+}
+
+pub(crate) fn exact_case_site_for_observer_at(
+    ctx: &ReducerContext,
+    observer_character_id: u64,
+    case_site_id: &str,
+    minute: u64,
+) -> Option<(CaseSiteAuthority, InvestigationLead)> {
+    let requested_place = canonical_case_site_place(case_site_id)?;
     let site = ctx
         .db
         .case_site_authority()
         .id_key()
         .find(&case_site_id.to_string())?;
+    if site.id.to_place()? != requested_place {
+        return None;
+    }
     let generated_aliases = case_site_provenance_reducer(ctx, &site)?;
     ctx.db
         .investigation_lead()
         .owner_character_id()
         .filter(observer_character_id)
         .find(|lead| {
-            lead.exact_location_id == case_site_id
+            canonical_case_site_place(&lead.exact_location_id)
+                .is_some_and(|lead_place| lead_place == requested_place)
                 && (lead.case_id == site.case_id
                     || generated_aliases
                         .as_ref()
                         .is_some_and(|aliases| lead.case_id == aliases.1.as_str()))
                 && lead.latitude_e7 == site.latitude_e7
                 && lead.longitude_e7 == site.longitude_e7
-                && lead.corrected_by.is_empty()
+                && lead_is_live_at(ctx, lead, minute)
                 && matches!(
                     lead.destination_stage.as_str(),
                     "exact_believed" | "visited"
                 )
         })
         .map(|lead| (site, lead))
+}
+
+/// Observer-safe physical occupancy at one disclosed canonical case site.
+pub(crate) fn case_site_presence_for_observer(
+    ctx: &ReducerContext,
+    observer_character_id: u64,
+    character_id: u64,
+    minute: u64,
+) -> Option<adventuresim_core::strategic_presence::StrategicPresence> {
+    let occupancy = crate::investigation::character_case_site_occupancy_at(ctx, character_id, minute)?;
+    let place = occupancy.case_site_id.to_place()?;
+    let (site, _) = exact_case_site_for_observer_at(
+        ctx,
+        observer_character_id,
+        occupancy.case_site_id.as_str(),
+        minute,
+    )?;
+    if site.id.to_place()? != place {
+        return None;
+    }
+    adventuresim_core::strategic_presence::StrategicPresence::case_site_occupancy(
+        character_id,
+        place,
+        adventuresim_core::strategic_presence::PresenceFrontier {
+            observer_character_id,
+            personal_minute: minute,
+        },
+        true,
+        crate::relationship::character_alive_at(ctx, character_id, minute),
+    )
+    .ok()
+}
+
+/// Observer-safe contextual actor presence. The expected revision is supplied
+/// by the caller's live projection so stale contexts fail closed.
+pub(crate) fn case_context_presence_for_observer(
+    ctx: &ReducerContext,
+    observer_character_id: u64,
+    membership: &crate::world_actor::CharacterContextMembership,
+    expected_membership_id: &str,
+    expected_revision: u32,
+    minute: u64,
+) -> Option<adventuresim_core::strategic_presence::StrategicPresence> {
+    if !matches!(
+        membership.context_kind,
+        crate::world_actor::CharacterContextKind::CaseSite
+            | crate::world_actor::CharacterContextKind::HostileGroup
+    ) {
+        return None;
+    }
+    let place = canonical_case_site_place(&membership.location_id)?;
+    let (site, _) = exact_case_site_for_observer_at(
+        ctx,
+        observer_character_id,
+        &membership.location_id,
+        minute,
+    )?;
+    if site.id.to_place()? != place {
+        return None;
+    }
+    adventuresim_core::strategic_presence::StrategicPresence::case_context_membership(
+        membership.character_id,
+        place,
+        adventuresim_core::strategic_presence::PresenceFrontier {
+            observer_character_id,
+            personal_minute: minute,
+        },
+        crate::world_actor::context_membership_valid_at(membership, minute),
+        expected_membership_id,
+        membership.id.as_str(),
+        expected_revision,
+        membership.revision,
+        crate::relationship::character_alive_at(ctx, membership.character_id, minute),
+    )
+    .ok()
 }
 
 pub(crate) fn disclose_exact_case_site(
@@ -512,4 +626,21 @@ pub(crate) fn mark_case_site_visited(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod temporal_disclosure_tests {
+    use super::lead_temporally_live;
+
+    #[test]
+    fn future_disclosure_is_not_visible_at_an_earlier_frontier() {
+        assert!(!lead_temporally_live(101, None, 100));
+        assert!(lead_temporally_live(100, None, 100));
+    }
+
+    #[test]
+    fn correction_only_retires_a_lead_when_the_correction_reaches_the_frontier() {
+        assert!(lead_temporally_live(50, Some(101), 100));
+        assert!(!lead_temporally_live(50, Some(101), 101));
+    }
 }

--- a/crates/adventuresim-stdb-module/src/investigation/tests/sites_and_actions.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/tests/sites_and_actions.rs
@@ -405,7 +405,44 @@ fn corrected_exact_site_knowledge_is_not_live_action_support() {
     assert!(legacy_site_lookup.contains("observer_character_id: u64"));
     assert!(legacy_site_lookup.contains("case_site_id: &str"));
     assert!(legacy_site_lookup.contains("Option<(CaseSiteAuthority, InvestigationLead)>"));
+    assert!(legacy_site_lookup.contains("canonical_case_site_place(case_site_id)"));
+    assert!(legacy_site_lookup.contains("site.id.to_place()? != requested_place"));
     assert!(!legacy_site_lookup.contains("InvestigationActionCapability"));
+}
+
+#[test]
+fn case_site_transport_and_presence_adapters_fail_closed() {
+    assert!(CaseSiteId::try_new("case:valid").is_ok());
+    assert!(CaseSiteId::try_new("malformed case site").is_err());
+
+    let source = INVESTIGATION_SOURCE;
+    let occupancy = source
+        .split("pub(crate) fn case_site_presence_for_observer")
+        .nth(1)
+        .and_then(|tail| tail.split("pub(crate) fn case_context_presence_for_observer").next())
+        .expect("observer-safe case occupancy adapter");
+    assert!(occupancy.contains("exact_case_site_for_observer_at"));
+    assert!(occupancy.contains("character_case_site_occupancy_at"));
+    assert!(occupancy.contains("character_alive_at"));
+    let context = source
+        .split("pub(crate) fn case_context_presence_for_observer")
+        .nth(1)
+        .and_then(|tail| tail.split("pub(crate) fn disclose_exact_case_site").next())
+        .expect("observer-safe case context adapter");
+    assert!(context.contains("context_membership_valid_at"));
+    assert!(context.contains("expected_membership_id"));
+    assert!(context.contains("expected_revision"));
+    assert!(context.contains("membership.revision"));
+    assert!(context.contains("exact_case_site_for_observer_at"));
+
+    let transition = source
+        .split("pub(crate) fn set_character_case_site")
+        .nth(1)
+        .and_then(|tail| tail.split("pub struct InvestigationSharingReceipt").next())
+        .expect("case-site transition authority");
+    assert!(transition.contains("-> Result<(), String>"));
+    assert!(transition.contains("CaseSiteId::try_new"));
+    assert!(transition.contains("current.left_at = Some(minute)"));
 }
 
 #[test]

--- a/crates/adventuresim-stdb-module/src/outbreak.rs
+++ b/crates/adventuresim-stdb-module/src/outbreak.rs
@@ -3,6 +3,9 @@
 //! Canonical disease, source and remediation facts never cross a public view.
 
 use spacetimedb::{ReducerContext, Table, ViewContext, table};
+use std::str::FromStr;
+
+use adventuresim_core::strategic_place::{StrategicFixtureId, StrategicPlaceId};
 
 use crate::{
     character::{character, character_attributes, character_death},
@@ -11,7 +14,6 @@ use crate::{
     local_problem::{local_problem_receipt, local_problem_receipt__view},
     relationship::character_kinship,
     settlement_population::{settlement_resident_presence, settlement_resident_profile},
-    strategic::party_authority,
     time::character_time,
     world_actor::character_context_membership,
 };
@@ -31,8 +33,10 @@ pub struct OutbreakAuthority {
     pub transmission_route: String,
     pub source_kind: String,
     pub source_json: String,
-    pub physical_source_site_id: String,
-    pub patient_presentation_site_id: String,
+    /// Canonical `StrategicFixtureId::OutbreakSource` encoding.
+    pub physical_source_fixture_id: String,
+    /// Canonical `StrategicPlaceId::CaseSite` encoding.
+    pub patient_presentation_place_id: String,
     pub responsible_resident_character_id: Option<u64>,
     pub culpability: Option<String>,
     pub carrier_threat_id: Option<String>,
@@ -69,7 +73,8 @@ pub struct OutbreakSourcePresenceSpan {
     #[index(btree)]
     pub character_id: u64,
     #[index(btree)]
-    pub source_site_id: String,
+    /// Canonical `StrategicPlaceId::CaseSite` encoding.
+    pub source_place_id: String,
     pub started_at: u64,
     pub ended_at: Option<u64>,
 }
@@ -81,6 +86,7 @@ pub(crate) fn case_patient_visible_to_character_view(
     ctx: &ViewContext,
     character_id: u64,
     case_id: &str,
+    minute: u64,
 ) -> bool {
     let Some(authority) = ctx
         .db
@@ -97,13 +103,15 @@ pub(crate) fn case_patient_visible_to_character_view(
         .any(|receipt| {
             receipt.problem_id == authority.problem_id
                 && receipt.settlement_id == authority.settlement_id
+                && receipt.learned_at <= minute
         })
 }
 
-pub(crate) fn case_patient_visible_to_party(
+pub(crate) fn case_patient_visible_to_character(
     ctx: &ReducerContext,
-    party_id: &str,
+    character_id: u64,
     case_id: &str,
+    minute: u64,
 ) -> bool {
     let Some(authority) = ctx
         .db
@@ -113,16 +121,14 @@ pub(crate) fn case_patient_visible_to_party(
     else {
         return false;
     };
-    let Some(party) = ctx.db.party_authority().id().find(&party_id.to_owned()) else {
-        return false;
-    };
     ctx.db
         .local_problem_receipt()
         .character_id()
-        .filter(party.leader_id)
+        .filter(character_id)
         .any(|receipt| {
             receipt.problem_id == authority.problem_id
                 && receipt.settlement_id == authority.settlement_id
+                && receipt.learned_at <= minute
         })
 }
 
@@ -156,7 +162,7 @@ fn materialize_patient_corpse(
         ctx,
         exposure.patient_character_id,
         Some(outbreak.patient_presentation_site.0.clone()),
-    );
+    )?;
     let death_source_id = format!("outbreak-victim:{}", generated.canonical_case_id);
     if let Some(existing) = ctx
         .db
@@ -270,6 +276,20 @@ pub(crate) fn remediation_id(
         .ok_or("Outbreak has no exact remediation objective".into())
 }
 
+fn outbreak_source_fixture(case_id: &str, site_id: &str) -> Result<StrategicFixtureId, String> {
+    StrategicFixtureId::outbreak_source(
+        StrategicPlaceId::case_site(site_id.to_owned())
+            .map_err(|_| "Outbreak source case-site identity is malformed")?,
+        case_id.to_owned(),
+    )
+    .map_err(|_| "Outbreak source fixture identity is malformed".into())
+}
+
+fn parse_outbreak_source_fixture(value: &str, case_id: &str) -> Option<StrategicFixtureId> {
+    let fixture = StrategicFixtureId::from_str(value).ok()?;
+    (fixture.outbreak_id() == Some(case_id)).then_some(fixture)
+}
+
 pub(crate) fn materialize_generated_outbreak(
     ctx: &ReducerContext,
     generated: &adventuresim_core::quest_generation::GeneratedCase,
@@ -292,14 +312,32 @@ pub(crate) fn materialize_generated_outbreak(
         OutbreakSource::Environmental { .. } => ("environmental", None),
     };
     let responsible = outbreak.responsible_npc.as_ref();
+    let physical_source_fixture = outbreak_source_fixture(
+        &generated.canonical_case_id,
+        &outbreak.physical_source_site.0,
+    )?;
+    let patient_presentation_place =
+        StrategicPlaceId::case_site(outbreak.patient_presentation_site.0.clone())
+            .map_err(|_| "Outbreak patient case-site identity is malformed")?;
+    let disease_id = crate::disease::disease_key(outbreak.disease).to_string();
+    let transmission_route = format!("{:?}", outbreak.transmission_route).to_ascii_lowercase();
+    let source_json =
+        serde_json::to_string(&outbreak.source).map_err(|_| "Could not encode outbreak source")?;
+    let responsible_resident_character_id =
+        responsible.map(|value| value.resident_character_id.clone());
+    let culpability =
+        responsible.map(|value| format!("{:?}", value.culpability).to_ascii_lowercase());
+    let carrier_threat_id = carrier.map(str::to_owned);
+    let chronology_json = serde_json::to_string(&outbreak.exposure_chronology)
+        .map_err(|_| "Could not encode outbreak chronology")?;
+    let remediation_json = serde_json::to_string(&outbreak.remediation)
+        .map_err(|_| "Could not encode outbreak remediation")?;
     if let Some(existing) = ctx
         .db
         .outbreak_authority()
         .case_id()
         .find(&generated.canonical_case_id)
     {
-        let chronology_json = serde_json::to_string(&outbreak.exposure_chronology)
-            .map_err(|_| "Could not encode outbreak chronology")?;
         let exact_patients = outbreak.exposure_chronology.iter().all(|exposure| {
             ctx.db
                 .outbreak_patient_authority()
@@ -322,8 +360,18 @@ pub(crate) fn materialize_generated_outbreak(
         });
         return if existing.problem_id == generated.problem_id
             && existing.settlement_id == settlement_id
-            && existing.disease_id == crate::disease::disease_key(outbreak.disease)
+            && existing.disease_id == disease_id
+            && existing.transmission_route == transmission_route
+            && existing.source_kind == source_kind
+            && existing.source_json == source_json
+            && existing.physical_source_fixture_id == physical_source_fixture.to_string()
+            && existing.patient_presentation_place_id == patient_presentation_place.to_string()
+            && existing.responsible_resident_character_id == responsible_resident_character_id
+            && existing.culpability == culpability
+            && existing.carrier_threat_id == carrier_threat_id
             && existing.chronology_json == chronology_json
+            && existing.remediation_id == exact_remediation_id
+            && existing.remediation_json == remediation_json
             && exact_patients
         {
             Ok(())
@@ -344,23 +392,18 @@ pub(crate) fn materialize_generated_outbreak(
         case_id: generated.canonical_case_id.clone(),
         problem_id: generated.problem_id.clone(),
         settlement_id: settlement_id.into(),
-        disease_id: crate::disease::disease_key(outbreak.disease).into(),
-        transmission_route: format!("{:?}", outbreak.transmission_route).to_ascii_lowercase(),
+        disease_id,
+        transmission_route,
         source_kind: source_kind.into(),
-        source_json: serde_json::to_string(&outbreak.source)
-            .map_err(|_| "Could not encode outbreak source")?,
-        physical_source_site_id: outbreak.physical_source_site.0.clone(),
-        patient_presentation_site_id: outbreak.patient_presentation_site.0.clone(),
-        responsible_resident_character_id: responsible
-            .map(|value| value.resident_character_id.clone()),
-        culpability: responsible
-            .map(|value| format!("{:?}", value.culpability).to_ascii_lowercase()),
-        carrier_threat_id: carrier.map(str::to_owned),
-        chronology_json: serde_json::to_string(&outbreak.exposure_chronology)
-            .map_err(|_| "Could not encode outbreak chronology")?,
+        source_json,
+        physical_source_fixture_id: physical_source_fixture.to_string(),
+        patient_presentation_place_id: patient_presentation_place.to_string(),
+        responsible_resident_character_id,
+        culpability,
+        carrier_threat_id,
+        chronology_json,
         remediation_id: exact_remediation_id,
-        remediation_json: serde_json::to_string(&outbreak.remediation)
-            .map_err(|_| "Could not encode outbreak remediation")?,
+        remediation_json,
         remediated_at: None,
         remediated_by_party_id: None,
         remediation_source_id: None,
@@ -533,6 +576,13 @@ pub(crate) fn materialize_generated_outbreak(
             )
             .map_err(|_| "Outbreak patient ordinal exceeds its bounded roster")?,
             active: patient_active,
+            entered_at: exposure.became_symptomatic_at,
+            left_at: (!patient_active).then_some(
+                resolved_exposure
+                    .died_at
+                    .unwrap_or(course_end)
+                    .min(course_end),
+            ),
             revision: 1,
             treatment_consent: true,
         };
@@ -562,6 +612,9 @@ pub(crate) fn materialize_generated_outbreak(
                 || existing.character_id != membership.character_id
                 || existing.context_kind != membership.context_kind
                 || existing.role != membership.role
+                || existing.ordinal != membership.ordinal
+                || existing.entered_at != membership.entered_at
+                || existing.treatment_consent != membership.treatment_consent
             {
                 return Err("Outbreak Patient context provenance collision".into());
             }
@@ -618,8 +671,9 @@ pub(crate) fn commit_source_remediation(
         .case_id()
         .find(&case_id.to_owned())
         .ok_or("Outbreak authority not found")?;
+    let source_fixture = outbreak_source_fixture(case_id, source_site_id)?;
     if authority.remediation_id != remediation_id
-        || authority.physical_source_site_id != source_site_id
+        || authority.physical_source_fixture_id != source_fixture.to_string()
     {
         return Err("Intervention does not match the authoritative outbreak source".into());
     }
@@ -639,12 +693,12 @@ pub(crate) fn commit_source_remediation(
     authority.remediated_by_party_id = Some(party_id.into());
     authority.remediation_source_id = Some(source_id.into());
     ctx.db.outbreak_authority().case_id().update(authority);
-    deactivate_outbreak_patient_contexts(ctx, case_id);
+    deactivate_outbreak_patient_contexts(ctx, case_id, at_minute);
     Ok(())
 }
 
-fn deactivate_outbreak_patient_contexts(ctx: &ReducerContext, case_id: &str) {
-    crate::world_actor::deactivate_context_roster(ctx, case_id);
+fn deactivate_outbreak_patient_contexts(ctx: &ReducerContext, case_id: &str, at_minute: u64) {
+    crate::world_actor::deactivate_context_roster_at(ctx, case_id, at_minute);
     for mut patient in ctx
         .db
         .outbreak_patient_authority()
@@ -777,6 +831,8 @@ pub(crate) fn refresh_patient_context_after_time_write(
             .find(&membership_id)
         {
             membership.active = false;
+            membership.left_at = Some(minute.max(membership.entered_at));
+            membership.revision = membership.revision.saturating_add(1);
             ctx.db
                 .character_context_membership()
                 .id()
@@ -831,7 +887,7 @@ pub(crate) fn commit_carrier_remediation(
     authority.remediated_by_party_id = Some(party_id.into());
     authority.remediation_source_id = Some(source_id.into());
     ctx.db.outbreak_authority().case_id().update(authority);
-    deactivate_outbreak_patient_contexts(ctx, case_id);
+    deactivate_outbreak_patient_contexts(ctx, case_id, at_minute);
     Ok(())
 }
 
@@ -909,7 +965,13 @@ pub(crate) fn exposure_windows(
             .outbreak_source_presence_span()
             .character_id()
             .filter(character_id)
-            .filter(|span| span.source_site_id == authority.physical_source_site_id)
+            .filter(|span| {
+                parse_outbreak_source_fixture(
+                    &authority.physical_source_fixture_id,
+                    &authority.case_id,
+                )
+                .is_some_and(|fixture| fixture.place().to_string() == span.source_place_id)
+            })
             .filter_map(|span| {
                 let low = from.max(span.started_at);
                 let high = exposure_to.min(span.ended_at.unwrap_or(exposure_to));
@@ -945,8 +1007,14 @@ pub(crate) fn record_case_site_presence_transition(
     let Some(site_id) = destination_site_id else {
         return;
     };
+    let Some(destination_place) = crate::investigation::canonical_case_site_place(site_id) else {
+        return;
+    };
     if !ctx.db.outbreak_authority().iter().any(|authority| {
-        authority.physical_source_site_id == site_id && authority.remediated_at.is_none()
+        parse_outbreak_source_fixture(&authority.physical_source_fixture_id, &authority.case_id)
+            .is_some_and(|fixture| {
+                fixture.place() == &destination_place && authority.remediated_at.is_none()
+            })
     }) {
         return;
     }
@@ -963,7 +1031,7 @@ pub(crate) fn record_case_site_presence_transition(
             .insert(OutbreakSourcePresenceSpan {
                 id,
                 character_id,
-                source_site_id: site_id.into(),
+                source_place_id: destination_place.to_string(),
                 started_at: minute,
                 ended_at: None,
             });
@@ -1053,18 +1121,56 @@ mod tests {
         let production = source.split("#[cfg(test)]").next().unwrap();
         assert!(production.contains("case_patient_visible_to_character_view"));
         assert!(production.contains("local_problem_receipt()"));
+        assert!(production.contains("receipt.learned_at <= minute"));
+    }
+
+    #[test]
+    fn patient_problem_knowledge_is_frontier_bounded() {
+        let visible = |learned_at: u64, minute: u64| learned_at <= minute;
+        assert!(!visible(101, 100));
+        assert!(visible(100, 100));
     }
 
     #[test]
     fn remediation_is_exact_idempotent_and_uses_normal_outcome_authority() {
         let source = include_str!("outbreak.rs");
         assert!(source.contains("authority.remediation_id != remediation_id"));
-        assert!(source.contains("authority.physical_source_site_id != source_site_id"));
+        assert!(source.contains("physical_source_fixture_id != source_fixture.to_string()"));
+        assert!(source.contains("StrategicFixtureId::outbreak_source"));
+        assert!(source.contains("parse_outbreak_source_fixture"));
         assert!(source.contains("remediation_source_id.as_deref() == Some(source_id)"));
         let actions = include_str!("investigation/actions.rs");
         assert!(actions.contains("OutcomeFactKind::SourceRemediated"));
         let objectives = include_str!("strategic/custody_objectives.rs");
         assert!(objectives.contains("accepted_hostile_remediation"));
+    }
+
+    #[test]
+    fn generated_outbreak_retry_checks_every_immutable_authority_field() {
+        let source = include_str!("outbreak.rs");
+        let retry = source
+            .split("pub(crate) fn materialize_generated_outbreak")
+            .nth(1)
+            .and_then(|tail| tail.split("Generated outbreak provenance collision").next())
+            .expect("generated outbreak retry comparison");
+        for field in [
+            "problem_id",
+            "settlement_id",
+            "disease_id",
+            "transmission_route",
+            "source_kind",
+            "source_json",
+            "physical_source_fixture_id",
+            "patient_presentation_place_id",
+            "responsible_resident_character_id",
+            "culpability",
+            "carrier_threat_id",
+            "chronology_json",
+            "remediation_id",
+            "remediation_json",
+        ] {
+            assert!(retry.contains(field), "retry omitted {field}");
+        }
     }
 
     #[test]

--- a/crates/adventuresim-stdb-module/src/simulation.rs
+++ b/crates/adventuresim-stdb-module/src/simulation.rs
@@ -540,7 +540,7 @@ pub fn configure_simulation_character(
         return Err("Simulation character must still lead its fresh solo party".into());
     }
     character.current_settlement_id = Some(settlement_id.clone());
-    crate::investigation::set_character_case_site(ctx, character.id, None);
+    crate::investigation::set_character_case_site(ctx, character.id, None)?;
     ctx.db.character().id().update(character);
     solo_party.current_settlement_id = Some(settlement_id.clone());
     solo_party.current_case_site_id = None;

--- a/crates/adventuresim-stdb-module/src/social.rs
+++ b/crates/adventuresim-stdb-module/src/social.rs
@@ -2741,9 +2741,9 @@ fn validate_social_pair(
         return Err("Social actions require the same party".into());
     }
     if !is_self
-        && (actor.current_settlement_id != target.current_settlement_id
-            || crate::investigation::character_case_site_id(ctx, actor.id)
-                != crate::investigation::character_case_site_id(ctx, target.id))
+        && !(actor.current_settlement_id.is_some()
+            && actor.current_settlement_id == target.current_settlement_id
+            || crate::world_actor::characters_are_contextually_present(ctx, actor.id, target.id))
     {
         return Err("Characters must be co-located".into());
     }

--- a/crates/adventuresim-stdb-module/src/strategic/authority_model.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/authority_model.rs
@@ -225,7 +225,11 @@ pub fn backend_contracts(ctx: &ViewContext) -> Vec<BackendContract> {
                         .case_site_id_key()
                         .find(&site.id.value)
                         .filter(|group| {
-                            group.case_site_id_key == group.case_site_id.value
+                            crate::investigation::canonical_case_site_place(
+                                &group.case_site_id_key,
+                            )
+                            .zip(group.case_site_id.to_place())
+                            .is_some_and(|(key_place, typed_place)| key_place == typed_place)
                                 && group.case_site_id == site.id
                         })
                 })
@@ -1343,7 +1347,9 @@ fn materialize_hostile_group(
     if let Some(existing) = ctx.db.hostile_group_authority().id().find(&group.id) {
         return if existing.case_site_id == group.case_site_id
             && existing.case_site_id_key == group.case_site_id_key
-            && existing.case_site_id_key == existing.case_site_id.value
+            && crate::investigation::canonical_case_site_place(&existing.case_site_id_key)
+                .zip(existing.case_site_id.to_place())
+                .is_some_and(|(key_place, typed_place)| key_place == typed_place)
             && existing.enemy_type == group.enemy_type
             && existing.base_enemy_count == group.base_enemy_count
             && existing.base_difficulty == group.base_difficulty

--- a/crates/adventuresim-stdb-module/src/strategic/challenges.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/challenges.rs
@@ -2482,7 +2482,7 @@ fn materialize_order_errantry(
                 .find(member_id)
                 .ok_or("Party member not found")?;
             member.current_settlement_id = None;
-            crate::investigation::set_character_case_site(ctx, member_id, None);
+            crate::investigation::set_character_case_site(ctx, member_id, None)?;
             ctx.db.character().id().update(member);
         }
         bind_errantry_trials_to_current_camp(ctx, &party_id)?;

--- a/crates/adventuresim-stdb-module/src/strategic/contracts.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/contracts.rs
@@ -290,6 +290,9 @@ pub fn track_case_site(
     case_site_id: CaseSiteId,
 ) -> Result<(), String> {
     require_strategic_gateway(ctx)?;
+    case_site_id
+        .to_place()
+        .ok_or("Case-site identity is malformed")?;
     let character = crate::character::require_living_character(ctx, character_id)?;
     let party_id = character
         .party_id

--- a/crates/adventuresim-stdb-module/src/strategic/dialogue_effects.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/dialogue_effects.rs
@@ -532,11 +532,9 @@ fn apply_dialogue_investigation_action(
 }
 
 fn same_location(ctx: &ReducerContext, left: &crate::Character, right: &crate::Character) -> bool {
-    let left_site = crate::investigation::character_case_site_id(ctx, left.id);
-    let right_site = crate::investigation::character_case_site_id(ctx, right.id);
-    left.current_settlement_id == right.current_settlement_id
-        && left_site == right_site
-        && (left.current_settlement_id.is_some() || left_site.is_some())
+    (left.current_settlement_id.is_some()
+        && left.current_settlement_id == right.current_settlement_id)
+        || crate::world_actor::characters_are_contextually_present(ctx, left.id, right.id)
 }
 
 fn player_conversation_parties(

--- a/crates/adventuresim-stdb-module/src/strategic/governance.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/governance.rs
@@ -758,7 +758,7 @@ pub(crate) fn attach_seeded_party_member(
         ctx,
         member_id,
         crate::investigation::character_case_site_id(ctx, leader_id),
-    );
+    )?;
     crate::social::reset_familiarity_after_join(ctx, member_id);
     ctx.db.party_member().insert(PartyMember {
         id: 0,
@@ -1551,7 +1551,7 @@ pub fn accept_party_join_request(
                 ctx,
                 member.character_id,
                 party.current_case_site_id.clone().map(|id| id.value),
-            );
+            )?;
             crate::social::reset_familiarity_after_join(ctx, member.character_id);
         }
     }

--- a/crates/adventuresim-stdb-module/src/strategic/incidents.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/incidents.rs
@@ -121,7 +121,7 @@ fn create_strategic_incident(
                 ctx,
                 member.id,
                 Some(case_site_id.clone()),
-            );
+            )?;
             ctx.db.character().id().update(member);
         }
     }

--- a/crates/adventuresim-stdb-module/src/strategic/mission_bootstrap.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/mission_bootstrap.rs
@@ -517,7 +517,7 @@ pub fn seed_standalone_tactical_mission(
         ctx,
         character_id,
         Some(case_site.id.value.clone()),
-    );
+    )?;
     let capability_id = format!("mission-approach:standalone:{mission_id}");
     if ctx
         .db

--- a/crates/adventuresim-stdb-module/src/strategic/travel_reducers.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/travel_reducers.rs
@@ -5,6 +5,9 @@ pub fn travel_to_case_site(
     case_site_id: CaseSiteId,
 ) -> Result<(), String> {
     require_strategic_gateway(ctx)?;
+    case_site_id
+        .to_place()
+        .ok_or("Case-site identity is malformed")?;
     travel_to_case_site_impl(ctx, character_id, case_site_id.value, None)
 }
 
@@ -16,6 +19,9 @@ pub fn travel_to_case_site_planned(
     route: JourneyRoutePlan,
 ) -> Result<(), String> {
     require_strategic_gateway(ctx)?;
+    case_site_id
+        .to_place()
+        .ok_or("Case-site identity is malformed")?;
     travel_to_case_site_impl(ctx, character_id, case_site_id.value, Some(route))
 }
 
@@ -228,9 +234,7 @@ fn travel_to_case_site_impl(
         &party,
         origin_endpoint,
         JourneyEndpoint::CaseSite(JourneyCaseSiteEndpoint {
-            id: CaseSiteId {
-                value: site.id.value.clone(),
-            },
+            id: CaseSiteId::try_new(site.id.value.clone())?,
             name: site.name.clone(),
         }),
         travel_minutes,
@@ -274,7 +278,7 @@ fn travel_to_case_site_impl(
                 .find(member_id)
                 .ok_or("Party member not found")?;
             member.current_settlement_id = None;
-            crate::investigation::set_character_case_site(ctx, member.id, None);
+            crate::investigation::set_character_case_site(ctx, member.id, None)?;
             ctx.db.character().id().update(member);
         }
         set_party_journey_state(
@@ -306,7 +310,7 @@ fn travel_to_case_site_impl(
                 ctx,
                 member.id,
                 Some(case_site_id.clone()),
-            );
+            )?;
             ctx.db.character().id().update(member);
             mark_case_site_visited(ctx, member_id, &site)?;
         }
@@ -512,9 +516,7 @@ fn travel_to_settlement_impl(
                     name: origin_name.clone(),
                 }),
                 "case_site" => JourneyEndpoint::CaseSite(JourneyCaseSiteEndpoint {
-                    id: CaseSiteId {
-                        value: origin_id.clone(),
-                    },
+                    id: CaseSiteId::try_new(origin_id.clone())?,
                     name: origin_name.clone(),
                 }),
                 _ => return Err("Journey origin kind is invalid".into()),
@@ -573,7 +575,7 @@ fn travel_to_settlement_impl(
                     .find(traveler_id)
                     .ok_or("Party member not found")?;
                 traveler.current_settlement_id = None;
-                crate::investigation::set_character_case_site(ctx, traveler.id, None);
+                crate::investigation::set_character_case_site(ctx, traveler.id, None)?;
                 ctx.db.character().id().update(traveler);
             }
             let party = party.as_mut().expect("party was just reloaded");
@@ -611,7 +613,7 @@ fn travel_to_settlement_impl(
             .find(traveler_id)
             .ok_or("Party member not found")?;
         traveler.current_settlement_id = Some(settlement_id.clone());
-        crate::investigation::set_character_case_site(ctx, traveler.id, None);
+        crate::investigation::set_character_case_site(ctx, traveler.id, None)?;
         ctx.db.character().id().update(traveler);
         crate::condition::replenish_needs_at_settlement(ctx, traveler_id)?;
         crate::condition::refresh_character_strategic_condition(ctx, traveler_id)?;
@@ -852,7 +854,7 @@ pub fn continue_camp_travel(ctx: &ReducerContext, character_id: u64) -> Result<(
                     .find(member_id)
                     .ok_or("Party member not found")?;
                 member.current_settlement_id = Some(destination_id.clone());
-                crate::investigation::set_character_case_site(ctx, member.id, None);
+                crate::investigation::set_character_case_site(ctx, member.id, None)?;
                 ctx.db.character().id().update(member);
                 crate::condition::replenish_needs_at_settlement(ctx, member_id)?;
                 crate::condition::refresh_character_strategic_condition(ctx, member_id)?;
@@ -884,7 +886,7 @@ pub fn continue_camp_travel(ctx: &ReducerContext, character_id: u64) -> Result<(
                     ctx,
                     member.id,
                     Some(destination_id.clone()),
-                );
+                )?;
                 ctx.db.character().id().update(member);
                 mark_case_site_visited(ctx, member_id, &site)?;
                 crate::condition::refresh_character_strategic_condition(ctx, member_id)?;

--- a/crates/adventuresim-stdb-module/src/surgery.rs
+++ b/crates/adventuresim-stdb-module/src/surgery.rs
@@ -821,11 +821,8 @@ fn infection_control_check(ctx: &ReducerContext, actor_id: u64, surgical_skill: 
 fn require_together(ctx: &ReducerContext, actor_id: u64, patient_id: u64) -> Result<(), String> {
     let actor = crate::require_living_character(ctx, actor_id)?;
     let patient = crate::require_living_character(ctx, patient_id)?;
-    let actor_site = crate::investigation::character_case_site_id(ctx, actor.id);
-    let patient_site = crate::investigation::character_case_site_id(ctx, patient.id);
     let same_place = actor.current_settlement_id.is_some()
         && actor.current_settlement_id == patient.current_settlement_id
-        || actor_site.is_some() && actor_site == patient_site
         || crate::world_actor::characters_are_contextually_present(ctx, actor_id, patient_id);
     if !same_place {
         return Err("Surgeon and patient must be together".into());

--- a/crates/adventuresim-stdb-module/src/time.rs
+++ b/crates/adventuresim-stdb-module/src/time.rs
@@ -15,7 +15,7 @@ use crate::capability::StrategicEquipment;
 use crate::character::character;
 use crate::condition::{character_condition as _, character_strategic_condition as _};
 use crate::disease::character_illness_status as _;
-use crate::investigation::{case_site_authority as _, character_case_site_occupancy as _};
+use crate::investigation::case_site_authority as _;
 use crate::organization::organization_membership as _;
 use crate::personality::{
     Sociability as CharacterSociability, Transparency as CharacterTransparency,
@@ -176,11 +176,8 @@ fn activity_execution_location(
             origin_settlement_id: Some(settlement_id),
         });
     }
-    if let Some(occupancy) = ctx
-        .db
-        .character_case_site_occupancy()
-        .character_id()
-        .find(character_id)
+    if let Some(occupancy) =
+        crate::investigation::current_character_case_site_occupancy(ctx, character_id)
     {
         let site = ctx
             .db
@@ -803,7 +800,6 @@ pub fn synchronize_party_for_activity(ctx: &ReducerContext, leader_id: u64) -> R
     if member_ids.is_empty() || !member_ids.contains(&leader_id) {
         return Err("Party has no living leader for activity synchronization".into());
     }
-    let leader_case_site = crate::investigation::character_case_site_id(ctx, leader_id);
     for member_id in &member_ids {
         let member = ctx
             .db
@@ -811,10 +807,14 @@ pub fn synchronize_party_for_activity(ctx: &ReducerContext, leader_id: u64) -> R
             .id()
             .find(*member_id)
             .ok_or("Party member not found")?;
+        let together_at_settlement = leader.current_settlement_id.is_some()
+            && member.current_settlement_id == leader.current_settlement_id
+            && member.current_settlement_id == party.current_settlement_id;
         if member.party_id.as_deref() != Some(party_id.as_str())
-            || member.current_settlement_id != leader.current_settlement_id
-            || member.current_settlement_id != party.current_settlement_id
-            || crate::investigation::character_case_site_id(ctx, *member_id) != leader_case_site
+            || !(together_at_settlement
+                || crate::world_actor::characters_are_contextually_present(
+                    ctx, leader_id, *member_id,
+                ))
         {
             return Err("Party members must be co-located before activity synchronization".into());
         }

--- a/crates/adventuresim-stdb-module/src/world_actor.rs
+++ b/crates/adventuresim-stdb-module/src/world_actor.rs
@@ -3,15 +3,23 @@
 use spacetimedb::{ReducerContext, SpacetimeType, Table, ViewContext, reducer, table, view};
 
 use crate::{
-    character::{character, character__view},
+    character::{character, character__view, character_death__view},
     condition::character_strategic_condition,
-    investigation::character_case_site_id,
+    investigation::{
+        canonical_case_site_place, case_context_presence_for_observer, case_site_authority__view,
+        case_site_presence_for_observer, case_site_provenance_view,
+        character_case_site_occupancy__view, investigation_lead__view,
+    },
+    relationship::character_birth__view,
     strategic::{
-        hostile_group_authority, party_authority, party_authority__view, road_challenge_authority,
+        party_authority, party_authority__view, road_challenge_authority,
         road_challenge_authority__view, strategic_encounter, strategic_encounter__view,
         strategic_gateway_authority__view,
     },
+    time::{character_time, character_time__view},
 };
+
+const EXACT_CASE_CONTEXT_CONTACT_REF: &str = "exact_case_context";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, SpacetimeType)]
 pub enum CharacterContextKind {
@@ -45,6 +53,8 @@ pub struct CharacterContextMembership {
     pub role: CharacterContextRole,
     pub ordinal: u16,
     pub active: bool,
+    pub entered_at: u64,
+    pub left_at: Option<u64>,
     pub revision: u32,
     /// Explicit permission for ordinary medical treatment. Incapacitation is
     /// evaluated live and is not copied into this authority.
@@ -54,8 +64,9 @@ pub struct CharacterContextMembership {
 #[derive(Clone, Debug, SpacetimeType)]
 pub struct BackendContextCharacter {
     pub party_id: String,
-    /// Public encounter ID for random encounters, or the already-visible case
-    /// site / road-challenge ID. Private hostile-group IDs never cross this view.
+    /// Public encounter/road-challenge ID, or the fixed action/context
+    /// discriminator for case-site and hostile actors. Private case and
+    /// hostile-group IDs never cross this view.
     pub contact_ref: String,
     pub context_kind: CharacterContextKind,
     pub location_id: String,
@@ -115,30 +126,72 @@ pub fn backend_context_characters(ctx: &ViewContext) -> Vec<BackendContextCharac
         .character_context_membership()
         .character_id()
         .filter(0u64..)
-        .filter(|row| row.active)
     {
+        if !context_membership_interval_is_well_formed(&row) {
+            continue;
+        }
+        if !matches!(
+            row.context_kind,
+            CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup
+        ) && !row.active
+        {
+            continue;
+        }
         let Some(character) = ctx.db.character().id().find(row.character_id) else {
             continue;
         };
         let parties = match row.context_kind {
-            CharacterContextKind::CaseSite => ctx
+            CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup => ctx
                 .db
                 .party_authority()
                 .gateway_bucket()
                 .filter(0u8)
                 .filter(|party| {
-                    party
-                        .current_case_site_id
-                        .as_ref()
-                        .is_some_and(|site| site.value == row.location_id)
-                        && (row.role != CharacterContextRole::Patient
-                            || crate::outbreak::case_patient_visible_to_character_view(
-                                ctx,
-                                party.leader_id,
-                                &row.context_id,
-                            ))
+                    ctx.db
+                        .character_time()
+                        .character_id()
+                        .find(party.leader_id)
+                        .is_some_and(|time| {
+                            context_membership_valid_at(&row, time.minutes)
+                                && character_case_site_occupancy_at_view(
+                                    ctx,
+                                    party.leader_id,
+                                    time.minutes,
+                                )
+                                .and_then(|occupancy| occupancy.case_site_id.to_place())
+                                .zip(canonical_case_site_place(&row.location_id))
+                                .is_some_and(
+                                    |(party_place, context_place)| party_place == context_place,
+                                )
+                                && exact_case_site_visible_to_observer_view(
+                                    ctx,
+                                    party.leader_id,
+                                    &row.location_id,
+                                    time.minutes,
+                                )
+                                && (row.role != CharacterContextRole::Patient
+                                    || crate::outbreak::case_patient_visible_to_character_view(
+                                        ctx,
+                                        party.leader_id,
+                                        &row.context_id,
+                                        time.minutes,
+                                    ))
+                        })
                 })
-                .map(|party| (party.id, row.location_id.clone()))
+                .filter_map(|party| {
+                    let minute = ctx
+                        .db
+                        .character_time()
+                        .character_id()
+                        .find(party.leader_id)?
+                        .minutes;
+                    let party_id = party.id;
+                    Some((
+                        party_id,
+                        EXACT_CASE_CONTEXT_CONTACT_REF.to_string(),
+                        character_alive_at_for_view(ctx, row.character_id, minute),
+                    ))
+                })
                 .collect(),
             CharacterContextKind::StrategicEncounter => ctx
                 .db
@@ -154,52 +207,47 @@ pub fn backend_context_characters(ctx: &ViewContext) -> Vec<BackendContextCharac
                             encounter.encounter_id == row.context_id
                                 && encounter.status == "awaiting_choice"
                         })
-                        .map(|encounter| (encounter.party_id, row.context_id.clone()))
+                        .map(|encounter| {
+                            (encounter.party_id, row.context_id.clone(), character.alive)
+                        })
                 })
                 .collect::<Vec<_>>(),
-            CharacterContextKind::HostileGroup => ctx
-                .db
-                .party_authority()
-                .gateway_bucket()
-                .filter(0u8)
-                .filter(|party| {
-                    party
-                        .current_case_site_id
-                        .as_ref()
-                        .is_some_and(|site| site.value == row.location_id)
-                })
-                .map(|party| (party.id, row.location_id.clone()))
-                .collect(),
             CharacterContextKind::RoadEncounter => ctx
                 .db
                 .road_challenge_authority()
                 .gateway_bucket()
                 .filter(0u8)
                 .filter(|challenge| challenge.id == row.context_id && challenge.open)
-                .map(|challenge| (challenge.party_id, challenge.id))
+                .map(|challenge| (challenge.party_id, challenge.id, character.alive))
                 .collect(),
         };
-        for (party_id, contact_ref) in parties {
+        for (party_id, contact_ref, alive_at_frontier) in parties {
             let contact_id = party_context_contact_id(&party_id, &row.context_id);
-            let revision = ctx
-                .db
-                .party_context_contact_authority()
-                .id()
-                .find(&contact_id)
-                .map_or_else(
-                    || {
-                        if row.context_kind == CharacterContextKind::StrategicEncounter {
-                            ctx.db
-                                .strategic_encounter()
-                                .party_id()
-                                .find(&party_id)
-                                .map_or(row.revision, |encounter| encounter.revision)
-                        } else {
-                            1
-                        }
-                    },
-                    |contact| contact.revision,
-                );
+            let revision = if matches!(
+                row.context_kind,
+                CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup
+            ) {
+                row.revision
+            } else {
+                ctx.db
+                    .party_context_contact_authority()
+                    .id()
+                    .find(&contact_id)
+                    .map_or_else(
+                        || {
+                            if row.context_kind == CharacterContextKind::StrategicEncounter {
+                                ctx.db
+                                    .strategic_encounter()
+                                    .party_id()
+                                    .find(&party_id)
+                                    .map_or(row.revision, |encounter| encounter.revision)
+                            } else {
+                                1
+                            }
+                        },
+                        |contact| contact.revision,
+                    )
+            };
             result.push(BackendContextCharacter {
                 party_id,
                 contact_ref,
@@ -208,7 +256,7 @@ pub fn backend_context_characters(ctx: &ViewContext) -> Vec<BackendContextCharac
                 character_id: row.character_id,
                 role: row.role,
                 ordinal: row.ordinal,
-                alive: character.alive,
+                alive: alive_at_frontier,
                 revision,
                 treatment_consent: row.treatment_consent,
             });
@@ -255,7 +303,7 @@ pub(crate) fn context_members(
         .character_context_membership()
         .context_id()
         .filter(&context_id.to_string())
-        .filter(|row| row.active)
+        .filter(|row| context_membership_interval_is_well_formed(row) && row.active)
         .collect::<Vec<_>>();
     rows.sort_by_key(|row| row.ordinal);
     rows
@@ -289,6 +337,7 @@ pub(crate) fn materialize_context_roster(
     archetype: &str,
     count: u32,
 ) -> Result<Vec<u64>, String> {
+    let entered_at = crate::time::refresh_clock(ctx)?;
     let expected = count.min(u32::from(u16::MAX));
     let existing = context_members(ctx, context_id);
     if !existing.is_empty() {
@@ -331,6 +380,8 @@ pub(crate) fn materialize_context_roster(
                 role: CharacterContextRole::Counterparty,
                 ordinal,
                 active: true,
+                entered_at,
+                left_at: None,
                 revision: 1,
                 treatment_consent: false,
             });
@@ -348,6 +399,7 @@ pub(crate) fn rebind_road_cast_to_strategic_encounter(
     archetype: &str,
     count: u32,
 ) -> Result<Vec<u64>, String> {
+    let entered_at = crate::time::refresh_clock(ctx)?;
     let mut eligible = context_members(ctx, road_context_id)
         .into_iter()
         .filter(|membership| {
@@ -376,6 +428,8 @@ pub(crate) fn rebind_road_cast_to_strategic_encounter(
             role: CharacterContextRole::Counterparty,
             ordinal,
             active: true,
+            entered_at,
+            left_at: None,
             revision: 1,
             treatment_consent: false,
         };
@@ -409,12 +463,156 @@ fn title_case(value: &str) -> String {
         .unwrap_or_else(|| "Unknown".into())
 }
 
-pub(crate) fn deactivate_context_roster(ctx: &ReducerContext, context_id: &str) {
+fn context_interval_is_well_formed(active: bool, entered_at: u64, left_at: Option<u64>) -> bool {
+    active == left_at.is_none() && left_at.is_none_or(|left_at| left_at >= entered_at)
+}
+
+pub(crate) fn context_membership_interval_is_well_formed(row: &CharacterContextMembership) -> bool {
+    context_interval_is_well_formed(row.active, row.entered_at, row.left_at)
+}
+
+pub(crate) fn context_membership_valid_at(row: &CharacterContextMembership, minute: u64) -> bool {
+    context_membership_interval_is_well_formed(row)
+        && row.entered_at <= minute
+        && row.left_at.is_none_or(|left_at| minute < left_at)
+}
+
+fn exact_context_claim_matches(
+    kind: CharacterContextKind,
+    contact_ref: &str,
+    expected_revision: u32,
+    actual_revision: u32,
+) -> bool {
+    matches!(
+        kind,
+        CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup
+    ) && contact_ref == EXACT_CASE_CONTEXT_CONTACT_REF
+        && expected_revision == actual_revision
+}
+
+fn exactly_one<T>(mut values: impl Iterator<Item = T>) -> Option<T> {
+    let value = values.next()?;
+    values.next().is_none().then_some(value)
+}
+
+fn projected_case_context_claim(
+    ctx: &ReducerContext,
+    observer_character_id: u64,
+    membership: &CharacterContextMembership,
+    minute: u64,
+) -> Option<(String, u32)> {
+    context_membership_valid_at(membership, minute)
+        .then(|| (membership.id.clone(), membership.revision))
+        .filter(|_| {
+            crate::investigation::exact_case_site_for_observer_at(
+                ctx,
+                observer_character_id,
+                &membership.location_id,
+                minute,
+            )
+            .is_some()
+        })
+}
+
+fn character_case_site_occupancy_at_view(
+    ctx: &ViewContext,
+    character_id: u64,
+    minute: u64,
+) -> Option<crate::investigation::CharacterCaseSiteOccupancy> {
+    let mut rows = ctx
+        .db
+        .character_case_site_occupancy()
+        .character_id()
+        .filter(character_id)
+        .filter(|row| row.entered_at <= minute && row.left_at.is_none_or(|left| minute < left));
+    let row = rows.next()?;
+    rows.next().is_none().then_some(row)
+}
+
+fn character_alive_at_for_view(ctx: &ViewContext, character_id: u64, minute: u64) -> bool {
+    ctx.db.character().id().find(character_id).is_some()
+        && ctx
+            .db
+            .character_birth()
+            .character_id()
+            .find(character_id)
+            .is_none_or(|birth| i128::from(birth.birth_minute) <= i128::from(minute))
+        && ctx
+            .db
+            .character_death()
+            .character_id()
+            .find(character_id)
+            .is_none_or(|death| death.strategic_minute > minute)
+}
+
+fn exact_case_site_visible_to_observer_view(
+    ctx: &ViewContext,
+    observer_character_id: u64,
+    case_site_id: &str,
+    minute: u64,
+) -> bool {
+    let Some(place) = canonical_case_site_place(case_site_id) else {
+        return false;
+    };
+    let Some(site) = ctx
+        .db
+        .case_site_authority()
+        .id_key()
+        .find(&case_site_id.to_owned())
+    else {
+        return false;
+    };
+    if site.id.to_place().as_ref() != Some(&place) {
+        return false;
+    }
+    let Some(generated_aliases) = case_site_provenance_view(ctx, &site) else {
+        return false;
+    };
+    ctx.db
+        .investigation_lead()
+        .owner_character_id()
+        .filter(observer_character_id)
+        .any(|lead| {
+            lead.recorded_at <= minute
+                && canonical_case_site_place(&lead.exact_location_id).as_ref() == Some(&place)
+                && (lead.case_id == site.case_id
+                    || generated_aliases
+                        .as_ref()
+                        .is_some_and(|aliases| lead.case_id == aliases.1.as_str()))
+                && lead.latitude_e7 == site.latitude_e7
+                && lead.longitude_e7 == site.longitude_e7
+                && matches!(
+                    lead.destination_stage.as_str(),
+                    "exact_believed" | "visited"
+                )
+                && (lead.corrected_by.is_empty()
+                    || ctx
+                        .db
+                        .investigation_lead()
+                        .id()
+                        .find(&lead.corrected_by)
+                        .is_some_and(|correction| {
+                            correction.owner_character_id == lead.owner_character_id
+                                && correction.recorded_at > minute
+                        }))
+        })
+}
+
+pub(crate) fn deactivate_context_roster_at(ctx: &ReducerContext, context_id: &str, minute: u64) {
     for mut row in context_members(ctx, context_id) {
+        if !row.active {
+            continue;
+        }
         row.active = false;
+        row.left_at = Some(minute.max(row.entered_at));
         row.revision = row.revision.saturating_add(1);
         ctx.db.character_context_membership().id().update(row);
     }
+}
+
+pub(crate) fn deactivate_context_roster(ctx: &ReducerContext, context_id: &str) {
+    let minute = crate::time::refresh_clock(ctx).unwrap_or(0);
+    deactivate_context_roster_at(ctx, context_id, minute);
 }
 
 /// Materialize every individualized mortal in a compiled road cast as an
@@ -461,6 +659,7 @@ pub(crate) fn materialize_road_encounter_cast(
                     || membership.context_kind != CharacterContextKind::RoadEncounter
                     || membership.role != expected_role
                     || membership.ordinal != ordinal
+                    || !context_membership_interval_is_well_formed(&membership)
                     || !membership.active
                     || membership.treatment_consent != *treatment_consent
                     || character.name != speaker.name
@@ -495,6 +694,8 @@ pub(crate) fn materialize_road_encounter_cast(
                 role: expected_role,
                 ordinal,
                 active: true,
+                entered_at: absolute_minute,
+                left_at: None,
                 revision: 1,
                 treatment_consent: *treatment_consent,
             });
@@ -528,24 +729,66 @@ pub(crate) fn characters_are_contextually_present(
     {
         return true;
     }
-    let actor_site = character_case_site_id(ctx, actor_id);
-    if actor_site.is_some() && actor_site == character_case_site_id(ctx, target_id) {
+    let actor_minute = ctx
+        .db
+        .character_time()
+        .character_id()
+        .find(actor_id)
+        .map(|row| row.minutes);
+    let actor_case_presence = actor_minute.and_then(|minute| {
+        case_site_presence_for_observer(ctx, actor_id, actor_id, minute)
+            .map(|presence| (presence, minute))
+    });
+    if let Some((actor_presence, minute)) = actor_case_presence.as_ref()
+        && case_site_presence_for_observer(ctx, actor_id, target_id, *minute).is_some_and(
+            |target_presence| {
+                adventuresim_core::strategic_presence::are_co_present(
+                    actor_presence,
+                    &target_presence,
+                )
+            },
+        )
+    {
         return true;
     }
     ctx.db
         .character_context_membership()
         .character_id()
         .filter(target_id)
-        .filter(|row| row.active)
+        .filter(|row| {
+            context_membership_interval_is_well_formed(row)
+                && (row.active
+                    || matches!(
+                        row.context_kind,
+                        CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup
+                    ))
+        })
         .any(|row| match row.context_kind {
-            CharacterContextKind::CaseSite => actor_site.as_ref() == Some(&row.location_id),
-            CharacterContextKind::HostileGroup => actor_site.as_ref().is_some_and(|site| {
-                ctx.db
-                    .hostile_group_authority()
-                    .id()
-                    .find(&row.context_id)
-                    .is_some_and(|group| group.case_site_id.value == *site)
-            }),
+            CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup => {
+                actor_case_presence
+                    .as_ref()
+                    .is_some_and(|(actor_presence, minute)| {
+                        let Some((projected_id, projected_revision)) =
+                            projected_case_context_claim(ctx, actor_id, &row, *minute)
+                        else {
+                            return false;
+                        };
+                        case_context_presence_for_observer(
+                            ctx,
+                            actor_id,
+                            &row,
+                            &projected_id,
+                            projected_revision,
+                            *minute,
+                        )
+                        .is_some_and(|target_presence| {
+                            adventuresim_core::strategic_presence::are_co_present(
+                                actor_presence,
+                                &target_presence,
+                            )
+                        })
+                    })
+            }
             CharacterContextKind::StrategicEncounter => {
                 actor.party_id.as_ref().is_some_and(|party_id| {
                     ctx.db
@@ -594,20 +837,39 @@ pub(crate) fn contextual_interaction_is_authorized(
     let Some(party_id) = actor.party_id.as_deref() else {
         return false;
     };
+    let Some(actor_minute) = ctx
+        .db
+        .character_time()
+        .character_id()
+        .find(actor_id)
+        .map(|row| row.minutes)
+    else {
+        return false;
+    };
     ctx.db
         .character_context_membership()
         .character_id()
         .filter(target_id)
-        .filter(|row| row.active)
+        .filter(|row| {
+            if matches!(
+                row.context_kind,
+                CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup
+            ) {
+                context_membership_valid_at(row, actor_minute)
+            } else {
+                context_membership_interval_is_well_formed(row) && row.active
+            }
+        })
         .any(|row| {
             (!require_treatment_consent || row.treatment_consent)
                 && characters_are_contextually_present(ctx, actor_id, target_id)
                 && match row.context_kind {
                     CharacterContextKind::CaseSite => {
-                        crate::outbreak::case_patient_visible_to_party(
+                        crate::outbreak::case_patient_visible_to_character(
                             ctx,
-                            party_id,
+                            actor_id,
                             &row.context_id,
+                            actor_minute,
                         )
                     }
                     CharacterContextKind::RoadEncounter => ctx
@@ -690,21 +952,70 @@ pub fn contact_context_character(
         .find(actor_id)
         .ok_or("Contact actor does not exist")?;
     let party_id = actor.party_id.ok_or("Contact requires an active party")?;
-    let membership = ctx
+    let actor_minute = ctx
+        .db
+        .character_time()
+        .character_id()
+        .find(actor_id)
+        .ok_or("Contact actor has no personal time")?
+        .minutes;
+    let actor_case_presence =
+        case_site_presence_for_observer(ctx, actor_id, actor_id, actor_minute);
+    let candidates = ctx
         .db
         .character_context_membership()
         .character_id()
         .filter(target_id)
-        .find(|row| {
-            row.active
-                && match row.context_kind {
-                    CharacterContextKind::StrategicEncounter => row.context_id == contact_ref,
-                    CharacterContextKind::HostileGroup
-                    | CharacterContextKind::CaseSite
-                    | CharacterContextKind::RoadEncounter => row.location_id == contact_ref,
+        .filter(|row| {
+            (if matches!(
+                row.context_kind,
+                CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup
+            ) {
+                context_membership_valid_at(row, actor_minute)
+            } else {
+                context_membership_interval_is_well_formed(row) && row.active
+            }) && match row.context_kind {
+                CharacterContextKind::StrategicEncounter => row.context_id == contact_ref,
+                CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup => {
+                    exact_context_claim_matches(
+                        row.context_kind,
+                        &contact_ref,
+                        expected_revision,
+                        row.revision,
+                    ) && actor_case_presence.as_ref().is_some_and(|actor_presence| {
+                        case_context_presence_for_observer(
+                            ctx,
+                            actor_id,
+                            row,
+                            &row.id,
+                            expected_revision,
+                            actor_minute,
+                        )
+                        .is_some_and(|target_presence| {
+                            adventuresim_core::strategic_presence::are_co_present(
+                                actor_presence,
+                                &target_presence,
+                            )
+                        })
+                    })
                 }
+                CharacterContextKind::RoadEncounter => row.location_id == contact_ref,
+            }
         })
-        .ok_or("Target is not present in that context")?;
+        .collect::<Vec<_>>();
+    let membership = exactly_one(candidates.into_iter())
+        .ok_or("Target context claim is unavailable or ambiguous")?;
+    if membership.context_kind == CharacterContextKind::CaseSite
+        && membership.role == CharacterContextRole::Patient
+        && !crate::outbreak::case_patient_visible_to_character(
+            ctx,
+            actor_id,
+            &membership.context_id,
+            actor_minute,
+        )
+    {
+        return Err("Patient context is not visible at the actor frontier".into());
+    }
     if !contextual_interaction_is_authorized(ctx, actor_id, target_id, false) {
         return Err("Target is not an authorized co-present Character".into());
     }
@@ -729,10 +1040,17 @@ pub fn contact_context_character(
         .party_context_contact_authority()
         .id()
         .find(&contact_id);
-    let current_revision = existing_contact.as_ref().map_or_else(
-        || encounter.as_ref().map_or(1, |encounter| encounter.revision),
-        |contact| contact.revision,
-    );
+    let current_revision = if matches!(
+        membership.context_kind,
+        CharacterContextKind::CaseSite | CharacterContextKind::HostileGroup
+    ) {
+        membership.revision
+    } else {
+        existing_contact.as_ref().map_or_else(
+            || encounter.as_ref().map_or(1, |encounter| encounter.revision),
+            |contact| contact.revision,
+        )
+    };
     if current_revision != expected_revision {
         return Err("Context contact revision is stale".into());
     }
@@ -790,6 +1108,55 @@ pub fn contact_context_character(
 
 #[cfg(test)]
 mod tests {
+    use super::{
+        CharacterContextKind, EXACT_CASE_CONTEXT_CONTACT_REF, context_interval_is_well_formed,
+        exact_context_claim_matches, exactly_one,
+    };
+
+    #[test]
+    fn context_intervals_reject_malformed_active_and_chronology_shapes() {
+        assert!(context_interval_is_well_formed(true, 10, None));
+        assert!(context_interval_is_well_formed(false, 10, Some(10)));
+        assert!(!context_interval_is_well_formed(true, 10, Some(11)));
+        assert!(!context_interval_is_well_formed(false, 10, None));
+        assert!(!context_interval_is_well_formed(false, 10, Some(9)));
+    }
+
+    #[test]
+    fn exact_context_claim_rejects_forged_discriminators_and_stale_revisions() {
+        assert!(exact_context_claim_matches(
+            CharacterContextKind::CaseSite,
+            EXACT_CASE_CONTEXT_CONTACT_REF,
+            3,
+            3,
+        ));
+        assert!(exact_context_claim_matches(
+            CharacterContextKind::HostileGroup,
+            EXACT_CASE_CONTEXT_CONTACT_REF,
+            3,
+            3,
+        ));
+        assert!(!exact_context_claim_matches(
+            CharacterContextKind::CaseSite,
+            "forged_private_context",
+            3,
+            3,
+        ));
+        assert!(!exact_context_claim_matches(
+            CharacterContextKind::CaseSite,
+            EXACT_CASE_CONTEXT_CONTACT_REF,
+            2,
+            3,
+        ));
+    }
+
+    #[test]
+    fn context_claim_resolution_fails_closed_on_zero_or_ambiguous_rows() {
+        assert_eq!(exactly_one(std::iter::empty::<u8>()), None);
+        assert_eq!(exactly_one([7].into_iter()), Some(7));
+        assert_eq!(exactly_one([7, 8].into_iter()), None);
+    }
+
     #[test]
     fn contextual_actions_share_privacy_consent_and_physiology_authority() {
         let source = include_str!("world_actor.rs");
@@ -798,7 +1165,7 @@ mod tests {
             .nth(1)
             .and_then(|tail| tail.split("pub(crate) fn treatment_is_authorized").next())
             .expect("contextual authorization");
-        assert!(authorization.contains("case_patient_visible_to_party"));
+        assert!(authorization.contains("case_patient_visible_to_character"));
         assert!(authorization.contains("challenge.party_id == party_id"));
         assert!(authorization.contains("row.treatment_consent"));
 
@@ -822,5 +1189,23 @@ mod tests {
         assert!(rebound.contains("character_id: road_membership.character_id"));
         assert!(rebound.contains("CharacterContextKind::StrategicEncounter"));
         assert!(rebound.contains("materialize_context_roster"));
+    }
+
+    #[test]
+    fn case_context_joins_use_typed_observer_relative_presence() {
+        let source = include_str!("world_actor.rs");
+        let presence = source
+            .split("pub(crate) fn characters_are_contextually_present")
+            .nth(1)
+            .and_then(|tail| {
+                tail.split("pub(crate) fn contextual_interaction_is_authorized")
+                    .next()
+            })
+            .expect("contextual presence projection");
+        assert!(presence.contains("case_site_presence_for_observer"));
+        assert!(presence.contains("case_context_presence_for_observer"));
+        assert!(presence.contains("are_co_present"));
+        assert!(!presence.contains("actor_site == character_case_site_id"));
+        assert!(!presence.contains("actor_site.as_ref() == Some(&row.location_id)"));
     }
 }

--- a/crates/strategic-web/src/routes/quests.rs
+++ b/crates/strategic-web/src/routes/quests.rs
@@ -33,7 +33,7 @@ use crate::spacetimedb::{
     Settlement,
 };
 use crate::templates::quest::{
-    CaseSitePagePresentation, CaseSiteRecoveryNotice, quest_location_enemy_page,
+    CaseSitePagePresentation, CaseSiteRecoveryNotice, QuestCounterparty, quest_location_enemy_page,
     quest_location_map_page,
 };
 
@@ -1117,15 +1117,16 @@ async fn render_quest_location(
         ))
         .await
         .unwrap_or_default();
-    let counterparty_contact = context_memberships
-        .first()
-        .map(|row| (row.contact_ref.clone(), row.revision));
     let mut counterparties = Vec::new();
     for membership in context_memberships.into_iter().filter(|row| row.alive) {
         if let Ok(Some(counterparty)) =
             super::data::character(&state, membership.character_id).await
         {
-            counterparties.push(counterparty);
+            counterparties.push(QuestCounterparty {
+                character: counterparty,
+                contact_ref: membership.contact_ref,
+                revision: membership.revision,
+            });
         }
     }
     let onsite_actions = onsite_investigation_actions(
@@ -1204,12 +1205,6 @@ async fn render_quest_location(
             character.as_ref(),
             &party_members,
             &counterparties,
-            counterparty_contact
-                .as_ref()
-                .map(|(contact_ref, _)| contact_ref.as_str()),
-            counterparty_contact
-                .as_ref()
-                .map_or(1, |(_, revision)| *revision),
             can_fight,
             resolved,
             autoresolve_report.as_ref(),

--- a/crates/strategic-web/src/templates/quest.rs
+++ b/crates/strategic-web/src/templates/quest.rs
@@ -273,6 +273,39 @@ fn autoresolve_info_messages(report: Option<&AutoresolveReport>) -> Vec<String> 
     messages
 }
 
+#[derive(Clone, Debug)]
+pub struct QuestCounterparty {
+    pub character: Character,
+    pub contact_ref: String,
+    pub revision: u32,
+}
+
+fn quest_counterparty_strip(case_site_id: &str, counterparties: &[QuestCounterparty]) -> Markup {
+    html! {
+        nav class="settlement-npc-strip counterparty-strip" aria-label="Counterparty" {
+            @for counterparty in counterparties {
+                div class="npc-portrait counterparty-portrait" {
+                    span class="npc-portrait-image" aria-hidden="true" { "?" }
+                    span class="npc-portrait-name" { (&counterparty.character.name) }
+                    form method="post" action=(format!("/locations/case-site/{case_site_id}/counterparty/contact")) {
+                        input type="hidden" name="target_id" value=(counterparty.character.id);
+                        input type="hidden" name="contact_ref" value=(&counterparty.contact_ref);
+                        input type="hidden" name="expected_revision" value=(counterparty.revision);
+                        input type="hidden" name="action_id" value=(format!("quest-contact:{case_site_id}:{}:{}", counterparty.revision, counterparty.character.id));
+                        button type="submit" class="btn btn-secondary btn-small" { "Talk" }
+                    }
+                    @if counterparty.character.alive {
+                        form method="post" action=(format!("/locations/case-site/{case_site_id}/counterparty/bandage")) {
+                            input type="hidden" name="patient_id" value=(counterparty.character.id);
+                            button type="submit" class="btn btn-secondary btn-small" { "Bandage" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Enemy encounter and, once resolved, its loot at an off-road quest location.
 pub fn quest_location_enemy_page(
     presentation: &CaseSitePagePresentation,
@@ -280,9 +313,7 @@ pub fn quest_location_enemy_page(
     onsite_actions: &[BackendInvestigationAction],
     active_character: Option<&Character>,
     party_members: &[Character],
-    counterparties: &[Character],
-    counterparty_contact_ref: Option<&str>,
-    counterparty_contact_revision: u32,
+    counterparties: &[QuestCounterparty],
     can_fight: bool,
     resolved: bool,
     autoresolve_report: Option<&AutoresolveReport>,
@@ -305,27 +336,7 @@ pub fn quest_location_enemy_page(
         aside class="left-sidebar" {
             @if !resolved && !counterparties.is_empty() {
                 (sidebar_section("Counterparty", html! {
-                    nav class="settlement-npc-strip counterparty-strip" aria-label="Counterparty" {
-                        @for counterparty in counterparties {
-                            div class="npc-portrait counterparty-portrait" {
-                                span class="npc-portrait-image" aria-hidden="true" { "?" }
-                                span class="npc-portrait-name" { (&counterparty.name) }
-                                form method="post" action=(format!("/locations/case-site/{}/counterparty/contact", site.case_site_id)) {
-                                    input type="hidden" name="target_id" value=(counterparty.id);
-                                    input type="hidden" name="contact_ref" value=(counterparty_contact_ref.unwrap_or(&site.case_site_id));
-                                    input type="hidden" name="expected_revision" value=(counterparty_contact_revision);
-                                    input type="hidden" name="action_id" value=(format!("quest-contact:{}:{}:{}", site.case_site_id, counterparty_contact_revision, counterparty.id));
-                                    button type="submit" class="btn btn-secondary btn-small" { "Talk" }
-                                }
-                                @if counterparty.alive {
-                                    form method="post" action=(format!("/locations/case-site/{}/counterparty/bandage", site.case_site_id)) {
-                                        input type="hidden" name="patient_id" value=(counterparty.id);
-                                        button type="submit" class="btn btn-secondary btn-small" { "Bandage" }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    (quest_counterparty_strip(&site.case_site_id, counterparties))
                 }))
             }
             @if !resolved {
@@ -467,7 +478,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn case_site_counterparties_use_shared_contact_and_treatment_actions() {
+    fn case_site_counterparties_use_per_row_contact_and_treatment_actions() {
         let template = include_str!("quest.rs")
             .split("#[cfg(test)]")
             .next()
@@ -476,8 +487,61 @@ mod tests {
         assert!(template.contains("/counterparty/contact"));
         assert!(template.contains("/counterparty/bandage"));
         assert!(routes.contains("\"treat_limb\""));
+        let projection = routes
+            .split("let context_memberships: Vec<BackendContextCharacter>")
+            .nth(1)
+            .and_then(|tail| tail.split("let can_fight").next())
+            .expect("case-site counterparty projection");
+        assert!(!projection.contains(".first()"));
+        assert!(projection.contains("contact_ref: membership.contact_ref"));
+        assert!(projection.contains("revision: membership.revision"));
         assert!(!template.contains("examine_outbreak_patient"));
         assert!(!template.contains("outbreak_patient_examination"));
+    }
+
+    #[test]
+    fn each_counterparty_renders_its_own_contact_claim() {
+        let character = |id, name: &str| Character {
+            id,
+            name: name.into(),
+            xp: 0,
+            level: 1,
+            gold: 0,
+            current_settlement_id: None,
+            current_case_site_id: Some("case-site:known".into()),
+            party_id: None,
+            age_years: 30,
+            alive: true,
+            temporary: false,
+            social_notification_count: 0,
+            automatic_social_chat_enabled: false,
+        };
+        let rows = [
+            QuestCounterparty {
+                character: character(41, "Alice"),
+                contact_ref: "claim-a".into(),
+                revision: 3,
+            },
+            QuestCounterparty {
+                character: character(42, "Bert"),
+                contact_ref: "claim-b".into(),
+                revision: 7,
+            },
+        ];
+        let markup = quest_counterparty_strip("case-site:known", &rows).into_string();
+        let cards = markup
+            .split("counterparty-portrait")
+            .skip(1)
+            .collect::<Vec<_>>();
+        assert_eq!(cards.len(), 2);
+        assert!(cards[0].contains("Alice"));
+        assert!(cards[0].contains("value=\"41\""));
+        assert!(cards[0].contains("value=\"claim-a\""));
+        assert!(cards[0].contains("value=\"3\""));
+        assert!(cards[1].contains("Bert"));
+        assert!(cards[1].contains("value=\"42\""));
+        assert!(cards[1].contains("value=\"claim-b\""));
+        assert!(cards[1].contains("value=\"7\""));
     }
 
     #[test]

--- a/wiki/reference/strategic-places.md
+++ b/wiki/reference/strategic-places.md
@@ -57,7 +57,8 @@ gateway rules expose them.
 contract. Each presence names a Character, a canonical `StrategicPlaceId`, the
 authorized observer's personal-time frontier, and one closed evidence basis:
 coarse settlement membership, validated instantaneous venue selection, scheduled
-resident presence, or chronological residence occupancy. Co-presence requires
+resident presence, chronological residence occupancy, physical case-site
+occupancy, or an active revision-matched case-context membership. Co-presence requires
 the same canonical place projected for the same observer frontier. It does not
 require the observed Character's independent clock to equal the observer's;
 pairwise-soft consumers continue to inspect only the actor's chronology.
@@ -80,10 +81,21 @@ The typed basis distinguishes an owner who also occupies the home from a
 household occupant; ownership alone is neither presence nor occupancy. Private
 holding, household, and role facts remain inside the residence owner module.
 
-The current SpacetimeDB investigation module still owns its serialized
-`CaseSiteId` wrapper and generated client shape. The schema-adapter PR in this
-stack must validate that value into `StrategicPlaceId::CaseSite`, convert the
-cross-system joins, and then remove the feature-specific identity. Keeping the
-schema wrapper unchanged in this pure-core PR avoids an otherwise unrelated
-schema and generated-binding change; it is an ordered conversion boundary, not
-approval for two permanent case-site identities.
+SpacetimeDB's serialized `CaseSiteId` is only the transport for the opaque site
+component. It has no independent identity semantics: one centralized adapter
+must validate it into `StrategicPlaceId::CaseSite` before a case authority,
+party occupancy, or contextual membership can be compared. Observer-safe
+case-site presence additionally requires that observer's exact live disclosure,
+the observer's personal chronology, a living Character, and (for contextual
+actors) a matching projected membership identity and revision. Physical
+occupancy and contextual membership are chronological intervals, so a current
+row cannot authorize presence before entry or after departure. Exact leads are
+likewise effective only after their recorded minute and remain effective until
+the recorded minute of their correction. Different observers cannot reuse one
+another's disclosure.
+
+Outbreak authority persists its physical source as a canonical
+`StrategicFixtureId::OutbreakSource` encoding, and source-exposure spans persist
+the canonical case-site place encoding. Both are constructor-produced and
+parse-validated before comparison; raw generated site strings cannot directly
+join outbreak remediation, exposure, investigation, or contextual presence.


### PR DESCRIPTION
## What changed

Adapt investigation case-site occupancy and movement to the canonical place and presence primitives.

## Why

This is layer 3 of 14 for issue #414. It establishes one reviewable portion of the shared strategic-world foundation while preserving existing gameplay behavior and privacy boundaries.

## Stack

- Base: `agent/414-presence-core`
- Head: `agent/414-case-presence`
- Review and merge in numeric stack order.

## Validation

Focused case-presence and authority tests; module compile; formatting and diff checks.

Implementation used isolated worktrees and independent correctness/security review. The final layer supplies the composed simulator and live browser proof for the complete stack.