### PR TITLE
Adapt investigation to shared planning and knowledge

### DIFF
--- a/crates/adventuresim-core/src/investigation.rs
+++ b/crates/adventuresim-core/src/investigation.rs
@@ -49,6 +49,175 @@ stable_id!(BeliefId);
 stable_id!(LeadId);
 stable_id!(RevisionId);
 stable_id!(SharingReceiptId);
+stable_id!(EvidenceKnowledgeSourceId);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvidenceKnowledgeSubject {
+    Evidence(EvidenceId),
+}
+impl crate::knowledge::DomainKnowledgeSubject for EvidenceKnowledgeSubject {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvidenceKnowledgeProposition {
+    pub case_id: CaseId,
+    pub evidence_id: EvidenceId,
+}
+impl crate::knowledge::DomainProposition for EvidenceKnowledgeProposition {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvidenceKnowledgeSource {
+    InvestigationAction(EvidenceKnowledgeSourceId),
+}
+impl crate::knowledge::DomainKnowledgeSource for EvidenceKnowledgeSource {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvidenceKnowledgeVisibility {}
+impl crate::knowledge::DomainVisibilityRule for EvidenceKnowledgeVisibility {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvidenceKnownBelief {
+    pub evidence_id: EvidenceId,
+}
+impl crate::knowledge::DomainBelief for EvidenceKnownBelief {}
+
+pub type EvidenceKnowledgeRecord = crate::knowledge::ObserverKnowledgeRecord<
+    EvidenceKnowledgeSubject,
+    EvidenceKnowledgeProposition,
+    EvidenceKnowledgeSource,
+    EvidenceKnowledgeVisibility,
+    EvidenceKnownBelief,
+>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AdaptedEvidenceKnowledge {
+    persisted_id: String,
+    record: EvidenceKnowledgeRecord,
+}
+
+impl AdaptedEvidenceKnowledge {
+    pub fn persisted_id(&self) -> &str {
+        &self.persisted_id
+    }
+
+    pub const fn record(&self) -> &EvidenceKnowledgeRecord {
+        &self.record
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EvidenceKnowledgeAdapterError {
+    InvalidObserver,
+    InvalidDomainIdentity(ValidationError),
+    InvalidKnowledge(crate::knowledge::KnowledgeError),
+}
+
+/// Adapts one existing evidence-custody row to the observer-private knowledge
+/// contract without changing its persisted identity or chronology.
+///
+/// The numeric record id is a deterministic adapter key, not a replacement DB
+/// primary key. A persistence adapter must reject a collision between distinct
+/// string ids before storing or joining by this key.
+pub fn adapt_evidence_knowledge(
+    persisted_id: &str,
+    owner_character_id: u64,
+    case_id: &str,
+    evidence_id: &str,
+    source_id: &str,
+    learned_at: u64,
+    observer_personal_minute: u64,
+) -> Result<AdaptedEvidenceKnowledge, EvidenceKnowledgeAdapterError> {
+    use crate::knowledge::{
+        KnowledgeConfidence, KnowledgeEnvelope, KnowledgeLineage, KnowledgeRecordId,
+        KnowledgeRevision, KnowledgeSource, KnowledgeSubject, KnowledgeVisibility,
+        ObserverKnowledgeRecord,
+    };
+    use sha2::Digest as _;
+
+    let observer = crate::physical_object::CustodyCharacterId::try_new(owner_character_id)
+        .map_err(|_| EvidenceKnowledgeAdapterError::InvalidObserver)?;
+    let case_id =
+        CaseId::new(case_id).map_err(EvidenceKnowledgeAdapterError::InvalidDomainIdentity)?;
+    let evidence_id = EvidenceId::new(evidence_id)
+        .map_err(EvidenceKnowledgeAdapterError::InvalidDomainIdentity)?;
+    let source_id = EvidenceKnowledgeSourceId::new(source_id)
+        .map_err(EvidenceKnowledgeAdapterError::InvalidDomainIdentity)?;
+    let digest = sha2::Sha256::digest(persisted_id.as_bytes());
+    let mut numeric = u64::from_le_bytes(digest[..8].try_into().expect("SHA-256 prefix"));
+    if numeric == 0 {
+        numeric = 1;
+    }
+    let envelope = KnowledgeEnvelope::try_new(
+        KnowledgeRecordId::try_new(numeric)
+            .map_err(EvidenceKnowledgeAdapterError::InvalidKnowledge)?,
+        observer,
+        KnowledgeSubject::Domain(EvidenceKnowledgeSubject::Evidence(evidence_id.clone())),
+        EvidenceKnowledgeProposition {
+            case_id,
+            evidence_id: evidence_id.clone(),
+        },
+        KnowledgeSource::Domain(EvidenceKnowledgeSource::InvestigationAction(source_id)),
+        learned_at,
+        learned_at,
+        observer_personal_minute,
+        KnowledgeConfidence::try_new(10_000)
+            .map_err(EvidenceKnowledgeAdapterError::InvalidKnowledge)?,
+        KnowledgeVisibility::ObserverPrivate,
+        KnowledgeLineage::try_new(
+            KnowledgeRevision::try_new(1)
+                .map_err(EvidenceKnowledgeAdapterError::InvalidKnowledge)?,
+            None,
+        )
+        .map_err(EvidenceKnowledgeAdapterError::InvalidKnowledge)?,
+    )
+    .map_err(EvidenceKnowledgeAdapterError::InvalidKnowledge)?;
+    Ok(AdaptedEvidenceKnowledge {
+        persisted_id: persisted_id.to_owned(),
+        record: ObserverKnowledgeRecord::new(envelope, EvidenceKnownBelief { evidence_id }),
+    })
+}
+
+#[cfg(test)]
+mod evidence_knowledge_adapter_tests {
+    use super::*;
+    use crate::knowledge::{KnowledgeError, KnowledgeVisibility};
+
+    #[test]
+    fn evidence_adapter_is_observer_private_and_respects_personal_time() {
+        let record = adapt_evidence_knowledge(
+            "evidence-knowledge:7:case:mill:evidence:print",
+            7,
+            "case:mill",
+            "evidence:print",
+            "attempt:inspect:1",
+            120,
+            120,
+        )
+        .unwrap();
+        assert_eq!(
+            record.persisted_id(),
+            "evidence-knowledge:7:case:mill:evidence:print"
+        );
+        assert_eq!(record.record().envelope().observer().get(), 7);
+        assert!(matches!(
+            record.record().envelope().visibility(),
+            KnowledgeVisibility::ObserverPrivate
+        ));
+        assert_eq!(
+            adapt_evidence_knowledge(
+                "evidence-knowledge:7:case:mill:evidence:print",
+                7,
+                "case:mill",
+                "evidence:print",
+                "attempt:inspect:1",
+                120,
+                119,
+            ),
+            Err(EvidenceKnowledgeAdapterError::InvalidKnowledge(
+                KnowledgeError::BeyondObserverTime
+            ))
+        );
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BasisPoints(u16);

--- a/crates/adventuresim-core/src/investigation_action.rs
+++ b/crates/adventuresim-core/src/investigation_action.rs
@@ -6,6 +6,23 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::{
+    physical_object::CustodyCharacterId,
+    rights::{
+        DecisionProvenance, DomainJurisdiction, DomainRightsOperation, DomainRightsResource,
+        DomainRightsSubject, PrivateRightsDecision, RightsDecisionKind, RightsJurisdiction,
+        RightsOperation, RightsQuestion, RightsQuestionError, RightsResource, RightsRevision,
+        RightsSubject,
+    },
+    strategic_action::{
+        ActionCoordinates, ActionEffect, ActionRequirement, AuthoritativeSnapshot,
+        CalculatedAction, DomainCapability, DomainEffect, DomainInterruption, DomainRequirement,
+        DomainTarget, PlanInput, PlanProvenance, PlanningOutcome, PublicPreview, PublicRejection,
+        RequestedDuration, RequirementCheck, TimeBoundaries, build_plan,
+    },
+    strategic_place::StrategicPlaceId,
+};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum InvestigationActionKind {
@@ -159,6 +176,381 @@ pub struct Resolution {
     pub risk_bps: u16,
     pub risk_triggered: bool,
     pub effective_skill_bps: u16,
+}
+
+#[cfg(test)]
+mod planning_adapter_tests {
+    use super::*;
+    use crate::strategic_action::{
+        ActionDefinitionId, ActionRequestId, ActionTarget, AuthorityBinding, PlanProvenance,
+        ScheduledInterruption, SnapshotDigest, SnapshotRevision,
+    };
+
+    fn authority(boundary: Option<u64>) -> InvestigationPlanAuthority {
+        let actor = CustodyCharacterId::try_new(7).unwrap();
+        let place = StrategicPlaceId::case_site("case:site:mill").unwrap();
+        let question = investigation_rights_question(actor, Some(place.clone())).unwrap();
+        let rights = decide_investigation_rights(&question, true, false, 3);
+        InvestigationPlanAuthority {
+            coordinates: ActionCoordinates::try_new(
+                actor,
+                ActionTarget::Place(place.clone()),
+                place,
+                None,
+                vec![],
+            )
+            .unwrap(),
+            provenance: PlanProvenance {
+                request_id: ActionRequestId::try_new("attempt:7").unwrap(),
+                action_id: ActionDefinitionId::try_new("investigation:inspect_site").unwrap(),
+                input_digest: SnapshotDigest([2; 32]),
+                authority_binding: AuthorityBinding([3; 32]),
+            },
+            snapshot: AuthoritativeSnapshot {
+                revision: SnapshotRevision(3),
+                digest: SnapshotDigest([2; 32]),
+            },
+            current_minute: 100,
+            duration: RequestedDuration::try_new(45).unwrap(),
+            boundaries: TimeBoundaries {
+                terminal_minute: None,
+                interruption: boundary.map(|at_minute| ScheduledInterruption {
+                    at_minute,
+                    cause: InvestigationPlanInterruption::ParticipantBoundary,
+                }),
+            },
+            rights,
+            capability_current: true,
+            live_prerequisites: true,
+            generated_condition: true,
+            member_ids: vec![actor, CustodyCharacterId::try_new(8).unwrap()],
+            resolution: Resolution {
+                result: ActionResultKind::EvidenceFound,
+                success: true,
+                cost: StrategicCost {
+                    minutes: 45,
+                    fatigue: 80,
+                    food_units: 0,
+                    water_units: 1,
+                },
+                resulting_uncertainty_bps: 1_000,
+                risk_bps: 0,
+                risk_triggered: false,
+                effective_skill_bps: 7_000,
+            },
+        }
+    }
+
+    #[test]
+    fn participant_boundary_preserves_full_domain_interval_but_suppresses_commit() {
+        let PlanningOutcome::Ready(plan) = build_investigation_plan(authority(Some(120))) else {
+            panic!("authorized plan should be ready");
+        };
+        assert_eq!(plan.time().elapsed_minutes, 20);
+        assert_eq!(plan.effects().len(), 1);
+        assert!(matches!(
+            &plan.effects()[0],
+            ActionEffect::Domain(InvestigationPlanEffect::AttemptPartyInterval {
+                requested_minutes: 45,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn private_leader_approval_is_required_without_becoming_preview_data() {
+        let mut input = authority(None);
+        let question = investigation_rights_question(
+            CustodyCharacterId::try_new(7).unwrap(),
+            Some(StrategicPlaceId::case_site("case:site:mill").unwrap()),
+        )
+        .unwrap();
+        input.rights = decide_investigation_rights(&question, false, false, 3);
+        let PlanningOutcome::Rejected(rejection) = build_investigation_plan(input) else {
+            panic!("unauthorized plan should be rejected");
+        };
+        assert_eq!(rejection.sanitized(), PublicRejection::Unavailable);
+    }
+
+    #[test]
+    fn rights_digest_binds_exact_place_and_resource() {
+        let actor = CustodyCharacterId::try_new(7).unwrap();
+        let first = investigation_rights_question(
+            actor,
+            Some(StrategicPlaceId::case_site("site:first").unwrap()),
+        )
+        .unwrap();
+        let second = investigation_rights_question(
+            actor,
+            Some(StrategicPlaceId::case_site("site:second").unwrap()),
+        )
+        .unwrap();
+        let other_resource = RightsQuestion::try_new(
+            RightsSubject::Character(actor),
+            RightsResource::Domain(InvestigationRightsResource::CaseAction),
+            RightsOperation::Domain(InvestigationRightsOperation::Perform),
+            RightsJurisdiction::Place(StrategicPlaceId::case_site("site:first").unwrap()),
+        )
+        .unwrap();
+        assert_ne!(
+            investigation_rights_question_digest(&first),
+            investigation_rights_question_digest(&second)
+        );
+        assert_ne!(
+            investigation_rights_question_digest(&first),
+            investigation_rights_question_digest(&other_resource)
+        );
+        assert_ne!(
+            decide_investigation_rights(&first, true, false, 3)
+                .provenance()
+                .question_digest,
+            decide_investigation_rights(&second, true, false, 3)
+                .provenance()
+                .question_digest
+        );
+    }
+}
+
+/// Closed planner vocabulary for a generated investigation attempt.
+///
+/// Capability ids, private targets, seeds, and consequence authority stay in
+/// reducer-owned provenance rather than becoming a serializable target.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationPlanTarget {
+    GeneratedRoute,
+}
+impl DomainTarget for InvestigationPlanTarget {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationPlanRequirement {
+    CapabilityCurrent,
+    PartyAuthorized,
+    LivePrerequisites,
+    GeneratedCondition,
+}
+impl DomainRequirement for InvestigationPlanRequirement {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationPlanCapability {
+    RouteResolution,
+}
+impl DomainCapability for InvestigationPlanCapability {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationPlanInterruption {
+    ParticipantBoundary,
+}
+impl DomainInterruption for InvestigationPlanInterruption {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InvestigationPlanEffect {
+    /// The domain reducer owns the existing per-member interval algorithm.
+    AttemptPartyInterval {
+        member_ids: Vec<CustodyCharacterId>,
+        requested_minutes: u64,
+    },
+    CommitResolution(Resolution),
+}
+impl DomainEffect for InvestigationPlanEffect {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InvestigationPublicPreview {
+    pub cost: StrategicCost,
+}
+impl PublicPreview for InvestigationPublicPreview {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationRightsSubject {}
+impl DomainRightsSubject for InvestigationRightsSubject {}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationRightsResource {
+    PartyAction,
+    CaseAction,
+}
+impl DomainRightsResource for InvestigationRightsResource {}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationRightsOperation {
+    Perform,
+}
+impl DomainRightsOperation for InvestigationRightsOperation {}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationRightsJurisdiction {}
+impl DomainJurisdiction for InvestigationRightsJurisdiction {}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestigationRightsEvidence {
+    PartyLeader,
+    LeaderApproval,
+}
+
+pub type InvestigationRightsQuestion = RightsQuestion<
+    InvestigationRightsSubject,
+    InvestigationRightsResource,
+    InvestigationRightsOperation,
+    InvestigationRightsJurisdiction,
+>;
+
+pub fn investigation_rights_question(
+    actor: CustodyCharacterId,
+    place: Option<StrategicPlaceId>,
+) -> Result<InvestigationRightsQuestion, RightsQuestionError> {
+    RightsQuestion::try_new(
+        RightsSubject::Character(actor),
+        RightsResource::Domain(InvestigationRightsResource::PartyAction),
+        RightsOperation::Domain(InvestigationRightsOperation::Perform),
+        place.map_or(RightsJurisdiction::Global, RightsJurisdiction::Place),
+    )
+}
+
+pub fn investigation_rights_question_digest(question: &InvestigationRightsQuestion) -> [u8; 32] {
+    use sha2::Digest as _;
+
+    let mut hasher = sha2::Sha256::new();
+    let mut frame = |bytes: &[u8]| {
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
+    };
+    frame(b"investigation-rights-question-v1");
+    match question.subject() {
+        RightsSubject::Character(actor) => {
+            frame(b"character");
+            frame(&actor.get().to_le_bytes());
+        }
+        RightsSubject::Party(_) | RightsSubject::Domain(_) => frame(b"invalid-subject"),
+    }
+    match question.resource() {
+        RightsResource::Domain(InvestigationRightsResource::PartyAction) => frame(b"party-action"),
+        RightsResource::Domain(InvestigationRightsResource::CaseAction) => frame(b"case-action"),
+        RightsResource::Object(_) | RightsResource::Place(_) | RightsResource::Fixture(_) => {
+            frame(b"invalid-resource")
+        }
+    }
+    match question.operation() {
+        RightsOperation::Domain(InvestigationRightsOperation::Perform) => frame(b"perform"),
+        _ => frame(b"invalid-operation"),
+    }
+    match question.jurisdiction() {
+        RightsJurisdiction::Global => frame(b"global"),
+        RightsJurisdiction::Place(place) => {
+            frame(b"place");
+            frame(place.to_string().as_bytes());
+        }
+        RightsJurisdiction::Domain(_) => frame(b"invalid-jurisdiction"),
+    }
+    hasher.finalize().into()
+}
+
+pub fn decide_investigation_rights(
+    question: &InvestigationRightsQuestion,
+    is_party_leader: bool,
+    leader_approved: bool,
+    capability_revision: u32,
+) -> PrivateRightsDecision<InvestigationRightsEvidence> {
+    let provenance = DecisionProvenance {
+        evidence_revision: RightsRevision(u64::from(capability_revision)),
+        question_digest: investigation_rights_question_digest(question),
+    };
+    if is_party_leader {
+        PrivateRightsDecision::allowed(
+            vec![InvestigationRightsEvidence::PartyLeader],
+            None,
+            provenance,
+        )
+    } else if leader_approved {
+        PrivateRightsDecision::allowed(
+            vec![InvestigationRightsEvidence::LeaderApproval],
+            None,
+            provenance,
+        )
+    } else {
+        PrivateRightsDecision::denied(Vec::new(), provenance)
+    }
+}
+
+pub struct InvestigationPlanAuthority {
+    pub coordinates: ActionCoordinates<InvestigationPlanTarget>,
+    pub provenance: PlanProvenance,
+    pub snapshot: AuthoritativeSnapshot,
+    pub current_minute: u64,
+    pub duration: RequestedDuration,
+    pub boundaries: TimeBoundaries<InvestigationPlanInterruption>,
+    pub rights: PrivateRightsDecision<InvestigationRightsEvidence>,
+    pub capability_current: bool,
+    pub live_prerequisites: bool,
+    pub generated_condition: bool,
+    pub member_ids: Vec<CustodyCharacterId>,
+    pub resolution: Resolution,
+}
+
+pub type InvestigationPlanningOutcome = PlanningOutcome<
+    InvestigationPlanTarget,
+    InvestigationPlanRequirement,
+    InvestigationPlanCapability,
+    InvestigationPlanInterruption,
+    InvestigationPlanEffect,
+    InvestigationPublicPreview,
+>;
+
+pub fn build_investigation_plan(
+    authority: InvestigationPlanAuthority,
+) -> InvestigationPlanningOutcome {
+    let requirements = [
+        (
+            InvestigationPlanRequirement::CapabilityCurrent,
+            authority.capability_current,
+        ),
+        (
+            InvestigationPlanRequirement::PartyAuthorized,
+            authority.rights.kind() == RightsDecisionKind::Allowed,
+        ),
+        (
+            InvestigationPlanRequirement::LivePrerequisites,
+            authority.live_prerequisites,
+        ),
+        (
+            InvestigationPlanRequirement::GeneratedCondition,
+            authority.generated_condition,
+        ),
+    ]
+    .into_iter()
+    .map(|(requirement, satisfied)| RequirementCheck {
+        requirement: ActionRequirement::Domain(requirement),
+        satisfied,
+    })
+    .collect();
+    let resolution = authority.resolution;
+    let members = authority.member_ids;
+    build_plan(
+        PlanInput {
+            coordinates: authority.coordinates,
+            provenance: authority.provenance,
+            snapshot: authority.snapshot,
+            current_minute: authority.current_minute,
+            duration: authority.duration,
+            boundaries: authority.boundaries,
+            requirements,
+            sanitized_rejection: PublicRejection::Unavailable,
+        },
+        move |_, time| {
+            let mut effects = vec![ActionEffect::Domain(
+                InvestigationPlanEffect::AttemptPartyInterval {
+                    member_ids: members,
+                    requested_minutes: u64::from(resolution.cost.minutes),
+                },
+            )];
+            if time.permits_completion_effects() {
+                effects.push(ActionEffect::Domain(
+                    InvestigationPlanEffect::CommitResolution(resolution),
+                ));
+            }
+            CalculatedAction {
+                effects,
+                public_preview: InvestigationPublicPreview {
+                    cost: resolution.cost,
+                },
+            }
+        },
+    )
 }
 
 /// A valid generated investigation route always resolves by this attempt when

--- a/crates/adventuresim-stdb-module/src/investigation/actions.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/actions.rs
@@ -464,6 +464,7 @@ fn validate_generated_pattern_condition(
         capability.owner_character_id,
         &observer_case_id,
         &evidence_id,
+        started_at,
         ctx.db
             .investigation_evidence_knowledge()
             .owner_character_id()
@@ -980,6 +981,75 @@ fn capability_uses_bounded_progress(
     provenance_kind == "generated" && generated_progress_kind(kind)
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AttemptHistoryKind {
+    CompletedFailure,
+    Break,
+}
+
+fn failed_attempt_history_kind(private_resolution_json: &str) -> AttemptHistoryKind {
+    #[derive(Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct InterruptedReceipt {
+        status: String,
+        requested_minutes: u64,
+        completion_effects_applied: bool,
+    }
+
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(private_resolution_json) else {
+        return AttemptHistoryKind::Break;
+    };
+    if value.get("status").is_some() {
+        let Ok(receipt) = serde_json::from_value::<InterruptedReceipt>(value) else {
+            return AttemptHistoryKind::Break;
+        };
+        let _is_terminal_interruption = receipt.status == "interrupted"
+            && !receipt.completion_effects_applied
+            && receipt.requested_minutes > 0;
+        return AttemptHistoryKind::Break;
+    }
+    if let Ok(resolution) = serde_json::from_value::<action::Resolution>(value.clone())
+        && !resolution.success
+        && value.as_object().is_some_and(|object| {
+            object.len() == 7
+                && [
+                    "result",
+                    "success",
+                    "cost",
+                    "resulting_uncertainty_bps",
+                    "risk_bps",
+                    "risk_triggered",
+                    "effective_skill_bps",
+                ]
+                .into_iter()
+                .all(|key| object.contains_key(key))
+        })
+    {
+        return AttemptHistoryKind::CompletedFailure;
+    }
+    if let Some(resolution) = value
+        .get("resolution")
+        .cloned()
+        .and_then(|value| serde_json::from_value::<action::Resolution>(value).ok())
+        && !resolution.success
+        && value.as_object().is_some_and(|object| {
+            object.len() == 5
+                && [
+                    "resolution",
+                    "attempt_number",
+                    "persistent_progress_bps",
+                    "success_threshold_bps",
+                    "guaranteed_by_attempt",
+                ]
+                .into_iter()
+                .all(|key| object.contains_key(key))
+        })
+    {
+        return AttemptHistoryKind::CompletedFailure;
+    }
+    AttemptHistoryKind::Break
+}
+
 fn contiguous_failed_attempts(
     capability_id: &str,
     owner_character_id: u64,
@@ -993,19 +1063,25 @@ fn contiguous_failed_attempts(
             attempt.capability_id == capability_id
                 && attempt.owner_character_id == owner_character_id
                 && attempt.method == method
-                && !attempt.success
                 && attempt.expected_version < current_version
         })
-        .map(|attempt| (attempt.expected_version, attempt))
+        .map(|attempt| {
+            let kind = if attempt.success {
+                AttemptHistoryKind::Break
+            } else {
+                failed_attempt_history_kind(&attempt.private_resolution_json)
+            };
+            (attempt.expected_version, kind)
+        })
         .collect::<BTreeMap<_, _>>();
     let mut cursor = current_version;
     let mut failures = 0;
     while cursor > 0 {
         cursor -= 1;
-        if attempts.get(&cursor).is_none() {
-            break;
+        match attempts.get(&cursor) {
+            Some(AttemptHistoryKind::CompletedFailure) => failures += 1,
+            Some(AttemptHistoryKind::Break) | None => break,
         }
-        failures += 1;
     }
     failures
 }
@@ -1165,6 +1241,188 @@ fn reset_unsupported_capability_progress(
     Ok(())
 }
 
+fn site_bound_investigation_plan(
+    ctx: &ReducerContext,
+    actor_id: u64,
+    party_leader_id: u64,
+    rights: &adventuresim_core::rights::PrivateRightsDecision<
+        action::InvestigationRightsEvidence,
+    >,
+    rights_question: &action::InvestigationRightsQuestion,
+    capability: &InvestigationActionCapability,
+    attempt_id: &str,
+    started_at: u64,
+    members: &[u64],
+    resolution: action::Resolution,
+    resolution_input: action::ResolutionInput,
+) -> Result<Option<action::InvestigationPlanningOutcome>, String> {
+    use adventuresim_core::{
+        physical_object::CustodyCharacterId,
+        strategic_action::{
+            ActionCoordinates, ActionDefinitionId, ActionRequestId, ActionTarget,
+            AuthoritativeSnapshot, AuthorityBinding, PlanProvenance, RequestedDuration,
+            ScheduledInterruption, SnapshotDigest, SnapshotRevision, TimeBoundaries,
+        },
+    };
+    use sha2::Digest as _;
+
+    // This representative vertical deliberately covers exact site actions.
+    // Area and route actions retain their existing domain path until they have
+    // an equally canonical strategic-place representation.
+    if capability.target_kind != "site"
+        || resolution_input.kind != action::InvestigationActionKind::InspectSite
+    {
+        return Ok(None);
+    }
+    let Some((site, _, _)) = exact_action_case_site_for_observer(ctx, capability) else {
+        return Ok(None);
+    };
+    let place = site
+        .id
+        .to_place()
+        .ok_or("Investigation site identity is malformed")?;
+    let actor = CustodyCharacterId::try_new(actor_id)
+        .map_err(|_| "Investigation actor identity is malformed")?;
+    let coordinates = ActionCoordinates::try_new(
+        actor,
+        ActionTarget::Place(place.clone()),
+        place.clone(),
+        None,
+        Vec::new(),
+    )
+    .map_err(|_| "Investigation action coordinates are inconsistent")?;
+    let requested = u64::from(resolution.cost.minutes);
+    let safe = members.iter().try_fold(requested, |safe, member_id| {
+        crate::time::preview_travel_time(ctx, *member_id, requested).map(|value| safe.min(value))
+    })?;
+
+    let mut hasher = sha2::Sha256::new();
+    let mut frame = |bytes: &[u8]| {
+        hasher.update((bytes.len() as u64).to_le_bytes());
+        hasher.update(bytes);
+    };
+    frame(b"investigation-plan-snapshot-v2");
+    frame(place.to_string().as_bytes());
+    frame(capability.id.as_bytes());
+    frame(capability.provenance_kind.as_bytes());
+    frame(capability.generated_case_id.as_bytes());
+    frame(capability.case_id.as_bytes());
+    frame(capability.method.as_bytes());
+    frame(capability.target_kind.as_bytes());
+    frame(capability.target_id.as_bytes());
+    frame(capability.target_terrain.as_bytes());
+    frame(&capability.version.to_le_bytes());
+    frame(&capability.seed.to_le_bytes());
+    frame(&capability.evidence_age_origin_minute.to_le_bytes());
+    frame(&capability.uncertainty_bps.to_le_bytes());
+    frame(capability.required_action_id.as_bytes());
+    frame(capability.alternate_route_action_id.as_bytes());
+    frame(&[u8::from(capability.active)]);
+    frame(&actor_id.to_le_bytes());
+    frame(&party_leader_id.to_le_bytes());
+    frame(&started_at.to_le_bytes());
+    frame(&requested.to_le_bytes());
+    frame(&safe.to_le_bytes());
+    frame(
+        &serde_json::to_vec(&resolution_input)
+            .map_err(|_| "Investigation planning input could not be bound")?,
+    );
+    frame(&rights.provenance().evidence_revision.0.to_le_bytes());
+    frame(&rights.provenance().question_digest);
+    frame(
+        &serde_json::to_vec(&resolution)
+            .map_err(|_| "Investigation resolution could not be bound")?,
+    );
+    frame(&[match rights.kind() {
+        adventuresim_core::rights::RightsDecisionKind::Allowed => 1,
+        adventuresim_core::rights::RightsDecisionKind::Denied => 0,
+    }]);
+    frame(
+        &rights
+            .evidence()
+            .iter()
+            .map(|evidence| match evidence {
+                action::InvestigationRightsEvidence::PartyLeader => 1,
+                action::InvestigationRightsEvidence::LeaderApproval => 2,
+            })
+            .collect::<Vec<_>>(),
+    );
+    for member_id in members {
+        frame(&member_id.to_le_bytes());
+    }
+    let input_digest: [u8; 32] = hasher.finalize().into();
+    let mut binding_hasher = sha2::Sha256::new();
+    binding_hasher.update(b"investigation-plan-binding-v1\0");
+    binding_hasher.update(input_digest);
+    binding_hasher.update(attempt_id.as_bytes());
+    let authority_binding: [u8; 32] = binding_hasher.finalize().into();
+
+    if !matches!(
+        rights_question.jurisdiction(),
+        adventuresim_core::rights::RightsJurisdiction::Place(bound) if bound == &place
+    ) || rights.provenance().question_digest
+        != action::investigation_rights_question_digest(rights_question)
+    {
+        return Err("Investigation rights question is inconsistent".into());
+    }
+
+    let interruption = (safe < requested).then_some(ScheduledInterruption {
+        at_minute: started_at.saturating_add(safe),
+        cause: action::InvestigationPlanInterruption::ParticipantBoundary,
+    });
+    let member_ids = members
+        .iter()
+        .map(|id| {
+            CustodyCharacterId::try_new(*id)
+                .map_err(|_| "Investigation party identity is malformed".to_string())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Some(action::build_investigation_plan(
+        action::InvestigationPlanAuthority {
+            coordinates,
+            provenance: PlanProvenance {
+                request_id: ActionRequestId::try_new(attempt_id)
+                    .map_err(|_| "Investigation request identity is malformed")?,
+                action_id: ActionDefinitionId::try_new(format!(
+                    "investigation:{}",
+                    capability.method
+                ))
+                .map_err(|_| "Investigation definition identity is malformed")?,
+                input_digest: SnapshotDigest(input_digest),
+                authority_binding: AuthorityBinding(authority_binding),
+            },
+            snapshot: AuthoritativeSnapshot {
+                revision: SnapshotRevision(u64::from(capability.version)),
+                digest: SnapshotDigest(input_digest),
+            },
+            current_minute: started_at,
+            duration: RequestedDuration::try_new(requested)
+                .map_err(|_| "Investigation duration must be positive")?,
+            boundaries: TimeBoundaries {
+                terminal_minute: None,
+                interruption,
+            },
+            rights: rights.clone(),
+            capability_current: capability.active,
+            live_prerequisites: true,
+            generated_condition: true,
+            member_ids,
+            resolution,
+        },
+    )))
+}
+
+fn private_interrupted_action_resolution_json(
+    requested_minutes: u64,
+) -> Result<String, String> {
+    serde_json::to_string(&serde_json::json!({
+        "status": "interrupted",
+        "requested_minutes": requested_minutes,
+        "completion_effects_applied": false,
+    }))
+    .map_err(|_| "Interrupted investigation receipt could not be recorded".into())
+}
+
 pub(crate) fn perform_investigation_action_authorized(
     ctx: &ReducerContext,
     actor_id: u64,
@@ -1174,17 +1432,6 @@ pub(crate) fn perform_investigation_action_authorized(
     leader_approved: bool,
 ) -> Result<(), String> {
     require_strategic_character_authority(ctx, actor_id)?;
-    let actor = crate::character::require_living_character(ctx, actor_id)?;
-    let party_id = actor.party_id.clone().ok_or("Must be in a party")?;
-    let party = ctx
-        .db
-        .party_authority()
-        .id()
-        .find(&party_id)
-        .ok_or("Party not found")?;
-    if party.leader_id != actor_id && !leader_approved {
-        return Err("Party leader approval is required".into());
-    }
     let attempt_id = inv::compound_id(&[
         "attempt",
         &action_id,
@@ -1202,12 +1449,44 @@ pub(crate) fn perform_investigation_action_authorized(
             Err("Investigation attempt id conflicts with an earlier action".into())
         };
     }
-    let mut capability = ctx
+    let actor = crate::character::require_living_character(ctx, actor_id)?;
+    let party_id = actor.party_id.clone().ok_or("Must be in a party")?;
+    let party = ctx
+        .db
+        .party_authority()
+        .id()
+        .find(&party_id)
+        .ok_or("Party not found")?;
+    let capability_row = ctx
         .db
         .investigation_action_capability()
         .id()
-        .find(&action_id)
-        .ok_or("Investigation action is unavailable")?;
+        .find(&action_id);
+    let rights_place = capability_row
+        .as_ref()
+        .filter(|capability| {
+            capability.owner_character_id == actor_id
+                && capability.target_kind == "site"
+                && capability.method == "inspect_site"
+        })
+        .and_then(|capability| exact_action_case_site_for_observer(ctx, capability))
+        .and_then(|(site, _, _)| site.id.to_place());
+    let rights_question = action::investigation_rights_question(
+        adventuresim_core::physical_object::CustodyCharacterId::try_new(actor_id)
+            .map_err(|_| "Investigation actor identity is malformed")?,
+        rights_place,
+    )
+    .map_err(|_| "Investigation rights question is inconsistent")?;
+    let rights = action::decide_investigation_rights(
+        &rights_question,
+        party.leader_id == actor_id,
+        leader_approved,
+        expected_version,
+    );
+    if rights.kind() != adventuresim_core::rights::RightsDecisionKind::Allowed {
+        return Err("Party leader approval is required".into());
+    }
+    let mut capability = capability_row.ok_or("Investigation action is unavailable")?;
     if capability.owner_character_id != actor_id
         || !capability.active
         || capability.method != method
@@ -1263,21 +1542,154 @@ pub(crate) fn perform_investigation_action_authorized(
     let resolution = bounded_progress
         .map(|progress| progress.resolution)
         .unwrap_or_else(|| action::resolve(resolution_input));
+    let planned_site_action = site_bound_investigation_plan(
+        ctx,
+        actor_id,
+        party.leader_id,
+        &rights,
+        &rights_question,
+        &capability,
+        &attempt_id,
+        started_at,
+        &members,
+        resolution,
+        resolution_input,
+    )?;
     // This is the final mutation-boundary validation. Browser previews and
     // party votes are UX; only this transaction authorizes the shared time.
     validate_live_action_prerequisites(ctx, &actor, &party_id, &capability, kind)?;
     validate_generated_pattern_condition(ctx, &capability, kind, started_at)?;
+    let planned_site_action = match planned_site_action {
+        Some(adventuresim_core::strategic_action::PlanningOutcome::Ready(planned)) => {
+            let replanned = site_bound_investigation_plan(
+                ctx,
+                actor_id,
+                party.leader_id,
+                &rights,
+                &rights_question,
+                &capability,
+                &attempt_id,
+                started_at,
+                &members,
+                resolution,
+                resolution_input,
+            )?
+            .ok_or("Investigation site authority changed before commit")?;
+            let current_snapshot = match &replanned {
+                adventuresim_core::strategic_action::PlanningOutcome::Ready(plan) => {
+                    plan.snapshot()
+                }
+                adventuresim_core::strategic_action::PlanningOutcome::Rejected(_) => {
+                    return Err("Investigation prerequisites changed before commit".into());
+                }
+            };
+            let provenance = planned.provenance();
+            adventuresim_core::strategic_action::validate_commit(
+                &planned,
+                &replanned,
+                current_snapshot,
+                &adventuresim_core::strategic_action::CommitAttempt {
+                    request_id: provenance.request_id.clone(),
+                    action_id: provenance.action_id.clone(),
+                    authority_binding: provenance.authority_binding,
+                },
+                None,
+            )
+            .map_err(|_| "Investigation authority changed before commit")?;
+            Some(planned)
+        }
+        Some(adventuresim_core::strategic_action::PlanningOutcome::Rejected(_)) => {
+            return Err("Investigation action is unavailable".into());
+        }
+        None => None,
+    };
+
+    let (effect_members, effect_minutes, permits_resolution) = if let Some(plan) =
+        &planned_site_action
+    {
+        let mut interval = None;
+        let mut commit = None;
+        for effect in plan.effects() {
+            match effect {
+                adventuresim_core::strategic_action::ActionEffect::Domain(
+                    action::InvestigationPlanEffect::AttemptPartyInterval {
+                        member_ids,
+                        requested_minutes,
+                    },
+                ) => interval = Some((member_ids, *requested_minutes)),
+                adventuresim_core::strategic_action::ActionEffect::Domain(
+                    action::InvestigationPlanEffect::CommitResolution(value),
+                ) => commit = Some(*value),
+                _ => return Err("Investigation planner emitted an unsupported effect".into()),
+            }
+        }
+        let (member_ids, requested_minutes) =
+            interval.ok_or("Investigation planner omitted the party interval")?;
+        let effect_members = member_ids.iter().map(|id| id.get()).collect::<Vec<_>>();
+        if effect_members != members
+            || requested_minutes != u64::from(resolution.cost.minutes)
+            || commit.is_some_and(|value| value != resolution)
+        {
+            return Err("Investigation planner effects do not match domain authority".into());
+        }
+        (effect_members, requested_minutes, commit.is_some())
+    } else {
+        (
+            members.clone(),
+            u64::from(resolution.cost.minutes),
+            true,
+        )
+    };
     let mut interval_completed = true;
-    for member_id in &members {
+    for member_id in &effect_members {
         interval_completed &=
-            advance_investigation_time(ctx, *member_id, u64::from(resolution.cost.minutes))?;
+            advance_investigation_time(ctx, *member_id, effect_minutes)?;
     }
     if !interval_completed {
         // Time, exposure, and death are already authoritative writes. Never
         // roll them back merely because the planned action interval clipped.
         let _ = crate::strategic::normalize_and_elect_party_leader(ctx, &party_id);
         let _ = crate::strategic::reconcile_party_objective_continuity(ctx, &party_id);
+        let completed_at = effect_members
+            .iter()
+            .filter_map(|member_id| {
+                ctx.db
+                    .character_time()
+                    .character_id()
+                    .find(*member_id)
+                    .map(|time| time.minutes)
+            })
+            .max()
+            .unwrap_or(started_at);
+        ctx.db
+            .investigation_action_attempt()
+            .insert(InvestigationActionAttempt {
+                id: attempt_id.clone(),
+                capability_id: action_id.clone(),
+                owner_character_id: actor_id,
+                expected_version,
+                method: method.clone(),
+                started_at,
+                completed_at,
+                duration_minutes: completed_at
+                    .saturating_sub(started_at)
+                    .min(u64::from(u32::MAX)) as u32,
+                success: false,
+                resulting_uncertainty_bps: capability.uncertainty_bps,
+                private_resolution_json: private_interrupted_action_resolution_json(
+                    effect_minutes,
+                )?,
+            });
+        capability.version = capability.version.saturating_add(1);
+        capability.seed = ctx.random::<u64>();
+        ctx.db
+            .investigation_action_capability()
+            .id()
+            .update(capability);
         return Ok(());
+    }
+    if !permits_resolution {
+        return Err("Investigation interval crossed a planned participant boundary".into());
     }
     crate::strategic::normalize_and_elect_party_leader(ctx, &party_id)?;
     crate::strategic::reconcile_party_objective_continuity(ctx, &party_id)?;

--- a/crates/adventuresim-stdb-module/src/investigation/capabilities.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/capabilities.rs
@@ -609,6 +609,11 @@ fn capability_has_live_pattern_support_reducer(
         &observer_case_id,
         &evidence_id,
         ctx.db
+            .character_time()
+            .character_id()
+            .find(capability.owner_character_id)
+            .map_or(0, |time| time.minutes),
+        ctx.db
             .investigation_evidence_knowledge()
             .owner_character_id()
             .filter(capability.owner_character_id),

--- a/crates/adventuresim-stdb-module/src/investigation/projections.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/projections.rs
@@ -966,12 +966,38 @@ fn observer_pattern_route_has_live_corroborated_clue(
     owner_character_id: u64,
     case_id: &str,
     evidence_id: &str,
+    observer_personal_minute: u64,
     knowledge: impl IntoIterator<Item = InvestigationEvidenceKnowledge>,
 ) -> bool {
-    knowledge.into_iter().any(|knowledge| {
-        knowledge.owner_character_id == owner_character_id
-            && knowledge.case_id == case_id
-            && knowledge.evidence_id == evidence_id
+    let mut numeric_ids = BTreeMap::new();
+    let mut adapted = Vec::new();
+    for row in knowledge {
+        if row.owner_character_id != owner_character_id {
+            continue;
+        }
+        let Ok(record) = inv::adapt_evidence_knowledge(
+            &row.id,
+            row.owner_character_id,
+            &row.case_id,
+            &row.evidence_id,
+            &row.source_id,
+            row.learned_at,
+            observer_personal_minute,
+        ) else {
+            return false;
+        };
+        let numeric_id = record.record().envelope().record_id().get();
+        if numeric_ids
+            .insert(numeric_id, record.persisted_id().to_owned())
+            .is_some_and(|prior| prior != record.persisted_id())
+        {
+            return false;
+        }
+        adapted.push(record);
+    }
+    adapted.into_iter().any(|record| {
+        let proposition = record.record().envelope().proposition();
+        proposition.case_id.as_str() == case_id && proposition.evidence_id.as_str() == evidence_id
     })
 }
 
@@ -1007,6 +1033,11 @@ fn capability_has_live_pattern_support_view(
         capability.owner_character_id,
         &observer_case_id,
         &evidence_id,
+        ctx.db
+            .character_time()
+            .character_id()
+            .find(capability.owner_character_id)
+            .map_or(0, |time| time.minutes),
         ctx.db
             .investigation_evidence_knowledge()
             .owner_character_id()
@@ -1356,6 +1387,7 @@ fn projected_night_window_wait_minutes(
         capability.owner_character_id,
         &capability.case_id,
         &evidence_id,
+        started_at,
         ctx.db
             .investigation_evidence_knowledge()
             .owner_character_id()

--- a/crates/adventuresim-stdb-module/src/investigation/tests/action_authority.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/tests/action_authority.rs
@@ -299,30 +299,42 @@ fn pattern_route_support_requires_exact_observer_clue_knowledge() {
         7,
         "case",
         "pattern-clue",
+        50_000,
         [learned.clone()],
     ));
     assert!(!observer_pattern_route_has_live_corroborated_clue(
         7,
         "case",
         "pattern-clue",
+        49_999,
+        [learned.clone()],
+    ));
+    assert!(!observer_pattern_route_has_live_corroborated_clue(
+        7,
+        "case",
+        "pattern-clue",
+        50_000,
         Vec::<InvestigationEvidenceKnowledge>::new(),
     ));
     assert!(!observer_pattern_route_has_live_corroborated_clue(
         8,
         "case",
         "pattern-clue",
+        50_000,
         [learned.clone()],
     ));
     assert!(!observer_pattern_route_has_live_corroborated_clue(
         7,
         "other-case",
         "pattern-clue",
+        50_000,
         [learned.clone()],
     ));
     assert!(!observer_pattern_route_has_live_corroborated_clue(
         7,
         "case",
         "other-clue",
+        50_000,
         [learned],
     ));
 
@@ -921,4 +933,61 @@ fn case_summary_subject_comes_only_from_immutable_journal_history() {
     assert!(projection.contains("for lead in leads"));
     assert!(projection.contains("case.2 = case.2.max(lead.recorded_at)"));
     assert!(!projection.contains("case.1 = lead.summary"));
+}
+
+#[test]
+fn exact_site_actions_replan_typed_effects_without_replacing_replay_or_private_receipts() {
+    let reducer = INVESTIGATION_SOURCE
+        .split("pub(crate) fn perform_investigation_action_authorized")
+        .nth(1)
+        .expect("action reducer");
+    let replay = reducer.find("investigation_action_attempt().id().find").unwrap();
+    let living_actor = reducer.find("require_living_character").unwrap();
+    let rights = reducer.find("decide_investigation_rights").unwrap();
+    let plan = reducer.find("site_bound_investigation_plan").unwrap();
+    let revalidate = reducer
+        .find("// This is the final mutation-boundary validation")
+        .unwrap();
+    let commit = reducer.find("validate_commit").unwrap();
+    let interval = reducer.find("advance_investigation_time").unwrap();
+    let receipt = reducer.find("private_resolution_json").unwrap();
+    assert!(replay < living_actor && replay < rights);
+    assert!(rights < plan && plan < revalidate && revalidate < commit);
+    assert!(!reducer.contains("party.leader_id != actor_id"));
+    assert!(reducer.contains("rights.kind()"));
+    assert!(commit < interval && interval < receipt);
+    assert!(reducer.contains("InvestigationPlanEffect::AttemptPartyInterval"));
+    assert!(reducer.contains("InvestigationPlanEffect::CommitResolution"));
+    assert!(reducer.contains("interval_completed &="));
+    let clipped = reducer
+        .split("if !interval_completed")
+        .nth(1)
+        .and_then(|tail| tail.split("if !permits_resolution").next())
+        .unwrap();
+    assert!(clipped.contains("private_interrupted_action_resolution_json"));
+    assert!(clipped.contains("investigation_action_attempt()"));
+
+    let adapter = INVESTIGATION_SOURCE
+        .split("fn site_bound_investigation_plan")
+        .nth(1)
+        .and_then(|tail| {
+            tail.split("pub(crate) fn perform_investigation_action_authorized")
+                .next()
+        })
+        .unwrap();
+    assert!(adapter.contains("capability.target_kind != \"site\""));
+    assert!(adapter.contains("InvestigationActionKind::InspectSite"));
+    assert!(adapter.contains("investigation-plan-snapshot-v2"));
+    assert!(adapter.contains("resolution_input"));
+    assert!(adapter.contains("rights.evidence()"));
+    assert!(adapter.contains("question_digest"));
+
+    let knowledge = INVESTIGATION_SOURCE
+        .split("fn observer_pattern_route_has_live_corroborated_clue")
+        .nth(1)
+        .expect("knowledge authority");
+    assert!(knowledge.contains("knowledge.owner_character_id == owner_character_id"));
+    assert!(knowledge.contains("adapt_evidence_knowledge"));
+    assert!(knowledge.contains("observer_personal_minute"));
+    assert!(!knowledge.contains("u64::MAX"));
 }

--- a/crates/adventuresim-stdb-module/src/investigation/tests/bestiary_and_corrections.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/tests/bestiary_and_corrections.rs
@@ -200,7 +200,9 @@
             duration_minutes: 1,
             success,
             resulting_uncertainty_bps: 9_000,
-            private_resolution_json: "{}".into(),
+            private_resolution_json: format!(
+                r#"{{"result":"no_new_information","success":{success},"cost":{{"minutes":1,"fatigue":0,"food_units":0,"water_units":0}},"resulting_uncertainty_bps":9000,"risk_bps":0,"risk_triggered":false,"effective_skill_bps":0}}"#
+            ),
         }
     }
 

--- a/crates/adventuresim-stdb-module/src/investigation/tests/projection_and_referrals.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/tests/projection_and_referrals.rs
@@ -59,6 +59,41 @@ fn bounded_progress_history_is_exact_contiguous_and_nontransferable() {
         contiguous_failed_attempts("cap-a", 7, "reacquire_tracks", 3, success_break),
         0
     );
+    let mut interrupted = failed_attempt("a2", "cap-a", 7, "reacquire_tracks", 2, false);
+    interrupted.private_resolution_json = serde_json::json!({
+        "status": "interrupted",
+        "requested_minutes": 120,
+        "completion_effects_applied": false,
+    })
+    .to_string();
+    assert_eq!(
+        contiguous_failed_attempts(
+            "cap-a",
+            7,
+            "reacquire_tracks",
+            3,
+            [
+                failed_attempt("a0", "cap-a", 7, "reacquire_tracks", 0, false),
+                failed_attempt("a1", "cap-a", 7, "reacquire_tracks", 1, false),
+                interrupted,
+            ],
+        ),
+        0,
+        "an interrupted terminal receipt breaks rather than advances bounded progress"
+    );
+    let mut malformed = failed_attempt("a2", "cap-a", 7, "reacquire_tracks", 2, false);
+    malformed.private_resolution_json = "{}".into();
+    assert_eq!(
+        contiguous_failed_attempts(
+            "cap-a",
+            7,
+            "reacquire_tracks",
+            3,
+            [malformed],
+        ),
+        0,
+        "malformed private receipts fail closed"
+    );
 }
 
 #[test]

--- a/wiki/reference/quest-generation-and-investigation.md
+++ b/wiki/reference/quest-generation-and-investigation.md
@@ -763,12 +763,52 @@ text use the site's safe generated name; opaque site IDs remain navigation
 authority and are not shown as destination labels. Watches, patrols, and
 ambush preparation remain strategic actions; they do not persist tactical tick
 state and cannot fabricate a combat result.
+After caller authorization, an exact existing attempt receipt is terminal
+before living-character, party, or current leader checks; death and party
+changes cannot make a committed request spend time again. A terminal injury or
+disease clip writes an interrupted receipt in the same transaction as its time
+effects. That receipt records no successful resolution, consequence, lead, or
+uncertainty change. Its capability revision advances so a surviving observer
+may make a distinct later request, while an exact retry of the clipped version
+returns before interval effects.
+Interrupted receipts and malformed private receipt payloads break the
+contiguous completed-failure chain and grant no bounded-progress credit.
 Before spending time the reducer revalidates party readiness, co-location,
 journey and camp state, unresolved encounters, predecessor knowledge,
 position, and typed prerequisites. Party clocks synchronize first, with night
 defined as before 06:00 or from 20:00 onward. Browser estimates are broad
 method-derived duration ranges; exact terrain, needs, fatigue, success, and
 risk remain authoritative.
+
+Exact-site attempts additionally pass through the shared strategic-action
+planner using the canonical case-site place, the current opaque capability
+revision, a private leader-or-approval rights decision, and a reducer-authored
+snapshot/binding. The reducer replans at the final mutation boundary and
+applies only the closed investigation interval and resolution effects. This
+does not change replay receipts, deterministic formulas, mutation order, or
+the public action DTO. Area and route actions remain on their existing path
+until those domains have a canonical strategic-place identity; they must not
+invent a case-site identity merely to enter the planner.
+The rights provenance digest comes from that exact checked typed question
+(actor subject, investigation resource and operation, and exact place or
+explicit global jurisdiction), not from a parallel action tuple.
+
+The planner's participant boundary suppresses completion effects, while the
+domain interval effect intentionally retains the historical per-member full
+duration request. Injury or disease clipping can therefore leave unequal
+party clocks before the existing leadership/objective normalization. Changing
+that behavior requires a separate party-time contract rather than an adapter
+side effect.
+
+Evidence-custody rows have an observer-private knowledge adapter with typed
+subject, proposition, source, confidence, visibility, chronology, and initial
+revision. Its numeric record key is only a deterministic adapter key; the
+existing string primary key remains authoritative and adapters must reject a
+collision between distinct persisted IDs. This adds no public evidence fields
+and does not make hidden evidence authority sufficient proof by itself. Route
+eligibility hydrates the record against the observer's exact personal clock;
+malformed, future, cross-observer, or colliding records fail the entire check
+closed.
 
 Location is revalidated at execution, not merely at issuance. Contact actions
 use the referred NPC's current settlement and presence window (or the same


### PR DESCRIPTION
## What changed

Move representative investigation actions onto shared planning, rights, custody, and private knowledge while preserving existing outcomes.

## Why

This is layer 10 of 14 for issue #414. It establishes one reviewable portion of the shared strategic-world foundation while preserving existing gameplay behavior and privacy boundaries.

## Stack

- Base: `agent/414-knowledge-core`
- Head: `agent/414-representative-adapters`
- Review and merge in numeric stack order.

## Validation

Focused investigation/authority tests; module and web checks; binding verification; formatting and diff checks.

Implementation used isolated worktrees and independent correctness/security review. The final layer supplies the composed simulator and live browser proof for the complete stack.