### PR TITLE
Harden strategic NPC simulation after live quest runs

### DIFF
--- a/crates/adventuresim-stdb-module/src/investigation/projections.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/projections.rs
@@ -1322,6 +1322,151 @@ fn projected_target_changed_availability() -> ProjectedActionAvailability {
     }
 }
 
+fn public_contact_schedule_wait_minutes(
+    presence: &crate::SettlementResidentPresence,
+    minute: u64,
+) -> Option<u32> {
+    if crate::settlement_population::npc_presence_remaining_minutes(presence, minute).is_some() {
+        return Some(0);
+    }
+    if presence.context_suppressed || presence.health_suppressed {
+        return None;
+    }
+    let current = minute % 1_440;
+    let start = u64::from(presence.start_minute);
+    let wait = (start + 1_440 - current) % 1_440;
+    Some(if wait == 0 { 1_440 } else { wait } as u32)
+}
+
+fn referred_contact_target_matches(
+    expected: &adventuresim_core::quest_generation::WitnessCandidate,
+    current: &adventuresim_core::quest_generation::WitnessCandidate,
+    settlement_id: &str,
+    expected_settlement_id: &str,
+) -> bool {
+    adventuresim_core::quest_generation::pattern_target_matches(
+        &adventuresim_core::quest_generation::GeneratedPatternTarget {
+            cohort_id: "referred-contact".into(),
+            resident_character_id: expected.resident_character_id,
+            demographic: expected.demographic,
+            age_band: expected.age_band.clone(),
+            sex: expected.sex.clone(),
+            profession: expected.profession.clone(),
+            expected_settlement_id: expected_settlement_id.into(),
+            expected_location: expected.expected_location.clone(),
+            expected_location_label: expected.expected_location_label.clone(),
+            presence_version: expected.presence_version,
+        },
+        current,
+        settlement_id,
+    )
+}
+
+fn referred_contact_is_current_view(
+    ctx: &ViewContext,
+    capability: &InvestigationActionCapability,
+    presence: &crate::SettlementResidentPresence,
+) -> bool {
+    let Ok(resident_character_id) = capability.target_id.parse::<u64>() else {
+        return false;
+    };
+    let Some((_, context_json)) = generated_authority_view(ctx, capability).ok().flatten() else {
+        return false;
+    };
+    let Ok(context) = serde_json::from_str::<
+        adventuresim_core::quest_generation::GenerationContext,
+    >(&context_json)
+    else {
+        return false;
+    };
+    let Some(expected) = context
+        .witness_candidates
+        .iter()
+        .find(|candidate| candidate.resident_character_id == resident_character_id)
+    else {
+        return false;
+    };
+    let Some(npc) =
+        crate::settlement_population::resolve_settlement_resident_view(ctx, resident_character_id)
+    else {
+        return false;
+    };
+    let Some(current) = (if expected.sex.is_empty() {
+        crate::strategic::developer_npc_witness_candidate(&npc, presence)
+    } else {
+        Some(adventuresim_core::quest_generation::WitnessCandidate {
+            resident_character_id: npc.character_id,
+            display_name: npc.name.clone(),
+            demographic: crate::strategic::generated_npc_demographic(&npc),
+            age_band: format!("{:?}", npc.age_band).to_ascii_lowercase(),
+            sex: format!("{:?}", npc.sex).to_ascii_lowercase(),
+            profession: npc.profession.clone(),
+            visible_description: String::new(),
+            expected_location: presence.location_id.clone(),
+            expected_location_label: presence.location_id.clone(),
+            presence_version: crate::strategic::generated_npc_presence_version(&npc, presence),
+            allowed_circumstances: Default::default(),
+        })
+    }) else {
+        return false;
+    };
+    referred_contact_target_matches(
+        expected,
+        &current,
+        &presence.settlement_id,
+        &context.settlement_id,
+    )
+}
+
+fn projected_contact_presence_availability(
+    ctx: &ViewContext,
+    capability: &InvestigationActionCapability,
+    kind: action::InvestigationActionKind,
+    settlement_id: Option<&str>,
+    started_at: Option<u64>,
+) -> Option<ProjectedActionAvailability> {
+    if kind != action::InvestigationActionKind::LocateContact
+        || capability.target_kind != "contact"
+    {
+        return None;
+    }
+    let presence = capability
+        .target_id
+        .parse::<u64>()
+        .ok()
+        .and_then(|character_id| {
+            ctx.db
+                .settlement_resident_presence()
+                .character_id()
+                .find(character_id)
+        });
+    let Some(presence) = presence else {
+        return Some(projected_target_changed_availability());
+    };
+    if settlement_id != Some(presence.settlement_id.as_str())
+        || !referred_contact_is_current_view(ctx, capability, &presence)
+    {
+        return Some(projected_target_changed_availability());
+    }
+    match started_at.and_then(|minute| public_contact_schedule_wait_minutes(&presence, minute)) {
+        Some(0) => None,
+        Some(wait_minutes) => Some(ProjectedActionAvailability {
+            unavailable_reason: Some(
+                "Wait until the referred contact's public schedule resumes.".into(),
+            ),
+            unavailable_reason_code: "contact_schedule_window".into(),
+            can_travel_to_required_site: false,
+            wait_minutes,
+        }),
+        None => Some(ProjectedActionAvailability {
+            unavailable_reason: Some("The referred contact is not currently available.".into()),
+            unavailable_reason_code: "contact_not_present".into(),
+            can_travel_to_required_site: false,
+            wait_minutes: 0,
+        }),
+    }
+}
+
 fn night_window_wait_minutes(minute: u64) -> u32 {
     let minute = minute % 1_440;
     if (360..1_200).contains(&minute) {
@@ -1581,7 +1726,17 @@ fn action_unavailable_reason_view(
             .and_then(|site| site.to_place())
             .zip(canonical_case_site_place(required_case_site_id))
             .is_some_and(|(occupied, required)| occupied == required);
-    let temporal_wait_minutes = projected_party_activity_minute(ctx, &party_id)
+    let projected_started_at = projected_party_activity_minute(ctx, &party_id);
+    if let Some(availability) = projected_contact_presence_availability(
+        ctx,
+        capability,
+        kind,
+        character.current_settlement_id.as_deref(),
+        projected_started_at,
+    ) {
+        return availability;
+    }
+    let temporal_wait_minutes = projected_started_at
         .map_or(0, |started_at| {
             projected_night_window_wait_minutes(ctx, capability, started_at)
         });

--- a/crates/adventuresim-stdb-module/src/investigation/tests/sites_and_actions.rs
+++ b/crates/adventuresim-stdb-module/src/investigation/tests/sites_and_actions.rs
@@ -674,6 +674,86 @@ fn nighttime_projection_wait_is_exact_and_bounded() {
 }
 
 #[test]
+fn locate_contact_projection_mirrors_public_scheduled_presence() {
+    let presence = crate::SettlementResidentPresence {
+        character_id: 9,
+        settlement_id: "lubeck".into(),
+        location_id: "market".into(),
+        start_minute: 480,
+        end_minute: 1_020,
+        is_default: false,
+        context_suppressed: false,
+        health_suppressed: false,
+    };
+    assert_eq!(public_contact_schedule_wait_minutes(&presence, 600), Some(0));
+    assert_eq!(public_contact_schedule_wait_minutes(&presence, 1_020), Some(900));
+
+    let mut suppressed = presence.clone();
+    suppressed.health_suppressed = true;
+    assert_eq!(public_contact_schedule_wait_minutes(&suppressed, 600), None);
+
+    let source = INVESTIGATION_SOURCE;
+    let projection = source
+        .split("fn projected_contact_presence_availability")
+        .nth(1)
+        .and_then(|tail| tail.split("fn night_window_wait_minutes").next())
+        .expect("public contact presence projection");
+    assert!(projection.contains("InvestigationActionKind::LocateContact"));
+    assert!(projection.contains("settlement_resident_presence()"));
+    assert!(projection.contains("contact_schedule_window"));
+    assert!(projection.contains("contact_not_present"));
+
+    let reducer = source
+        .split("fn validate_action_position")
+        .nth(1)
+        .and_then(|tail| tail.split("fn validate_generated_pattern_condition").next())
+        .expect("reducer contact presence validation");
+    assert!(reducer.contains("InvestigationActionKind::LocateContact"));
+    assert!(reducer.contains("npc_is_present"));
+}
+
+#[test]
+fn locate_contact_stale_target_beats_off_hours_schedule_wait() {
+    use adventuresim_core::quest_generation::{WitnessCandidate, WitnessDemographic};
+
+    let candidate = |location: &str, presence_version: u64| WitnessCandidate {
+        resident_character_id: 9,
+        display_name: "Ada".into(),
+        demographic: WitnessDemographic::Laborer,
+        age_band: "adult".into(),
+        sex: "female".into(),
+        profession: "weaver".into(),
+        visible_description: String::new(),
+        expected_location: location.into(),
+        expected_location_label: location.into(),
+        presence_version,
+        allowed_circumstances: Default::default(),
+    };
+    let expected = candidate("market", 7);
+    assert!(!referred_contact_target_matches(
+        &expected,
+        &candidate("inn", 7),
+        "lubeck",
+        "lubeck",
+    ));
+    assert!(!referred_contact_target_matches(
+        &expected,
+        &candidate("market", 8),
+        "lubeck",
+        "lubeck",
+    ));
+
+    let projection = INVESTIGATION_SOURCE
+        .split("fn projected_contact_presence_availability")
+        .nth(1)
+        .and_then(|tail| tail.split("fn night_window_wait_minutes").next())
+        .expect("locate-contact projection");
+    let validates_target = projection.find("referred_contact_is_current_view").unwrap();
+    let computes_wait = projection.find("public_contact_schedule_wait_minutes").unwrap();
+    assert!(validates_target < computes_wait);
+}
+
+#[test]
 fn progressed_single_patrol_frontier_is_valid_after_public_night_wait() {
     let mut inspect = InvestigationActionCapability {
         id: "inspect".into(),

--- a/crates/adventuresim-stdb-module/src/strategic/encounters.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/encounters.rs
@@ -206,9 +206,23 @@ pub(crate) fn advance_party_journey_delay(
         .party_id()
         .find(&party_id.to_string())
         .ok_or("Travel delay requires a durable journey")?;
-    journey.completed_elapsed_minutes = journey.completed_elapsed_minutes.saturating_add(minutes);
+    (journey.completed_elapsed_minutes, journey.total_elapsed_minutes) =
+        journey_elapsed_after_delay(
+            journey.completed_elapsed_minutes,
+            journey.total_elapsed_minutes,
+            minutes,
+        );
     ctx.db.party_journey_authority().party_id().update(journey);
-    Ok(())
+    // Narrative and combat delays consume real time without movement. Rebuild
+    // the remaining itinerary from that later frontier so future camp windows
+    // and the total elapsed forecast remain canonical.
+    refresh_party_journey_forecast(ctx, party_id)
+}
+
+fn journey_elapsed_after_delay(completed: u64, total: u64, delay: u64) -> (u64, u64) {
+    let remaining = total.saturating_sub(completed);
+    let completed = completed.saturating_add(delay);
+    (completed, completed.saturating_add(remaining))
 }
 
 pub(crate) fn build_strategic_encounter(

--- a/crates/adventuresim-stdb-module/src/strategic/travel_reducers.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/travel_reducers.rs
@@ -296,9 +296,10 @@ fn travel_to_case_site_impl(
             record_party_journey_interruption(ctx, &party_id, leg_minutes);
             commit_encounter_scan(ctx, &party_id, next_roll, encounter, narrative)?;
         } else {
-            if leg_minutes > 0 {
-                record_party_journey_camp(ctx, &party_id, leg_minutes)?;
-            }
+            // A departure outside the walking window reaches a real initial
+            // camp at movement minute zero. Persist that reached identity just
+            // like every later camp so rest/continue and fixture custody agree.
+            record_party_journey_camp(ctx, &party_id, leg_minutes)?;
             commit_encounter_scan(ctx, &party_id, next_roll, None, None)?;
         }
         return Ok(());
@@ -594,9 +595,7 @@ fn travel_to_settlement_impl(
                 record_party_journey_interruption(ctx, &party.id, leg_minutes);
                 commit_encounter_scan(ctx, &party.id, next_roll, encounter, narrative)?;
             } else {
-                if leg_minutes > 0 {
-                    record_party_journey_camp(ctx, &party.id, leg_minutes)?;
-                }
+                record_party_journey_camp(ctx, &party.id, leg_minutes)?;
                 commit_encounter_scan(ctx, &party.id, next_roll, None, None)?;
             }
             return Ok(());
@@ -821,9 +820,7 @@ pub fn continue_camp_travel(ctx: &ReducerContext, character_id: u64) -> Result<(
             record_party_journey_interruption(ctx, &party_id, leg_minutes);
             commit_encounter_scan(ctx, &party_id, next_roll, encounter, narrative)?;
         } else {
-            if leg_minutes > 0 {
-                record_party_journey_camp(ctx, &party_id, leg_minutes)?;
-            }
+            record_party_journey_camp(ctx, &party_id, leg_minutes)?;
             commit_encounter_scan(ctx, &party_id, next_roll, None, None)?;
         }
         return Ok(());

--- a/crates/adventuresim-stdb-module/src/strategic/travel_tests.rs
+++ b/crates/adventuresim-stdb-module/src/strategic/travel_tests.rs
@@ -6,13 +6,20 @@ mod departure_invariant_tests {
         JourneyTerrainKind, JourneyTerrainSpan, JourneyTerrainWeights, Party, PartyJourneyRoute,
         common_movement_prefix, core_encounter_terrain, departure_requires_ready_party,
         departure_snapshot_allows_travel, party_can_continue_travel,
-        pending_incident_allows_departure, reconstruct_legacy_journey_coordinates,
+        journey_elapsed_after_delay, pending_incident_allows_departure,
+        reconstruct_legacy_journey_coordinates,
         route_position_at_minute, set_party_journey_state, straight_line_distance_m,
         authoritative_straight_line_case_route,
         terrain_training_exposure, validate_camp_redirect_weather_interval,
         validate_journey_route_payload, validate_route_departure_weather_interval,
         zero_boundary_requires_settlement,
     };
+
+    #[test]
+    fn journey_delay_preserves_remaining_elapsed_forecast() {
+        assert_eq!(journey_elapsed_after_delay(240, 260, 180), (420, 440));
+        assert_eq!(journey_elapsed_after_delay(420, 260, 180), (600, 600));
+    }
 
     fn endpoint_name(endpoint: &JourneyEndpoint) -> &str {
         match endpoint {
@@ -146,6 +153,27 @@ mod departure_invariant_tests {
             .find("refresh_party_journey_forecast")
             .expect("journey forecast refresh");
         assert!(custody < refresh);
+    }
+
+    #[test]
+    fn every_uninterrupted_departure_camp_records_even_zero_movement_identity() {
+        let travel_source = include_str!("travel_reducers.rs");
+        assert_eq!(
+            travel_source.matches("record_party_journey_camp(ctx,").count(),
+            3,
+            "case-site departure, settlement departure, and continuation share the camp invariant",
+        );
+        assert!(
+            !travel_source.contains("if leg_minutes > 0 {\n                record_party_journey_camp"),
+            "an initial nighttime camp at movement minute zero is still a reached camp",
+        );
+        let camp_source = include_str!("journey_camp.rs");
+        let recorder = camp_source
+            .split("fn record_party_journey_camp")
+            .nth(1)
+            .and_then(|tail| tail.split("pub(crate) fn journey_plan_version_is_canonical").next())
+            .expect("journey camp recorder");
+        assert!(recorder.contains("camp_stop_minutes.push(journey.completed_minutes)"));
     }
 
     fn route_fixture() -> JourneyRoutePlan {

--- a/crates/adventuresim-strategic-sim/src/live_core/bootstrap.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/bootstrap.rs
@@ -215,6 +215,10 @@ fn run_core_loop_inner(
         .add_query(|query| query.from.backend_character_times())
         .add_query(|query| query.from.backend_character_training_schedules())
         .add_query(|query| query.from.inventory_item())
+        .add_query(|query| query.from.inventory_item_amount())
+        .add_query(|query| query.from.inventory_object())
+        .add_query(|query| query.from.inventory_containment())
+        .add_query(|query| query.from.container_liquid())
         .add_query(|query| query.from.food_lot())
         .add_query(|query| query.from.item())
         .add_query(|query| query.from.item_condition())
@@ -222,6 +226,7 @@ fn run_core_loop_inner(
         .add_query(|query| query.from.local_problem_symptom())
         .add_query(|query| query.from.party())
         .add_query(|query| query.from.party_inventory_item())
+        .add_query(|query| query.from.party_item_amount())
         .add_query(|query| query.from.party_journey())
         .add_query(|query| query.from.party_journey_itinerary())
         .add_query(|query| query.from.party_join_request())
@@ -603,6 +608,23 @@ fn run_core_loop_inner(
         .ensure_settlement_activity_then(settlement.clone(), cb));
     runner.call(result)?;
 
+    // Character clocks are absolute world minutes. Capture the post-bootstrap
+    // baseline so a mature imported/disposable world does not make a fresh
+    // simulation appear to have already exhausted its duration budget.
+    let simulation_start_minutes = runner
+        .character_ids
+        .iter()
+        .map(|character_id| {
+            runner
+                .connection
+                .db
+                .backend_character_times()
+                .iter()
+                .find(|row| row.character_id == *character_id)
+                .map(|row| (*character_id, row.minutes))
+                .ok_or("missing simulation-start character clock")
+        })
+        .collect::<Result<HashMap<_, _>, _>>()?;
     let duration_minutes = u64::from(config.duration_days) * 1_440;
     for cycle in 0..config.cycles {
         let mut active = false;
@@ -637,15 +659,20 @@ fn run_core_loop_inner(
             let Some((pre_recovery_leader, _)) = runner.current_leader(party_id) else {
                 continue;
             };
-            let recovery_started_in_budget = runner
+            let recovery_started_at = runner
                 .connection
                 .db
                 .backend_character_times()
                 .iter()
                 .find(|row| row.character_id == pre_recovery_leader)
                 .ok_or("missing pre-recovery leader clock")?
-                .minutes
-                < duration_minutes;
+                .minutes;
+            let recovery_started_in_budget = simulation_elapsed_minutes(
+                *simulation_start_minutes
+                    .get(&pre_recovery_leader)
+                    .ok_or("missing simulation-start leader clock")?,
+                recovery_started_at,
+            ) < duration_minutes;
             if !recovery_started_in_budget {
                 continue;
             }
@@ -686,6 +713,12 @@ fn run_core_loop_inner(
                 .find(|row| row.character_id == leader)
                 .ok_or("missing leader clock")?
                 .minutes;
+            let elapsed = simulation_elapsed_minutes(
+                *simulation_start_minutes
+                    .get(&leader)
+                    .ok_or("missing simulation-start leader clock")?,
+                elapsed,
+            );
             if elapsed >= duration_minutes
                 && !(recovery_outcome == ExpeditionRecoveryOutcome::Resumed
                     && recovery_started_in_budget)
@@ -1115,7 +1148,12 @@ fn run_core_loop_inner(
                 worst_equipment_condition,
                 outstanding_repair_orders,
                 alive: character.alive,
-                elapsed_minutes,
+                elapsed_minutes: simulation_elapsed_minutes(
+                    *simulation_start_minutes
+                        .get(&character.id)
+                        .ok_or("missing simulation-start final character clock")?,
+                    elapsed_minutes,
+                ),
                 personal_gold_coin,
                 party_treasury,
                 party_stake,

--- a/crates/adventuresim-strategic-sim/src/live_core/expedition.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/expedition.rs
@@ -153,7 +153,14 @@ impl LiveRunner {
             .db
             .inventory_item()
             .iter()
-            .filter(|row| member_ids.contains(&row.character_id))
+            .filter(|row| {
+                member_ids.contains(&row.character_id)
+                    && self.public_row_is_carried(
+                        "personal",
+                        &row.character_id.to_string(),
+                        row.id,
+                    )
+            })
             .map(|row| row.id)
             .collect::<HashSet<_>>();
         let party_inventory_ids = self
@@ -161,7 +168,10 @@ impl LiveRunner {
             .db
             .party_inventory_item()
             .iter()
-            .filter(|row| row.party_id == party_id)
+            .filter(|row| {
+                row.party_id == party_id
+                    && self.public_row_is_carried("party", party_id, row.id)
+            })
             .map(|row| row.id)
             .collect::<HashSet<_>>();
         let stored_food_kcal = self
@@ -193,9 +203,16 @@ impl LiveRunner {
             .iter()
             .find(|party| party.id == party_id)
             .map_or(0.0, |party| party.pooled_water_ml.max(0.0));
+        let contained_water_ml = member_ids
+            .iter()
+            .map(|character_id| {
+                self.public_contained_water_ml("personal", &character_id.to_string())
+            })
+            .sum::<f32>()
+            + self.public_contained_water_ml("party", party_id);
         ExpeditionSuppliesObservation {
             stored_food_kcal,
-            portable_water_ml: carried_water_ml + pooled_water_ml,
+            portable_water_ml: carried_water_ml + pooled_water_ml + contained_water_ml,
         }
     }
 

--- a/crates/adventuresim-strategic-sim/src/live_core/generated_cases.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/generated_cases.rs
@@ -422,7 +422,13 @@ impl LiveRunner {
             .iter()
             .filter(|presence| {
                 presence.settlement_id == settlement_id
-                    && npc_is_publicly_present(presence.start_minute, presence.end_minute, minute)
+                    && npc_is_publicly_present(
+                        presence.start_minute,
+                        presence.end_minute,
+                        presence.context_suppressed,
+                        presence.health_suppressed,
+                        minute,
+                    )
             })
             .filter_map(|presence| {
                 self.connection
@@ -453,7 +459,7 @@ impl LiveRunner {
         cycle: u32,
         candidate: &PublicNpcCandidate,
         purpose: &str,
-    ) -> Result<String, String> {
+    ) -> Result<Option<String>, String> {
         self.dialogue_nonce = self.dialogue_nonce.saturating_add(1);
         let session_id = format!(
             "dialogue:{character_id}:sim-{cycle}-{}-{purpose}",
@@ -471,6 +477,15 @@ impl LiveRunner {
                 adventuresim_dialogue::CATALOG_DIGEST.to_owned(),
                 cb,
             ));
+        if result
+            .as_ref()
+            .is_err_and(|error| dialogue_contact_presence_changed(error))
+        {
+            // The public presence row can change between selection and the
+            // authoritative reducer call. Treat that observer-safe mismatch
+            // as a replan instead of weakening authority or aborting the run.
+            return Ok(None);
+        }
         self.call(result)?;
         let session_is_owned = self
             .connection
@@ -481,7 +496,7 @@ impl LiveRunner {
         if !session_is_owned {
             return Err("dialogue reducer completed without an owner-scoped session".into());
         }
-        Ok(session_id)
+        Ok(Some(session_id))
     }
 
     pub(super) fn official_world_minute(&self) -> u64 {
@@ -640,8 +655,26 @@ impl LiveRunner {
                 before.len().min(32),
             ),
         );
-        if let Err(error) = self.start_public_dialogue(character_id, cycle, &candidate, "discover")
-        {
+        let dialogue_start =
+            self.start_public_dialogue(character_id, cycle, &candidate, "discover");
+        if matches!(&dialogue_start, Ok(None)) {
+            self.metrics.generated_discovery_decisions_unproductive = self
+                .metrics
+                .generated_discovery_decisions_unproductive
+                .saturating_add(1);
+            self.event(
+                agent,
+                CoreLoopEventKind::GeneratedDiscoveryResult,
+                format!(
+                    "official_minute={official_minute};active_symptom_count={};oldest_symptom_age_bucket={oldest_symptom_age_bucket};visible_candidate_count={};location_class={location_class};owner_open_case_count={};public_backoff=false;dialogue_success=false;session_success=false;new_open_cases=0;rumor_delivered=false;result=unproductive;reason=contact_presence_changed;fallback=settlement_activity;activity_fallback=true",
+                    public_count_bucket(active_symptom_count),
+                    visible_candidate_count.min(32),
+                    before.len().min(32),
+                ),
+            );
+            return Ok(GeneratedDiscoveryOutcome::NoVisibleContacts);
+        }
+        if let Err(error) = dialogue_start {
             let dialogue_succeeded =
                 error == "dialogue reducer completed without an owner-scoped session";
             self.event(
@@ -819,7 +852,11 @@ impl LiveRunner {
             }) {
                 continue;
             }
-            let session_id = self.start_public_dialogue(character_id, cycle, &candidate, "case")?;
+            let Some(session_id) =
+                self.start_public_dialogue(character_id, cycle, &candidate, "case")?
+            else {
+                continue;
+            };
             let mut options = self
                 .connection
                 .db
@@ -923,7 +960,10 @@ impl LiveRunner {
             .backend_investigation_cases()
             .iter()
             .filter(|row| row.owner_character_id == character_id && row.case_id == case_id)
-            .map(|row| (row.case_id, row.status, row.latest_update_at))
+            // A journal timestamp can advance when dialogue republishes an
+            // already-known fact. Only a changed public case status is new
+            // investigative knowledge.
+            .map(|row| (row.case_id, row.status))
             .collect::<Vec<_>>();
         cases.sort();
         let mut leads = self
@@ -932,34 +972,49 @@ impl LiveRunner {
             .backend_investigation_leads()
             .iter()
             .filter(|row| row.owner_character_id == character_id && row.case_id == case_id)
-            .map(|row| {
-                (
-                    row.lead_id,
-                    row.recorded_at,
-                    row.summary,
-                    row.witness_name,
-                    row.corrected_by,
-                    row.expected_location,
-                    row.current_learned_location,
-                )
+            .map(|row| PublicDialogueLeadSemantic {
+                summary: row.summary,
+                source_label: row.source_label,
+                confidence_bps: row.confidence_bps,
+                destination_stage: row.destination_stage,
+                directions: row.directions,
+                exact_location_id: row.exact_location_id,
+                latitude_e7: row.latitude_e_7,
+                longitude_e7: row.longitude_e_7,
+                witness_name: row.witness_name,
+                witness_description: row.witness_description,
+                witness_occupation_or_relationship: row.witness_occupation_or_relationship,
+                expected_location: row.expected_location,
+                current_learned_location: row.current_learned_location,
+                contradiction_group: row.contradiction_group,
+                corrected_by: row.corrected_by,
             })
             .collect::<Vec<_>>();
         leads.sort();
+        // Repeating the same testimony may republish it with a fresh row ID
+        // and timestamp. Treat identical public knowledge as one fact so the
+        // dialogue no-progress guard remains stable.
+        leads.dedup();
         let mut actions = self
             .connection
             .db
             .backend_investigation_actions()
             .iter()
             .filter(|row| row.owner_character_id == character_id && row.case_id == case_id)
-            .map(|row| {
-                (
-                    row.action_id,
-                    row.expected_version,
-                    row.available,
-                    row.can_travel_to_required_site,
-                    row.unavailable_reason_code,
-                    row.wait_minutes,
-                )
+            .map(|row| PublicDialogueActionSemantic {
+                action_id: row.action_id,
+                method: row.method,
+                summary: row.summary,
+                known_prerequisites: row.known_prerequisites,
+                duration_min_minutes: row.duration_min_minutes,
+                duration_max_minutes: row.duration_max_minutes,
+                uncertainty_bps: row.uncertainty_bps,
+                skill_contributions: row.skill_contributions,
+                weather_available: row.weather_available,
+                required_case_site_id: row.required_case_site_id,
+                available: row.available,
+                can_travel_to_required_site: row.can_travel_to_required_site,
+                unavailable_reason_code: row.unavailable_reason_code,
             })
             .collect::<Vec<_>>();
         actions.sort();
@@ -969,7 +1024,7 @@ impl LiveRunner {
             .backend_investigation_action_outcomes()
             .iter()
             .filter(|row| row.owner_character_id == character_id && row.case_id == case_id)
-            .map(|row| (row.outcome_id, row.action_id, row.recorded_at))
+            .map(|row| (row.outcome_id, row.action_id))
             .collect::<Vec<_>>();
         outcomes.sort();
         let mut sites = self
@@ -1272,9 +1327,10 @@ impl LiveRunner {
         agent: u32,
         case_id: &str,
         action_id: &str,
+        reason_code: &str,
         wait_minutes: u32,
     ) -> Result<bool, String> {
-        let wait_minutes = projected_investigation_wait_minutes("night_window", wait_minutes)
+        let wait_minutes = projected_investigation_wait_minutes(reason_code, wait_minutes)
             .ok_or("projected investigation wait hint was invalid")?;
         let at_settlement = self
             .party_for(owner_character_id)?
@@ -1333,9 +1389,10 @@ impl LiveRunner {
             agent,
             CoreLoopEventKind::GeneratedInvestigationWait,
             format!(
-                "case={};action={};reason=night_window;wait_minutes={wait_minutes};mode={wait_mode}",
+                "case={};action={};reason={};wait_minutes={wait_minutes};mode={wait_mode}",
                 bounded_event_field(case_id),
                 bounded_event_field(action_id),
+                bounded_event_field(reason_code),
             ),
         );
         self.generated_actor_ready_after_time(party_id, owner_character_id, case_id)
@@ -1696,6 +1753,7 @@ impl LiveRunner {
                     &action,
                     "initial",
                 )?;
+                let action_elapsed_before = self.public_party_elapsed_max(party_id);
                 let result = reducer_call!(self, "perform_investigation_action", |cb| self
                     .connection
                     .reducers
@@ -1720,6 +1778,17 @@ impl LiveRunner {
                     })
                     .collect::<Vec<_>>();
                 outcomes.sort_by_key(|row| (row.recorded_at, row.outcome_id.clone()));
+                let action_elapsed_after = self.public_party_elapsed_max(party_id);
+                let actual_minutes = action_elapsed_after.saturating_sub(action_elapsed_before);
+                let outcome_class = if outcomes.is_empty() {
+                    // The ordinary completed failure path always publishes a
+                    // safe outcome. No new outcome after a successful reducer
+                    // call therefore identifies the authoritative planned
+                    // interval being clipped at a condition/death boundary.
+                    "planned_interval_clipped"
+                } else {
+                    "completed_with_public_outcome"
+                };
                 let wording = outcomes
                     .last()
                     .map_or("No new public outcome wording", |row| row.wording.as_str());
@@ -1728,12 +1797,14 @@ impl LiveRunner {
                     agent,
                     CoreLoopEventKind::GeneratedInvestigationAction,
                     format!(
-                        "case={};subject={};action={};method={};summary={};outcome={}",
+                        "case={};subject={};action={};method={};summary={};outcome_class={outcome_class};requested_min_minutes={};requested_max_minutes={};actual_minutes={actual_minutes};outcome={}",
                         bounded_event_field(case_id),
                         bounded_event_field(subject),
                         bounded_event_field(&action.action_id),
                         bounded_event_field(&action.method),
                         bounded_event_field(&action.summary),
+                        action.duration_min_minutes,
+                        action.duration_max_minutes,
                         bounded_event_field(wording)
                     ),
                 );
@@ -1744,6 +1815,13 @@ impl LiveRunner {
                         character_id,
                         case_id,
                     );
+                }
+                if at_settlement {
+                    // Settlement-bound actions such as locating a referred
+                    // contact do not create case-site occupancy. Re-read the
+                    // public action set in place; reserved-return validation
+                    // applies only to an action performed at a case site.
+                    continue;
                 }
                 let occupied_site_id = self
                     .party_by_id(party_id)?
@@ -1985,6 +2063,7 @@ impl LiveRunner {
                     agent,
                     case_id,
                     &action.action_id,
+                    &action.unavailable_reason_code,
                     wait_minutes,
                 )? {
                     return Ok(false);

--- a/crates/adventuresim-strategic-sim/src/live_core/model.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/model.rs
@@ -1,4 +1,7 @@
-use crate::{ActivityPreference, AgentProfile, BuildRole, EquipmentStyle, generate_profile};
+use crate::{
+    ActivityPreference, AgentProfile, BuildRole, Conscience, Conviction, Drive, EquipmentStyle,
+    Nerve, SelfRegard, Sociability, Transparency, generate_profile,
+};
 use adventuresim_core::simulation_security::{
     SIM_BOOTSTRAP_TOKEN_ENV as BOOTSTRAP_TOKEN_ENV,
     SIM_BOOTSTRAP_TOKEN_HEX_LEN as BOOTSTRAP_TOKEN_HEX_LEN,
@@ -61,12 +64,17 @@ use adventuresim_stdb_client::{
     ensure_settlement_activity_reducer::ensure_settlement_activity,
     equip_item_at_placement_reducer::equip_item_at_placement, equip_item_reducer::equip_item,
     equipment_occupancy_table::EquipmentOccupancyTableAccess, field_shelter_type::FieldShelter,
+    container_liquid_table::ContainerLiquidTableAccess,
     finalize_merchant_trade_reducer::finalize_merchant_trade, food_lot_table::FoodLotTableAccess,
-    inventory_item_table::InventoryItemTableAccess, item_condition_table::ItemConditionTableAccess,
+    inventory_containment_table::InventoryContainmentTableAccess,
+    inventory_item_amount_table::InventoryItemAmountTableAccess,
+    inventory_item_table::InventoryItemTableAccess, inventory_object_table::InventoryObjectTableAccess,
+    item_condition_table::ItemConditionTableAccess,
     item_table::ItemTableAccess, limb_injury_table::LimbInjuryTableAccess,
     liquidate_party_inventory_reducer::liquidate_party_inventory,
     local_problem_symptom_table::LocalProblemSymptomTableAccess,
     party_inventory_item_table::PartyInventoryItemTableAccess,
+    party_item_amount_table::PartyItemAmountTableAccess,
     party_join_request_table::PartyJoinRequestTableAccess,
     party_journey_itinerary_table::PartyJourneyItineraryTableAccess,
     party_journey_table::PartyJourneyTableAccess, party_member_table::PartyMemberTableAccess,
@@ -1718,16 +1726,139 @@ fn select_expedition_encounter_choice(
     })
 }
 
+fn simulation_elapsed_minutes(starting_minute: u64, current_minute: u64) -> u64 {
+    current_minute.saturating_sub(starting_minute)
+}
+
+fn public_effective_inventory_quantity(quantity: u32, measured_amount: Option<u32>) -> f32 {
+    measured_amount.map_or(quantity as f32, |amount| {
+        amount as f32
+            / adventuresim_core::inventory_measurement::FULL_AMOUNT_MILLIUNITS as f32
+    })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct NarrativeEncounterPolicyChoice {
+    choice: String,
+    reason: &'static str,
+    visible_alternatives: Vec<String>,
+    eligible_meaningful_alternatives: Vec<String>,
+}
+
+fn narrative_axis_fit(
+    profile: &AgentProfile,
+    development: &adventuresim_core::road_encounter_catalog::PersonalityDevelopment,
+) -> i32 {
+    use adventuresim_core::road_encounter_catalog::PersonalityAxisId;
+    let preferred_sign = match development.axis {
+        PersonalityAxisId::Nerve => match profile.personality.nerve {
+            Nerve::Brave => 1,
+            Nerve::Fearful => -1,
+            Nerve::Neutral => 0,
+        },
+        PersonalityAxisId::Drive => match profile.personality.drive {
+            Drive::Ambitious => 1,
+            Drive::Content => -1,
+            Drive::Neutral => 0,
+        },
+        PersonalityAxisId::Sociability => match profile.personality.sociability {
+            Sociability::Gregarious => 1,
+            Sociability::Solitary => -1,
+            Sociability::Neutral => 0,
+        },
+        PersonalityAxisId::Conscience => match profile.personality.conscience {
+            Conscience::Compassionate => 1,
+            Conscience::Callous | Conscience::Cruel => -1,
+            Conscience::Neutral => 0,
+        },
+        PersonalityAxisId::SelfRegard => match profile.personality.self_regard {
+            SelfRegard::Proud => 1,
+            SelfRegard::Humble => -1,
+            SelfRegard::Neutral => 0,
+        },
+        PersonalityAxisId::Conviction => match profile.personality.conviction {
+            Conviction::Zealous => 1,
+            Conviction::Irreverent => -1,
+            Conviction::Neutral => 0,
+        },
+        PersonalityAxisId::Transparency => match profile.personality.transparency {
+            Transparency::Open => 1,
+            Transparency::Guarded => -1,
+            Transparency::Neutral => 0,
+        },
+        PersonalityAxisId::Courtship => 0,
+    };
+    preferred_sign * i32::from(development.delta.signum())
+}
+
 fn select_public_narrative_encounter_choice(
     presentation_json: &str,
-) -> Result<Option<String>, serde_json::Error> {
+    profile: &AgentProfile,
+) -> Result<Option<NarrativeEncounterPolicyChoice>, serde_json::Error> {
     let presentation: adventuresim_core::road_encounter_catalog::EncounterPresentation =
         serde_json::from_str(presentation_json)?;
-    Ok(presentation
+    let mut visible_alternatives = presentation
         .choices
-        .into_iter()
-        .find(|choice| choice.id == "ignore" && choice.available)
-        .map(|choice| choice.id))
+        .iter()
+        .filter(|choice| choice.available)
+        .map(|choice| choice.id.clone())
+        .collect::<Vec<_>>();
+    visible_alternatives.sort();
+    let ignore = visible_alternatives.iter().any(|choice| choice == "ignore");
+    let mut meaningful = presentation
+        .choices
+        .iter()
+        .filter(|choice| choice.available && choice.id != "ignore")
+        .filter_map(|presented| {
+            let mut authored = adventuresim_core::road_encounter_catalog::definitions()
+                .iter()
+                .flat_map(|definition| definition.choices.iter())
+                .filter(|choice| choice.id == presented.id);
+            let choice = authored.next()?;
+            if authored.next().is_some()
+                || !choice.checks.is_empty()
+                || matches!(
+                    choice.transition.as_ref(),
+                    Some(adventuresim_core::road_encounter_catalog::EncounterTransition::StartCombat { .. })
+                )
+            {
+                return None;
+            }
+            let personality_fit = choice
+                .personality
+                .iter()
+                .map(|development| narrative_axis_fit(profile, development))
+                .sum::<i32>();
+            // Public availability and authored requirements prove only that
+            // a choice is legal. They do not establish that spending its
+            // resources is preferable to continuing safely.
+            (personality_fit > 0).then_some((presented.id.clone(), personality_fit))
+        })
+        .collect::<Vec<_>>();
+    meaningful.sort_by(|left, right| {
+        right
+            .1
+            .cmp(&left.1)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    let eligible_meaningful_alternatives = meaningful
+        .iter()
+        .map(|(choice, _)| choice.clone())
+        .collect::<Vec<_>>();
+    if let Some((choice, _)) = meaningful.into_iter().next() {
+        return Ok(Some(NarrativeEncounterPolicyChoice {
+            choice,
+            reason: "personality_aligned_check_free_noncombat",
+            visible_alternatives,
+            eligible_meaningful_alternatives,
+        }));
+    }
+    Ok(ignore.then_some(NarrativeEncounterPolicyChoice {
+        choice: "ignore".into(),
+        reason: "unconditional_check_free_noncombat_fallback",
+        visible_alternatives,
+        eligible_meaningful_alternatives,
+    }))
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -2264,11 +2395,22 @@ fn storefront_offer_unchanged(
     current.as_ref() == Some(selected)
 }
 
-fn visible_unique_default_provider(providers: &[(u64, u16, u16)], minute: u64) -> Option<u64> {
-    let [(provider, start_minute, end_minute)] = providers else {
+fn visible_unique_default_provider(
+    providers: &[(u64, u16, u16, bool, bool)],
+    minute: u64,
+) -> Option<u64> {
+    let [(provider, start_minute, end_minute, context_suppressed, health_suppressed)] = providers
+    else {
         return None;
     };
-    npc_is_publicly_present(*start_minute, *end_minute, minute).then_some(*provider)
+    npc_is_publicly_present(
+        *start_minute,
+        *end_minute,
+        *context_suppressed,
+        *health_suppressed,
+        minute,
+    )
+    .then_some(*provider)
 }
 
 fn retain_navigable_public_npc_candidates(
@@ -2439,11 +2581,47 @@ fn new_or_updated_public_discovery_referral(
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct PublicDialogueProgressFingerprint {
-    cases: Vec<(String, String, u64)>,
-    leads: Vec<(String, u64, String, String, String, String, String)>,
-    actions: Vec<(String, u32, bool, bool, String, u32)>,
-    outcomes: Vec<(String, String, u64)>,
+    cases: Vec<(String, String)>,
+    leads: Vec<PublicDialogueLeadSemantic>,
+    actions: Vec<PublicDialogueActionSemantic>,
+    outcomes: Vec<(String, String)>,
     sites: Vec<(String, String, bool, bool, bool)>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct PublicDialogueLeadSemantic {
+    summary: String,
+    source_label: String,
+    confidence_bps: u16,
+    destination_stage: String,
+    directions: String,
+    exact_location_id: String,
+    latitude_e7: i32,
+    longitude_e7: i32,
+    witness_name: String,
+    witness_description: String,
+    witness_occupation_or_relationship: String,
+    expected_location: String,
+    current_learned_location: String,
+    contradiction_group: String,
+    corrected_by: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct PublicDialogueActionSemantic {
+    action_id: String,
+    method: String,
+    summary: String,
+    known_prerequisites: String,
+    duration_min_minutes: u32,
+    duration_max_minutes: u32,
+    uncertainty_bps: u16,
+    skill_contributions: String,
+    weather_available: bool,
+    required_case_site_id: String,
+    available: bool,
+    can_travel_to_required_site: bool,
+    unavailable_reason_code: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -2501,7 +2679,16 @@ impl GeneratedDiscoveryOutcome {
     }
 }
 
-fn npc_is_publicly_present(start_minute: u16, end_minute: u16, minute: u64) -> bool {
+fn npc_is_publicly_present(
+    start_minute: u16,
+    end_minute: u16,
+    context_suppressed: bool,
+    health_suppressed: bool,
+    minute: u64,
+) -> bool {
+    if context_suppressed || health_suppressed {
+        return false;
+    }
     let minute = minute % 1_440;
     let start = u64::from(start_minute);
     let end = u64::from(end_minute);
@@ -2613,9 +2800,17 @@ fn occupied_case_pin_matches(
 }
 
 fn projected_investigation_wait_minutes(reason_code: &str, wait_minutes: u32) -> Option<u32> {
-    (reason_code == "night_window"
+    (matches!(reason_code, "night_window" | "contact_schedule_window")
         && (1..=MAX_PROJECTED_INVESTIGATION_WAIT_MINUTES).contains(&wait_minutes))
     .then_some(wait_minutes)
+}
+
+fn dialogue_contact_presence_changed(error: &str) -> bool {
+    matches!(
+        error,
+        "start_dialogue failed: Dialogue actor has no authoritative presence"
+            | "start_dialogue failed: Dialogue actor is not present at this time"
+    )
 }
 
 fn projected_case_site_journey_minutes(

--- a/crates/adventuresim-strategic-sim/src/live_core/survival.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/survival.rs
@@ -77,9 +77,95 @@ impl LiveRunner {
             .sum()
     }
 
-    fn public_stack_weight_kg(&self, item_id: &str, quantity: u32) -> f32 {
-        self.item_definition(item_id)
-            .map_or(0.0, |item| item.weight.max(0.0) * quantity as f32)
+    fn public_object_root_matches(&self, object_id: u64, kind: &str, owner: &str) -> bool {
+        let mut cursor = object_id;
+        let mut visited = HashSet::new();
+        for _ in 0..=adventuresim_core::inventory_containers::MAX_CONTAINER_DEPTH {
+            if !visited.insert(cursor) {
+                return false;
+            }
+            let Some(object) = self
+                .connection
+                .db
+                .inventory_object()
+                .iter()
+                .find(|object| object.id == cursor)
+            else {
+                return false;
+            };
+            if object.location_kind != kind || object.location_owner != owner {
+                return false;
+            }
+            let parent = self
+                .connection
+                .db
+                .inventory_containment()
+                .iter()
+                .find(|edge| edge.child_object_id == cursor)
+                .map(|edge| edge.parent_object_id);
+            let Some(parent) = parent else {
+                return true;
+            };
+            cursor = parent;
+        }
+        false
+    }
+
+    fn public_row_is_carried(&self, kind: &str, owner: &str, row_id: u64) -> bool {
+        let objects = self
+            .connection
+            .db
+            .inventory_object()
+            .iter()
+            .filter(|object| object.location_kind == kind && object.inventory_row_id == row_id)
+            .collect::<Vec<_>>();
+        match objects.as_slice() {
+            [] => true,
+            [object] => self.public_object_root_matches(object.id, kind, owner),
+            _ => false,
+        }
+    }
+
+    fn public_measured_stack_weight_kg(
+        &self,
+        kind: &str,
+        row_id: u64,
+        item_id: &str,
+        quantity: u32,
+    ) -> f32 {
+        let remaining = match kind {
+            "personal" => self
+                .connection
+                .db
+                .inventory_item_amount()
+                .iter()
+                .find(|amount| amount.inventory_item_id == row_id)
+                .map(|amount| amount.remaining_milliunits),
+            "party" => self
+                .connection
+                .db
+                .party_item_amount()
+                .iter()
+                .find(|amount| amount.party_inventory_item_id == row_id)
+                .map(|amount| amount.remaining_milliunits),
+            _ => None,
+        };
+        self.item_definition(item_id).map_or(0.0, |item| {
+            item.weight.max(0.0) * public_effective_inventory_quantity(quantity, remaining)
+        })
+    }
+
+    fn public_contained_water_ml(&self, kind: &str, owner: &str) -> f32 {
+        self.connection
+            .db
+            .container_liquid()
+            .iter()
+            .filter(|liquid| liquid.liquid_item_id == "water")
+            .filter(|liquid| {
+                self.public_object_root_matches(liquid.container_object_id, kind, owner)
+            })
+            .map(|liquid| liquid.water_ml as f32)
+            .sum()
     }
 
     fn public_personal_load_kg(&self, character_id: u64) -> f32 {
@@ -95,7 +181,14 @@ impl LiveRunner {
             .db
             .inventory_item()
             .iter()
-            .filter(|row| row.character_id == character_id)
+            .filter(|row| {
+                row.character_id == character_id
+                    && self.public_row_is_carried(
+                        "personal",
+                        &character_id.to_string(),
+                        row.id,
+                    )
+            })
             .map(|row| {
                 self.connection
                     .db
@@ -103,7 +196,14 @@ impl LiveRunner {
                     .iter()
                     .find(|lot| lot.inventory_item_id == Some(row.id))
                     .map_or_else(
-                        || self.public_stack_weight_kg(&row.item_id, row.quantity),
+                        || {
+                            self.public_measured_stack_weight_kg(
+                                "personal",
+                                row.id,
+                                &row.item_id,
+                                row.quantity,
+                            )
+                        },
                         |lot| lot.mass_kg.max(0.0),
                     )
             })
@@ -112,7 +212,9 @@ impl LiveRunner {
         // plus carried water. A character's own body mass is combat data, not
         // cargo, and including it creates a false overweight feedback loop
         // when a staggered condition temporarily halves carrying capacity.
-        water_weight + inventory_weight
+        water_weight
+            + inventory_weight
+            + self.public_contained_water_ml("personal", &character_id.to_string()) / 1_000.0
     }
 
     fn public_character_capacity_kg(&self, character_id: u64) -> f32 {
@@ -164,7 +266,10 @@ impl LiveRunner {
             .db
             .party_inventory_item()
             .iter()
-            .filter(|row| row.party_id == party_id)
+            .filter(|row| {
+                row.party_id == party_id
+                    && self.public_row_is_carried("party", party_id, row.id)
+            })
             .map(|row| {
                 self.connection
                     .db
@@ -172,7 +277,14 @@ impl LiveRunner {
                     .iter()
                     .find(|lot| lot.party_inventory_item_id == Some(row.id))
                     .map_or_else(
-                        || self.public_stack_weight_kg(&row.item_id, row.quantity),
+                        || {
+                            self.public_measured_stack_weight_kg(
+                                "party",
+                                row.id,
+                                &row.item_id,
+                                row.quantity,
+                            )
+                        },
                         |lot| lot.mass_kg.max(0.0),
                     )
             })
@@ -181,7 +293,9 @@ impl LiveRunner {
             .iter()
             .map(|id| self.public_character_capacity_kg(*id))
             .sum::<f32>();
-        let load = personal_load + pooled_load;
+        let load = personal_load
+            + pooled_load
+            + self.public_contained_water_ml("party", party_id) / 1_000.0;
         (
             load,
             capacity,
@@ -394,7 +508,15 @@ impl LiveRunner {
                     .settlement_resident_presence()
                     .iter()
                     .find(|presence| presence.character_id == npc.character_id)
-                    .map(|presence| (npc.character_id, presence.start_minute, presence.end_minute))
+                    .map(|presence| {
+                        (
+                            npc.character_id,
+                            presence.start_minute,
+                            presence.end_minute,
+                            presence.context_suppressed,
+                            presence.health_suppressed,
+                        )
+                    })
             })
             .collect::<Vec<_>>();
         visible_unique_default_provider(&providers, minute)

--- a/crates/adventuresim-strategic-sim/src/live_core/tests/control_policy.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/tests/control_policy.rs
@@ -457,3 +457,18 @@ fn quest_fixture_lane_plan_is_exact_and_order_independent() {
     assert!(bootstrap.contains("Some(FixtureQuestLane::Generated) => None"));
     assert!(bootstrap.contains("None => runner.choose_quest(&party, &profile)"));
 }
+#[test]
+fn simulation_duration_is_relative_to_the_post_bootstrap_world_clock() {
+    let absolute_start = 8_000_000;
+    assert_eq!(simulation_elapsed_minutes(absolute_start, absolute_start), 0);
+    assert_eq!(simulation_elapsed_minutes(absolute_start, absolute_start + 1_440), 1_440);
+    assert_eq!(simulation_elapsed_minutes(absolute_start, absolute_start - 1), 0);
+
+    let bootstrap = LIVE_CORE_SOURCE
+        .split("let simulation_start_minutes")
+        .nth(1)
+        .expect("absolute-clock baseline capture");
+    assert!(bootstrap.contains("simulation_elapsed_minutes("));
+    assert!(bootstrap.contains("recovery_started_at"));
+    assert!(bootstrap.contains("missing simulation-start final character clock"));
+}

--- a/crates/adventuresim-strategic-sim/src/live_core/tests/failure_security.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/tests/failure_security.rs
@@ -15,6 +15,11 @@ fn generated_runner_subscribes_only_to_public_projection_inventory() {
         ".backend_case_site_pins()",
         ".party_journey()",
         ".party_journey_itinerary()",
+        ".inventory_object()",
+        ".inventory_containment()",
+        ".inventory_item_amount()",
+        ".party_item_amount()",
+        ".container_liquid()",
     ] {
         assert!(
             production.contains(required),
@@ -412,7 +417,9 @@ fn generated_action_trace_uses_subject_and_public_attempt_evidence() {
     assert!(source.contains(
         "actor_time={actor_time};party_time_min={party_time_min};party_time_max={party_time_max}"
     ));
-    assert!(advance.contains("\"case={};subject={};action={};method={};summary={};outcome={}\""));
+    assert!(advance.contains("outcome_class={outcome_class}"));
+    assert!(advance.contains("requested_min_minutes={}"));
+    assert!(advance.contains("actual_minutes={actual_minutes}"));
     assert!(!advance.contains("\"case={};title={};action={};method={};summary={};outcome={}\""));
     assert!(advance.contains("self.call(result)?"));
     assert!(!advance.contains("victim_cohort_state_changed_failure"));
@@ -505,6 +512,10 @@ fn projected_night_wait_hints_are_strictly_bounded() {
     assert_eq!(
         projected_investigation_wait_minutes("night_window", 840),
         Some(840)
+    );
+    assert_eq!(
+        projected_investigation_wait_minutes("contact_schedule_window", 420),
+        Some(420)
     );
     assert_eq!(
         projected_investigation_wait_minutes("travel_required", 840),

--- a/crates/adventuresim-strategic-sim/src/live_core/tests/policy_and_discovery.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/tests/policy_and_discovery.rs
@@ -735,19 +735,49 @@ fn discovery_follows_only_new_or_updated_public_witness_referrals() {
     );
 }
 
+fn semantic_dialogue_lead() -> PublicDialogueLeadSemantic {
+    PublicDialogueLeadSemantic {
+        summary: "A witness may know more.".into(),
+        source_label: "local testimony".into(),
+        confidence_bps: 6_000,
+        destination_stage: "referred_contact".into(),
+        directions: "Ask at the inn.".into(),
+        exact_location_id: String::new(),
+        latitude_e7: 0,
+        longitude_e7: 0,
+        witness_name: "Agnes".into(),
+        witness_description: "A local weaver.".into(),
+        witness_occupation_or_relationship: "weaver".into(),
+        expected_location: "inn".into(),
+        current_learned_location: String::new(),
+        contradiction_group: "witness:agnes".into(),
+        corrected_by: String::new(),
+    }
+}
+
+fn semantic_dialogue_action() -> PublicDialogueActionSemantic {
+    PublicDialogueActionSemantic {
+        action_id: "action:inspect".into(),
+        method: "inspect".into(),
+        summary: "Inspect the mill.".into(),
+        known_prerequisites: "Bring light.".into(),
+        duration_min_minutes: 30,
+        duration_max_minutes: 60,
+        uncertainty_bps: 2_000,
+        skill_contributions: "observation".into(),
+        weather_available: true,
+        required_case_site_id: "site:mill".into(),
+        available: true,
+        can_travel_to_required_site: true,
+        unavailable_reason_code: String::new(),
+    }
+}
+
 #[test]
 fn dialogue_topics_suppress_no_progress_and_reenable_after_public_change() {
     let initial = PublicDialogueProgressFingerprint {
-        cases: vec![("journal:case".into(), "open".into(), 10)],
-        leads: vec![(
-            "lead:witness".into(),
-            10,
-            "A witness may know more.".into(),
-            "Agnes".into(),
-            String::new(),
-            "inn".into(),
-            String::new(),
-        )],
+        cases: vec![("journal:case".into(), "open".into())],
+        leads: vec![semantic_dialogue_lead()],
         actions: Vec::new(),
         outcomes: Vec::new(),
         sites: Vec::new(),
@@ -760,13 +790,92 @@ fn dialogue_topics_suppress_no_progress_and_reenable_after_public_change() {
     ));
 
     let mut progressed = initial.clone();
-    progressed
-        .actions
-        .push(("action:inspect".into(), 1, true, true, String::new(), 0));
+    progressed.actions.push(semantic_dialogue_action());
     assert!(public_dialogue_topic_made_progress(&initial, &progressed));
     assert!(public_dialogue_topic_attempt_allowed(
         Some(&initial),
         &progressed
+    ));
+}
+
+#[test]
+fn public_dialogue_presence_rejects_suppression_and_replans_authority_races() {
+    assert!(npc_is_publicly_present(480, 1_020, false, false, 900));
+    assert!(!npc_is_publicly_present(480, 1_020, true, false, 900));
+    assert!(!npc_is_publicly_present(480, 1_020, false, true, 900));
+    assert!(dialogue_contact_presence_changed(
+        "start_dialogue failed: Dialogue actor is not present at this time"
+    ));
+    assert!(!dialogue_contact_presence_changed(
+        "start_dialogue failed: Dialogue conversation is not valid for this NPC"
+    ));
+}
+
+#[test]
+fn repeated_testimony_metadata_does_not_count_as_dialogue_progress() {
+    fn semantic_fingerprint(
+        case_updated_at: u64,
+        lead_id: &str,
+        lead_recorded_at: u64,
+    ) -> PublicDialogueProgressFingerprint {
+        let _publication_metadata = (case_updated_at, lead_id, lead_recorded_at);
+        PublicDialogueProgressFingerprint {
+            cases: vec![("journal:case".into(), "open".into())],
+            leads: vec![semantic_dialogue_lead()],
+            actions: Vec::new(),
+            outcomes: Vec::new(),
+            sites: Vec::new(),
+        }
+    }
+
+    let original = semantic_fingerprint(10, "lead:first", 10);
+    let republished = semantic_fingerprint(20, "lead:duplicate", 20);
+
+    assert!(!public_dialogue_topic_made_progress(
+        &original,
+        &republished
+    ));
+    assert!(!public_dialogue_topic_attempt_allowed(
+        Some(&original),
+        &republished
+    ));
+
+    let fingerprint_source = LIVE_CORE_SOURCE
+        .split("pub(super) fn public_dialogue_progress_fingerprint")
+        .nth(1)
+        .and_then(|tail| tail.split("pub(super) fn generated_actor_ready_after_time").next())
+        .expect("public dialogue progress fingerprint");
+    for publication_field in [
+        "latest_update_at",
+        "recorded_at",
+        "expected_version",
+        "wait_minutes",
+    ] {
+        assert!(
+            !fingerprint_source.contains(publication_field),
+            "{publication_field} is publication metadata, not semantic investigation progress"
+        );
+    }
+}
+
+#[test]
+fn policy_relevant_lead_and_action_changes_count_as_dialogue_progress() {
+    let baseline = PublicDialogueProgressFingerprint {
+        cases: vec![("journal:case".into(), "open".into())],
+        leads: vec![semantic_dialogue_lead()],
+        actions: vec![semantic_dialogue_action()],
+        outcomes: Vec::new(),
+        sites: Vec::new(),
+    };
+    let mut changed_lead = baseline.clone();
+    changed_lead.leads[0].confidence_bps = 8_000;
+    assert!(public_dialogue_topic_made_progress(&baseline, &changed_lead));
+
+    let mut changed_action = baseline.clone();
+    changed_action.actions[0].weather_available = false;
+    assert!(public_dialogue_topic_made_progress(
+        &baseline,
+        &changed_action
     ));
 }
 

--- a/crates/adventuresim-strategic-sim/src/live_core/tests/recovery_and_cases.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/tests/recovery_and_cases.rs
@@ -763,3 +763,30 @@ fn active_journey_recovery_preserves_authoritative_camp_progress_and_redirect() 
     assert!(recovery.contains("public_journey_is_evacuation(party_id)"));
     assert!(recovery.contains("travel_to_settlement_then"));
 }
+#[test]
+fn investigation_trace_distinguishes_planned_interval_clipping_from_public_outcomes() {
+    let source = LIVE_CORE_SOURCE;
+    let action = source
+        .split("let action_elapsed_before")
+        .nth(1)
+        .and_then(|tail| tail.split("observe_generated_case_transition").next())
+        .expect("generated investigation action trace");
+    assert!(action.contains("outcomes.is_empty()"));
+    assert!(action.contains("planned_interval_clipped"));
+    assert!(action.contains("completed_with_public_outcome"));
+    assert!(action.contains("requested_min_minutes"));
+    assert!(action.contains("actual_minutes"));
+}
+
+#[test]
+fn nonterminal_settlement_investigation_does_not_require_case_site_occupancy() {
+    let source = LIVE_CORE_SOURCE;
+    let post_action = source
+        .split("if at_settlement {\n                    // Settlement-bound actions")
+        .nth(1)
+        .and_then(|tail| tail.split("let return_pin").next())
+        .expect("post-action settlement/site branch");
+    assert!(post_action.contains("continue;"));
+    assert!(post_action.contains("current_case_site_id"));
+    assert!(post_action.find("continue;").unwrap() < post_action.find("current_case_site_id").unwrap());
+}

--- a/crates/adventuresim-strategic-sim/src/live_core/tests/survival_readiness.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/tests/survival_readiness.rs
@@ -227,20 +227,29 @@ fn one_generated_action_attempt_takes_its_reserved_return_before_another_attempt
     let action_event = attempted_action
         .find("CoreLoopEventKind::GeneratedInvestigationAction")
         .expect("public action progress event");
-    let return_safety = attempted_action
+    let settlement_continue = attempted_action
+        .find("if at_settlement {")
+        .expect("settlement action continuation branch");
+    let occupied_site = attempted_action
+        .find("let occupied_site_id")
+        .expect("off-settlement occupancy boundary");
+    let off_settlement_return = &attempted_action[occupied_site..];
+    let return_safety = off_settlement_return
         .find("generated_action_return_thermal_decision(party_id, &return_pin, 0)")
         .expect("authoritative reserved-return safety recheck");
-    let return_reducer = attempted_action
+    let return_reducer = off_settlement_return
         .find("evacuate_generated_party_to_origin(")
         .expect("reserved return execution");
-    let progress_exit = attempted_action
+    let progress_exit = off_settlement_return
         .rfind("return Ok(true)")
         .expect("public-progress exit after reserved return");
-    assert!(action_event < return_safety && return_safety < return_reducer);
+    assert!(action_event < settlement_continue && settlement_continue < occupied_site);
+    assert!(return_safety < return_reducer);
     assert!(return_reducer < progress_exit);
-    assert!(!attempted_action.contains("generated_actor_ready_after_time"));
-    assert!(!attempted_action.contains("continue;"));
-    assert!(attempted_action.contains("plan=one_attempt_then_reserved_return"));
+    assert!(attempted_action[settlement_continue..occupied_site].contains("continue;"));
+    assert!(!off_settlement_return.contains("generated_actor_ready_after_time"));
+    assert!(!off_settlement_return.contains("continue;"));
+    assert!(off_settlement_return.contains("plan=one_attempt_then_reserved_return"));
     let evacuation = generated
         .split("fn evacuate_generated_party_to_origin")
         .nth(1)
@@ -578,8 +587,48 @@ fn public_encumbrance_counts_carried_mass_but_not_body_mass() {
         .expect("public personal-load projection");
     assert!(load.contains("carried_water_ml"));
     assert!(load.contains("inventory_weight"));
-    assert!(load.contains("water_weight + inventory_weight"));
+    assert!(load.contains("public_contained_water_ml"));
+    assert!(load.contains("public_measured_stack_weight_kg"));
+    assert!(load.contains("public_row_is_carried"));
     assert!(!load.contains("body_weight_kg"));
+}
+
+#[test]
+fn public_supply_and_load_accounting_include_nested_measured_objects() {
+    let source = LIVE_CORE_SOURCE;
+    for public_surface in [
+        ".inventory_object()",
+        ".inventory_containment()",
+        ".inventory_item_amount()",
+        ".party_item_amount()",
+        ".container_liquid()",
+    ] {
+        assert!(source.contains(public_surface), "{public_surface}");
+    }
+    let supplies = source
+        .split("fn expedition_supplies")
+        .nth(1)
+        .and_then(|tail| tail.split("fn emit_expedition_diagnostics").next())
+        .expect("public expedition supply observation");
+    assert!(supplies.contains("public_row_is_carried"));
+    assert!(supplies.contains("contained_water_ml"));
+}
+
+#[test]
+fn measured_inventory_amount_replaces_stack_quantity_at_canonical_scale() {
+    use adventuresim_core::inventory_measurement::FULL_AMOUNT_MILLIUNITS;
+
+    assert_eq!(public_effective_inventory_quantity(3, None), 3.0);
+    assert_eq!(
+        public_effective_inventory_quantity(3, Some(FULL_AMOUNT_MILLIUNITS)),
+        1.0,
+        "a measured row is one measured object, not quantity times its amount"
+    );
+    assert_eq!(
+        public_effective_inventory_quantity(7, Some(FULL_AMOUNT_MILLIUNITS / 2)),
+        0.5,
+        "half of a measured object remains half regardless of the legacy stack quantity"
+    );
 }
 
 #[test]
@@ -749,14 +798,24 @@ fn equipment_storefront_requires_service_and_matching_stock_category() {
 #[test]
 fn staggered_default_providers_remain_ambiguous_before_hours_filtering() {
     assert_eq!(
-        visible_unique_default_provider(&[(7, 0, 720), (8, 720, 1_440)], 300),
+        visible_unique_default_provider(
+            &[(7, 0, 720, false, false), (8, 720, 1_440, false, false)],
+            300
+        ),
         None
     );
     assert_eq!(
-        visible_unique_default_provider(&[(7, 0, 720)], 300),
+        visible_unique_default_provider(&[(7, 0, 720, false, false)], 300),
         Some(7)
     );
-    assert_eq!(visible_unique_default_provider(&[(7, 0, 720)], 900), None);
+    assert_eq!(
+        visible_unique_default_provider(&[(7, 0, 720, false, false)], 900),
+        None
+    );
+    assert_eq!(
+        visible_unique_default_provider(&[(7, 0, 720, true, false)], 300),
+        None
+    );
 }
 
 #[test]

--- a/crates/adventuresim-strategic-sim/src/live_core/tests/travel.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/tests/travel.rs
@@ -160,14 +160,21 @@ fn all_nonterminal_encounters_follow_authoritative_public_post_state() {
 }
 
 #[test]
-fn narrative_encounter_policy_uses_only_the_available_public_ignore_choice() {
+fn narrative_encounter_policy_uses_safe_meaningful_choices_and_keeps_ignore_fallback() {
+    let mut profile = generate_profile(42, 0);
+    profile.personality = crate::Personality::neutral();
     let presentation = adventuresim_core::road_encounter_catalog::EncounterPresentation {
         cast: Vec::new(),
         opening: Vec::new(),
         choices: vec![
             adventuresim_core::road_encounter_catalog::PresentationChoice {
-                id: "attempt_checked_action".into(),
+                id: "expose_charter".into(),
                 label: "Attempt a difficult checked action".into(),
+                available: true,
+            },
+            adventuresim_core::road_encounter_catalog::PresentationChoice {
+                id: "challenge_to_arms".into(),
+                label: "Start a fight".into(),
                 available: true,
             },
             adventuresim_core::road_encounter_catalog::PresentationChoice {
@@ -180,7 +187,9 @@ fn narrative_encounter_policy_uses_only_the_available_public_ignore_choice() {
     };
     let json = serde_json::to_string(&presentation).unwrap();
     assert_eq!(
-        select_public_narrative_encounter_choice(&json).unwrap(),
+        select_public_narrative_encounter_choice(&json, &profile)
+            .unwrap()
+            .map(|choice| choice.choice),
         Some("ignore".into())
     );
 
@@ -189,7 +198,7 @@ fn narrative_encounter_policy_uses_only_the_available_public_ignore_choice() {
         opening: Vec::new(),
         choices: vec![
             adventuresim_core::road_encounter_catalog::PresentationChoice {
-                id: "attempt_checked_action".into(),
+                id: "expose_charter".into(),
                 label: "Attempt a difficult checked action".into(),
                 available: true,
             },
@@ -203,7 +212,8 @@ fn narrative_encounter_policy_uses_only_the_available_public_ignore_choice() {
     };
     assert_eq!(
         select_public_narrative_encounter_choice(
-            &serde_json::to_string(&unavailable_ignore).unwrap()
+            &serde_json::to_string(&unavailable_ignore).unwrap(),
+            &profile,
         )
         .unwrap(),
         None
@@ -212,7 +222,7 @@ fn narrative_encounter_policy_uses_only_the_available_public_ignore_choice() {
         cast: Vec::new(),
         opening: Vec::new(),
         choices: vec![adventuresim_core::road_encounter_catalog::PresentationChoice {
-            id: "attempt_checked_action".into(),
+            id: "expose_charter".into(),
             label: "Attempt a difficult checked action".into(),
             available: true,
         }],
@@ -220,21 +230,53 @@ fn narrative_encounter_policy_uses_only_the_available_public_ignore_choice() {
     };
     assert_eq!(
         select_public_narrative_encounter_choice(
-            &serde_json::to_string(&missing_ignore).unwrap()
+            &serde_json::to_string(&missing_ignore).unwrap(),
+            &profile,
         )
         .unwrap(),
         None
     );
-    assert!(select_public_narrative_encounter_choice("not-json").is_err());
+    assert!(select_public_narrative_encounter_choice("not-json", &profile).is_err());
+
+    let available_barter = adventuresim_core::road_encounter_catalog::EncounterPresentation {
+        cast: Vec::new(),
+        opening: Vec::new(),
+        choices: vec![
+            adventuresim_core::road_encounter_catalog::PresentationChoice {
+                id: "barter_rations".into(),
+                label: "Barter rations".into(),
+                available: true,
+            },
+            adventuresim_core::road_encounter_catalog::PresentationChoice {
+                id: "ignore".into(),
+                label: "Continue on the road".into(),
+                available: true,
+            },
+        ],
+        response: Vec::new(),
+    };
+    let selected = select_public_narrative_encounter_choice(
+        &serde_json::to_string(&available_barter).unwrap(),
+        &profile,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(selected.choice, "ignore");
+    assert_eq!(
+        selected.reason,
+        "unconditional_check_free_noncombat_fallback"
+    );
+    assert!(selected.eligible_meaningful_alternatives.is_empty());
+    assert_eq!(selected.visible_alternatives, vec!["barter_rations", "ignore"]);
 
     let selector = LIVE_CORE_SOURCE
         .split("fn select_public_narrative_encounter_choice")
         .nth(1)
         .and_then(|tail| tail.split("struct PublicCombatFingerprint").next())
         .expect("public narrative selector");
-    assert!(selector.contains("choice.id == \"ignore\" && choice.available"));
-    assert!(!selector.contains("definitions()"));
-    assert!(!selector.contains("encounter("));
+    assert!(selector.contains("definitions()"));
+    assert!(selector.contains("!choice.checks.is_empty()"));
+    assert!(selector.contains("EncounterTransition::StartCombat"));
 }
 
 #[test]
@@ -590,7 +632,8 @@ fn travel_driver_uses_public_itinerary_and_observer_safe_provisioning() {
     assert!(coherent_camp.contains("projected_camp_rest_minutes("));
     assert!(travel.contains("let Some((travel_actor, travel_agent, _)) ="));
     assert!(travel.contains("self.expedition_recovery_actor(party_id)"));
-    assert!(travel.contains("self.event(\n                    travel_agent,"));
+    assert!(travel.contains("CoreLoopEventKind::Travel"));
+    assert!(travel.contains("travel_agent,"));
     assert!(travel.contains("rest_at_camp_with_party_shelter"));
     assert!(!travel.contains("rest_at_camp_with_party_shelter(\n                travel_actor,\n                1_440"));
     assert!(source.contains(

--- a/crates/adventuresim-strategic-sim/src/live_core/travel.rs
+++ b/crates/adventuresim-strategic-sim/src/live_core/travel.rs
@@ -454,6 +454,8 @@ impl LiveRunner {
                                     && npc_is_publicly_present(
                                         presence.start_minute,
                                         presence.end_minute,
+                                        presence.context_suppressed,
+                                        presence.health_suppressed,
                                         payer_minute,
                                     )
                             })
@@ -888,8 +890,13 @@ impl LiveRunner {
                         "narrative_encounter_has_no_actionable_leader",
                     );
                 };
-                let choice = match select_public_narrative_encounter_choice(
+                let profile = self
+                    .profiles
+                    .get(leader_agent as usize)
+                    .ok_or("narrative encounter leader profile is unavailable")?;
+                let policy_choice = match select_public_narrative_encounter_choice(
                     &challenge.presentation_json,
+                    profile,
                 ) {
                     Ok(Some(choice)) => choice,
                     Ok(None) => {
@@ -925,6 +932,7 @@ impl LiveRunner {
                         );
                     }
                 };
+                let choice = policy_choice.choice.clone();
                 let action_id = format!(
                     "sim-road-{}-r{}",
                     blake3::hash(challenge.id.as_bytes()).to_hex(),
@@ -950,9 +958,14 @@ impl LiveRunner {
                     leader_agent,
                     CoreLoopEventKind::Encounter,
                     format!(
-                        "kind=narrative;id={};revision={revision};choice={};status=resolved",
+                        "kind=narrative;id={};revision={revision};choice={};status=resolved;reason={};visible_alternatives={};eligible_meaningful_alternatives={}",
                         bounded_event_field(&challenge_id),
                         bounded_event_field(&choice),
+                        policy_choice.reason,
+                        bounded_event_field(&policy_choice.visible_alternatives.join(",")),
+                        bounded_event_field(
+                            &policy_choice.eligible_meaningful_alternatives.join(",")
+                        ),
                     ),
                 );
                 continue;

--- a/wiki/reference/strategic-simulation.md
+++ b/wiki/reference/strategic-simulation.md
@@ -168,6 +168,18 @@ protective response exists. Evacuation never attacks. The encounter event
 records the stable reason, evacuation flag, public run eligibility, and
 projected choice set.
 
+Absolute character clocks are sampled after bootstrap and all duration gates
+and final elapsed-time fields use monotonic deltas from that baseline. A fresh
+run in a mature world therefore receives its configured duration instead of
+being mistaken for a run that already exhausted it. For narrative road
+challenges, public available choice IDs are joined to the public authored
+catalog. The policy may select a uniquely identified, check-free, non-combat
+route only when it positively aligns with the leader's personality. Public
+requirements and availability are legality gates, not evidence that spending
+resources is desirable. Checked and combat-starting routes are rejected; the catalog's
+unconditional unchecked `ignore` remains the fallback. Telemetry records the
+visible alternatives, conservative meaningful candidates, and selection reason.
+
 Generated investigation actions are ranked by a stable pure score. It considers
 projected availability and progress (perform, travel, or bounded wait), the
 owner profile's fit for the projected method, public uncertainty, public
@@ -364,7 +376,11 @@ same-named public candidates are tried in stable order and only the candidate
 whose projected session exposes `referred-testimony` for the selected public
 case is selected. Public presence is filtered through the settlement's visible
 NPC locations before any dialogue attempt, so a resident scheduled at a hidden
-service location cannot become a reducer-failing contact. Investigation
+service location or carrying a public context/health suppression cannot become
+a reducer-failing contact. If that public presence changes between selection
+and the authoritative dialogue reducer, the runner records an observer-safe
+replan and resumes settlement activity instead of weakening the reducer's
+presence check or aborting the run. Investigation
 actions and their outcomes are likewise
 filtered by exact owner and public case before reducers receive the projected
 action ID, method, and version. Exact site travel selects only the pin matching
@@ -394,6 +410,19 @@ error.
 
 The state machine is bounded per cycle and falls back to sustainable settlement
 activity when no legal projected step is available.
+
+Dialogue retries use a semantic fingerprint of the owner-visible case status,
+deduplicated lead meaning, actionable projection state, outcomes, and site
+state. Publication timestamps, projection versions, wait countdowns, and fresh
+row IDs for repeated testimony do not count as investigation progress, so an
+unchanged witness topic is not reopened each cycle or allowed to exhaust the
+bounded dialogue-session history.
+
+Travel encounter delays consume ordinary character time and needs without
+granting movement. The journey authority extends its elapsed total by that
+delay and refreshes the remaining camp forecast, preserving both the delay's
+realism and the invariant that an active journey cannot have completed elapsed
+time beyond its total forecast.
 
 Reports separately count direct-contract attempts/completions, generated case
 intakes and owner-projection continuations, generated cases discovered, completed by the
@@ -458,9 +487,27 @@ minimum carrying margin, and peak exposure. Death events include the authoritati
 source ID, and strategic minute, and the
 structured failure artifact carry the same observer-safe survival context so a policy mistake can be
 distinguished from an authoritative reducer or mechanics failure without importing private state.
-The current simulator subscriptions also omit measured personal/party inventory-amount projections;
-load accounting therefore uses the public stack/item rows and cannot yet reproduce fractional
-contents mass for every non-food measured container.
+The simulator subscribes to public physical-object, containment, measured
+amount, and container-liquid projections. Load and recovery-supply accounting
+resolve ultimate personal or party custody, include nested objects and
+contained water, scale measured non-food material mass, and reject malformed or
+fixture-rooted object graphs. This is observer-safe accounting, not custody
+authority.
+
+Completed investigation failures publish an ordinary public outcome. When a
+successful reducer call advances the public party clock but publishes no new
+outcome, the trace instead records `planned_interval_clipped`, the projected
+duration band, and actual elapsed minutes. This preserves an authoritative
+condition or death interruption rather than calling it an unproductive agent
+decision.
+`locate_contact` availability also mirrors the referred resident's public
+scheduled presence at the projected party minute. An ordinary schedule gap
+publishes a bounded wait; public health/context suppression fails closed
+without exposing private outbreak state.
+
+Foraging remains intentionally outside autonomous policy. Its ordinary gateway
+flow requires authoritative terrain attestation; the simulator neither forges
+that attestation nor reads private terrain or resource authority to bypass it.
 
 Medical needs are evaluated before repairs, and repairs before equipment upgrades. The disposable
 fixture accepts a validated disease scenario ID, defaulting to influenza, behind the same claimed-run


### PR DESCRIPTION
## Summary
- audit strategic changes since the last NPC simulator update and bring public inventory, containment, presence, and investigation projections into the live runner
- fix simulator policy errors found by live party runs: relative duration accounting, nested measured supplies, conservative narrative choices, settlement actions, and semantic dialogue retry suppression
- fix strategic-server bugs found by the same runs: zero-minute camp identity, scheduled contact projection parity, and encounter-delay journey forecasts
- add observer-safe diagnostics for clipped investigation actions and document remaining intentional coverage boundaries

## Live evidence
- seed 42, population 4, party size 2, 60 days: required direct and generated quest lanes completed; 0 reducer failures, retries, stuck detections, defeats, or wipes
- generated outbreak quest required 6 investigation actions and repeated field trips; the direct acceptance fixture remained intentionally light
- seed 43 exposed a further completion issue after 4 investigation actions; follow-up diagnosis will continue on a branch stacked on this PR

## Verification
- cargo fmt --all -- --check
- cargo check -p adventuresim-stdb-module -p adventuresim-strategic-sim
- cargo test -p adventuresim-strategic-sim -- --skip investigation_eval::report::tests::checked_in_failure_fixture_replays_deterministically (193 unit, 2 auxiliary, 15 simulation tests passed; one live test ignored)
- just verify-db-client
- project map check and git diff --check

## Known upstream issue
The skipped checked-in investigation failure replay already fails on origin/main because the outbreak evaluator seed changed without regenerating the fixture.