### PR TITLE
Implement stable third-person camera rig

### DIFF
--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -6,6 +6,16 @@ Bevy. Skeletal animation is presentation-only: the server replicates compact
 the client selects and blends authored poses, then applies procedural look and
 terrain leg IK.
 
+The gameplay camera is likewise client presentation. A single retained rig
+blends from centered lowered-guard exploration to raised-guard right-shoulder
+aiming without smoothing manual yaw or pitch. Focus translation uses bounded
+anisotropic critical damping and a screen-space sweet spot. A sphere sweep
+retracts the boom around hard geometry, with hysteretic recovery and
+tight-space shoulder recentering. Raised aiming resolves the center-screen
+camera target and the subsequent muzzle path separately. Debug builds use
+`F6` to show rig, collision, smoothing, occlusion classification, and aim-ray
+telemetry.
+
 ## Animation export contract
 
 The humanoid base rig is independent from authored motions:

--- a/crates/adventuresim-tactical-client/assets/ui.css
+++ b/crates/adventuresim-tactical-client/assets/ui.css
@@ -72,6 +72,18 @@ text,span {
   z-index: -100;
 }
 
+#aim-blocked {
+  position: absolute;
+  top: 54px;
+  left: -54px;
+  width: 180px;
+  color: var(--error);
+  font-size: 13px;
+  font-weight: 800;
+  text-align: center;
+  text-shadow: #000 2px 2px;
+}
+
 #terminal-outcome {
   position: absolute;
   top: 28%;

--- a/crates/adventuresim-tactical-client/src/camera.rs
+++ b/crates/adventuresim-tactical-client/src/camera.rs
@@ -1,30 +1,47 @@
-use adventuresim_tactical_core::prelude::CharacterControllerCameraOf;
+use adventuresim_tactical_core::prelude::{
+    CharacterControllerCameraOf, CharacterControllerState, Collider, ShapeCastConfig, SpatialQuery,
+    SpatialQueryFilter, WeaponGuardState,
+};
+use adventuresim_tactical_netcode::client::WeaponGuardInputState;
 use bevy::prelude::*;
-
-const THIRD_PERSON_DISTANCE: f32 = 3.5;
-const THIRD_PERSON_HEIGHT: f32 = 0.25;
 
 pub struct TacticalCameraPlugin;
 
 #[derive(SystemSet, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum TacticalCameraSet {
     Offset,
+    Aim,
 }
 
 impl Plugin for TacticalCameraPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CameraMode>()
+            .init_resource::<CameraRigConfig>()
+            .init_resource::<CameraRigState>()
+            .init_resource::<CameraRigDebugState>()
+            .init_resource::<CameraAimState>()
+            .init_resource::<CameraDebugEnabled>()
             .add_systems(Update, toggle_camera_mode)
             .add_systems(
                 PostUpdate,
-                apply_third_person_offset
+                update_camera_rig
                     .in_set(TacticalCameraSet::Offset)
                     .before(TransformSystems::Propagate),
+            )
+            .add_systems(
+                PostUpdate,
+                update_camera_aim
+                    .in_set(TacticalCameraSet::Aim)
+                    .after(TacticalCameraSet::Offset)
+                    .before(TransformSystems::Propagate),
             );
+
+        #[cfg(feature = "debug")]
+        app.add_systems(Update, toggle_camera_debug);
     }
 }
 
-#[derive(Resource)]
+#[derive(Resource, Debug, Clone, Copy)]
 pub(crate) struct CameraMode {
     pub(crate) third_person: bool,
 }
@@ -34,6 +51,143 @@ impl Default for CameraMode {
         Self { third_person: true }
     }
 }
+
+/// A collider tagged as soft can obscure the subject but never retracts the
+/// camera. Foliage, particles, and thin decorative props should use this.
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub struct CameraSoftOccluder;
+
+#[derive(Debug, Clone, Copy)]
+pub struct CameraProfile {
+    pub distance: f32,
+    pub shoulder_offset: f32,
+    /// Height above the controller transform, which is centered in its capsule.
+    pub focus_height: f32,
+    pub horizontal_follow_time: f32,
+    pub vertical_follow_time: f32,
+    pub maximum_follow_error: f32,
+    /// Half-extents in normalized screen coordinates.
+    pub sweet_spot: Vec2,
+}
+
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct CameraRigConfig {
+    pub lowered: CameraProfile,
+    pub raised: CameraProfile,
+    pub transition_time: f32,
+    pub collision_radius: f32,
+    pub collision_margin: f32,
+    pub collision_recovery_time: f32,
+    pub collision_hysteresis: f32,
+    pub teleport_distance: f32,
+    pub crouch_focus_adjustment: f32,
+    pub aim_distance: f32,
+    pub muzzle_offset: Vec3,
+}
+
+impl Default for CameraRigConfig {
+    fn default() -> Self {
+        Self {
+            lowered: CameraProfile {
+                distance: 3.75,
+                shoulder_offset: 0.0,
+                focus_height: 0.48,
+                horizontal_follow_time: 0.18,
+                vertical_follow_time: 0.34,
+                maximum_follow_error: 0.85,
+                sweet_spot: Vec2::new(0.09, 0.065),
+            },
+            raised: CameraProfile {
+                distance: 2.75,
+                shoulder_offset: 0.5,
+                focus_height: 0.62,
+                horizontal_follow_time: 0.055,
+                vertical_follow_time: 0.08,
+                maximum_follow_error: 0.22,
+                sweet_spot: Vec2::splat(0.01),
+            },
+            transition_time: 0.18,
+            collision_radius: 0.22,
+            collision_margin: 0.04,
+            collision_recovery_time: 0.32,
+            collision_hysteresis: 0.08,
+            teleport_distance: 2.0,
+            crouch_focus_adjustment: -0.45,
+            aim_distance: 100.0,
+            // Local right, up, and forward from the controller center.
+            muzzle_offset: Vec3::new(0.28, 0.55, 0.42),
+        }
+    }
+}
+
+#[derive(Resource, Debug, Clone)]
+pub(crate) struct CameraRigState {
+    initialized: bool,
+    focus: Vec3,
+    focus_velocity: Vec3,
+    blend: f32,
+    blend_velocity: f32,
+    boom_distance: f32,
+    boom_velocity: f32,
+    shoulder_offset: f32,
+    shoulder_velocity: f32,
+    last_anchor: Vec3,
+    subject: Option<Entity>,
+}
+
+impl Default for CameraRigState {
+    fn default() -> Self {
+        Self {
+            initialized: false,
+            focus: Vec3::ZERO,
+            focus_velocity: Vec3::ZERO,
+            blend: 0.0,
+            blend_velocity: 0.0,
+            boom_distance: 0.0,
+            boom_velocity: 0.0,
+            shoulder_offset: 0.0,
+            shoulder_velocity: 0.0,
+            last_anchor: Vec3::ZERO,
+            subject: None,
+        }
+    }
+}
+
+#[derive(Resource, Debug, Clone, Copy, Default)]
+pub(crate) struct CameraRigDebugState {
+    pub(crate) active: bool,
+    pub(crate) raised_blend: f32,
+    pub(crate) subject: Vec3,
+    pub(crate) focus: Vec3,
+    pub(crate) shoulder: Vec3,
+    pub(crate) desired_endpoint: Vec3,
+    pub(crate) final_endpoint: Vec3,
+    pub(crate) collision_normal: Vec3,
+    pub(crate) collision_entity: Option<Entity>,
+    pub(crate) soft_occluder: Option<Entity>,
+    pub(crate) soft_occluder_point: Vec3,
+    pub(crate) desired_distance: f32,
+    pub(crate) limited_distance: f32,
+    pub(crate) focus_velocity: Vec3,
+    pub(crate) boom_velocity: f32,
+    pub(crate) screen_error: Vec2,
+    pub(crate) sweet_spot: Vec2,
+}
+
+#[derive(Resource, Debug, Clone, Copy, Default)]
+pub(crate) struct CameraAimState {
+    pub(crate) active: bool,
+    pub(crate) camera_origin: Vec3,
+    pub(crate) camera_target: Vec3,
+    pub(crate) camera_hit: Option<Entity>,
+    pub(crate) muzzle_origin: Vec3,
+    pub(crate) actual_target: Vec3,
+    pub(crate) actual_hit: Option<Entity>,
+    pub(crate) blocked: bool,
+}
+
+#[derive(Resource, Debug, Clone, Copy, Default)]
+pub(crate) struct CameraDebugEnabled(pub(crate) bool);
 
 fn toggle_camera_mode(keyboard: Res<ButtonInput<KeyCode>>, mut mode: ResMut<CameraMode>) {
     if keyboard.just_pressed(KeyCode::F9) {
@@ -45,26 +199,408 @@ fn toggle_camera_mode(keyboard: Res<ButtonInput<KeyCode>>, mut mode: ResMut<Came
     }
 }
 
-fn apply_third_person_offset(
-    mode: Res<CameraMode>,
-    mut cameras: Query<&mut Transform, With<CharacterControllerCameraOf>>,
+#[cfg(feature = "debug")]
+fn toggle_camera_debug(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut enabled: ResMut<CameraDebugEnabled>,
 ) {
-    if !mode.third_person {
-        return;
-    }
-
-    for mut transform in &mut cameras {
-        let rotation = transform.rotation;
-        transform.translation += third_person_offset(rotation);
+    if keyboard.just_pressed(KeyCode::F6) {
+        enabled.0 = !enabled.0;
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn update_camera_rig(
+    time: Res<Time>,
+    mode: Res<CameraMode>,
+    guard: Res<WeaponGuardInputState>,
+    config: Res<CameraRigConfig>,
+    spatial: SpatialQuery,
+    soft_occluders: Query<(), With<CameraSoftOccluder>>,
+    controllers: Query<
+        (&Transform, &CharacterControllerState),
+        Without<CharacterControllerCameraOf>,
+    >,
+    mut cameras: Query<(
+        &mut Transform,
+        &CharacterControllerCameraOf,
+        Option<&Projection>,
+    )>,
+    mut state: ResMut<CameraRigState>,
+    mut debug: ResMut<CameraRigDebugState>,
+) {
+    if !mode.third_person {
+        state.initialized = false;
+        debug.active = false;
+        return;
+    }
+
+    let dt = time.delta_secs().min(0.1);
+    for (mut camera, camera_of, projection) in &mut cameras {
+        let Ok((controller, controller_state)) = controllers.get(camera_of.character_controller)
+        else {
+            continue;
+        };
+        let target_blend = f32::from(guard.desired == WeaponGuardState::Raised);
+        state.blend = critical_damp_scalar(
+            state.blend,
+            target_blend,
+            &mut state.blend_velocity,
+            config.transition_time,
+            dt,
+        )
+        .clamp(0.0, 1.0);
+        let profile = blend_profile(config.lowered, config.raised, state.blend);
+        let crouch_adjustment = if controller_state.crouching {
+            config.crouch_focus_adjustment
+        } else {
+            0.0
+        };
+        let anchor = controller.translation + Vec3::Y * (profile.focus_height + crouch_adjustment);
+
+        let discontinuity = state.initialized
+            && (state.subject != Some(camera_of.character_controller)
+                || anchor.distance(state.last_anchor) > config.teleport_distance);
+        if !state.initialized || discontinuity {
+            state.initialized = true;
+            state.focus = anchor;
+            state.focus_velocity = Vec3::ZERO;
+            state.boom_distance = profile.distance;
+            state.boom_velocity = 0.0;
+            state.shoulder_offset = profile.shoulder_offset;
+            state.shoulder_velocity = 0.0;
+        }
+        state.last_anchor = anchor;
+        state.subject = Some(camera_of.character_controller);
+
+        let rotation = camera.rotation;
+        let (aspect, tan_half_fov) = camera_view_metrics(projection);
+        let (focus_target, screen_error) = sweet_spot_target(
+            anchor,
+            state.focus,
+            rotation,
+            profile.distance,
+            profile.sweet_spot,
+            aspect,
+            tan_half_fov,
+        );
+        state.focus = damp_focus(
+            state.focus,
+            focus_target,
+            &mut state.focus_velocity,
+            profile,
+            dt,
+        );
+        let follow_error = anchor - state.focus;
+        if follow_error.length() > profile.maximum_follow_error {
+            state.focus = anchor - follow_error.normalize() * profile.maximum_follow_error;
+            state.focus_velocity = state
+                .focus_velocity
+                .reject_from_normalized(follow_error.normalize());
+        }
+
+        state.shoulder_offset = critical_damp_scalar(
+            state.shoulder_offset,
+            profile.shoulder_offset,
+            &mut state.shoulder_velocity,
+            config.transition_time,
+            dt,
+        );
+        let right = rotation * Vec3::X;
+        let backward = rotation * Vec3::Z;
+        let shoulder = state.focus + right * state.shoulder_offset;
+        let desired_endpoint = shoulder + backward * profile.distance;
+        let cast_direction = Dir3::new(backward).unwrap_or(Dir3::Z);
+        let cast = spatial.cast_shape_predicate(
+            &Collider::sphere(config.collision_radius),
+            shoulder,
+            rotation,
+            cast_direction,
+            &ShapeCastConfig::from_max_distance(profile.distance)
+                .with_target_distance(config.collision_margin),
+            &SpatialQueryFilter::from_excluded_entities([camera_of.character_controller]),
+            &|entity| !soft_occluders.contains(entity),
+        );
+        let limited_distance = cast
+            .map_or(profile.distance, |hit| hit.distance)
+            .clamp(0.0, profile.distance);
+        state.boom_distance = update_boom_distance(
+            state.boom_distance,
+            profile.distance,
+            limited_distance,
+            &mut state.boom_velocity,
+            config.collision_recovery_time,
+            config.collision_hysteresis,
+            dt,
+        );
+        let shoulder_clearance = if profile.distance > 0.0 {
+            (state.boom_distance / profile.distance).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let collision_shoulder = state.focus + right * state.shoulder_offset * shoulder_clearance;
+        camera.translation = collision_shoulder + backward * state.boom_distance;
+        let subject_delta = anchor - camera.translation;
+        let subject_distance = subject_delta.length();
+        let subject_direction = Dir3::new(subject_delta).unwrap_or(Dir3::NEG_Z);
+        let soft_occlusion = spatial.cast_ray_predicate(
+            camera.translation,
+            subject_direction,
+            subject_distance,
+            true,
+            &SpatialQueryFilter::from_excluded_entities([camera_of.character_controller]),
+            &|entity| soft_occluders.contains(entity),
+        );
+
+        *debug = CameraRigDebugState {
+            active: true,
+            raised_blend: state.blend,
+            subject: anchor,
+            focus: state.focus,
+            shoulder: collision_shoulder,
+            desired_endpoint,
+            final_endpoint: camera.translation,
+            collision_normal: cast.map_or(Vec3::ZERO, |hit| hit.normal1),
+            collision_entity: cast.map(|hit| hit.entity),
+            soft_occluder: soft_occlusion.map(|hit| hit.entity),
+            soft_occluder_point: camera.translation
+                + *subject_direction * soft_occlusion.map_or(0.0, |hit| hit.distance),
+            desired_distance: profile.distance,
+            limited_distance,
+            focus_velocity: state.focus_velocity,
+            boom_velocity: state.boom_velocity,
+            screen_error,
+            sweet_spot: profile.sweet_spot,
+        };
+    }
+}
+
+fn update_camera_aim(
+    mode: Res<CameraMode>,
+    guard: Res<WeaponGuardInputState>,
+    config: Res<CameraRigConfig>,
+    spatial: SpatialQuery,
+    cameras: Query<(&Transform, &CharacterControllerCameraOf)>,
+    controllers: Query<&Transform, Without<CharacterControllerCameraOf>>,
+    mut aim: ResMut<CameraAimState>,
+) {
+    aim.active = mode.third_person && guard.desired == WeaponGuardState::Raised;
+    if !aim.active {
+        aim.blocked = false;
+        aim.camera_hit = None;
+        aim.actual_hit = None;
+        return;
+    }
+
+    for (camera, camera_of) in &cameras {
+        let Ok(controller) = controllers.get(camera_of.character_controller) else {
+            continue;
+        };
+        let filter = SpatialQueryFilter::from_excluded_entities([camera_of.character_controller]);
+        let camera_origin = camera.translation;
+        let camera_direction = camera.forward();
+        let camera_hit = spatial.cast_ray(
+            camera_origin,
+            camera_direction,
+            config.aim_distance,
+            true,
+            &filter,
+        );
+        let camera_target = camera_origin
+            + *camera_direction * camera_hit.map_or(config.aim_distance, |hit| hit.distance);
+
+        let planar_forward = Vec3::new(camera_direction.x, 0.0, camera_direction.z)
+            .try_normalize()
+            .unwrap_or(Vec3::NEG_Z);
+        let right = planar_forward.cross(Vec3::Y).normalize_or_zero();
+        let muzzle_origin = controller.translation
+            + right * config.muzzle_offset.x
+            + Vec3::Y * config.muzzle_offset.y
+            + planar_forward * config.muzzle_offset.z;
+        let muzzle_delta = camera_target - muzzle_origin;
+        let muzzle_distance = muzzle_delta.length();
+        let muzzle_direction = Dir3::new(muzzle_delta).unwrap_or(camera_direction);
+        let actual_hit = spatial.cast_ray(
+            muzzle_origin,
+            muzzle_direction,
+            muzzle_distance,
+            true,
+            &filter,
+        );
+        let actual_target = muzzle_origin
+            + *muzzle_direction * actual_hit.map_or(muzzle_distance, |hit| hit.distance);
+        let camera_entity = camera_hit.map(|hit| hit.entity);
+        let actual_entity = actual_hit.map(|hit| hit.entity);
+        *aim = CameraAimState {
+            active: true,
+            camera_origin,
+            camera_target,
+            camera_hit: camera_entity,
+            muzzle_origin,
+            actual_target,
+            actual_hit: actual_entity,
+            blocked: muzzle_path_is_blocked(
+                camera_entity,
+                actual_entity,
+                actual_target,
+                camera_target,
+            ),
+        };
+    }
+}
+
+fn camera_view_metrics(projection: Option<&Projection>) -> (f32, f32) {
+    match projection {
+        Some(Projection::Perspective(perspective)) => (
+            perspective.aspect_ratio.max(0.1),
+            (perspective.fov * 0.5).tan(),
+        ),
+        _ => (16.0 / 9.0, 40.0_f32.to_radians().tan()),
+    }
+}
+
+fn blend_profile(a: CameraProfile, b: CameraProfile, t: f32) -> CameraProfile {
+    CameraProfile {
+        distance: a.distance.lerp(b.distance, t),
+        shoulder_offset: a.shoulder_offset.lerp(b.shoulder_offset, t),
+        focus_height: a.focus_height.lerp(b.focus_height, t),
+        horizontal_follow_time: a.horizontal_follow_time.lerp(b.horizontal_follow_time, t),
+        vertical_follow_time: a.vertical_follow_time.lerp(b.vertical_follow_time, t),
+        maximum_follow_error: a.maximum_follow_error.lerp(b.maximum_follow_error, t),
+        sweet_spot: a.sweet_spot.lerp(b.sweet_spot, t),
+    }
+}
+
+fn sweet_spot_target(
+    anchor: Vec3,
+    focus: Vec3,
+    rotation: Quat,
+    distance: f32,
+    sweet_spot: Vec2,
+    aspect: f32,
+    tan_half_fov: f32,
+) -> (Vec3, Vec2) {
+    let right = rotation * Vec3::X;
+    let up = rotation * Vec3::Y;
+    let error = anchor - focus;
+    let half_height = distance * tan_half_fov;
+    let allowed_x = half_height * aspect * sweet_spot.x;
+    let allowed_y = half_height * sweet_spot.y;
+    let x = error.dot(right);
+    let y = error.dot(up);
+    let retained_x = x.clamp(-allowed_x, allowed_x);
+    let retained_y = y.clamp(-allowed_y, allowed_y);
+    let target = anchor - right * retained_x - up * retained_y;
+    let screen_error = Vec2::new(
+        if half_height > 0.0 {
+            x / (half_height * aspect)
+        } else {
+            0.0
+        },
+        if half_height > 0.0 {
+            y / half_height
+        } else {
+            0.0
+        },
+    );
+    (target, screen_error)
+}
+
+fn damp_focus(
+    current: Vec3,
+    target: Vec3,
+    velocity: &mut Vec3,
+    profile: CameraProfile,
+    dt: f32,
+) -> Vec3 {
+    let mut horizontal_velocity = Vec3::new(velocity.x, 0.0, velocity.z);
+    let horizontal = critical_damp_vec3(
+        Vec3::new(current.x, 0.0, current.z),
+        Vec3::new(target.x, 0.0, target.z),
+        &mut horizontal_velocity,
+        profile.horizontal_follow_time,
+        dt,
+    );
+    let mut vertical_velocity = velocity.y;
+    let y = critical_damp_scalar(
+        current.y,
+        target.y,
+        &mut vertical_velocity,
+        profile.vertical_follow_time,
+        dt,
+    );
+    *velocity = Vec3::new(
+        horizontal_velocity.x,
+        vertical_velocity,
+        horizontal_velocity.z,
+    );
+    Vec3::new(horizontal.x, y, horizontal.z)
+}
+
+fn critical_damp_vec3(
+    current: Vec3,
+    target: Vec3,
+    velocity: &mut Vec3,
+    smooth_time: f32,
+    dt: f32,
+) -> Vec3 {
+    let omega = 2.0 / smooth_time.max(0.0001);
+    let displacement = current - target;
+    let exponential = (-omega * dt).exp();
+    let temporary = (*velocity + displacement * omega) * dt;
+    *velocity = (*velocity - temporary * omega) * exponential;
+    target + (displacement + temporary) * exponential
+}
+
+fn critical_damp_scalar(
+    current: f32,
+    target: f32,
+    velocity: &mut f32,
+    smooth_time: f32,
+    dt: f32,
+) -> f32 {
+    let omega = 2.0 / smooth_time.max(0.0001);
+    let displacement = current - target;
+    let exponential = (-omega * dt).exp();
+    let temporary = (*velocity + displacement * omega) * dt;
+    *velocity = (*velocity - temporary * omega) * exponential;
+    target + (displacement + temporary) * exponential
+}
+
+fn update_boom_distance(
+    current: f32,
+    desired: f32,
+    limited: f32,
+    velocity: &mut f32,
+    recovery_time: f32,
+    hysteresis: f32,
+    dt: f32,
+) -> f32 {
+    if limited < current {
+        *velocity = 0.0;
+        return limited;
+    }
+    if limited < desired && limited - current <= hysteresis {
+        *velocity = 0.0;
+        return current.min(limited);
+    }
+    critical_damp_scalar(current, desired.min(limited), velocity, recovery_time, dt).min(limited)
+}
+
+fn muzzle_path_is_blocked(
+    camera_hit: Option<Entity>,
+    muzzle_hit: Option<Entity>,
+    _actual_target: Vec3,
+    _camera_target: Vec3,
+) -> bool {
+    muzzle_hit.is_some() && muzzle_hit != camera_hit
+}
+
+/// Legacy helper retained for deterministic animation captures. Gameplay uses
+/// the stateful rig above.
+#[allow(dead_code)]
 pub(crate) fn third_person_offset(rotation: Quat) -> Vec3 {
-    let back = rotation * Vec3::Z;
-    let horizontal_back = Vec3::new(back.x, 0.0, back.z)
-        .try_normalize()
-        .unwrap_or(Vec3::Z);
-    horizontal_back * THIRD_PERSON_DISTANCE + Vec3::Y * THIRD_PERSON_HEIGHT
+    rotation * Vec3::Z * CameraRigConfig::default().lowered.distance
 }
 
 #[cfg(test)]
@@ -78,23 +614,95 @@ mod tests {
         keyboard.press(KeyCode::F9);
         world.insert_resource(keyboard);
         world.insert_resource(CameraMode::default());
-
         world.run_system_cached(toggle_camera_mode).unwrap();
-
         assert!(!world.resource::<CameraMode>().third_person);
     }
 
     #[test]
-    fn camera_defaults_to_third_person() {
-        assert!(CameraMode::default().third_person);
+    fn critical_damping_is_nearly_render_rate_independent() {
+        let simulate = |steps: usize| {
+            let mut value = Vec3::ZERO;
+            let mut velocity = Vec3::ZERO;
+            for _ in 0..steps {
+                value = critical_damp_vec3(
+                    value,
+                    Vec3::new(2.0, 1.0, -3.0),
+                    &mut velocity,
+                    0.25,
+                    1.0 / steps as f32,
+                );
+            }
+            value
+        };
+        assert!(simulate(30).abs_diff_eq(simulate(144), 0.0001));
     }
 
     #[test]
-    fn third_person_offset_keeps_distance_independent_of_pitch() {
-        let rotation = Quat::from_euler(EulerRot::YXZ, 0.7, 1.2, 0.0);
-        let offset = third_person_offset(rotation);
+    fn sweet_spot_absorbs_small_motion_and_bounds_large_motion() {
+        let profile = CameraRigConfig::default().lowered;
+        let focus = Vec3::ZERO;
+        let (small, _) = sweet_spot_target(
+            Vec3::new(0.05, 0.02, 0.0),
+            focus,
+            Quat::IDENTITY,
+            profile.distance,
+            profile.sweet_spot,
+            16.0 / 9.0,
+            40.0_f32.to_radians().tan(),
+        );
+        assert!(small.abs_diff_eq(focus, 0.0001));
+        let (large, _) = sweet_spot_target(
+            Vec3::new(2.0, 0.0, 0.0),
+            focus,
+            Quat::IDENTITY,
+            profile.distance,
+            profile.sweet_spot,
+            16.0 / 9.0,
+            40.0_f32.to_radians().tan(),
+        );
+        assert!(large.x > 1.0 && large.x < 2.0);
+    }
 
-        assert!((offset.y - THIRD_PERSON_HEIGHT).abs() < 0.0001);
-        assert!((offset.xz().length() - THIRD_PERSON_DISTANCE).abs() < 0.0001);
+    #[test]
+    fn collision_pulls_in_immediately_and_recovers_monotonically() {
+        let mut velocity = 0.0;
+        let pulled = update_boom_distance(3.75, 3.75, 1.2, &mut velocity, 0.32, 0.08, 1.0 / 60.0);
+        assert_eq!(pulled, 1.2);
+        let first = update_boom_distance(pulled, 3.75, 3.75, &mut velocity, 0.32, 0.08, 1.0 / 60.0);
+        let second = update_boom_distance(first, 3.75, 3.75, &mut velocity, 0.32, 0.08, 1.0 / 60.0);
+        assert!(first > pulled && second > first && second <= 3.75);
+        let mut recovered = second;
+        for _ in 0..120 {
+            recovered =
+                update_boom_distance(recovered, 3.75, 3.75, &mut velocity, 0.32, 0.08, 1.0 / 60.0);
+        }
+        assert!(recovered > 3.74);
+    }
+
+    #[test]
+    fn reversing_a_mode_blend_continues_from_the_displayed_state() {
+        let mut velocity = 0.0;
+        let raised = critical_damp_scalar(0.0, 1.0, &mut velocity, 0.18, 0.08);
+        let reversed = critical_damp_scalar(raised, 0.0, &mut velocity, 0.18, 0.01);
+        assert!((reversed - raised).abs() < 0.1);
+        assert!(reversed > 0.0 && reversed < 1.0);
+    }
+
+    #[test]
+    fn a_different_muzzle_hit_reports_cover_blockage() {
+        let target = Entity::from_bits(1);
+        let cover = Entity::from_bits(2);
+        assert!(muzzle_path_is_blocked(
+            Some(target),
+            Some(cover),
+            Vec3::Z,
+            Vec3::Z * 10.0,
+        ));
+        assert!(!muzzle_path_is_blocked(
+            Some(target),
+            Some(target),
+            Vec3::Z * 10.0,
+            Vec3::Z * 10.0,
+        ));
     }
 }

--- a/crates/adventuresim-tactical-client/src/debug.rs
+++ b/crates/adventuresim-tactical-client/src/debug.rs
@@ -6,6 +6,7 @@ use bevy::{color::palettes::tailwind, prelude::*};
 
 use crate::{
     animation::TerrainIkEnabled,
+    camera::{CameraAimState, CameraDebugEnabled, CameraRigConfig, CameraRigDebugState},
     player::{ClientPlayer, HitPerformed, LimbHitbox},
 };
 
@@ -18,6 +19,7 @@ impl Plugin for DebugPlugin {
             .register_required_components_with::<Collider, _>(|| DebugRender::none())
             .add_systems(Update, toggle_debug_visuals)
             .add_systems(Update, draw_debug_rays)
+            .add_systems(Update, draw_camera_rig)
             .add_observer(on_hit_performed);
     }
 }
@@ -171,6 +173,59 @@ fn draw_debug_rays(
                 color.set_alpha(alpha);
             }
         }
+    }
+}
+
+fn draw_camera_rig(
+    enabled: Res<CameraDebugEnabled>,
+    rig: Res<CameraRigDebugState>,
+    aim: Res<CameraAimState>,
+    config: Res<CameraRigConfig>,
+    mut gizmos: Gizmos,
+) {
+    if !enabled.0 || !rig.active {
+        return;
+    }
+    gizmos.line(rig.subject, rig.focus, tailwind::LIME_400);
+    gizmos.line(rig.focus, rig.shoulder, tailwind::SKY_300);
+    gizmos.line(rig.shoulder, rig.desired_endpoint, tailwind::AMBER_300);
+    gizmos.line(rig.shoulder, rig.final_endpoint, tailwind::CYAN_300);
+    if rig.collision_entity.is_some() {
+        gizmos.line(
+            rig.final_endpoint,
+            rig.final_endpoint + rig.collision_normal * 0.6,
+            tailwind::RED_400,
+        );
+    }
+    if rig.soft_occluder.is_some() {
+        gizmos.line(
+            rig.soft_occluder_point - Vec3::Y * 0.25,
+            rig.soft_occluder_point + Vec3::Y * 0.25,
+            tailwind::ORANGE_400,
+        );
+    }
+    let radius = Vec3::splat(config.collision_radius);
+    gizmos.line(
+        rig.final_endpoint - Vec3::X * radius.x,
+        rig.final_endpoint + Vec3::X * radius.x,
+        tailwind::CYAN_200,
+    );
+    gizmos.line(
+        rig.final_endpoint - Vec3::Y * radius.y,
+        rig.final_endpoint + Vec3::Y * radius.y,
+        tailwind::CYAN_200,
+    );
+    if aim.active {
+        gizmos.line(aim.camera_origin, aim.camera_target, tailwind::PURPLE_300);
+        gizmos.line(
+            aim.muzzle_origin,
+            aim.actual_target,
+            if aim.blocked {
+                tailwind::RED_500
+            } else {
+                tailwind::GREEN_400
+            },
+        );
     }
 }
 

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -5,7 +5,7 @@ use adventuresim_tactical_netcode::{
 };
 use bevy::prelude::*;
 
-use crate::animation::spawn_fallback_t_pose;
+use crate::{animation::spawn_fallback_t_pose, camera::CameraAimState};
 
 const BODY_PART_HITBOXES: &[(BodyPart, Vec3, Vec3)] = &[
     (
@@ -210,11 +210,17 @@ fn update_attack_state_system(
     mut cmd: Commands,
     spatial: SpatialQuery,
     time: Res<Time>,
-    mut q_attacker: Query<(Entity, &mut AttackState, &CharacterControllerCamera)>,
+    aim: Res<CameraAimState>,
+    mut q_attacker: Query<(
+        Entity,
+        &Transform,
+        &mut AttackState,
+        &CharacterControllerCamera,
+    )>,
     q_camera: Query<&Transform>,
     q_collider: Query<(&ColliderOf, &LimbHitbox)>,
 ) {
-    for (attacker, mut state, camera) in &mut q_attacker {
+    for (attacker, attacker_transform, mut state, camera) in &mut q_attacker {
         state.pre_hit_timer.tick(time.delta());
         if !state.pre_hit_timer.is_finished() {
             continue;
@@ -227,21 +233,65 @@ fn update_attack_state_system(
             continue;
         };
 
-        let origin = camera_transform.translation;
-        let direction = camera_transform.forward();
-        let filter = SpatialQueryFilter::from_mask(HITBOX_LAYER);
+        let camera_origin = camera_transform.translation;
+        let camera_direction = camera_transform.forward();
+        let target_filter = SpatialQueryFilter::from_mask(HITBOX_LAYER);
         let reach = if state.ranged {
             state.reach
         } else {
             melee_interaction_range(state.reach)
         };
+        let selection_distance = camera_origin.distance(attacker_transform.translation) + reach;
 
-        if let Some(hit) = spatial.cast_ray(origin, direction, reach, true, &filter) {
-            let Ok((target, body_part)) = q_collider.get(hit.entity).map(|(c, h)| (c.body, h.0))
-            else {
-                break;
-            };
+        let intended = spatial.cast_ray(
+            camera_origin,
+            camera_direction,
+            selection_distance,
+            true,
+            &target_filter,
+        );
+        let Some(intended) = intended else {
+            if state.ranged {
+                cmd.client_trigger(RangedActionRequest::CompleteMiss);
+            }
+            cmd.trigger(HitPerformed {
+                entity: attacker,
+                direction: camera_direction,
+                origin: camera_origin,
+                length: selection_distance,
+            });
+            continue;
+        };
+        let Ok((target, body_part)) = q_collider
+            .get(intended.entity)
+            .map(|(collider, limb)| (collider.body, limb.0))
+        else {
+            continue;
+        };
+        let intended_point = camera_origin + *camera_direction * intended.distance;
+        let origin = if state.ranged && aim.active {
+            aim.muzzle_origin
+        } else {
+            attacker_transform.translation + Vec3::Y * 0.5
+        };
+        let delta = intended_point - origin;
+        let direction = Dir3::new(delta).unwrap_or(camera_direction);
+        let obstruction_filter = SpatialQueryFilter::from_excluded_entities([attacker]);
+        let obstruction = spatial.cast_ray(
+            origin,
+            direction,
+            delta.length().min(reach),
+            true,
+            &obstruction_filter,
+        );
+        let unobstructed = obstruction.is_some_and(|hit| {
+            hit.entity == target
+                || q_collider
+                    .get(hit.entity)
+                    .is_ok_and(|(collider, _)| collider.body == target)
+        });
 
+        if unobstructed {
             if state.ranged {
                 cmd.client_trigger(RangedActionRequest::CompleteHit {
                     target,
@@ -259,7 +309,7 @@ fn update_attack_state_system(
                 entity: attacker,
                 direction,
                 origin,
-                length: hit.distance,
+                length: obstruction.map_or(delta.length(), |hit| hit.distance),
             });
         } else {
             if state.ranged {
@@ -269,7 +319,7 @@ fn update_attack_state_system(
                 entity: attacker,
                 direction,
                 origin,
-                length: reach,
+                length: obstruction.map_or(delta.length().min(reach), |hit| hit.distance),
             });
         }
     }

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -21,9 +21,12 @@ use bevy_flair::prelude::*;
 #[cfg(feature = "debug")]
 use crate::animation::TerrainIkEnabled;
 #[cfg(feature = "debug")]
+use crate::camera::{CameraDebugEnabled, CameraRigDebugState};
+#[cfg(feature = "debug")]
 use crate::debug::DebugGameSpeed;
 use crate::{
     Args,
+    camera::CameraAimState,
     player::{AttackState, ClientPlayer},
 };
 
@@ -44,6 +47,7 @@ impl Plugin for UiPlugin {
                     update_items_ui.run_if(any_with_component::<ClientPlayer>),
                     update_attack_timer_ui.run_if(any_with_component::<ClientPlayer>),
                     update_weapon_guard_ui,
+                    update_camera_ui,
                     #[cfg(feature = "debug")]
                     update_terrain_ik_debug_ui,
                     #[cfg(feature = "debug")]
@@ -105,6 +109,16 @@ struct CombatStateSpan;
 #[derive(Component)]
 struct WeaponGuardSpan;
 
+#[derive(Component)]
+struct RaisedReticle;
+
+#[derive(Component)]
+struct AimBlockedSpan;
+
+#[cfg(feature = "debug")]
+#[derive(Component)]
+struct CameraDebugSpan;
+
 #[cfg(feature = "debug")]
 #[derive(Component)]
 struct TerrainIkDebugSpan;
@@ -150,7 +164,18 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ClassList::new("primary"),
                 Text::default(),
             ),
-            (Name::new("crosshair"), Node::default()),
+            (
+                Name::new("crosshair"),
+                RaisedReticle,
+                Visibility::Hidden,
+                Node::default(),
+                children![(
+                    Name::new("aim-blocked"),
+                    AimBlockedSpan,
+                    Visibility::Hidden,
+                    Text::new("MUZZLE BLOCKED"),
+                )],
+            ),
             (
                 Name::new("attack-info"),
                 Node::default(),
@@ -181,7 +206,8 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
                         "DEBUG: F2 to toggle body | F3 to toggle hitbox | F4 to toggle hitscan"
                     ),
                     (GameSpeedDebugSpan, TextSpan::new(" | F7 game speed: 1x")),
-                    (TerrainIkDebugSpan, TextSpan::new(" | F8 terrain IK: OFF"))
+                    (TerrainIkDebugSpan, TextSpan::new(" | F8 terrain IK: OFF")),
+                    (CameraDebugSpan, TextSpan::new(" | F6 camera rig: OFF"))
                 ],
             ),
             (
@@ -378,6 +404,47 @@ fn update_weapon_guard_ui(
         **span = match guard.desired {
             WeaponGuardState::Lowered => "Lowered".to_owned(),
             WeaponGuardState::Raised => "Raised".to_owned(),
+        };
+    }
+}
+
+fn update_camera_ui(
+    aim: Res<CameraAimState>,
+    mut reticle: Single<&mut Visibility, (With<RaisedReticle>, Without<AimBlockedSpan>)>,
+    mut blocked: Single<&mut Visibility, (With<AimBlockedSpan>, Without<RaisedReticle>)>,
+    #[cfg(feature = "debug")] enabled: Res<CameraDebugEnabled>,
+    #[cfg(feature = "debug")] debug: Res<CameraRigDebugState>,
+    #[cfg(feature = "debug")] mut debug_span: Single<&mut TextSpan, With<CameraDebugSpan>>,
+) {
+    **reticle = if aim.active {
+        Visibility::Inherited
+    } else {
+        Visibility::Hidden
+    };
+    **blocked = if aim.active && aim.blocked {
+        Visibility::Inherited
+    } else {
+        Visibility::Hidden
+    };
+    #[cfg(feature = "debug")]
+    {
+        debug_span.0 = if enabled.0 && debug.active {
+            format!(
+                " | F6 camera: {:.0}% | boom {:.2}/{:.2}m v{:.2} | focus v{:.2} | screen ({:.2},{:.2})/({:.2},{:.2}) | hard:{} soft:{}",
+                debug.raised_blend * 100.0,
+                debug.limited_distance,
+                debug.desired_distance,
+                debug.boom_velocity,
+                debug.focus_velocity.length(),
+                debug.screen_error.x,
+                debug.screen_error.y,
+                debug.sweet_spot.x,
+                debug.sweet_spot.y,
+                debug.collision_entity.is_some(),
+                debug.soft_occluder.is_some(),
+            )
+        } else {
+            " | F6 camera rig: OFF".to_owned()
         };
     }
 }

--- a/wiki/client/controls.md
+++ b/wiki/client/controls.md
@@ -57,10 +57,22 @@ One feature we quite want in the game eventually is a split between *direct* and
 We posit control schemes for both modes below.
 
 ### Direct controls
-These are designed primarily for first person. The tactical client defaults to
-first person and toggles its current centered third-person follow camera with
-<kbd>F9</kbd>. The third-person option intentionally does not yet adjust its
-distance around nearby walls or thin obstacles.
+The tactical client defaults to a stability-first third-person camera and
+retains <kbd>F9</kbd> as a development toggle for first person. One stateful rig
+supplies two continuous configurations. Lowered guard uses a centered orbit
+with bounded, vertically damped focus following and a modest screen-space
+sweet spot. Raised guard blends to a tighter right-shoulder view while
+preserving yaw, pitch, and the movement reference; direct look input is never
+rotationally smoothed in either configuration.
+
+The camera sweeps a volume from its shoulder pivot to the desired boom
+endpoint. Hard geometry retracts the boom immediately and clears with a slower
+hysteretic recovery; soft occluders may be tagged to remain outside the camera
+collision policy. Tight-space retraction also recenters the shoulder offset.
+Raised aiming selects a center-screen world point, then checks the actual path
+from a presentation muzzle origin. The reticle reports a blocked muzzle path,
+so the displaced camera cannot grant a shot through nearby cover. In debug
+builds, <kbd>F6</kbd> exposes rig, collision, smoothing, and aim telemetry.
 
 > Halbe: I assume that first person is easier because with third-person cameras, you need to handle a lot of edge cases to avoid awkwardness in tight spaces or near thin obstacles like trees, not to mention smoothing out the motion or reconciling the shoulder offset when aiming. However, if I am mistaken in my assumptions, we should implement whichever is easier for the MVP.
 
@@ -68,7 +80,7 @@ distance around nearby walls or thin obstacles.
 |-|-|-|-|
 | <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> | Left Stick | Movement. | |
 | Mouse | Right Stick | Look. | |
-| <kbd>F9</kbd> | | Toggle first-/third-person camera. | Third person uses the same look direction and a centered follow offset. |
+| <kbd>F9</kbd> | | Toggle first-/third-person camera. | Third person preserves the same immediate look direction across centered and raised-weapon shoulder profiles. |
 | LMB | RT | Attack! | |
 | Release <kbd>SPACE</kbd> | Full LT | Dodge or jump. | <ul><li>A quick tap is more like a hop or dash. Holding the button for a bit before releasing makes it a full-body jump. You can tell whether you have held long enough for a full jump by the state of your character's animation.<li>LT has to be held all the way, then released, to jump. |
 | <kbd>SHIFT</kbd> | Partial LT | Crouch or duck. | <ul><li>When crouching and attacked, your character automatically ducks in an appropriate direction, but only if you were not crouching before the attack began.<li>LT is only held partially here, so releasing it to un-crouch does not cause you to jump.


### PR DESCRIPTION
## Summary

- replace the fixed third-person offset with one retained rig that blends between centered lowered-guard exploration and raised-guard right-shoulder aiming
- add bounded anisotropic critical damping, a screen-space sweet spot, teleport/respawn reseeding, and uninterrupted manual yaw/pitch
- sweep a camera volume against hard blockers, retract immediately, recover with hysteresis, and recenter the shoulder in tight spaces
- separate hard camera blockers from soft occluders and expose rig, collision, smoothing, occlusion, and aim telemetry behind F6
- resolve raised aim in two stages from the center-screen camera ray and the presentation muzzle path, including blocked-reticle feedback and cover-safe hit selection
- document the updated controls and tactical camera behavior

## Why

The previous third-person implementation added a stateless fixed offset after controller camera synchronization. It had no retained filtering, guard-aware framing, collision volume, occlusion policy, transition continuity, or camera/muzzle parallax handling. This implements the stability-first camera recommendations in #424 while preserving immediate look and authoritative controller-facing seams.

## Player and developer impact

Lowered exploration now absorbs small motion without rotational lag, while raising the weapon blends continuously to a tighter shoulder view. Nearby hard geometry safely shortens the boom, soft occluders remain a separate policy, and the raised reticle reports when cover blocks the muzzle. Debug builds expose the complete rig state with F6 for tuning and regression diagnosis.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p adventuresim-tactical-client --bin adventuresim-tactical-client`
- focused camera tests: 6 passed
- supervised tactical playground launched successfully; client and server remained responsive with no camera-system panic
- `git diff --check`

Closes #424