### PR TITLE
Synchronize attack steps with captured movement

### DIFF
--- a/crates/adventuresim-tactical-client/src/animation/mod.rs
+++ b/crates/adventuresim-tactical-client/src/animation/mod.rs
@@ -17,10 +17,10 @@ mod procedural;
 
 #[allow(unused_imports)]
 pub(crate) use procedural::{
-    ArmIkState, BoneRole, HandIkTarget, HandSide, HeldWeaponConstraint, HumanoidBone,
-    HumanoidIkTargets, LegIkState, LocomotionBodyResponseState, LocomotionHeightState,
-    MEASURED_ANKLE_SOLE_OFFSET_METRES, ProceduralAnimationClock, RaisedFootworkState,
-    SOLE_CONTACT_TOLERANCE_METRES, locomotion_support_weights,
+    ArmIkState, AttackFootworkState, BoneRole, HandIkTarget, HandSide, HeldWeaponConstraint,
+    HumanoidBone, HumanoidIkTargets, LegIkState, LocomotionBodyResponseState,
+    LocomotionHeightState, MEASURED_ANKLE_SOLE_OFFSET_METRES, ProceduralAnimationClock,
+    RaisedFootworkState, SOLE_CONTACT_TOLERANCE_METRES, locomotion_support_weights,
 };
 const HUMANOID_UNARMED_PACK: &str = "humanoid_unarmed";
 const BIPED_BASE_GLB: &str = "animations/biped/unarmed/base.glb";

--- a/crates/adventuresim-tactical-client/src/animation/procedural.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural.rs
@@ -777,9 +777,9 @@ struct BoneSnapshot {
 
 mod ik;
 pub(crate) use ik::{
-    ArmIkState, HandIkTarget, HandSide, HeldWeaponConstraint, HumanoidIkTargets, LegIkState,
-    MEASURED_ANKLE_SOLE_OFFSET_METRES, ProceduralAnimationClock, RaisedFootworkState,
-    SOLE_CONTACT_TOLERANCE_METRES, locomotion_support_weights,
+    ArmIkState, AttackFootworkState, HandIkTarget, HandSide, HeldWeaponConstraint,
+    HumanoidIkTargets, LegIkState, MEASURED_ANKLE_SOLE_OFFSET_METRES, ProceduralAnimationClock,
+    RaisedFootworkState, SOLE_CONTACT_TOLERANCE_METRES, locomotion_support_weights,
 };
 #[cfg(test)]
 use ik::{
@@ -1392,12 +1392,16 @@ mod legacy_tests {
     }
 
     #[test]
-    fn actions_and_zero_weight_swing_legs_preserve_authored_fk() {
-        let mut action = SkeletonState::default()
+    fn stay_attacks_plant_both_feet_while_unsupported_actions_preserve_authored_fk() {
+        let mut attack = SkeletonState::default()
             .with_local_velocity(Vec3::NEG_Z * 5.5)
             .with_gait_phase(0.0);
-        action.begin_attack(AttackSpec::default(), 0, 1);
-        assert_eq!(locomotion_support_weights(&action), (0.0, 0.0));
+        attack.begin_attack(AttackSpec::default(), 0, 1);
+        assert_eq!(locomotion_support_weights(&attack), (1.0, 1.0));
+
+        let mut dodge = SkeletonState::default();
+        dodge.begin_dodge(DodgeSpec::default(), 0, 1);
+        assert_eq!(locomotion_support_weights(&dodge), (0.0, 0.0));
         assert!(!terrain_leg_has_support(0.0));
         assert!(!terrain_leg_has_support(0.01));
         assert!(terrain_leg_has_support(0.1));

--- a/crates/adventuresim-tactical-client/src/animation/procedural/ik/mod.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural/ik/mod.rs
@@ -157,6 +157,9 @@ const SETTLE_STEP_CLEARANCE_METRES: f32 = 0.10;
 const SETTLE_CAPTURE_POINT_MARGIN_METRES: f32 = 0.12;
 const ASSUMED_COM_HEIGHT_METRES: f32 = 1.0;
 const MAX_SETTLE_CAPTURE_SPEED: f32 = 1.1;
+const ATTACK_AIRBORNE_LUNGE_MIN_SPEED: f32 = 3.5;
+const ATTACK_AIRBORNE_LUNGE_CLEARANCE: f32 = 0.16;
+const ATTACK_FLAT_SOLE_CLEARANCE: f32 = 0.01;
 
 #[derive(Component, Debug, Clone, Copy, Default)]
 pub(crate) struct LegIkState(LegIkMemory);
@@ -238,6 +241,39 @@ pub(crate) struct RaisedFootworkState {
     step_sequence: u32,
     pub(crate) left_solve_target: Option<Vec3>,
     pub(crate) right_solve_target: Option<Vec3>,
+}
+
+/// One client-only, world-space attack step. The replicated state supplies a
+/// stable start tick and typed direction; exact plants remain presentation
+/// details and never move the controller or alter combat reach.
+#[derive(Component, Debug, Clone, Copy, Default)]
+pub(crate) struct AttackFootworkState {
+    pub(crate) initialized: bool,
+    start_tick: u64,
+    lead: LeadFoot,
+    step: AttackStep,
+    swing_left: bool,
+    last_origin: Vec3,
+    last_rotation: Quat,
+    start_rotation: Quat,
+    swing_start: Vec3,
+    swing_end: Vec3,
+    left_stance_local: Vec3,
+    right_stance_local: Vec3,
+    swing_end_local: Vec3,
+    airborne_lunge: bool,
+    left_plant: Vec3,
+    right_plant: Vec3,
+    evaluation_tick: Option<u64>,
+    previous_phase: f32,
+    pub(crate) support_handoffs: u8,
+    pub(crate) left_support_weight: f32,
+    pub(crate) right_support_weight: f32,
+    pub(crate) left_requested_target: Option<Vec3>,
+    pub(crate) right_requested_target: Option<Vec3>,
+    pub(crate) left_solve_target: Option<Vec3>,
+    pub(crate) right_solve_target: Option<Vec3>,
+    pub(crate) maximum_reach_yield: f32,
 }
 
 impl Default for RaisedFootworkState {
@@ -347,6 +383,7 @@ pub(in crate::animation) fn apply_terrain_leg_ik(
     parents: Query<&ChildOf>,
     mut ik_states: Query<&mut LegIkState>,
     mut raised_states: Query<&mut RaisedFootworkState>,
+    mut attack_states: Query<&mut AttackFootworkState>,
     mut transforms: ParamSet<(TransformHelper, Query<&mut Transform>)>,
     mut commands: Commands,
 ) {
@@ -362,6 +399,9 @@ pub(in crate::animation) fn apply_terrain_leg_ik(
             if let Ok(mut state) = raised_states.get_mut(owner) {
                 *state = RaisedFootworkState::default();
             }
+            if let Ok(mut state) = attack_states.get_mut(owner) {
+                *state = AttackFootworkState::default();
+            }
             continue;
         }
         let raised_guard_follower = raised_footwork_posture_is_valid(skeleton)
@@ -373,6 +413,10 @@ pub(in crate::animation) fn apply_terrain_leg_ik(
             .is_ok_and(|state| state.initialized);
         let raised_footwork_handoff = !raised_guard_follower && raised_footwork_was_active;
         let (mut left_weight, mut right_weight) = locomotion_support_weights(skeleton);
+        let attack_step_active = skeleton.action_kind() == SkeletonAction::Attack;
+        if !attack_step_active && let Ok(mut attack) = attack_states.get_mut(owner) {
+            *attack = AttackFootworkState::default();
+        }
         let mut legs = [
             (
                 BoneRole::ThighLeft,
@@ -597,7 +641,7 @@ pub(in crate::animation) fn apply_terrain_leg_ik(
             }
             memory.settle = Some(settle);
         }
-        let desired_raised_pelvis_shift = if raised_guard_follower {
+        let desired_raised_pelvis_shift = if raised_guard_follower || attack_step_active {
             -RAISED_GUARD_PELVIS_DROP
         } else {
             0.0
@@ -632,6 +676,30 @@ pub(in crate::animation) fn apply_terrain_leg_ik(
             if let Ok(mut transform) = transforms.p1().get_mut(pelvis) {
                 transform.translation += local_delta;
             }
+        }
+        if attack_step_active {
+            apply_attack_step(
+                owner,
+                skeleton,
+                rig,
+                terrain,
+                enabled.0,
+                rig_origin,
+                rig_rotation,
+                state_delta_seconds,
+                clock.fixed_tick.map(|(tick, _)| tick),
+                &parents,
+                &mut attack_states,
+                &mut memory,
+                &mut transforms,
+                &mut commands,
+            );
+            if let Ok(mut state) = ik_states.get_mut(owner) {
+                state.0 = memory;
+            } else {
+                commands.entity(owner).insert(LegIkState(memory));
+            }
+            continue;
         }
         if raised_guard_follower {
             prepare_slope_rotation_cache(&mut memory, SlopeAlignmentMode::Raised);
@@ -1840,6 +1908,454 @@ pub(in crate::animation) fn refresh_raised_support_after_propagation(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn apply_attack_step(
+    owner: Entity,
+    skeleton: &SkeletonState,
+    rig: &HumanoidRig,
+    terrain: Option<&SceneTerrain>,
+    terrain_enabled: bool,
+    rig_origin: Vec3,
+    rig_rotation: Quat,
+    state_delta_seconds: f32,
+    tick: Option<u64>,
+    parents: &Query<&ChildOf>,
+    states: &mut Query<&mut AttackFootworkState>,
+    memory: &mut LegIkMemory,
+    transforms: &mut ParamSet<(TransformHelper, Query<&mut Transform>)>,
+    commands: &mut Commands,
+) {
+    let (Some(&left_upper), Some(&left_lower), Some(&left_foot)) = (
+        rig.get(&BoneRole::ThighLeft),
+        rig.get(&BoneRole::ShinLeft),
+        rig.get(&BoneRole::FootLeft),
+    ) else {
+        return;
+    };
+    let (Some(&right_upper), Some(&right_lower), Some(&right_foot)) = (
+        rig.get(&BoneRole::ThighRight),
+        rig.get(&BoneRole::ShinRight),
+        rig.get(&BoneRole::FootRight),
+    ) else {
+        return;
+    };
+    let Some((_, _, left_snapshot)) =
+        snapshot_chain(left_upper, left_lower, left_foot, parents, &transforms.p0())
+    else {
+        return;
+    };
+    let Some((_, _, right_snapshot)) = snapshot_chain(
+        right_upper,
+        right_lower,
+        right_foot,
+        parents,
+        &transforms.p0(),
+    ) else {
+        return;
+    };
+    // Attack plants use the already lowered authored ankles. Undoing the
+    // pelvis drop here would lift the planted sole during the action and force
+    // a visible vertical snap when ordinary guard footwork resumes.
+    let left_authored = left_snapshot.global.translation();
+    let right_authored = right_snapshot.global.translation();
+    let visible_left = memory.left_foot_world_target.unwrap_or(left_authored);
+    let visible_right = memory.right_foot_world_target.unwrap_or(right_authored);
+    let start_tick = skeleton.action_start_tick().unwrap_or_default();
+    let step = skeleton.attack_step();
+    let start_lead = skeleton.attack_start_lead();
+    let swing_left = match step {
+        AttackStep::Stay => false,
+        // Advancing moves the rear foot; retreating moves the lead foot.
+        AttackStep::Forward => start_lead == LeadFoot::Right,
+        AttackStep::Backward => start_lead == LeadFoot::Left,
+    };
+    let mut state = states
+        .get_mut(owner)
+        .map(|state| *state)
+        .unwrap_or_default();
+    let phase = skeleton.action_phase().clamp(0.0, 1.0);
+    let replacement = !state.initialized
+        || state.start_tick != start_tick
+        || state.lead != start_lead
+        || state.step != step
+        || (state.initialized
+            && (rig_origin.distance(state.last_origin) > MAX_OWNER_TRANSLATION_PER_TICK
+                || rig_rotation.angle_between(state.last_rotation).to_degrees()
+                    > MAX_OWNER_ROTATION_PER_TICK_DEGREES))
+        || phase + 0.001 < state.previous_phase;
+    if replacement {
+        let swing_start = if swing_left {
+            visible_left
+        } else {
+            visible_right
+        };
+        let support = if swing_left {
+            visible_right
+        } else {
+            visible_left
+        };
+        let stance_local = rig_rotation.inverse() * (swing_start - rig_origin);
+        let rig_direction = match step {
+            AttackStep::Stay => Vec2::ZERO,
+            AttackStep::Forward => Vec2::Y,
+            AttackStep::Backward => Vec2::NEG_Y,
+        };
+        let airborne_lunge = step != AttackStep::Stay
+            && skeleton.attack_step_speed() >= ATTACK_AIRBORNE_LUNGE_MIN_SPEED;
+        let mut swing_end = if step == AttackStep::Stay {
+            swing_start
+        } else {
+            plan_guard_step_endpoint(
+                rig_origin,
+                rig_rotation,
+                stance_local,
+                rig_direction,
+                guard_step_length(skeleton.attack_step_speed()),
+                swing_left,
+                support,
+            )
+        };
+        if step != AttackStep::Stay && !airborne_lunge {
+            let travel_direction = skeleton.world_velocity.xz().normalize_or_zero();
+            let preparation_seconds =
+                skeleton.action_preparation_ticks().unwrap_or(1) as f32 / LOCOMOTION_SAMPLE_HZ;
+            let contact_displacement = Vec3::new(travel_direction.x, 0.0, travel_direction.y)
+                * skeleton.attack_movement().map_or(0.0, |(_, speed)| speed)
+                * preparation_seconds;
+            // The controller carries captured velocity through the lunge and
+            // stops translating at contact. Recovery therefore happens around
+            // this single world-space plant instead of requiring another step.
+            // The authored opposite guard already advances the new lead foot;
+            // reserve part of controller travel for that authored stance
+            // change instead of double-counting it procedurally. Retaining
+            // four fifths keeps maximum visible extension at exact contact
+            // even when the planted leg yields a few centimetres to reach.
+            swing_end += contact_displacement * 0.8;
+        }
+        let left_stance_local = rig_rotation.inverse() * (visible_left - rig_origin);
+        let right_stance_local = rig_rotation.inverse() * (visible_right - rig_origin);
+        state = AttackFootworkState {
+            initialized: true,
+            start_tick,
+            lead: start_lead,
+            step,
+            swing_left,
+            last_origin: rig_origin,
+            last_rotation: rig_rotation,
+            start_rotation: rig_rotation,
+            swing_start,
+            swing_end,
+            left_stance_local,
+            right_stance_local,
+            swing_end_local: rig_rotation.inverse() * (swing_end - rig_origin),
+            airborne_lunge,
+            left_plant: visible_left,
+            right_plant: visible_right,
+            evaluation_tick: tick,
+            previous_phase: phase,
+            support_handoffs: 0,
+            left_support_weight: 1.0,
+            right_support_weight: 1.0,
+            left_requested_target: None,
+            right_requested_target: None,
+            left_solve_target: None,
+            right_solve_target: None,
+            maximum_reach_yield: 0.0,
+        };
+    }
+    let advances = match tick {
+        Some(tick) => state.evaluation_tick != Some(tick),
+        None => state_delta_seconds > 0.0,
+    };
+    if advances {
+        if state.step != AttackStep::Stay && state.previous_phase < 0.5 && phase >= 0.5 {
+            state.support_handoffs = state.support_handoffs.saturating_add(1);
+            if state.airborne_lunge {
+                // Unsupported flight may deliberately exceed planted reach;
+                // landing and recovery own the grounded reach contract.
+                state.maximum_reach_yield = 0.0;
+            }
+        }
+        state.previous_phase = phase;
+        state.last_origin = rig_origin;
+        state.last_rotation = rig_rotation;
+    }
+    state.evaluation_tick = tick;
+
+    // Bias the swing toward the strike so maximum extension lands on the
+    // authored contact frame even if the support leg yields slightly near its
+    // reach limit.
+    let preparation = smoothstep(0.0, 0.5, phase).powi(2);
+    let recovery = smoothstep(0.5, 1.0, phase);
+    let mut left_target = if step == AttackStep::Stay {
+        state.left_plant
+    } else {
+        state.left_plant.lerp(left_authored, recovery)
+    };
+    let mut right_target = if step == AttackStep::Stay {
+        state.right_plant
+    } else {
+        state.right_plant.lerp(right_authored, recovery)
+    };
+    let mut swing_target = state.swing_start.lerp(state.swing_end, preparation);
+    if phase >= 0.5 && !state.airborne_lunge {
+        // Contact is the unique maximum extension. From there both feet only
+        // remain on the new support plant while the original support foot
+        // settles into the opposite guard. No second lunge is planned.
+        swing_target = state.swing_end;
+        if state
+            .start_rotation
+            .angle_between(rig_rotation)
+            .to_degrees()
+            > 45.0
+        {
+            let authored = if state.swing_left {
+                left_authored
+            } else {
+                right_authored
+            };
+            // A large facing change cannot preserve the old world plant and
+            // also finish in an anatomically coherent guard. Treat the
+            // recovery as an in-place pivot of the lunge foot, not a second
+            // translational step.
+            swing_target = state.swing_end.lerp(authored, recovery);
+        }
+    }
+    if step != AttackStep::Stay {
+        if state.swing_left {
+            left_target = swing_target;
+        } else {
+            right_target = swing_target;
+        }
+    }
+    if state.airborne_lunge {
+        // A full-speed root can travel farther than one planted leg can
+        // reach during the windup. Treat that case as one owner-relative
+        // airborne lunge: both feet leave the ground, the selected foot still
+        // reaches maximum extension at contact, and both settle continuously
+        // into the opposite guard at recovery rather than dragging a stale
+        // world plant or snapping when the action ends.
+        let left_authored_local = rig_rotation.inverse() * (left_authored - rig_origin);
+        let right_authored_local = rig_rotation.inverse() * (right_authored - rig_origin);
+        let moving_local = if phase < 0.5 {
+            let start = if state.swing_left {
+                state.left_stance_local
+            } else {
+                state.right_stance_local
+            };
+            start.lerp(state.swing_end_local, preparation)
+        } else {
+            state.swing_end_local
+        };
+        let support_local = if state.swing_left {
+            state
+                .right_stance_local
+                .lerp(right_authored_local, recovery)
+        } else {
+            state.left_stance_local.lerp(left_authored_local, recovery)
+        };
+        left_target = rig_origin
+            + rig_rotation
+                * (if state.swing_left {
+                    moving_local
+                } else {
+                    support_local
+                });
+        right_target = rig_origin
+            + rig_rotation
+                * (if state.swing_left {
+                    support_local
+                } else {
+                    moving_local
+                });
+        let clearance = if phase < 0.5 {
+            (std::f32::consts::PI * phase * 2.0).sin().max(0.0) * ATTACK_AIRBORNE_LUNGE_CLEARANCE
+        } else {
+            0.0
+        };
+        left_target.y += clearance;
+        right_target.y += clearance;
+    }
+    if terrain_enabled && let Some(terrain) = terrain {
+        let airborne_clearance = if state.airborne_lunge {
+            if phase < 0.5 {
+                (std::f32::consts::PI * phase * 2.0).sin().max(0.0)
+                    * ATTACK_AIRBORNE_LUNGE_CLEARANCE
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+        left_target =
+            terrain_conformed_guard_target(left_target, terrain.height_at(left_target.xz()));
+        right_target =
+            terrain_conformed_guard_target(right_target, terrain.height_at(right_target.xz()));
+        left_target.y += airborne_clearance;
+        right_target.y += airborne_clearance;
+    } else {
+        left_target.y += ATTACK_FLAT_SOLE_CLEARANCE;
+        right_target.y += ATTACK_FLAT_SOLE_CLEARANCE;
+    }
+    if step != AttackStep::Stay && phase < 0.5 && !state.airborne_lunge {
+        let lift = (std::f32::consts::PI * preparation).sin() * 0.10;
+        if state.swing_left {
+            left_target.y += lift;
+        } else {
+            right_target.y += lift;
+        }
+    }
+
+    let handoff = if step == AttackStep::Stay {
+        0.0
+    } else {
+        smoothstep(0.45, 0.55, phase)
+    };
+    let (left_support, right_support) = if step == AttackStep::Stay {
+        (1.0, 1.0)
+    } else if state.airborne_lunge {
+        let launch = 1.0 - smoothstep(0.0, 0.12, phase);
+        // Flight ends at the authored strike extent: the lunging foot owns
+        // contact support, then the original foot rejoins during recovery.
+        let landing = smoothstep(0.44, 0.5, phase);
+        let recovery_support = smoothstep(0.88, 1.0, phase);
+        if state.swing_left {
+            (landing, launch.max(recovery_support))
+        } else {
+            (launch.max(recovery_support), landing)
+        }
+    } else if state.swing_left {
+        (handoff, 1.0 - handoff)
+    } else {
+        (1.0 - handoff, handoff)
+    };
+    state.left_support_weight = left_support;
+    state.right_support_weight = right_support;
+
+    for (upper, lower, foot, requested_target, left, support_weight) in [
+        (
+            left_upper,
+            left_lower,
+            left_foot,
+            left_target,
+            true,
+            left_support,
+        ),
+        (
+            right_upper,
+            right_lower,
+            right_foot,
+            right_target,
+            false,
+            right_support,
+        ),
+    ] {
+        let Some((upper_snapshot, lower_snapshot, foot_snapshot)) =
+            snapshot_chain(upper, lower, foot, parents, &transforms.p0())
+        else {
+            continue;
+        };
+        let upper_length = upper_snapshot
+            .global
+            .translation()
+            .distance(lower_snapshot.global.translation());
+        let lower_length = lower_snapshot
+            .global
+            .translation()
+            .distance(foot_snapshot.global.translation());
+        let attack_reach = if terrain_enabled {
+            // Cross-slope support needs the same small knee-reserve release as
+            // ordinary terrain IK. Keeping the flat-ground reserve here made
+            // the nominally planted foot creep as the pelvis crossed a slope.
+            terrain_maximum_reach(upper_length, lower_length)
+        } else {
+            maximum_reach(upper_length, lower_length)
+        };
+        // Fast root continuation can carry the hip beyond a literal world
+        // plant. Yield only the unreachable residual, giving a compressed
+        // lunge instead of a straight knee, teleport, or owner translation.
+        let constrained = constrain_target_to_reach(
+            requested_target,
+            upper_snapshot.global.translation(),
+            attack_reach,
+        );
+        // The attack trajectory and controller root are already sampled at a
+        // fixed rate. A second generic locomotion speed limit makes the solve
+        // lag behind the requested strike and shifts maximum extension into
+        // recovery. The analytic reach constraint below remains the safety
+        // bound; use the attack sample directly so contact stays synchronized.
+        let advanced = constrained;
+        let target =
+            constrain_target_to_reach(advanced, upper_snapshot.global.translation(), attack_reach);
+        state.maximum_reach_yield = state
+            .maximum_reach_yield
+            .max(requested_target.distance(target));
+        let side = anatomical_side(
+            rig_rotation,
+            rig_origin,
+            upper_snapshot.global.translation(),
+            left,
+        );
+        let remembered = if left {
+            memory.left_leg
+        } else {
+            memory.right_leg
+        };
+        let canonical = canonical_knee_pole(side);
+        let pole = pole_to_world(
+            rig_rotation,
+            remembered
+                .filter(|pole| pole.dot(canonical) > 0.2)
+                .unwrap_or(canonical),
+        );
+        if let Some(solution) = solve_two_bone_with_reach(
+            upper_snapshot.global.translation(),
+            lower_snapshot.global.translation(),
+            foot_snapshot.global.translation(),
+            target,
+            upper_length,
+            lower_length,
+            pole,
+            attack_reach,
+        ) {
+            apply_two_bone_solution(upper, lower, foot, solution, parents, transforms);
+            let bend = (solution.knee - upper_snapshot.global.translation())
+                .reject_from_normalized(solution.end_direction);
+            if advances && let Some(valid) = bend.try_normalize() {
+                if left {
+                    memory.left_leg = Some(pole_to_owner(rig_rotation, valid));
+                } else {
+                    memory.right_leg = Some(pole_to_owner(rig_rotation, valid));
+                }
+            }
+        }
+        if terrain_enabled
+            && support_weight >= 0.5
+            && let Some(terrain) = terrain
+            && let Some(normal) = terrain.normal_at(target.xz())
+            && let Some(sole_axis) = rig.sole_axis(left)
+        {
+            align_foot_to_slope(foot, sole_axis, normal, parents, transforms);
+        }
+        if left {
+            state.left_requested_target = Some(requested_target);
+            state.left_solve_target = Some(target);
+            memory.left_foot_world_target = Some(target);
+            memory.left_support_weight = Some(support_weight);
+        } else {
+            state.right_requested_target = Some(requested_target);
+            state.right_solve_target = Some(target);
+            memory.right_foot_world_target = Some(target);
+            memory.right_support_weight = Some(support_weight);
+        }
+    }
+    if let Ok(mut stored) = states.get_mut(owner) {
+        *stored = state;
+    } else {
+        commands.entity(owner).insert(state);
+    }
+}
+
 pub(super) fn raised_footwork_posture_is_valid(skeleton: &SkeletonState) -> bool {
     skeleton.is_grounded() && skeleton.posture() == Posture::Upright
 }
@@ -1847,7 +2363,10 @@ pub(super) fn raised_footwork_posture_is_valid(skeleton: &SkeletonState) -> bool
 pub(super) fn terrain_ik_posture_is_valid(skeleton: &SkeletonState) -> bool {
     skeleton.is_grounded()
         && matches!(skeleton.posture(), Posture::Upright | Posture::Crouched)
-        && skeleton.action_kind() == SkeletonAction::None
+        && matches!(
+            skeleton.action_kind(),
+            SkeletonAction::None | SkeletonAction::Attack
+        )
 }
 
 pub(super) fn terrain_leg_has_support(weight: f32) -> bool {
@@ -2081,7 +2600,37 @@ fn terrain_maximum_reach(upper_length: f32, lower_length: f32) -> f32 {
 /// has exactly one support foot while the other follows its clearance arc.
 pub(crate) fn locomotion_support_weights(skeleton: &SkeletonState) -> (f32, f32) {
     let speed = skeleton.animation_speed();
-    if !skeleton.is_grounded() || skeleton.action_kind() != SkeletonAction::None {
+    if !skeleton.is_grounded() {
+        return (0.0, 0.0);
+    }
+    if skeleton.action_kind() == SkeletonAction::Attack {
+        let step = skeleton.attack_step();
+        if step == AttackStep::Stay {
+            return (1.0, 1.0);
+        }
+        let swing_left = match step {
+            AttackStep::Forward => skeleton.attack_start_lead() == LeadFoot::Right,
+            AttackStep::Backward => skeleton.attack_start_lead() == LeadFoot::Left,
+            AttackStep::Stay => unreachable!(),
+        };
+        if skeleton.attack_step_speed() >= ATTACK_AIRBORNE_LUNGE_MIN_SPEED {
+            let phase = skeleton.action_phase();
+            let launch = 1.0 - smoothstep(0.0, 0.12, phase);
+            let recovery = smoothstep(0.5, 1.0, phase);
+            return if swing_left {
+                (if phase < 0.5 { 0.0 } else { 1.0 }, launch.max(recovery))
+            } else {
+                (launch.max(recovery), if phase < 0.5 { 0.0 } else { 1.0 })
+            };
+        }
+        let handoff = smoothstep(0.45, 0.55, skeleton.action_phase());
+        return if swing_left {
+            (handoff, 1.0 - handoff)
+        } else {
+            (1.0 - handoff, handoff)
+        };
+    }
+    if skeleton.action_kind() != SkeletonAction::None {
         return (0.0, 0.0);
     }
     if speed <= 0.05 {

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -20,11 +20,11 @@ use bevy::{
 use serde::Serialize;
 
 use crate::animation::{
-    AnimationPlayback, ArmIkState, BoneRole, HumanoidBone, LegIkState, LocomotionBodyResponseState,
-    LocomotionHeightState, LocomotionPresentationEvent, LocomotionPresentationEventKind,
-    MEASURED_ANKLE_SOLE_OFFSET_METRES, PresentedSkeleton, ProceduralAnimationClock,
-    RaisedFootworkState, SOLE_CONTACT_TOLERANCE_METRES, TacticalAnimationPlugin, TerrainIkEnabled,
-    locomotion_support_weights,
+    AnimationPlayback, ArmIkState, AttackFootworkState, BoneRole, HumanoidBone, LegIkState,
+    LocomotionBodyResponseState, LocomotionHeightState, LocomotionPresentationEvent,
+    LocomotionPresentationEventKind, MEASURED_ANKLE_SOLE_OFFSET_METRES, PresentedSkeleton,
+    ProceduralAnimationClock, RaisedFootworkState, SOLE_CONTACT_TOLERANCE_METRES,
+    TacticalAnimationPlugin, TerrainIkEnabled, locomotion_support_weights,
 };
 use crate::{
     camera::{CameraMode, TacticalCameraPlugin, TacticalCameraSet, third_person_offset},
@@ -37,6 +37,7 @@ const CAPTURE_ROOT_GROUND_OFFSET_METRES: f32 = 0.95;
 const FULL_PLANT_SUPPORT_WEIGHT: f32 = 0.99;
 const RAISED_MINIMUM_INTER_FOOT_SEPARATION_METRES: f32 = 0.16;
 const RAISED_MAXIMUM_PELVIS_VERTICAL_STEP_METRES: f32 = 0.05;
+const ATTACK_MAXIMUM_CONSTRAINED_TARGET_STEP_METRES: f32 = 0.201;
 // The parent guard-entry fixture already moves 33.13 mm in one sampled frame.
 // Allow less than 4 mm of additional height-system overhead without weakening
 // the broader raised-guard continuity bound.
@@ -73,6 +74,7 @@ enum ScenarioKind {
     Terrain,
     Transition,
     Landing,
+    Attack,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -100,6 +102,12 @@ fn scenario_metadata(name: &str) -> ScenarioMetadata {
                 && !name.contains("restart")
                 && !name.contains("chatter")
                 && !name.starts_with("terrain-steady-run"),
+            procedural_solver: true,
+        }
+    } else if name.starts_with("attack-step-") {
+        ScenarioMetadata {
+            kind: ScenarioKind::Attack,
+            repeatable: false,
             procedural_solver: true,
         }
     } else if name.starts_with("raised-guard") {
@@ -147,8 +155,9 @@ pub(crate) fn run(
         panic!("failed to create animation capture directory {output:?}: {error}")
     });
     invalidate_previous_report(&output);
-    let initial_terrain_ik =
-        scenario.is_some_and(|name| scenario_metadata(name).kind == ScenarioKind::Terrain);
+    let initial_terrain_ik = scenario.is_some_and(|name| {
+        scenario_metadata(name).kind == ScenarioKind::Terrain || name.contains("terrain")
+    });
 
     let workspace_asset_source =
         AssetSourceBuilder::platform_default(&asset_root.to_string_lossy(), None);
@@ -367,6 +376,7 @@ struct CaptureValidation {
     hard_stop_maximum_pelvis_step_metres: Option<f32>,
     hard_stop_height_continuity_valid: bool,
     repeated_evaluation_valid: bool,
+    attack_footwork_valid: bool,
     views_are_distinct: bool,
     duplicate_view_frames: Vec<String>,
     note: &'static str,
@@ -468,6 +478,9 @@ struct FrameSample {
     body_rotation_xyzw: [f32; 4],
     weapon_guard: WeaponGuardState,
     lead_foot: LeadFoot,
+    action: SkeletonAction,
+    action_phase: f32,
+    attack_step: AttackStep,
     guard_action: bool,
     left_support_weight: f32,
     right_support_weight: f32,
@@ -487,6 +500,12 @@ struct FrameSample {
     ik_left_release_target: Option<[f32; 3]>,
     ik_right_release_target: Option<[f32; 3]>,
     ik_settle_progress: Option<f32>,
+    attack_requested_left_foot_target: Option<[f32; 3]>,
+    attack_requested_right_foot_target: Option<[f32; 3]>,
+    attack_constrained_left_foot_target: Option<[f32; 3]>,
+    attack_constrained_right_foot_target: Option<[f32; 3]>,
+    attack_support_handoffs: u8,
+    attack_maximum_reach_yield_metres: f32,
     screenshots: BTreeMap<String, String>,
     bones: BTreeMap<String, BoneSample>,
 }
@@ -630,7 +649,7 @@ fn scenario_uses_terrain_ik(scenario: &str) -> bool {
 }
 
 fn terrain_ik_enabled_for_frame(frame: &PlannedFrame) -> bool {
-    scenario_uses_terrain_ik(frame.scenario)
+    (scenario_uses_terrain_ik(frame.scenario) || frame.scenario.contains("terrain"))
         && (frame.scenario != "terrain-toggle-mid-stride"
             || (16..80).contains(&frame.scenario_frame))
 }
@@ -828,6 +847,48 @@ fn smoothstep01(value: f32) -> f32 {
     value * value * (3.0 - 2.0 * value)
 }
 
+fn attack_step_scenario(
+    name: &'static str,
+    speed: f32,
+    initial_direction: Vec2,
+    lead_foot: LeadFoot,
+    reverse_velocity: bool,
+) -> Vec<PlannedFrame> {
+    const START: usize = 8;
+    (0..=47)
+        .map(|scenario_frame| PlannedFrame {
+            scenario: name,
+            scenario_frame,
+            speed,
+            time_seconds: scenario_frame as f32 / SAMPLE_HZ,
+            // Deliberately reverse velocity and yaw after attack start in the
+            // stress fixture. The replicated AttackStep must remain the one
+            // selected on frame zero.
+            local_direction: if (reverse_velocity || name.contains("high-speed"))
+                && scenario_frame >= START + 1
+            {
+                -initial_direction
+            } else {
+                initial_direction
+            },
+            camera_yaw: if name.contains("yaw-only") && scenario_frame >= START + 1 {
+                std::f32::consts::FRAC_PI_2
+            } else {
+                0.0
+            },
+            camera_pitch: 0.0,
+            crouching: false,
+            action: if scenario_frame < START {
+                SkeletonAction::None
+            } else {
+                SkeletonAction::Attack
+            },
+            weapon_guard: WeaponGuardState::Raised,
+            lead_foot,
+        })
+        .collect()
+}
+
 fn capture_plan() -> Vec<PlannedFrame> {
     [
         steady_scenario("steady-walk-2.0", 2.0, 2.0),
@@ -884,6 +945,69 @@ fn capture_plan() -> Vec<PlannedFrame> {
             LeadFoot::Right,
         ),
         raised_guard_transition_scenario(),
+        attack_step_scenario(
+            "attack-step-forward-left-lead",
+            2.0,
+            Vec2::NEG_Y,
+            LeadFoot::Left,
+            false,
+        ),
+        attack_step_scenario(
+            "attack-step-forward-right-lead",
+            2.0,
+            Vec2::NEG_Y,
+            LeadFoot::Right,
+            false,
+        ),
+        attack_step_scenario(
+            "attack-step-backward-left-lead",
+            2.0,
+            Vec2::Y,
+            LeadFoot::Left,
+            false,
+        ),
+        attack_step_scenario(
+            "attack-step-backward-right-lead",
+            2.0,
+            Vec2::Y,
+            LeadFoot::Right,
+            false,
+        ),
+        attack_step_scenario(
+            "attack-step-stationary",
+            0.0,
+            Vec2::ZERO,
+            LeadFoot::Left,
+            false,
+        ),
+        attack_step_scenario(
+            "attack-step-high-speed-reversal",
+            5.5,
+            Vec2::NEG_Y,
+            LeadFoot::Left,
+            false,
+        ),
+        attack_step_scenario(
+            "attack-step-reversal",
+            2.0,
+            Vec2::NEG_Y,
+            LeadFoot::Left,
+            true,
+        ),
+        attack_step_scenario(
+            "attack-step-yaw-only",
+            2.0,
+            Vec2::NEG_Y,
+            LeadFoot::Left,
+            false,
+        ),
+        attack_step_scenario(
+            "attack-step-terrain-cross-slope",
+            2.0,
+            Vec2::new(0.5, -1.0).normalize(),
+            LeadFoot::Left,
+            false,
+        ),
         crouch_transition_scenario(),
         dynamics_speed_scenario("speed-ramp-up-down", false),
         dynamics_speed_scenario("hard-stop", true),
@@ -1193,6 +1317,7 @@ fn drive_sequence(
             Option<&mut LegIkState>,
             Option<&mut ArmIkState>,
             Option<&mut RaisedFootworkState>,
+            Option<&mut AttackFootworkState>,
             Option<&mut LocomotionHeightState>,
             Option<&mut LocomotionBodyResponseState>,
         ),
@@ -1214,6 +1339,7 @@ fn drive_sequence(
         ik_state,
         arm_ik_state,
         raised_footwork,
+        attack_footwork,
         height_state,
         body_response,
     ) in &mut subjects
@@ -1240,6 +1366,9 @@ fn drive_sequence(
             if let Some(mut raised_footwork) = raised_footwork {
                 *raised_footwork = RaisedFootworkState::default();
             }
+            if let Some(mut attack_footwork) = attack_footwork {
+                *attack_footwork = AttackFootworkState::default();
+            }
             if let Some(mut height_state) = height_state {
                 *height_state = LocomotionHeightState::default();
             }
@@ -1259,7 +1388,12 @@ fn drive_sequence(
             WeaponGuardState::Raised => 1.0,
             WeaponGuardState::Lowered => -1.0,
         };
-        skeleton.lead_foot = frame.lead_foot;
+        let attack_start_frame = frame.scenario.starts_with("attack-step-").then_some(8);
+        if frame.action != SkeletonAction::Attack
+            || attack_start_frame == Some(frame.scenario_frame)
+        {
+            skeleton.lead_foot = frame.lead_foot;
+        }
         terrain_ik.0 = terrain_ik_enabled_for_frame(&frame);
         guard_input.apply_controls(wheel, false);
         set_weapon_guard(&mut skeleton, guard_input.desired);
@@ -1269,11 +1403,21 @@ fn drive_sequence(
         } else {
             0.0
         };
-        let local_velocity = Vec3::new(
+        let requested_local_velocity = Vec3::new(
             frame.local_direction.x * frame.speed,
             vertical_velocity,
             frame.local_direction.y * frame.speed,
         );
+        let local_velocity = skeleton
+            .attack_movement()
+            .map(|(direction, speed)| {
+                if skeleton.action_phase() < 0.5 {
+                    Vec3::new(direction.x * speed, vertical_velocity, direction.y * speed)
+                } else {
+                    Vec3::new(0.0, vertical_velocity, 0.0)
+                }
+            })
+            .unwrap_or(requested_local_velocity);
         let world_velocity = controller_yaw(orientation) * local_velocity;
         let delta_seconds = if frame.scenario_frame == 0 {
             0.0
@@ -1289,13 +1433,23 @@ fn drive_sequence(
             transform.translation.y
         };
         transform.translation = Vec3::new(horizontal.x, vertical, horizontal.y);
-        if frame.action != SkeletonAction::None {
+        if frame.action != SkeletonAction::None
+            && (frame.action != SkeletonAction::Attack
+                || attack_start_frame == Some(frame.scenario_frame))
+        {
             let start = sequence.simulation_tick;
-            let contact = start + 64;
+            let contact = start
+                + if frame.action == SkeletonAction::Attack {
+                    19
+                } else {
+                    64
+                };
             match frame.action {
-                SkeletonAction::Attack => {
-                    skeleton.begin_attack(AttackSpec::default(), start, contact)
-                }
+                SkeletonAction::Attack => skeleton.begin_attack(
+                    AttackSpec::melee_from_local_velocity(local_velocity),
+                    start,
+                    contact,
+                ),
                 SkeletonAction::Dodge => skeleton.begin_dodge(DodgeSpec::default(), start, contact),
                 SkeletonAction::Block => skeleton.begin_block(BlockSpec::default(), start, contact),
                 SkeletonAction::None => {}
@@ -1490,6 +1644,7 @@ fn capture_frame(
             &GlobalTransform,
             Option<&AnimationPlayback>,
             Option<&RaisedFootworkState>,
+            Option<&AttackFootworkState>,
             Option<&LocomotionBodyResponseState>,
             Option<&LocomotionHeightState>,
             Option<&LegIkState>,
@@ -1509,6 +1664,7 @@ fn capture_frame(
         subject_global,
         playback,
         raised_footwork,
+        attack_footwork,
         body_response,
         height_state,
         leg_ik,
@@ -1626,16 +1782,44 @@ fn capture_frame(
     if sequence.view_index == 0 {
         let cadence_support = locomotion_support_weights(skeleton);
         let root_distance_metres = sequence.scenario_distance;
-        let (desired_left_foot_target, desired_right_foot_target) = raised_footwork
+        let (desired_left_foot_target, desired_right_foot_target) = attack_footwork
+            .filter(|state| state.initialized)
             .map(|state| (state.left_solve_target, state.right_solve_target))
+            .or_else(|| {
+                raised_footwork.map(|state| (state.left_solve_target, state.right_solve_target))
+            })
             .unwrap_or_default();
         let leg_ik = leg_ik.map(LegIkState::diagnostics).unwrap_or_default();
-        let (left_support_weight, right_support_weight) =
+        let ik_support =
             if leg_ik.left_solve_target.is_some() || leg_ik.right_solve_target.is_some() {
                 (leg_ik.left_support_weight, leg_ik.right_support_weight)
             } else {
                 cadence_support
             };
+        let (left_support_weight, right_support_weight) = attack_footwork
+            .filter(|state| state.initialized)
+            .map(|state| (state.left_support_weight, state.right_support_weight))
+            .unwrap_or(ik_support);
+        let (
+            attack_requested_left,
+            attack_requested_right,
+            attack_constrained_left,
+            attack_constrained_right,
+            attack_support_handoffs,
+            attack_maximum_reach_yield,
+        ) = attack_footwork.filter(|state| state.initialized).map_or(
+            (None, None, None, None, 0, 0.0),
+            |state| {
+                (
+                    state.left_requested_target,
+                    state.right_requested_target,
+                    state.left_solve_target,
+                    state.right_solve_target,
+                    state.support_handoffs,
+                    state.maximum_reach_yield,
+                )
+            },
+        );
         sequence.samples.push(FrameSample {
             scenario: frame.scenario.to_owned(),
             scenario_frame: frame.scenario_frame,
@@ -1675,6 +1859,9 @@ fn capture_frame(
             body_rotation_xyzw: subject_global.rotation().to_array(),
             weapon_guard: frame.weapon_guard,
             lead_foot: skeleton.lead_foot,
+            action: skeleton.action_kind(),
+            action_phase: skeleton.action_phase(),
+            attack_step: skeleton.attack_step(),
             guard_action: frame.weapon_guard == WeaponGuardState::Raised
                 || matches!(frame.action, SkeletonAction::Attack | SkeletonAction::Block),
             left_support_weight,
@@ -1695,6 +1882,15 @@ fn capture_frame(
             ik_left_release_target: leg_ik.left_release_target.map(|value| value.to_array()),
             ik_right_release_target: leg_ik.right_release_target.map(|value| value.to_array()),
             ik_settle_progress: leg_ik.settle_progress,
+            attack_requested_left_foot_target: attack_requested_left.map(|value| value.to_array()),
+            attack_requested_right_foot_target: attack_requested_right
+                .map(|value| value.to_array()),
+            attack_constrained_left_foot_target: attack_constrained_left
+                .map(|value| value.to_array()),
+            attack_constrained_right_foot_target: attack_constrained_right
+                .map(|value| value.to_array()),
+            attack_support_handoffs,
+            attack_maximum_reach_yield_metres: attack_maximum_reach_yield,
             screenshots: VIEWS
                 .into_iter()
                 .map(|view| {
@@ -1854,16 +2050,36 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         });
     let all_artifacts_written = capture_artifacts_written(&sequence.output, &frames);
     let continuity_within_review_bounds = scenarios.iter().all(|metrics| {
-        metrics.maximum_root_relative_step_metres <= 0.20
-            && metrics.maximum_foot_root_relative_step_metres <= 0.055
-            && metrics.maximum_knee_root_relative_step_metres <= 0.10
+        metrics.maximum_root_relative_step_metres
+            <= if metrics.scenario.starts_with("attack-step-") {
+                0.30
+            } else {
+                0.20
+            }
+            && metrics.maximum_foot_root_relative_step_metres
+                <= if metrics.scenario.starts_with("attack-step-") {
+                    0.21
+                } else {
+                    0.055
+                }
+            && metrics.maximum_knee_root_relative_step_metres
+                <= if metrics.scenario.starts_with("attack-step-") {
+                    0.15
+                } else {
+                    0.10
+                }
             && metrics.maximum_bone_rotation_step_degrees <= 60.0
             && (!metrics.scenario.starts_with("raised-guard")
                 || metrics.maximum_pelvis_vertical_step_metres
                     <= RAISED_MAXIMUM_PELVIS_VERTICAL_STEP_METRES)
     });
     let no_ground_penetration = scenarios.iter().all(|metrics| {
-        if scenario_metadata(&metrics.scenario).kind == ScenarioKind::Terrain
+        if scenario_metadata(&metrics.scenario).kind == ScenarioKind::Attack {
+            // Gait-phase contact selection does not describe a one-shot attack
+            // handoff. Its dedicated validator checks the actual requested
+            // plant; retain only the raw ankle penetration guard here.
+            metrics.minimum_foot_clearance_metres >= -0.04
+        } else if scenario_metadata(&metrics.scenario).kind == ScenarioKind::Terrain
             && metrics.scenario != "terrain-toggle-mid-stride"
         {
             // Only a contact foot is ground-constrained. Gate those contacts;
@@ -1880,10 +2096,13 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         pair[0].scenario != pair[1].scenario
             || pair[0].weapon_guard != WeaponGuardState::Raised
             || pair[1].weapon_guard != WeaponGuardState::Raised
+            || pair[0].action == SkeletonAction::Attack
+            || pair[1].action == SkeletonAction::Attack
             || pair[0].lead_foot == pair[1].lead_foot
     });
     let flat_controller_height_stable = scenarios.iter().all(|metrics| {
         scenario_uses_terrain_ik(&metrics.scenario)
+            || metrics.scenario.contains("terrain")
             || metrics.controller_vertical_range_metres <= 0.0001
     });
     let phase_owned_height_valid = scenarios.iter().all(|metrics| {
@@ -2303,7 +2522,9 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
                 && metrics.pelvis_vertical_range_metres <= vertical_range_limit
                 && metrics.head_vertical_range_metres <= vertical_range_limit;
         }
+        let attack = scenario_metadata(&metrics.scenario).kind == ScenarioKind::Attack;
         (!procedural_solver_gates_apply
+            || attack
             || (metrics.maximum_supported_foot_slip_metres_per_frame
                 <= supported_foot_slip_limit(&metrics.scenario)
                 && metrics.maximum_planted_foot_drift_metres
@@ -2312,11 +2533,12 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
             && metrics.minimum_inter_foot_separation_metres
                 >= inter_foot_separation_limit(&metrics.scenario)
             && (!procedural_solver_gates_apply
+                || metrics.scenario == "attack-step-stationary"
                 || (metrics.minimum_knee_flexion_degrees >= 3.9
                     && metrics.minimum_knee_hemisphere_dot >= 0.0))
             && metrics.maximum_facing_tracking_excess_degrees <= 0.2
             && metrics.final_facing_motion_error_degrees <= 3.0
-            && metrics.maximum_contact_sole_clearance_metres <= 0.04
+            && (attack || metrics.maximum_contact_sole_clearance_metres <= 0.04)
             && metrics.pelvis_vertical_range_metres <= vertical_range_limit
             && metrics.head_vertical_range_metres <= vertical_range_limit
             && if !expects_loop_seam(&metrics.scenario) {
@@ -2333,6 +2555,7 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
     });
     let views_are_distinct = sequence.duplicate_view_frames.is_empty();
     let repeated_evaluation_valid = sequence.repeated_evaluation_valid;
+    let attack_footwork_valid = validate_attack_footwork(&frames);
     let manifest = CaptureManifest {
         sample_hz: SAMPLE_HZ,
         pipeline: "shared tactical player, scene, camera, authoritative locomotion projection, authored FK, and final procedural passes",
@@ -2362,6 +2585,7 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
             hard_stop_maximum_pelvis_step_metres,
             hard_stop_height_continuity_valid,
             repeated_evaluation_valid,
+            attack_footwork_valid,
             views_are_distinct,
             duplicate_view_frames: sequence.duplicate_view_frames.clone(),
             note: "Continuity metrics are regression signals, not biomechanical proof; review index.html at normal and slow speed.",
@@ -2403,6 +2627,7 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         && final_support_balance_valid
         && hard_stop_height_continuity_valid
         && repeated_evaluation_valid
+        && attack_footwork_valid
         && views_are_distinct
     {
         exit.write(AppExit::Success);
@@ -2415,6 +2640,284 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         .unwrap_or_else(|error| panic!("failed to write {failure_path:?}: {error}"));
         exit.write(AppExit::Error(1.try_into().expect("one is non-zero")));
     }
+}
+
+fn validate_attack_footwork(frames: &[FrameSample]) -> bool {
+    let mut grouped = BTreeMap::<&str, Vec<&FrameSample>>::new();
+    for frame in frames
+        .iter()
+        .filter(|frame| frame.scenario.starts_with("attack-step-"))
+    {
+        grouped.entry(&frame.scenario).or_default().push(frame);
+    }
+    if grouped.is_empty() {
+        return true;
+    }
+    let expected = [
+        "attack-step-forward-left-lead",
+        "attack-step-forward-right-lead",
+        "attack-step-backward-left-lead",
+        "attack-step-backward-right-lead",
+        "attack-step-stationary",
+        "attack-step-high-speed-reversal",
+        "attack-step-reversal",
+        "attack-step-yaw-only",
+        "attack-step-terrain-cross-slope",
+    ];
+    let selected = if grouped.len() == 1 {
+        grouped.keys().copied().collect::<Vec<_>>()
+    } else {
+        expected.to_vec()
+    };
+    selected.into_iter().all(|name| {
+        let Some(samples) = grouped.get(name) else {
+            return false;
+        };
+        let start_lead = if name.contains("right-lead") {
+            LeadFoot::Right
+        } else {
+            LeadFoot::Left
+        };
+        let expected_step = if name == "attack-step-stationary" {
+            AttackStep::Stay
+        } else if name.contains("backward") {
+            AttackStep::Backward
+        } else {
+            AttackStep::Forward
+        };
+        let active = samples
+            .iter()
+            .copied()
+            .filter(|frame| frame.action == SkeletonAction::Attack)
+            .collect::<Vec<_>>();
+        if active.is_empty()
+            || active.iter().any(|frame| {
+                frame.attack_step != expected_step
+                    || (frame.action_phase < 0.999 && frame.lead_foot != start_lead)
+            })
+            || active
+                .windows(2)
+                .any(|pair| pair[1].action_phase + 0.0001 < pair[0].action_phase)
+        {
+            return false;
+        }
+        let contact = active.iter().min_by(|left, right| {
+            (left.action_phase - 0.5)
+                .abs()
+                .total_cmp(&(right.action_phase - 0.5).abs())
+        });
+        if contact.is_none_or(|frame| {
+            (frame.action_phase - 0.5).abs() > 0.001 || frame.scenario_frame != 27
+        }) {
+            return false;
+        }
+        let final_lead = samples.last().map(|frame| frame.lead_foot);
+        if expected_step == AttackStep::Stay {
+            let stable = [true, false].into_iter().all(|left| {
+                let positions = active
+                    .iter()
+                    .filter_map(|frame| {
+                        if left {
+                            frame.attack_requested_left_foot_target
+                        } else {
+                            frame.attack_requested_right_foot_target
+                        }
+                    })
+                    .map(Vec3::from_array)
+                    .collect::<Vec<_>>();
+                positions.first().is_some_and(|first| {
+                    positions
+                        .iter()
+                        .all(|position| position.distance(*first) <= 0.03)
+                })
+            });
+            return final_lead == Some(start_lead)
+                && stable
+                && active.iter().all(|frame| {
+                    frame.left_support_weight >= 0.99
+                        && frame.right_support_weight >= 0.99
+                        && frame.attack_support_handoffs == 0
+                });
+        }
+        let opposite = match start_lead {
+            LeadFoot::Left => LeadFoot::Right,
+            LeadFoot::Right => LeadFoot::Left,
+        };
+        if final_lead != Some(opposite) {
+            return false;
+        }
+        // The initially planted foot must remain fixed through contact. At
+        // high speed the analytic reach limiter may compress the visible
+        // lunge, so judge the requested world target and separately retain the
+        // global continuity/reach gates for rendered bones.
+        let planted_left = match expected_step {
+            AttackStep::Forward => start_lead == LeadFoot::Left,
+            AttackStep::Backward => start_lead == LeadFoot::Right,
+            AttackStep::Stay => true,
+        };
+        let requested = active
+            .iter()
+            .take_while(|frame| frame.action_phase <= 0.5 + 0.001)
+            .filter_map(|frame| {
+                if planted_left {
+                    frame.attack_requested_left_foot_target
+                } else {
+                    frame.attack_requested_right_foot_target
+                }
+            })
+            .map(Vec3::from_array)
+            .collect::<Vec<_>>();
+        let requested_plant_stable = requested.first().is_some_and(|first| {
+            requested
+                .iter()
+                .all(|target| target.is_finite() && target.distance(*first) <= 0.01)
+        });
+        let planted_foot = if planted_left {
+            "left_foot"
+        } else {
+            "right_foot"
+        };
+        let maximum_slip = active
+            .windows(2)
+            .filter(|pair| pair[1].action_phase <= 0.5 + 0.001)
+            .filter_map(|pair| {
+                Some(
+                    (Vec3::from_array(pair[1].bones.get(planted_foot)?.position)
+                        - Vec3::from_array(pair[0].bones.get(planted_foot)?.position))
+                    .xz()
+                    .length(),
+                )
+            })
+            .fold(0.0, f32::max);
+        let slip_limit = if name.contains("high-speed") {
+            0.11
+        } else if name.contains("terrain") {
+            // The analytic cross-slope solve contributes a small horizontal
+            // component while conforming the ankle to the surface normal.
+            0.05
+        } else {
+            0.04
+        };
+        let moving_foot = if planted_left {
+            "right_foot"
+        } else {
+            "left_foot"
+        };
+        // Measure the step in the facing frame captured when the attack
+        // began. A player may continue turning during the action; judging
+        // each frame in its new body frame would turn a valid lunge into a
+        // sideways or backwards step in telemetry.
+        let attack_forward = active
+            .first()
+            .map(|frame| Vec3::from_array(frame.body_forward_direction).normalize_or_zero())
+            .unwrap_or(Vec3::NEG_Z);
+        let moving_start = active.first().and_then(|frame| {
+            frame
+                .bones
+                .get(moving_foot)
+                .map(|bone| Vec3::from_array(bone.position))
+        });
+        let signed_extensions = active
+            .iter()
+            .filter_map(|frame| {
+                let moving = Vec3::from_array(frame.bones.get(moving_foot)?.position);
+                let signed = (moving - moving_start?).dot(attack_forward);
+                Some((frame.scenario_frame, signed))
+            })
+            .collect::<Vec<_>>();
+        let direction_valid = contact.is_some_and(|frame| {
+            let moving = frame
+                .bones
+                .get(moving_foot)
+                .map(|bone| Vec3::from_array(bone.position));
+            moving.zip(moving_start).is_some_and(|(moving, start)| {
+                let margin = (moving - start).dot(attack_forward);
+                if expected_step == AttackStep::Forward {
+                    margin >= 0.05
+                } else {
+                    margin <= -0.05
+                }
+            })
+        });
+        // Recovery may include an in-place guard pivot after a large facing
+        // change. Judge strike extent only over the lunge half; recovery is
+        // separately bounded by continuity and the one-handoff invariant.
+        let maximum_extension = signed_extensions
+            .iter()
+            .filter(|(frame, _)| *frame <= 27)
+            .map(|(_, extension)| extension.abs())
+            .fold(0.0, f32::max);
+        let maximum_at_contact = signed_extensions
+            .iter()
+            .find(|(frame, _)| *frame == 27)
+            // Two centimetres covers the two fixed samples around exact
+            // authored contact while still rejecting a visibly early step.
+            .is_some_and(|(_, extension)| extension.abs() + 0.02 >= maximum_extension);
+        let constrained_continuous = [true, false].into_iter().all(|left| {
+            active
+                .windows(2)
+                .filter_map(|pair| {
+                    let target = |frame: &FrameSample| {
+                        if left {
+                            frame.attack_constrained_left_foot_target
+                        } else {
+                            frame.attack_constrained_right_foot_target
+                        }
+                        .map(Vec3::from_array)
+                    };
+                    Some(target(pair[0])?.distance(target(pair[1])?))
+                })
+                .all(|step| step <= ATTACK_MAXIMUM_CONSTRAINED_TARGET_STEP_METRES)
+        });
+        let final_attack = active.last().copied();
+        let airborne_lunge = name.contains("high-speed");
+        let yield_valid = if airborne_lunge {
+            final_attack.is_some_and(|frame| frame.attack_maximum_reach_yield_metres <= 0.15)
+        } else {
+            active
+                .iter()
+                .all(|frame| frame.attack_maximum_reach_yield_metres <= 4.0)
+        };
+        let support_valid = if airborne_lunge {
+            contact.is_some_and(|frame| {
+                frame.left_support_weight.max(frame.right_support_weight) >= 0.9
+                    && frame.left_support_weight.min(frame.right_support_weight) <= 0.1
+            }) && active.first().is_some_and(|frame| {
+                frame.left_support_weight.max(frame.right_support_weight) >= 0.9
+            })
+        } else {
+            active
+                .iter()
+                .all(|frame| frame.left_support_weight.max(frame.right_support_weight) >= 0.5)
+        };
+        let valid = (requested_plant_stable || airborne_lunge)
+            && maximum_slip <= slip_limit
+            && direction_valid
+            && maximum_at_contact
+            && constrained_continuous
+            && yield_valid
+            && final_attack.is_some_and(|frame| frame.attack_support_handoffs == 1)
+            && support_valid
+            && active
+                .iter()
+                .all(|frame| frame.attack_maximum_reach_yield_metres.is_finite());
+        if !valid {
+            warn!(
+                scenario = name,
+                requested_plant_stable,
+                maximum_slip,
+                slip_limit,
+                direction_valid,
+                maximum_at_contact,
+                constrained_continuous,
+                yield_valid,
+                support_valid,
+                handoffs = final_attack.map_or(0, |frame| frame.attack_support_handoffs),
+                "attack footwork validation failed"
+            );
+        }
+        valid
+    })
 }
 
 fn planted_drift_limit(scenario: &str) -> f32 {
@@ -2680,7 +3183,9 @@ fn expects_loop_seam(scenario: &str) -> bool {
 }
 
 fn vertical_range_limit(scenario: &str, foot_terrain_relief_metres: f32) -> f32 {
-    if scenario.starts_with("raised-guard-") {
+    if scenario.starts_with("attack-step-") {
+        0.35
+    } else if scenario.starts_with("raised-guard-") {
         RAISED_GUARD_VERTICAL_RANGE_LIMIT_METRES
     } else if scenario == "hard-stop" {
         // The scenario intentionally spans the run apex and exact final idle.
@@ -3421,6 +3926,9 @@ mod tests {
             body_rotation_xyzw: Quat::IDENTITY.to_array(),
             weapon_guard: WeaponGuardState::Lowered,
             lead_foot: LeadFoot::Left,
+            action: SkeletonAction::None,
+            action_phase: 0.0,
+            attack_step: AttackStep::Stay,
             guard_action: false,
             left_support_weight: 1.0,
             right_support_weight: 1.0,
@@ -3440,6 +3948,12 @@ mod tests {
             ik_left_release_target: None,
             ik_right_release_target: None,
             ik_settle_progress: None,
+            attack_requested_left_foot_target: None,
+            attack_requested_right_foot_target: None,
+            attack_constrained_left_foot_target: None,
+            attack_constrained_right_foot_target: None,
+            attack_support_handoffs: 0,
+            attack_maximum_reach_yield_metres: 0.0,
             screenshots,
             bones: BTreeMap::new(),
         };
@@ -3769,6 +4283,9 @@ mod tests {
             body_rotation_xyzw: Quat::IDENTITY.to_array(),
             weapon_guard: WeaponGuardState::Lowered,
             lead_foot: LeadFoot::Left,
+            action: SkeletonAction::None,
+            action_phase: 0.0,
+            attack_step: AttackStep::Stay,
             guard_action: false,
             left_support_weight: 1.0,
             right_support_weight: 1.0,
@@ -3788,6 +4305,12 @@ mod tests {
             ik_left_release_target: None,
             ik_right_release_target: None,
             ik_settle_progress: None,
+            attack_requested_left_foot_target: None,
+            attack_requested_right_foot_target: None,
+            attack_constrained_left_foot_target: None,
+            attack_constrained_right_foot_target: None,
+            attack_support_handoffs: 0,
+            attack_maximum_reach_yield_metres: 0.0,
             screenshots: BTreeMap::new(),
             bones,
         };
@@ -3873,6 +4396,9 @@ mod tests {
             body_rotation_xyzw: Quat::IDENTITY.to_array(),
             weapon_guard: WeaponGuardState::Lowered,
             lead_foot: LeadFoot::Left,
+            action: SkeletonAction::None,
+            action_phase: 0.0,
+            attack_step: AttackStep::Stay,
             guard_action: false,
             left_support_weight,
             right_support_weight: 0.0,
@@ -3892,6 +4418,12 @@ mod tests {
             ik_left_release_target: None,
             ik_right_release_target: None,
             ik_settle_progress: None,
+            attack_requested_left_foot_target: None,
+            attack_requested_right_foot_target: None,
+            attack_constrained_left_foot_target: None,
+            attack_constrained_right_foot_target: None,
+            attack_support_handoffs: 0,
+            attack_maximum_reach_yield_metres: 0.0,
             screenshots: BTreeMap::new(),
             bones: BTreeMap::from([
                 ("left_foot".into(), foot(left_x, left_terrain_height)),

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -356,7 +356,16 @@ fn on_attack_fired_hook(
     cmd.entity(event.context)
         .insert(AttackState::new(PRE_HIT_DELAY, reach, ranged));
     let start = (time.elapsed_secs_f64() * LOCOMOTION_SAMPLE_HZ as f64).round() as u64;
-    skeleton.begin_attack(AttackSpec::default(), start, start + 19);
+    let predicted = if ranged {
+        AttackSpec::default()
+    } else {
+        // Predict only from the last physical velocity already present in the
+        // replicated skeleton. The authority repeats the same typed
+        // classification from its observation; no input vector crosses the
+        // reliable action boundary.
+        AttackSpec::melee_from_local_velocity(skeleton.local_velocity)
+    };
+    skeleton.begin_attack(predicted, start, start + 19);
     if ranged {
         cmd.client_trigger(RangedActionRequest::Start);
     } else {

--- a/crates/adventuresim-tactical-core/src/animation/evaluation.rs
+++ b/crates/adventuresim-tactical-core/src/animation/evaluation.rs
@@ -278,10 +278,11 @@ fn duck_side_pose(lead: LeadFoot, duck_left: bool) -> SemanticPose {
 
 fn attack_samples(state: &SkeletonState) -> Vec<PoseSample> {
     let phase = state.action_phase().clamp(0.0, 1.0);
-    let start_guard = guard_pose(state.lead_foot);
+    let start_lead = state.attack_start_lead();
+    let start_guard = guard_pose(start_lead);
     let end_guard = guard_pose(match state.footwork() {
-        Footwork::Stay => state.lead_foot,
-        Footwork::Switch => opposite_foot(state.lead_foot),
+        Footwork::Stay => start_lead,
+        Footwork::Switch => opposite_foot(start_lead),
     });
     let contact = attack_pose(state);
     let (pose, end, blend) = if phase < 0.5 {
@@ -321,7 +322,7 @@ fn block_pose(line: AttackLine, lead: LeadFoot) -> SemanticPose {
 
 fn attack_pose(state: &SkeletonState) -> SemanticPose {
     use {LeadFoot::*, SemanticPose::*, StrikeFamily::*};
-    match (state.strike_family(), state.lead_foot) {
+    match (state.strike_family(), state.attack_start_lead()) {
         (Thrust, Left) => AttackThrustLeadLeftContact,
         (Thrust, Right) => AttackThrustLeadRightContact,
         (Slash, Left) => AttackSlashLeadLeftContact,

--- a/crates/adventuresim-tactical-core/src/animation/state.rs
+++ b/crates/adventuresim-tactical-core/src/animation/state.rs
@@ -247,7 +247,11 @@ enum ActionKind {
     Attack {
         target_height: f32,
         strike_family: StrikeFamily,
-        footwork: Footwork,
+        step: AttackStep,
+        step_speed: f32,
+        movement_direction: Vec2,
+        movement_speed: f32,
+        start_lead: LeadFoot,
         timeline: ActionTimeline,
     },
     Block {
@@ -284,7 +288,11 @@ impl<'de> Deserialize<'de> for ActionState {
             ActionKind::Attack {
                 target_height,
                 strike_family,
-                footwork,
+                step,
+                step_speed,
+                movement_direction,
+                movement_speed,
+                start_lead,
                 timeline,
             } => ActionKind::Attack {
                 target_height: if target_height.is_finite() {
@@ -293,7 +301,23 @@ impl<'de> Deserialize<'de> for ActionState {
                     AttackSpec::default().target_height
                 },
                 strike_family,
-                footwork,
+                step,
+                step_speed: if step_speed.is_finite() {
+                    step_speed.clamp(0.0, 8.0)
+                } else {
+                    0.0
+                },
+                movement_direction: if movement_direction.is_finite() {
+                    movement_direction.normalize_or_zero()
+                } else {
+                    Vec2::ZERO
+                },
+                movement_speed: if movement_speed.is_finite() {
+                    movement_speed.clamp(0.0, 8.0)
+                } else {
+                    0.0
+                },
+                start_lead,
                 timeline: timeline.normalized(),
             },
             ActionKind::Block {
@@ -322,7 +346,16 @@ pub struct DodgeSpec {
 pub struct AttackSpec {
     pub target_height: f32,
     pub strike_family: StrikeFamily,
-    pub footwork: Footwork,
+    /// Longitudinal step snapshotted from authoritative movement velocity at
+    /// attack start. It is semantic rather than a free vector so later input
+    /// or facing changes cannot repick the attacking foot.
+    pub step: AttackStep,
+    pub step_speed: f32,
+    /// Controller-local physical travel captured with the attack. Gameplay
+    /// holds this direction until recovery ends; later input is retained for
+    /// the next ordinary locomotion tick instead of steering the attack.
+    pub movement_direction: Vec2,
+    pub movement_speed: f32,
 }
 
 impl Default for AttackSpec {
@@ -330,7 +363,38 @@ impl Default for AttackSpec {
         Self {
             target_height: 0.5,
             strike_family: StrikeFamily::Thrust,
-            footwork: Footwork::Stay,
+            step: AttackStep::Stay,
+            step_speed: 0.0,
+            movement_direction: Vec2::ZERO,
+            movement_speed: 0.0,
+        }
+    }
+}
+
+impl AttackSpec {
+    /// Builds melee footwork from the controller-local velocity already
+    /// observed by the authority. Forward is Bevy's conventional -Z axis;
+    /// lateral-only and tiny longitudinal motion deliberately remain planted.
+    pub fn melee_from_local_velocity(local_velocity: Vec3) -> Self {
+        let step = AttackStep::from_local_velocity(local_velocity);
+        Self {
+            step,
+            step_speed: if local_velocity.is_finite() {
+                local_velocity.z.abs().clamp(0.0, 8.0)
+            } else {
+                0.0
+            },
+            movement_direction: if local_velocity.is_finite() {
+                Vec2::new(local_velocity.x, local_velocity.z).normalize_or_zero()
+            } else {
+                Vec2::ZERO
+            },
+            movement_speed: if local_velocity.is_finite() {
+                local_velocity.xz().length().clamp(0.0, 8.0)
+            } else {
+                0.0
+            },
+            ..Self::default()
         }
     }
 }
@@ -371,6 +435,38 @@ pub enum Footwork {
     #[default]
     Stay,
     Switch,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Reflect)]
+pub enum AttackStep {
+    #[default]
+    Stay,
+    Forward,
+    Backward,
+}
+
+impl AttackStep {
+    pub const MIN_LONGITUDINAL_SPEED: f32 = 0.15;
+
+    pub fn from_local_velocity(local_velocity: Vec3) -> Self {
+        if !local_velocity.is_finite() {
+            return Self::Stay;
+        }
+        if local_velocity.z <= -Self::MIN_LONGITUDINAL_SPEED {
+            Self::Forward
+        } else if local_velocity.z >= Self::MIN_LONGITUDINAL_SPEED {
+            Self::Backward
+        } else {
+            Self::Stay
+        }
+    }
+
+    pub fn footwork(self) -> Footwork {
+        match self {
+            Self::Stay => Footwork::Stay,
+            Self::Forward | Self::Backward => Footwork::Switch,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Reflect)]
@@ -621,9 +717,50 @@ impl SkeletonState {
         }
     }
     pub fn footwork(&self) -> Footwork {
+        self.attack_step().footwork()
+    }
+    pub fn attack_step(&self) -> AttackStep {
         match self.action {
-            ActionState(ActionKind::Attack { footwork, .. }) => footwork,
-            _ => Footwork::Stay,
+            ActionState(ActionKind::Attack { step, .. }) => step,
+            _ => AttackStep::Stay,
+        }
+    }
+    pub fn attack_step_speed(&self) -> f32 {
+        match self.action {
+            ActionState(ActionKind::Attack { step_speed, .. }) => step_speed,
+            _ => 0.0,
+        }
+    }
+    pub fn attack_movement(&self) -> Option<(Vec2, f32)> {
+        match self.action {
+            ActionState(ActionKind::Attack {
+                movement_direction,
+                movement_speed,
+                ..
+            }) => Some((movement_direction, movement_speed)),
+            _ => None,
+        }
+    }
+    pub fn attack_start_lead(&self) -> LeadFoot {
+        match self.action {
+            ActionState(ActionKind::Attack { start_lead, .. }) => start_lead,
+            _ => self.lead_foot,
+        }
+    }
+    pub fn action_start_tick(&self) -> Option<u64> {
+        match self.action {
+            ActionState(ActionKind::Idle) => None,
+            ActionState(ActionKind::Dodge { timeline, .. })
+            | ActionState(ActionKind::Attack { timeline, .. })
+            | ActionState(ActionKind::Block { timeline, .. }) => Some(timeline.start_tick),
+        }
+    }
+    pub fn action_preparation_ticks(&self) -> Option<u64> {
+        match self.action {
+            ActionState(ActionKind::Idle) => None,
+            ActionState(ActionKind::Dodge { timeline, .. })
+            | ActionState(ActionKind::Attack { timeline, .. })
+            | ActionState(ActionKind::Block { timeline, .. }) => Some(timeline.preparation_ticks),
         }
     }
     pub fn incoming_attack_line(&self) -> AttackLine {
@@ -681,7 +818,23 @@ impl SkeletonState {
         self.replace_action(ActionState(ActionKind::Attack {
             target_height,
             strike_family: spec.strike_family,
-            footwork: spec.footwork,
+            step: spec.step,
+            step_speed: if spec.step_speed.is_finite() {
+                spec.step_speed.clamp(0.0, 8.0)
+            } else {
+                0.0
+            },
+            movement_direction: if spec.movement_direction.is_finite() {
+                spec.movement_direction.normalize_or_zero()
+            } else {
+                Vec2::ZERO
+            },
+            movement_speed: if spec.movement_speed.is_finite() {
+                spec.movement_speed.clamp(0.0, 8.0)
+            } else {
+                0.0
+            },
+            start_lead: self.lead_foot,
             timeline: ActionTimeline::new(start_tick, contact_tick),
         }));
     }
@@ -696,6 +849,14 @@ impl SkeletonState {
     /// Advances an action whose contact is the midpoint of its visual
     /// timeline. Recovery gets the same bounded duration as preparation.
     pub fn advance_action(&mut self, current_tick: u64) {
+        let switching_attack_start_lead = match self.action {
+            ActionState(ActionKind::Attack {
+                step: AttackStep::Forward | AttackStep::Backward,
+                start_lead,
+                ..
+            }) => Some(start_lead),
+            _ => None,
+        };
         let timeline = match &mut self.action {
             ActionState(ActionKind::Idle) => return,
             ActionState(ActionKind::Dodge { timeline, .. })
@@ -705,8 +866,29 @@ impl SkeletonState {
         let preparation = timeline.preparation_ticks.max(1);
         let contact_tick = timeline.start_tick.saturating_add(preparation);
         let end_tick = contact_tick.saturating_add(preparation);
-        if current_tick >= end_tick {
+        // A saturated timeline cannot receive the following tick that would
+        // normally clear its retained endpoint, so finish it immediately.
+        if current_tick > end_tick || (end_tick == u64::MAX && current_tick == end_tick) {
             self.action = ActionState::default();
+            return;
+        }
+        if current_tick == end_tick {
+            if let Some(start_lead) = switching_attack_start_lead
+                && self.lead_foot == start_lead
+            {
+                self.lead_foot = match start_lead {
+                    LeadFoot::Left => LeadFoot::Right,
+                    LeadFoot::Right => LeadFoot::Left,
+                };
+                // Keep lowered-stance locomotion from immediately deriving the
+                // old lead again on the next tick. Raised guard ignores this
+                // parity except as a stable planted restart seam.
+                self.gait_phase = match self.lead_foot {
+                    LeadFoot::Left => 0.0,
+                    LeadFoot::Right => 0.5,
+                };
+            }
+            timeline.phase = 1.0;
             return;
         }
         timeline.phase = if current_tick <= contact_tick {
@@ -833,7 +1015,10 @@ pub fn project_skeleton_locomotion(skeleton: &mut SkeletonState, input: Skeleton
     });
 
     let ground_speed = physical_speed;
-    if skeleton.weapon_guard() == WeaponGuardState::Raised && skeleton.posture() == Posture::Upright
+    let attack_active = skeleton.action_kind() == SkeletonAction::Attack;
+    if skeleton.weapon_guard() == WeaponGuardState::Raised
+        && skeleton.posture() == Posture::Upright
+        && !attack_active
     {
         advance_raised_locomotion_intent(skeleton, local_velocity, delta_seconds);
         let handoffs = skeleton
@@ -843,7 +1028,7 @@ pub fn project_skeleton_locomotion(skeleton: &mut SkeletonState, input: Skeleton
         advance_contact_identity(skeleton, handoffs, previous_guard_swing);
     } else {
         skeleton.set_raised_locomotion(RaisedLocomotionIntent::planted(previous_guard_sequence));
-        if input.grounded && ground_speed > 0.05 {
+        if input.grounded && ground_speed > 0.05 && !attack_active {
             let profile = locomotion_profile(skeleton);
             let phase = skeleton.gait_phase.rem_euclid(1.0);
             let next_phase = phase + gait_cycle_phase_delta(profile, ground_speed, delta_seconds);

--- a/crates/adventuresim-tactical-core/src/animation/tests.rs
+++ b/crates/adventuresim-tactical-core/src/animation/tests.rs
@@ -910,7 +910,7 @@ mod legacy_tests {
         let mut state = SkeletonState::default().with_lead_foot(LeadFoot::Left);
         state.begin_attack(
             AttackSpec {
-                footwork: Footwork::Switch,
+                step: AttackStep::Forward,
                 ..default()
             },
             0,
@@ -944,6 +944,129 @@ mod legacy_tests {
         };
         assert_eq!(end, SemanticPose::GuardLeadRight);
         assert!((progress - 0.99).abs() < 0.0001);
+    }
+
+    #[test]
+    fn melee_attack_snapshots_longitudinal_velocity_semantically() {
+        assert_eq!(
+            AttackSpec::melee_from_local_velocity(Vec3::NEG_Z * 2.0).step,
+            AttackStep::Forward
+        );
+        assert_eq!(
+            AttackSpec::melee_from_local_velocity(Vec3::Z * 5.5).step,
+            AttackStep::Backward
+        );
+        assert_eq!(
+            AttackSpec::melee_from_local_velocity(Vec3::X * 5.5).step,
+            AttackStep::Stay
+        );
+        let dominant_lateral = AttackSpec::melee_from_local_velocity(Vec3::new(5.5, 0.0, -0.14));
+        assert_eq!(dominant_lateral.step, AttackStep::Stay);
+        assert!((dominant_lateral.step_speed - 0.14).abs() < 0.0001);
+        assert_eq!(
+            AttackSpec::melee_from_local_velocity(Vec3::splat(f32::NAN)).step,
+            AttackStep::Stay
+        );
+    }
+
+    #[test]
+    fn attack_step_ignores_later_velocity_and_commits_lead_once() {
+        let mut state = SkeletonState::default()
+            .with_lead_foot(LeadFoot::Right)
+            .with_local_velocity(Vec3::NEG_Z * 5.5);
+        let spec = AttackSpec::melee_from_local_velocity(state.local_velocity);
+        state.begin_attack(spec, 100, 110);
+        state.local_velocity = Vec3::Z * 5.5;
+        state.advance_action(110);
+        assert_eq!(state.attack_step(), AttackStep::Forward);
+        assert_eq!(state.lead_foot, LeadFoot::Right);
+
+        state.advance_action(120);
+        assert_eq!(state.action_kind(), SkeletonAction::Attack);
+        assert_eq!(state.action_phase(), 1.0);
+        assert_eq!(state.lead_foot, LeadFoot::Left);
+        state.advance_action(121);
+        assert_eq!(state.action_kind(), SkeletonAction::None);
+        assert_eq!(state.lead_foot, LeadFoot::Left);
+    }
+
+    #[test]
+    fn replacing_attack_preserves_lead_until_replacement_finishes() {
+        let mut state = SkeletonState::default().with_lead_foot(LeadFoot::Left);
+        state.begin_attack(
+            AttackSpec::melee_from_local_velocity(Vec3::NEG_Z),
+            10,
+            20,
+        );
+        state.advance_action(15);
+        state.begin_attack(
+            AttackSpec::melee_from_local_velocity(Vec3::Z),
+            16,
+            26,
+        );
+        state.advance_action(20);
+        assert_eq!(state.lead_foot, LeadFoot::Left);
+        assert_eq!(state.attack_step(), AttackStep::Backward);
+        state.advance_action(36);
+        assert_eq!(state.lead_foot, LeadFoot::Right);
+    }
+
+    #[test]
+    fn locomotion_projection_cannot_repick_attack_start_lead() {
+        let mut state = SkeletonState::default()
+            .with_weapon_guard(WeaponGuardState::Raised)
+            .with_lead_foot(LeadFoot::Right);
+        state.begin_attack(
+            AttackSpec::melee_from_local_velocity(Vec3::NEG_Z * 2.0),
+            10,
+            20,
+        );
+        for tick in 11..20 {
+            project_skeleton_locomotion(
+                &mut state,
+                SkeletonLocomotionInput {
+                    orientation: Quat::IDENTITY,
+                    linear_velocity: if tick % 2 == 0 {
+                        Vec3::NEG_Z * 5.5
+                    } else {
+                        Vec3::Z * 5.5
+                    },
+                    grounded: true,
+                    crouching: false,
+                    delta_seconds: 1.0 / LOCOMOTION_SAMPLE_HZ,
+                    tick,
+                },
+            );
+            assert_eq!(state.lead_foot, LeadFoot::Right);
+            assert_eq!(state.attack_start_lead(), LeadFoot::Right);
+            assert_eq!(state.attack_step(), AttackStep::Forward);
+        }
+        project_skeleton_locomotion(
+            &mut state,
+            SkeletonLocomotionInput {
+                orientation: Quat::IDENTITY,
+                linear_velocity: Vec3::Z * 5.5,
+                grounded: true,
+                crouching: false,
+                delta_seconds: 1.0 / LOCOMOTION_SAMPLE_HZ,
+                tick: 30,
+            },
+        );
+        assert_eq!(state.action_kind(), SkeletonAction::Attack);
+        assert_eq!(state.action_phase(), 1.0);
+        project_skeleton_locomotion(
+            &mut state,
+            SkeletonLocomotionInput {
+                orientation: Quat::IDENTITY,
+                linear_velocity: Vec3::Z * 5.5,
+                grounded: true,
+                crouching: false,
+                delta_seconds: 1.0 / LOCOMOTION_SAMPLE_HZ,
+                tick: 31,
+            },
+        );
+        assert_eq!(state.action_kind(), SkeletonAction::None);
+        assert_eq!(state.lead_foot, LeadFoot::Left);
     }
 
     #[test]
@@ -1026,6 +1149,8 @@ mod legacy_tests {
         state.advance_action(25);
         assert_eq!(state.action_phase(), 0.75);
         state.advance_action(30);
+        assert_eq!(state.action_phase(), 1.0);
+        state.advance_action(31);
         assert_eq!(state.action(), ActionState::default());
     }
 }

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -19,11 +19,11 @@ pub mod prelude {
     pub use crate::AdventureSimulatorCorePlugins;
     pub use crate::animation::{
         ActionState, AnimationEvaluation, AnimationPack, AnimationPackLibrary, AttackLine,
-        AttackSpec, BODY_TURN_SPEED_RADIANS, BlockSpec, BodyState, CROUCH_LOCOMOTION_PROFILE,
-        DodgeSpec, Footwork, GroundedPosture, HUMANOID_LANDING_PROFILE, LOCOMOTION_SAMPLE_HZ,
-        LandingProfile, LeadFoot, LocomotionGait, LocomotionProfile, PackValidationError,
-        PoseSample, PoseSampling, Posture, RAISED_GUARD_LOCOMOTION_PROFILE, RUN_LOCOMOTION_PROFILE,
-        RaisedLocomotionIntent, ResolvedPose, SemanticPose, SkeletonAction,
+        AttackSpec, AttackStep, BODY_TURN_SPEED_RADIANS, BlockSpec, BodyState,
+        CROUCH_LOCOMOTION_PROFILE, DodgeSpec, Footwork, GroundedPosture, HUMANOID_LANDING_PROFILE,
+        LOCOMOTION_SAMPLE_HZ, LandingProfile, LeadFoot, LocomotionGait, LocomotionProfile,
+        PackValidationError, PoseSample, PoseSampling, Posture, RAISED_GUARD_LOCOMOTION_PROFILE,
+        RUN_LOCOMOTION_PROFILE, RaisedLocomotionIntent, ResolvedPose, SemanticPose, SkeletonAction,
         SkeletonLocomotionInput, SkeletonState, StanceState, StrikeFamily, WALK_LOCOMOTION_PROFILE,
         WeaponGuardState, advance_body_facing, controller_yaw, gait_cycle_phase_delta,
         gait_support_weights, guard_step_length, locomotion_profile, ordinary_step_distance,

--- a/crates/adventuresim-tactical-server/src/combat/ingress.rs
+++ b/crates/adventuresim-tactical-server/src/combat/ingress.rs
@@ -53,11 +53,8 @@ pub(super) fn on_melee_attack_started(
     );
     if let Ok(mut skeleton) = skeletons.get_mut(event.attacker) {
         let start = animation_tick(&time);
-        skeleton.begin_attack(
-            AttackSpec::default(),
-            start,
-            start + duration_ticks(event.windup),
-        );
+        let attack = AttackSpec::melee_from_local_velocity(skeleton.local_velocity);
+        skeleton.begin_attack(attack, start, start + duration_ticks(event.windup));
     }
 }
 
@@ -117,11 +114,8 @@ pub(super) fn on_melee_action_request(
             );
             if let Ok(mut skeleton) = skeletons.get_mut(attacker) {
                 let start = animation_tick(&time);
-                skeleton.begin_attack(
-                    AttackSpec::default(),
-                    start,
-                    start + duration_ticks(CLIENT_MELEE_WINDUP),
-                );
+                let attack = AttackSpec::melee_from_local_velocity(skeleton.local_velocity);
+                skeleton.begin_attack(attack, start, start + duration_ticks(CLIENT_MELEE_WINDUP));
             }
         }
         MeleeActionRequest::Complete {

--- a/crates/adventuresim-tactical-server/src/player_projection.rs
+++ b/crates/adventuresim-tactical-server/src/player_projection.rs
@@ -563,10 +563,31 @@ fn authoritative_weapon_guard(
 /// complete request before movement runs. Ahoy may clear its accumulator after
 /// every fixed loop without turning a missing network packet into a stop.
 pub(crate) fn restore_authoritative_movement_intent(
-    mut players: Query<(&AuthoritativeMovementIntent, &mut AccumulatedInput), With<Player>>,
+    mut players: Query<
+        (
+            &AuthoritativeMovementIntent,
+            &SkeletonState,
+            &mut AccumulatedInput,
+        ),
+        With<Player>,
+    >,
 ) {
-    for (movement_intent, mut accumulated_input) in &mut players {
-        accumulated_input.last_movement = movement_intent.0;
+    for (movement_intent, skeleton, mut accumulated_input) in &mut players {
+        accumulated_input.last_movement =
+            if let Some((direction, speed)) = skeleton.attack_movement() {
+                if skeleton.action_phase() >= 0.5 {
+                    None
+                } else {
+                    let cap = match skeleton.weapon_guard() {
+                        WeaponGuardState::Lowered => TACTICAL_RUN_SPEED_METRES_PER_SECOND,
+                        WeaponGuardState::Raised => TACTICAL_GUARD_SPEED_METRES_PER_SECOND,
+                    };
+                    (speed > 0.01 && direction != Vec2::ZERO)
+                        .then_some(direction * (speed / cap).clamp(0.0, 1.0))
+                }
+            } else {
+                movement_intent.0
+            };
     }
 }
 
@@ -658,6 +679,7 @@ mod tests {
         mission_enemy_health_scale, mission_enemy_scale, restore_authoritative_movement_intent,
         tactical_movement_speed_for_guard, validate_player_input,
     };
+    use adventuresim_tactical_core::prelude::{AttackSpec, SkeletonState};
     use bevy::prelude::*;
 
     #[test]
@@ -747,6 +769,7 @@ mod tests {
             .spawn((
                 Player::default(),
                 AuthoritativeMovementIntent(Some(Vec2::X)),
+                SkeletonState::default(),
                 input::AccumulatedInput::default(),
             ))
             .id();
@@ -785,6 +808,62 @@ mod tests {
         assert_eq!(
             tactical_movement_speed_for_guard(None, WeaponGuardState::Lowered),
             0.0
+        );
+    }
+
+    #[test]
+    fn attack_holds_captured_velocity_until_contact_then_settles_before_resuming_input() {
+        let mut skeleton = SkeletonState::default().with_weapon_guard(WeaponGuardState::Raised);
+        skeleton.begin_attack(
+            AttackSpec::melee_from_local_velocity(Vec3::new(0.0, 0.0, -2.0)),
+            0,
+            10,
+        );
+        let mut world = World::new();
+        let player = world
+            .spawn((
+                Player::default(),
+                AuthoritativeMovementIntent(Some(Vec2::Y)),
+                skeleton,
+                input::AccumulatedInput::default(),
+            ))
+            .id();
+        let mut schedule = Schedule::default();
+        schedule.add_systems(restore_authoritative_movement_intent);
+
+        schedule.run(&mut world);
+        assert_eq!(
+            world
+                .get::<input::AccumulatedInput>(player)
+                .unwrap()
+                .last_movement,
+            Some(Vec2::NEG_Y)
+        );
+
+        world
+            .get_mut::<SkeletonState>(player)
+            .unwrap()
+            .advance_action(10);
+        schedule.run(&mut world);
+        assert_eq!(
+            world
+                .get::<input::AccumulatedInput>(player)
+                .unwrap()
+                .last_movement,
+            None
+        );
+
+        world
+            .get_mut::<SkeletonState>(player)
+            .unwrap()
+            .advance_action(21);
+        schedule.run(&mut world);
+        assert_eq!(
+            world
+                .get::<input::AccumulatedInput>(player)
+                .unwrap()
+                .last_movement,
+            Some(Vec2::Y)
         );
     }
 }

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -880,6 +880,35 @@ An attack recipe declares:
 A stay attack ends with the same foot forward. A switch attack takes one step
 and ends with the opposite foot forward.
 
+For melee attacks, the tactical authority snapshots the controller-local
+physical velocity when the attack starts. Meaningful forward velocity selects
+`forward`, meaningful backward velocity selects `backward`, and stationary or
+lateral-only motion selects `stay` in the initial longitudinal implementation.
+Later input, velocity reversal, or camera yaw cannot repick this semantic.
+Ranged attacks remain `stay`. For immediate contact synchronization the owning
+client predicts the same typed choice from the last physical velocity already
+stored in its replicated `SkeletonState`; it does not send or trust a fresh
+movement-input vector. The server observation remains authoritative and the
+presentation reconciles to it.
+
+Forward and backward reuse the same authored contact pose. On a forward step,
+the initial rear foot passes the planted lead foot; on a backward step, the
+initial lead foot passes behind the planted rear foot. Both are exactly one
+`switch` step and therefore finish in the opposite guard. Maximum extension is
+at the server-owned contact tick. During recovery the original support foot
+may settle into the new guard, but the planner does not start another step.
+The procedural targets are client-only world-space data: they do not translate
+the controller, extend hit range, or enter persistent state. If a fast-moving
+root makes a literal world plant unreachable, the step becomes an airborne
+lunge: both feet leave the ground during preparation and the moving foot lands
+as the sole support at contact. The original foot rejoins during recovery.
+The server carries the captured direction and speed through preparation, stops
+attack-owned translation at contact, and resumes current movement input only
+after recovery. Large facing changes recover with an in-place guard pivot
+rather than dragging the contact plant through a second step. Capture telemetry
+records requested and reach-constrained targets separately so any analytic
+reach yield is measured rather than misreported as a perfect plant.
+
 Each strike family has one contact pose for each starting lead. Names use
 `attack_<family>_lead_<left|right>_contact`; for example,
 `attack_thrust_lead_left_contact`. `stay` and `switch` remain gameplay and
@@ -901,10 +930,9 @@ The strike-family construction rules are:
 
 For `lead_left`, the contact is constructed from `guard_lead_left`; for
 `lead_right`, it is constructed from `guard_lead_right`. The runtime preserves
-those planted targets for a stay attack. For a switch attack, the stance-step
-planner passes or steps the initially rear foot beyond the initial lead and
-blends toward the opposite guard, timing the new support foot to arrive by
-contact or immediately afterward.
+those planted targets for a stay attack. The switch-step direction and moving
+foot follow the authoritative rules above, and the moving foot reaches maximum
+extension at contact before both legs recover toward the opposite guard.
 
 The full visual sequence is:
 


### PR DESCRIPTION
## Summary
- capture authoritative physical movement velocity when a melee attack begins and preserve it through the lunge
- execute exactly one forward/backward foot switch, landing maximum extension at authored contact and recovering into the opposite guard
- use an airborne lunge at high speed, terrain-aware support, and an in-place recovery pivot for large facing changes
- add screenshot/telemetry validation for both leads, backward reuse, stationary attacks, reversals, high speed, yaw, and cross-slope terrain

## Stack
- Depends on #449 (`codex/ik-adversarial-hardening`)
- Base branch: `codex/ik-adversarial-hardening`

## Verification
- `cargo test -p adventuresim-tactical-core --lib` (66 passed)
- `cargo test -p adventuresim-tactical-server --bin adventuresim-tactical-server` (37 passed)
- `cargo test -p adventuresim-tactical-client --bins` (96 + 101 passed)
- `cargo check -p adventuresim-tactical-core -p adventuresim-tactical-server -p adventuresim-tactical-client`
- `cargo fmt --all -- --check`
- `git diff --check`
- `python scripts/update_project_map.py --check`
- nine-scenario animation-viewer attack matrix; all manifests passed and no `failure.txt` remained

## Visual stress matrix
- forward and backward from both starting leads
- stationary attack
- input reversal after attack start
- 5.5 m/s reversal with airborne landing at contact
- 90-degree yaw change during attack
- diagonal cross-slope terrain