### PR TITLE
Keep strategic chat topic tabs icon-only

### DIFF
--- a/crates/strategic-web/src/templates/settlement/social.rs
+++ b/crates/strategic-web/src/templates/settlement/social.rs
@@ -276,7 +276,7 @@ pub fn party_social_dialog(
                         aria-controls=(format!("conversation-panel-{id}-{}", selected.id))
                         aria-selected=(if selected_tab { "true" } else { "false" }) tabindex=(if selected_tab { "0" } else { "-1" })
                         data-conversation-tab=(id) data-strategic-tooltip=(if id == "about" { "About this person" } else { label }) {
-                        (decorative_game_icon(icon)) span class="visually-hidden" { (label) }
+                        (decorative_game_icon(icon)) span class="sr-only" { (label) }
                       }
                     }
                   }
@@ -627,7 +627,7 @@ fn chat_area(
                           aria-controls=(format!("dialogue-category-panel-{id}")) aria-selected=(if selected_tab { "true" } else { "false" })
                           tabindex=(if selected_tab { "0" } else { "-1" }) data-dialogue-category=(id)
                           data-strategic-tooltip=(if id == "about" { "About this person" } else { label }) {
-                          (decorative_game_icon(icon)) span class="visually-hidden" { (label) }
+                          (decorative_game_icon(icon)) span class="sr-only" { (label) }
                         }
                       }
                     }
@@ -1141,6 +1141,9 @@ mod tests {
             assert!(markup.contains(&format!("aria-label=\"{label}\" title=\"{label}\"")));
             assert!(!markup.contains(&format!(">{label}</")));
         }
+        assert_eq!(markup.matches("class=\"conversation-tab\"").count(), 4);
+        assert_eq!(markup.matches("class=\"sr-only\"").count(), 4);
+        assert!(!markup.contains("class=\"visually-hidden\""));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- hide the visible text labels on strategic chat topic tabs while retaining their accessible names
- keep category descriptions available through the existing hover/focus tooltips
- cover both settlement chat and party conversation variants
- add regression assertions for the screen-reader-only utility

## Root cause

The topic labels used an undefined `visually-hidden` class. The project's supported utility is `sr-only`, so the labels rendered visibly beneath the icons and made the controls wider at constrained viewport sizes.

## Validation

- `cargo test -p strategic-web chat_uses_one_stream_with_all_channel_filters`
- `cargo test -p strategic-web chat_css_keeps_fallbacks_and_mobile_message_space`
- strategic chat browser tests: 11 passed
- responsive browser check at 700px: four 34x34px icon tabs, clipped accessible labels, and working hover tooltip
- `git diff --check`
