### PR TITLE
Route semantic animation through graph runtime

### DIFF
--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -52,6 +52,21 @@ Those runs must use a trusted internal branch/check or report the private-fetch
 check as unavailable; do not weaken the exact pin or make the dependency public
 to bypass credential provisioning.
 
+The semantic bridge queries dependency-owned ordinary-locomotion and
+raised-guard/attack graphs with sparse semantic anchors. A dependency pose-blend
+chain composes locomotion weights and each action span's start/end contribution;
+the graph-returned values reconstruct the exact `PoseSample` weights and span
+progress consumed by the effective-pack resolver and FK player. A missing or
+invalid graph output atomically selects the untouched legacy evaluation.
+Persistent per-player graph contexts seek to authoritative gait/action phase.
+Diagnostic JSONL records requested and selected routes, read-only inputs,
+runtime success, and output equivalence. Every captured frame records that same
+evidence, and the viewer manifest fails if any frame expected to use a migrated
+route falls back. Existing bind restore,
+mirroring, body response, terrain IK/attack footwork, and weapon constraints
+still run after FK; graph root motion, events, inertialization, and IK remain
+unused.
+
 ## Animation export contract
 
 The humanoid base rig is independent from authored motions:

--- a/crates/adventuresim-tactical-client/src/animation/diagnostics.rs
+++ b/crates/adventuresim-tactical-client/src/animation/diagnostics.rs
@@ -97,6 +97,7 @@ pub(super) fn log_animation_diagnostics(
             &SkeletonState,
             &PresentedSkeleton,
             &AnimationPlayback,
+            Option<&semantic_graph::SemanticGraphTrace>,
         ),
         (With<Player>, With<crate::player::ClientPlayer>),
     >,
@@ -115,7 +116,7 @@ pub(super) fn log_animation_diagnostics(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_micros().min(u64::MAX as u128) as u64)
         .unwrap_or_default();
-    for (transform, authoritative, presented, playback) in &players {
+    for (transform, authoritative, presented, playback, semantic_graph) in &players {
         let evaluation = AnimationEvaluation::from_skeleton(presented);
         let transition = playback.presentation_transition.as_ref().map(|transition| {
             serde_json::json!({
@@ -153,6 +154,13 @@ pub(super) fn log_animation_diagnostics(
             "presentation_phase_measurement_error": presented.last_phase_measurement_error,
             "presentation_phase_source_changed": presented.last_phase_source_changed,
             "evaluation": evaluation,
+            "semantic_graph": semantic_graph.map(|trace| serde_json::json!({
+                "requested_path": trace.requested_path,
+                "path": trace.path,
+                "inputs": &trace.inputs,
+                "runtime_evaluated": trace.runtime_evaluated,
+                "evaluation_equivalent": trace.evaluation == evaluation,
+            })),
             "playback": {
                 "use_authored_bind_pose": playback.use_authored_bind_pose,
                 "whole_body_mirror": playback.whole_body_mirror,

--- a/crates/adventuresim-tactical-client/src/animation/mod.rs
+++ b/crates/adventuresim-tactical-client/src/animation/mod.rs
@@ -38,6 +38,7 @@ use diagnostics::log_animation_diagnostics;
 pub(crate) use diagnostics::{
     AnimationDiagnosticLog, DiagnosticInputStatus, RenderScheduleTelemetry,
 };
+pub(crate) mod semantic_graph;
 
 fn animation_asset_path(path: &str) -> String {
     #[cfg(not(target_family = "wasm"))]
@@ -194,10 +195,21 @@ fn evaluate_skeletons(
     runtime: Res<AnimationRuntime>,
     time: Res<Time>,
     procedural_clock: Res<ProceduralAnimationClock>,
-    players: Query<(Entity, &PresentedSkeleton, Option<&mut AnimationPlayback>), With<Player>>,
+    players: Query<
+        (
+            Entity,
+            &PresentedSkeleton,
+            &semantic_graph::SemanticGraphTrace,
+            Option<&mut AnimationPlayback>,
+        ),
+        With<Player>,
+    >,
 ) {
-    for (entity, skeleton, playback) in players {
-        let evaluation = AnimationEvaluation::from_skeleton(skeleton);
+    for (entity, skeleton, graph_trace, playback) in players {
+        // This evaluation contains weights/progress decoded from the dependency
+        // graph's returned Pose. The preceding chained system always inserts a
+        // trace, including an explicit legacy fallback trace on graph errors.
+        let evaluation = graph_trace.evaluation.clone();
         let samples = if evaluation.action.is_empty() {
             &evaluation.base
         } else {

--- a/crates/adventuresim-tactical-client/src/animation/presentation.rs
+++ b/crates/adventuresim-tactical-client/src/animation/presentation.rs
@@ -227,11 +227,13 @@ struct LocomotionEventCursor {
 
 impl Plugin for TacticalAnimationPlugin {
     fn build(&self, app: &mut App) {
-        // The dependency is intentionally dormant in this integration layer.
-        // Semantic paths opt into it explicitly; the legacy evaluator remains
-        // the sole pose-output authority until then.
+        if !app.is_plugin_added::<bevy_animation_graph::AnimationGraphPlugin>() {
+            app.add_plugins(bevy_animation_graph::AnimationGraphPlugin::default());
+        }
         app.init_resource::<AnimationPackCatalog>()
             .init_resource::<AnimationRuntime>()
+            .init_resource::<semantic_graph::SemanticGraphLibrary>()
+            .init_resource::<semantic_graph::SemanticGraphTelemetry>()
             .init_resource::<TerrainIkEnabled>()
             .init_resource::<ProceduralAnimationClock>()
             .add_message::<LocomotionPresentationEvent>()
@@ -249,6 +251,7 @@ impl Plugin for TacticalAnimationPlugin {
                     procedural::cache_humanoid_rigs,
                     procedural::capture_humanoid_rig_axes,
                     capture_authored_bind_transforms,
+                    semantic_graph::evaluate_semantic_graph_paths,
                     evaluate_skeletons,
                     log_animation_diagnostics,
                     tick_impact_reactions,
@@ -280,6 +283,7 @@ impl Plugin for TacticalAnimationPlugin {
                 )
                     .chain()
                     .after(AnimationSystems)
+                    .after(bevy_animation_graph::core::plugin::AnimationGraphSet::Final)
                     .before(TransformSystems::Propagate),
             )
             .add_systems(

--- a/crates/adventuresim-tactical-client/src/animation/semantic_graph.rs
+++ b/crates/adventuresim-tactical-client/src/animation/semantic_graph.rs
@@ -1,0 +1,504 @@
+use std::collections::{BTreeMap, HashSet};
+
+use adventuresim_tactical_core::prelude::*;
+use bevy::{
+    animation::AnimationTargetId,
+    asset::{Assets, Handle},
+    platform::collections::HashMap,
+    prelude::*,
+};
+use bevy_animation_graph::core::{
+    animation_graph::{
+        AnimationGraph as DependencyAnimationGraph, DEFAULT_OUTPUT_POSE, GraphInputPin, NodeId,
+        TimeUpdate,
+    },
+    animation_node::AnimationNode,
+    context::{
+        deferred_gizmos::DeferredGizmos, graph_context_arena::GraphContextArena,
+        io_env::IoOverrides, system_resources::SystemResources,
+    },
+    edge_data::{DataSpec, DataValue},
+    id::BoneId,
+    pose::{BonePose, Pose},
+};
+
+use crate::animation_graph_nodes::SparseSemanticBlendNode;
+
+use super::PresentedSkeleton;
+
+pub(crate) const MAX_GRAPH_ANCHORS: usize = 16;
+const WEIGHT_EPSILON: f32 = 0.0001;
+
+fn pose_pin(index: usize) -> String {
+    format!("semantic_pose_{index}")
+}
+
+fn factor_pin(index: usize) -> String {
+    format!("semantic_factor_{index}")
+}
+
+/// Read-only coordinates presented to the semantic graph bridge. Every field
+/// comes from client presentation state or its pure semantic evaluation.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub(crate) struct SemanticGraphInputs {
+    pub speed: f32,
+    pub direction: Vec2,
+    pub gait_phase: f32,
+    pub action: SkeletonAction,
+    pub crouch: f32,
+    pub airborne: bool,
+    pub target_height: f32,
+    pub lead: LeadFoot,
+    pub support: LeadFoot,
+    pub contact_sequence: u64,
+    pub pack: String,
+    pub captured_step: AttackStep,
+    pub captured_step_direction: Vec2,
+    pub captured_step_speed: f32,
+}
+
+impl SemanticGraphInputs {
+    pub(crate) fn from_presented(
+        skeleton: &PresentedSkeleton,
+        evaluation: &AnimationEvaluation,
+    ) -> Self {
+        let (captured_step_direction, captured_step_speed) =
+            skeleton.attack_movement().unwrap_or((Vec2::ZERO, 0.0));
+        Self {
+            speed: evaluation.movement_speed,
+            direction: skeleton.animation_local_velocity().xz().normalize_or_zero(),
+            gait_phase: evaluation.gait_phase,
+            action: skeleton.action_kind(),
+            crouch: evaluation.crouch_amount,
+            airborne: !skeleton.is_grounded(),
+            target_height: evaluation.attack_target_height,
+            lead: skeleton.lead_foot,
+            support: skeleton.contact_foot,
+            contact_sequence: skeleton.contact_sequence,
+            pack: skeleton.animation_pack.clone(),
+            captured_step: skeleton.attack_step(),
+            captured_step_direction,
+            captured_step_speed,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SemanticGraphPath {
+    LegacyFallback,
+    OrdinaryLocomotion,
+    RaisedGuardAttack,
+}
+
+impl SemanticGraphPath {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyFallback => "legacy_fallback",
+            Self::OrdinaryLocomotion => "ordinary_locomotion",
+            Self::RaisedGuardAttack => "raised_guard_attack",
+        }
+    }
+}
+
+#[derive(Component, Debug, Clone)]
+pub(crate) struct SemanticGraphTrace {
+    pub inputs: SemanticGraphInputs,
+    pub requested_path: SemanticGraphPath,
+    pub path: SemanticGraphPath,
+    pub evaluation: AnimationEvaluation,
+    pub runtime_evaluated: bool,
+}
+
+#[derive(Resource, Debug, Default)]
+pub(crate) struct SemanticGraphTelemetry {
+    counts: BTreeMap<SemanticGraphPath, u64>,
+}
+
+#[derive(Resource)]
+pub(super) struct SemanticGraphLibrary {
+    pub(super) ordinary: Handle<DependencyAnimationGraph>,
+    pub(super) raised: Handle<DependencyAnimationGraph>,
+    contexts: HashMap<(Entity, SemanticGraphPath), GraphContextArena>,
+    marker_ids: Vec<BoneId>,
+    #[cfg(test)]
+    pub(super) factor_override: Option<[f32; MAX_GRAPH_ANCHORS - 1]>,
+    #[cfg(test)]
+    pub(super) corrupt_last_marker: bool,
+}
+
+impl FromWorld for SemanticGraphLibrary {
+    fn from_world(world: &mut World) -> Self {
+        let mut assets = world.resource_mut::<Assets<DependencyAnimationGraph>>();
+        Self {
+            ordinary: assets.add(build_semantic_route_graph(
+                SemanticGraphPath::OrdinaryLocomotion,
+            )),
+            raised: assets.add(build_semantic_route_graph(
+                SemanticGraphPath::RaisedGuardAttack,
+            )),
+            contexts: HashMap::new(),
+            marker_ids: (0..MAX_GRAPH_ANCHORS).map(marker_id).collect(),
+            #[cfg(test)]
+            factor_override: None,
+            #[cfg(test)]
+            corrupt_last_marker: false,
+        }
+    }
+}
+
+/// Central graph definition used by gameplay, tests, and the native editor
+/// preflight. Each node performs a genuine dependency Pose linear blend.
+pub(crate) fn build_semantic_route_graph(path: SemanticGraphPath) -> DependencyAnimationGraph {
+    let mut graph = DependencyAnimationGraph::new();
+    for index in 0..MAX_GRAPH_ANCHORS {
+        graph.add_input_data(GraphInputPin::passthrough(pose_pin(index)), DataSpec::Pose);
+    }
+    for index in 1..MAX_GRAPH_ANCHORS {
+        graph.add_input_data(GraphInputPin::passthrough(factor_pin(index)), DataSpec::F32);
+    }
+    graph.add_output_data(DEFAULT_OUTPUT_POSE.into(), DataSpec::Pose);
+
+    let mut previous: Option<NodeId> = None;
+    for index in 1..MAX_GRAPH_ANCHORS {
+        let node = AnimationNode::new(
+            format!("{}-blend-{index}", path.as_str()),
+            SparseSemanticBlendNode,
+        );
+        let node_id = node.id;
+        graph.add_node(node);
+        match previous {
+            Some(previous) => graph.add_node_parameter_edge(
+                previous,
+                SparseSemanticBlendNode::OUTPUT,
+                node_id,
+                SparseSemanticBlendNode::POSE_A,
+            ),
+            None => graph.add_input_data_edge(
+                GraphInputPin::passthrough(pose_pin(0)),
+                node_id,
+                SparseSemanticBlendNode::POSE_A,
+            ),
+        }
+        graph.add_input_data_edge(
+            GraphInputPin::passthrough(pose_pin(index)),
+            node_id,
+            SparseSemanticBlendNode::POSE_B,
+        );
+        graph.add_input_data_edge(
+            GraphInputPin::passthrough(factor_pin(index)),
+            node_id,
+            SparseSemanticBlendNode::FACTOR,
+        );
+        previous = Some(node_id);
+    }
+    graph.add_output_data_edge(
+        previous.expect("semantic graph has blend nodes"),
+        SparseSemanticBlendNode::OUTPUT,
+        DEFAULT_OUTPUT_POSE,
+    );
+    graph
+}
+
+fn marker_id(index: usize) -> BoneId {
+    AnimationTargetId::from_names([Name::new(format!("semantic-sample-{index}"))].iter()).into()
+}
+
+fn selected_samples(evaluation: &AnimationEvaluation) -> &[PoseSample] {
+    if evaluation.action.is_empty() {
+        &evaluation.base
+    } else {
+        &evaluation.action
+    }
+}
+
+fn selected_samples_mut(evaluation: &mut AnimationEvaluation) -> &mut [PoseSample] {
+    if evaluation.action.is_empty() {
+        &mut evaluation.base
+    } else {
+        &mut evaluation.action
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FlatAnchorRole {
+    Anchor { sample: usize },
+    SpanStart { sample: usize },
+    SpanEnd { sample: usize },
+}
+
+fn encode_sparse_inputs(
+    evaluation: &AnimationEvaluation,
+    marker_ids: &[BoneId],
+) -> Option<(Vec<Pose>, [f32; MAX_GRAPH_ANCHORS - 1], Vec<FlatAnchorRole>)> {
+    let samples = selected_samples(evaluation);
+    let mut flattened = Vec::new();
+    for (sample_index, sample) in samples.iter().enumerate() {
+        match sample.sampling {
+            PoseSampling::Anchor => flattened.push((
+                FlatAnchorRole::Anchor {
+                    sample: sample_index,
+                },
+                sample.weight,
+            )),
+            PoseSampling::Span { progress, .. } => {
+                let progress = progress.clamp(0.0, 1.0);
+                flattened.push((
+                    FlatAnchorRole::SpanStart {
+                        sample: sample_index,
+                    },
+                    sample.weight * (1.0 - progress),
+                ));
+                flattened.push((
+                    FlatAnchorRole::SpanEnd {
+                        sample: sample_index,
+                    },
+                    sample.weight * progress,
+                ));
+            }
+        }
+    }
+    if flattened.is_empty()
+        || flattened.len() > MAX_GRAPH_ANCHORS
+        || flattened
+            .iter()
+            .any(|(_, weight)| !weight.is_finite() || *weight < 0.0)
+    {
+        return None;
+    }
+
+    let mut poses = Vec::with_capacity(MAX_GRAPH_ANCHORS);
+    for active_index in 0..MAX_GRAPH_ANCHORS {
+        let mut pose = Pose::default();
+        for index in 0..flattened.len() {
+            pose.add_bone(
+                BonePose {
+                    translation: Some(Vec3::X * (index == active_index) as u8 as f32),
+                    ..default()
+                },
+                marker_ids[index],
+            );
+        }
+        poses.push(pose);
+    }
+
+    let mut factors = [0.0; MAX_GRAPH_ANCHORS - 1];
+    let mut accumulated = flattened[0].1;
+    for index in 1..flattened.len() {
+        let weight = flattened[index].1;
+        let total = accumulated + weight;
+        factors[index - 1] = if total > f32::EPSILON {
+            weight / total
+        } else {
+            0.0
+        };
+        accumulated = total;
+    }
+    Some((
+        poses,
+        factors,
+        flattened.into_iter().map(|(role, _)| role).collect(),
+    ))
+}
+
+fn decode_graph_pose(
+    legacy: &AnimationEvaluation,
+    pose: &Pose,
+    marker_ids: &[BoneId],
+    roles: &[FlatAnchorRole],
+) -> Option<AnimationEvaluation> {
+    let mut decoded = legacy.clone();
+    let samples = selected_samples_mut(&mut decoded);
+    if samples.is_empty() || pose.bones.len() != roles.len() {
+        return None;
+    }
+    let mut start_weights = vec![0.0; samples.len()];
+    let mut end_weights = vec![0.0; samples.len()];
+    let mut weight_sum = 0.0;
+    for (index, role) in roles.iter().enumerate() {
+        let marker = pose
+            .get_bone(marker_ids[index])
+            .and_then(|bone| bone.translation)?;
+        if !marker.is_finite()
+            || marker.x < -WEIGHT_EPSILON
+            || marker.x > 1.0 + WEIGHT_EPSILON
+            || marker.y.abs() > WEIGHT_EPSILON
+            || marker.z.abs() > WEIGHT_EPSILON
+        {
+            return None;
+        }
+        let weight = marker.x.clamp(0.0, 1.0);
+        match *role {
+            FlatAnchorRole::Anchor { sample } | FlatAnchorRole::SpanStart { sample } => {
+                *start_weights.get_mut(sample)? = weight;
+            }
+            FlatAnchorRole::SpanEnd { sample } => *end_weights.get_mut(sample)? = weight,
+        }
+        weight_sum += weight;
+    }
+    if (weight_sum - 1.0).abs() > WEIGHT_EPSILON {
+        return None;
+    }
+    for (index, sample) in samples.iter_mut().enumerate() {
+        match &mut sample.sampling {
+            PoseSampling::Anchor => sample.weight = start_weights[index],
+            PoseSampling::Span { progress, .. } => {
+                let total = start_weights[index] + end_weights[index];
+                if total <= f32::EPSILON {
+                    return None;
+                }
+                sample.weight = total;
+                *progress = (end_weights[index] / total).clamp(0.0, 1.0);
+            }
+        }
+    }
+    Some(decoded)
+}
+
+fn evaluate_dependency_graph(
+    graph_handle: &Handle<DependencyAnimationGraph>,
+    arena: &mut GraphContextArena,
+    poses: Vec<Pose>,
+    factors: [f32; MAX_GRAPH_ANCHORS - 1],
+    absolute_time: f32,
+    resources: &SystemResources,
+) -> Option<Pose> {
+    let graph = resources.animation_graph_assets.get(graph_handle)?;
+    let mut gizmos = DeferredGizmos::default();
+    let entity_map = HashMap::new();
+    let global_inputs = HashMap::new();
+    let mut io = IoOverrides::default();
+    for (index, pose) in poses.into_iter().enumerate() {
+        io.data.insert(
+            GraphInputPin::passthrough(pose_pin(index)),
+            DataValue::Pose(pose),
+        );
+    }
+    for (index, factor) in factors.into_iter().enumerate() {
+        io.data.insert(
+            GraphInputPin::passthrough(factor_pin(index + 1)),
+            DataValue::F32(factor),
+        );
+    }
+    graph
+        .query_with_env(
+            TimeUpdate::Absolute(absolute_time),
+            arena,
+            resources,
+            &io,
+            Entity::PLACEHOLDER,
+            &entity_map,
+            &mut gizmos,
+            &global_inputs,
+        )
+        .ok()?
+        .remove(DEFAULT_OUTPUT_POSE)?
+        .into_pose()
+        .ok()
+}
+
+fn requested_path(skeleton: &PresentedSkeleton) -> SemanticGraphPath {
+    if skeleton.action_kind() == SkeletonAction::Attack
+        || skeleton.weapon_guard() == WeaponGuardState::Raised
+    {
+        SemanticGraphPath::RaisedGuardAttack
+    } else if skeleton.is_grounded()
+        && matches!(skeleton.posture(), Posture::Upright | Posture::Crouched)
+    {
+        SemanticGraphPath::OrdinaryLocomotion
+    } else {
+        SemanticGraphPath::LegacyFallback
+    }
+}
+
+pub(super) fn route_semantic_graph(
+    graphs: &mut SemanticGraphLibrary,
+    resources: &SystemResources,
+    entity: Entity,
+    skeleton: &PresentedSkeleton,
+) -> SemanticGraphTrace {
+    let legacy = AnimationEvaluation::from_skeleton(skeleton);
+    let inputs = SemanticGraphInputs::from_presented(skeleton, &legacy);
+    let requested = requested_path(skeleton);
+    let graph_handle = match requested {
+        SemanticGraphPath::OrdinaryLocomotion => Some(graphs.ordinary.clone()),
+        SemanticGraphPath::RaisedGuardAttack => Some(graphs.raised.clone()),
+        SemanticGraphPath::LegacyFallback => None,
+    };
+    let mut evaluation = None;
+    if let Some(graph_handle) = graph_handle
+        && let Some((poses, factors, roles)) = encode_sparse_inputs(&legacy, &graphs.marker_ids)
+    {
+        #[cfg(test)]
+        let factors = graphs.factor_override.unwrap_or(factors);
+        let arena = graphs
+            .contexts
+            .entry((entity, requested))
+            .or_insert_with(|| GraphContextArena::new(graph_handle.id()));
+        let absolute_time = if skeleton.action_kind() == SkeletonAction::Attack {
+            legacy.action_phase
+        } else {
+            legacy.gait_phase
+        };
+        if let Some(pose) = evaluate_dependency_graph(
+            &graph_handle,
+            arena,
+            poses,
+            factors,
+            absolute_time,
+            resources,
+        ) {
+            #[cfg(test)]
+            let pose = {
+                let mut pose = pose;
+                if graphs.corrupt_last_marker
+                    && let Some(last) = pose.bones.last_mut()
+                {
+                    last.translation = Some(Vec3::splat(f32::NAN));
+                }
+                pose
+            };
+            evaluation = decode_graph_pose(&legacy, &pose, &graphs.marker_ids, &roles);
+        }
+    }
+    let runtime_evaluated = evaluation.is_some();
+    SemanticGraphTrace {
+        inputs,
+        requested_path: requested,
+        path: if runtime_evaluated {
+            requested
+        } else {
+            SemanticGraphPath::LegacyFallback
+        },
+        evaluation: evaluation.unwrap_or(legacy),
+        runtime_evaluated,
+    }
+}
+
+pub(super) fn evaluate_semantic_graph_paths(
+    mut commands: Commands,
+    mut graphs: ResMut<SemanticGraphLibrary>,
+    resources: SystemResources,
+    mut telemetry: ResMut<SemanticGraphTelemetry>,
+    players: Query<(Entity, &PresentedSkeleton), With<Player>>,
+) {
+    let mut live = HashSet::new();
+    for (entity, skeleton) in &players {
+        live.insert(entity);
+        let trace = route_semantic_graph(&mut graphs, &resources, entity, skeleton);
+        *telemetry.counts.entry(trace.path).or_default() += 1;
+        commands.entity(entity).insert(trace);
+    }
+    graphs
+        .contexts
+        .retain(|(entity, _), _| live.contains(entity));
+}
+
+#[cfg(test)]
+pub(super) fn route_semantic_graph_for_test(
+    In((skeleton, entity)): In<(PresentedSkeleton, Entity)>,
+    mut graphs: ResMut<SemanticGraphLibrary>,
+    resources: SystemResources,
+) -> SemanticGraphTrace {
+    route_semantic_graph(&mut graphs, &resources, entity, &skeleton)
+}

--- a/crates/adventuresim-tactical-client/src/animation/tests.rs
+++ b/crates/adventuresim-tactical-client/src/animation/tests.rs
@@ -3,20 +3,275 @@ use super::*;
 #[cfg(test)]
 mod legacy_tests {
     use super::*;
+    use bevy_animation_graph::core::animation_graph::{DEFAULT_OUTPUT_POSE, TargetPin};
+    use semantic_graph::{SemanticGraphPath, SemanticGraphTrace};
+
+    fn graph_test_app() -> App {
+        let mut app = App::new();
+        app.add_plugins(MinimalPlugins)
+            .add_plugins(bevy::asset::AssetPlugin::default())
+            .add_plugins(bevy_animation_graph::AnimationGraphPlugin::default())
+            .init_resource::<semantic_graph::SemanticGraphLibrary>();
+        app
+    }
+
+    fn route(app: &mut App, skeleton: SkeletonState) -> SemanticGraphTrace {
+        app.world_mut()
+            .run_system_cached_with(
+                semantic_graph::route_semantic_graph_for_test,
+                (PresentedSkeleton::new(skeleton, None), Entity::PLACEHOLDER),
+            )
+            .unwrap()
+    }
 
     #[test]
-    fn dependency_layer_keeps_legacy_evaluator_active() {
-        let mut app = App::new();
-        app.add_plugins(TacticalAnimationPlugin);
-
-        assert!(!app.is_plugin_added::<bevy_animation_graph::AnimationGraphPlugin>());
-
+    fn ordinary_semantic_graph_runtime_drives_legacy_equivalent_samples() {
+        let mut app = graph_test_app();
         let skeleton = SkeletonState::default()
             .with_local_velocity(Vec3::NEG_Z * 2.0)
             .with_world_velocity(Vec3::NEG_Z * 2.0);
         let before = AnimationEvaluation::from_skeleton(&skeleton);
-        let after = AnimationEvaluation::from_skeleton(&skeleton);
-        assert_eq!(before, after);
+        let after = route(&mut app, skeleton);
+        assert_eq!(after.path, SemanticGraphPath::OrdinaryLocomotion);
+        assert!(after.runtime_evaluated);
+        assert_eq!(before, after.evaluation);
+    }
+
+    #[test]
+    fn semantic_graph_inputs_are_read_only_and_cover_attack_capture() {
+        let mut skeleton = SkeletonState::default()
+            .with_weapon_guard(WeaponGuardState::Raised)
+            .with_local_velocity(Vec3::NEG_Z * 3.0)
+            .with_world_velocity(Vec3::NEG_Z * 3.0);
+        skeleton.begin_attack(
+            AttackSpec {
+                step: AttackStep::Forward,
+                step_speed: 3.0,
+                movement_direction: Vec2::NEG_Y,
+                movement_speed: 3.0,
+                ..default()
+            },
+            10,
+            20,
+        );
+        skeleton.advance_action(15);
+        let before = serde_json::to_vec(&skeleton).unwrap();
+        let presented = PresentedSkeleton::new(skeleton, None);
+        let evaluation = AnimationEvaluation::from_skeleton(&presented);
+        let inputs = semantic_graph::SemanticGraphInputs::from_presented(&presented, &evaluation);
+
+        assert_eq!(inputs.action, SkeletonAction::Attack);
+        assert_eq!(inputs.captured_step, AttackStep::Forward);
+        assert_eq!(inputs.captured_step_direction, Vec2::NEG_Y);
+        assert_eq!(inputs.captured_step_speed, 3.0);
+        assert_eq!(before, serde_json::to_vec(&presented.state).unwrap());
+    }
+
+    #[test]
+    fn semantic_graph_routes_raised_attack_without_retiming_contact() {
+        let mut app = graph_test_app();
+        for (tick, expected_phase) in [(10, 0.0), (15, 0.25), (20, 0.5), (25, 0.75), (30, 1.0)] {
+            let mut skeleton = SkeletonState::default()
+                .with_weapon_guard(WeaponGuardState::Raised)
+                .with_lead_foot(LeadFoot::Left);
+            skeleton.begin_attack(AttackSpec::default(), 10, 20);
+            skeleton.advance_action(tick);
+            let presented = PresentedSkeleton::new(skeleton.clone(), None);
+            let legacy = AnimationEvaluation::from_skeleton(&skeleton);
+            let routed = route(&mut app, skeleton);
+
+            assert_eq!(routed.path, SemanticGraphPath::RaisedGuardAttack);
+            assert!(routed.runtime_evaluated);
+            assert_eq!(routed.evaluation, legacy);
+            assert!((routed.inputs.gait_phase - presented.gait_phase).abs() < f32::EPSILON);
+            assert!((routed.evaluation.action_phase - expected_phase).abs() < f32::EPSILON);
+        }
+    }
+
+    #[test]
+    fn missing_dependency_graph_output_falls_back_to_legacy() {
+        let mut app = graph_test_app();
+        let handle = app
+            .world()
+            .resource::<semantic_graph::SemanticGraphLibrary>()
+            .ordinary
+            .clone();
+        app.world_mut()
+            .resource_mut::<Assets<bevy_animation_graph::core::animation_graph::AnimationGraph>>()
+            .get_mut(&handle)
+            .unwrap()
+            .remove_edge_by_target(&TargetPin::OutputData(DEFAULT_OUTPUT_POSE.into()));
+
+        let skeleton = SkeletonState::default()
+            .with_local_velocity(Vec3::NEG_Z)
+            .with_world_velocity(Vec3::NEG_Z);
+        let legacy = AnimationEvaluation::from_skeleton(&skeleton);
+        let routed = route(&mut app, skeleton);
+
+        assert_eq!(routed.path, SemanticGraphPath::LegacyFallback);
+        assert!(!routed.runtime_evaluated);
+        assert_eq!(routed.evaluation, legacy);
+    }
+
+    #[test]
+    fn dropped_dependency_graph_asset_falls_back_to_legacy() {
+        let mut app = graph_test_app();
+        let handle = app
+            .world()
+            .resource::<semantic_graph::SemanticGraphLibrary>()
+            .raised
+            .clone();
+        app.world_mut()
+            .resource_mut::<Assets<bevy_animation_graph::core::animation_graph::AnimationGraph>>()
+            .remove(&handle);
+
+        let skeleton = SkeletonState::default().with_weapon_guard(WeaponGuardState::Raised);
+        let legacy = AnimationEvaluation::from_skeleton(&skeleton);
+        let routed = route(&mut app, skeleton);
+
+        assert_eq!(routed.path, SemanticGraphPath::LegacyFallback);
+        assert!(!routed.runtime_evaluated);
+        assert_eq!(routed.evaluation, legacy);
+    }
+
+    #[test]
+    fn malformed_late_graph_marker_discards_all_partial_decode_changes() {
+        let mut app = graph_test_app();
+        app.world_mut()
+            .resource_mut::<semantic_graph::SemanticGraphLibrary>()
+            .corrupt_last_marker = true;
+        let skeleton = SkeletonState::default()
+            .with_local_velocity(Vec3::NEG_Z * 2.0)
+            .with_world_velocity(Vec3::NEG_Z * 2.0);
+        let legacy = AnimationEvaluation::from_skeleton(&skeleton);
+        let routed = route(&mut app, skeleton);
+
+        assert_eq!(routed.requested_path, SemanticGraphPath::OrdinaryLocomotion);
+        assert_eq!(routed.path, SemanticGraphPath::LegacyFallback);
+        assert!(!routed.runtime_evaluated);
+        assert_eq!(routed.evaluation, legacy);
+    }
+
+    #[test]
+    fn non_identity_graph_blend_changes_weighted_fk_playback_input() {
+        let mut skeleton = SkeletonState::default()
+            .with_local_velocity(Vec3::NEG_Z * 3.75)
+            .with_world_velocity(Vec3::NEG_Z * 3.75);
+        skeleton.gait_phase = 0.25;
+        assert!(AnimationEvaluation::from_skeleton(&skeleton).base.len() > 1);
+
+        let mut production_app = graph_test_app();
+        let production = route(&mut production_app, skeleton.clone());
+        let mut changed_app = graph_test_app();
+        let active_anchors = AnimationEvaluation::from_skeleton(&skeleton)
+            .base
+            .iter()
+            .map(|sample| match sample.sampling {
+                PoseSampling::Anchor => 1,
+                PoseSampling::Span { .. } => 2,
+            })
+            .sum::<usize>();
+        let mut factors = [0.0; semantic_graph::MAX_GRAPH_ANCHORS - 1];
+        factors[..active_anchors.saturating_sub(1)].fill(0.25);
+        changed_app
+            .world_mut()
+            .resource_mut::<semantic_graph::SemanticGraphLibrary>()
+            .factor_override = Some(factors);
+        let changed = route(&mut changed_app, skeleton);
+
+        assert!(production.runtime_evaluated);
+        assert!(changed.runtime_evaluated);
+        assert_ne!(production.evaluation, changed.evaluation);
+
+        let catalog = AnimationPackCatalog::default();
+        let runtime = runtime_with_available([
+            SemanticPose::WalkContact,
+            SemanticPose::WalkPassing,
+            SemanticPose::RunContact,
+            SemanticPose::RunFlight,
+        ]);
+        let resolve_playback = |evaluation: &AnimationEvaluation| {
+            let samples = if evaluation.action.is_empty() {
+                &evaluation.base
+            } else {
+                &evaluation.action
+            };
+            let mut clips = Vec::new();
+            for sample in samples {
+                append_resolved_sample(
+                    &mut clips,
+                    &runtime,
+                    &catalog,
+                    HUMANOID_UNARMED_PACK,
+                    *sample,
+                    None,
+                );
+            }
+            AnimationPlayback { clips, ..default() }
+        };
+        let production_playback = resolve_playback(&production.evaluation);
+        let changed_playback = resolve_playback(&changed.evaluation);
+        let production_weights = production_playback
+            .clips
+            .iter()
+            .map(|clip| (clip.clip.node, clip.weight))
+            .collect::<Vec<_>>();
+        let changed_weights = changed_playback
+            .clips
+            .iter()
+            .map(|clip| (clip.clip.node, clip.weight))
+            .collect::<Vec<_>>();
+        assert_ne!(production_weights, changed_weights);
+    }
+
+    #[test]
+    fn non_identity_attack_graph_blend_changes_span_fk_playback_input() {
+        let mut skeleton = SkeletonState::default().with_lead_foot(LeadFoot::Left);
+        skeleton.begin_attack(AttackSpec::default(), 10, 20);
+        skeleton.advance_action(15);
+        let legacy = AnimationEvaluation::from_skeleton(&skeleton);
+        assert!(matches!(
+            legacy.action[0].sampling,
+            PoseSampling::Span { progress, .. } if progress > 0.0 && progress < 1.0
+        ));
+
+        let mut production_app = graph_test_app();
+        let production = route(&mut production_app, skeleton.clone());
+        let mut changed_app = graph_test_app();
+        changed_app
+            .world_mut()
+            .resource_mut::<semantic_graph::SemanticGraphLibrary>()
+            .factor_override = Some([0.0; semantic_graph::MAX_GRAPH_ANCHORS - 1]);
+        let changed = route(&mut changed_app, skeleton);
+
+        assert!(production.runtime_evaluated);
+        assert!(changed.runtime_evaluated);
+        assert_ne!(production.evaluation.action, changed.evaluation.action);
+
+        let catalog = AnimationPackCatalog::default();
+        let runtime = runtime_with_available([
+            SemanticPose::GuardLeadLeft,
+            SemanticPose::AttackThrustLeadLeftContact,
+        ]);
+        let resolve = |sample: PoseSample| {
+            let mut weighted = Vec::new();
+            append_resolved_sample(
+                &mut weighted,
+                &runtime,
+                &catalog,
+                HUMANOID_UNARMED_PACK,
+                sample,
+                None,
+            );
+            weighted
+                .into_iter()
+                .map(|clip| (clip.clip.node, clip.weight))
+                .collect::<Vec<_>>()
+        };
+        assert_ne!(
+            resolve(production.evaluation.action[0]),
+            resolve(changed.evaluation.action[0])
+        );
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation_graph_nodes.rs
+++ b/crates/adventuresim-tactical-client/src/animation_graph_nodes.rs
@@ -1,0 +1,49 @@
+use bevy::prelude::*;
+use bevy_animation_graph::core::{
+    animation_node::{NodeLike, ReflectNodeLike},
+    context::{new_context::NodeContext, spec_context::SpecContext},
+    edge_data::{DataSpec, DataValue, bone_mask::BoneMask},
+    errors::GraphError,
+    interpolation::linear::LinearInterpolator,
+};
+
+/// Non-trivially composes two sparse semantic poses inside the dependency
+/// runtime. Adventure Simulator supplies normalized factors; the graph-returned
+/// pose is decoded into the authored FK sample weights.
+#[derive(Reflect, Clone, Debug, Default)]
+#[reflect(Default, NodeLike)]
+#[type_path = "adventuresim_tactical_client::animation_graph_nodes"]
+pub(crate) struct SparseSemanticBlendNode;
+
+impl SparseSemanticBlendNode {
+    pub(crate) const POSE_A: &'static str = "pose_a";
+    pub(crate) const POSE_B: &'static str = "pose_b";
+    pub(crate) const FACTOR: &'static str = "factor";
+    pub(crate) const OUTPUT: &'static str = "pose";
+}
+
+impl NodeLike for SparseSemanticBlendNode {
+    fn display_name(&self) -> String {
+        "Adventure Simulator sparse semantic blend".into()
+    }
+
+    fn update(&self, mut ctx: NodeContext) -> Result<(), GraphError> {
+        let mut pose_a = ctx.data_back(Self::POSE_A)?.into_pose()?;
+        let pose_b = ctx.data_back(Self::POSE_B)?.into_pose()?;
+        let factor = ctx.data_back(Self::FACTOR)?.as_f32()?.clamp(0.0, 1.0);
+        LinearInterpolator {
+            bone_mask: BoneMask::all(),
+        }
+        .interpolate_pose(&mut pose_a, &pose_b, factor);
+        ctx.set_data_fwd(Self::OUTPUT, DataValue::Pose(pose_a));
+        Ok(())
+    }
+
+    fn spec(&self, mut ctx: SpecContext) -> Result<(), GraphError> {
+        ctx.add_input_data(Self::POSE_A, DataSpec::Pose)
+            .add_input_data(Self::POSE_B, DataSpec::Pose)
+            .add_input_data(Self::FACTOR, DataSpec::F32)
+            .add_output_data(Self::OUTPUT, DataSpec::Pose);
+        Ok(())
+    }
+}

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -24,6 +24,7 @@ use crate::animation::{
     LocomotionPresentationEventKind, MEASURED_ANKLE_SOLE_OFFSET_METRES, PresentedSkeleton,
     ProceduralAnimationClock, RaisedFootworkState, SOLE_CONTACT_TOLERANCE_METRES,
     TacticalAnimationPlugin, TerrainIkEnabled, locomotion_support_weights,
+    semantic_graph::{SemanticGraphPath, SemanticGraphTrace},
 };
 use crate::{
     camera::{CameraMode, TacticalCameraPlugin, TacticalCameraSet, third_person_offset},
@@ -336,6 +337,7 @@ struct CaptureManifest {
     scenarios: Vec<ScenarioMetrics>,
     frames: Vec<FrameSample>,
     presentation_events: Vec<PresentationEventSample>,
+    semantic_graph_path_counts: BTreeMap<String, u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -375,6 +377,7 @@ struct CaptureValidation {
     hard_stop_height_continuity_valid: bool,
     repeated_evaluation_valid: bool,
     attack_footwork_valid: bool,
+    semantic_graph_paths_exercised: bool,
     views_are_distinct: bool,
     duplicate_view_frames: Vec<String>,
     note: &'static str,
@@ -504,6 +507,9 @@ struct FrameSample {
     attack_constrained_right_foot_target: Option<[f32; 3]>,
     attack_support_handoffs: u8,
     attack_maximum_reach_yield_metres: f32,
+    semantic_graph_requested_path: SemanticGraphPath,
+    semantic_graph_selected_path: SemanticGraphPath,
+    semantic_graph_runtime_evaluated: bool,
     screenshots: BTreeMap<String, String>,
     bones: BTreeMap<String, BoneSample>,
 }
@@ -1646,6 +1652,7 @@ fn capture_frame(
             Option<&LocomotionBodyResponseState>,
             Option<&LocomotionHeightState>,
             Option<&LegIkState>,
+            Option<&SemanticGraphTrace>,
         ),
         With<CaptureSubject>,
     >,
@@ -1666,6 +1673,7 @@ fn capture_frame(
         body_response,
         height_state,
         leg_ik,
+        semantic_graph,
     )) = subjects.single()
     else {
         wait_or_fail(&mut sequence, "capture subject is missing", &mut exit);
@@ -1675,6 +1683,14 @@ fn capture_frame(
         wait_or_fail(
             &mut sequence,
             "capture subject has no AnimationPlayback",
+            &mut exit,
+        );
+        return;
+    };
+    let Some(semantic_graph) = semantic_graph else {
+        wait_or_fail(
+            &mut sequence,
+            "capture subject has no semantic graph trace",
             &mut exit,
         );
         return;
@@ -1889,6 +1905,9 @@ fn capture_frame(
                 .map(|value| value.to_array()),
             attack_support_handoffs,
             attack_maximum_reach_yield_metres: attack_maximum_reach_yield,
+            semantic_graph_requested_path: semantic_graph.requested_path,
+            semantic_graph_selected_path: semantic_graph.path,
+            semantic_graph_runtime_evaluated: semantic_graph.runtime_evaluated,
             screenshots: VIEWS
                 .into_iter()
                 .map(|view| {
@@ -2554,9 +2573,20 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
     let views_are_distinct = sequence.duplicate_view_frames.is_empty();
     let repeated_evaluation_valid = sequence.repeated_evaluation_valid;
     let attack_footwork_valid = validate_attack_footwork(&frames);
+    let semantic_graph_paths_exercised = frames.iter().all(|frame| {
+        frame.semantic_graph_requested_path == SemanticGraphPath::LegacyFallback
+            || (frame.semantic_graph_runtime_evaluated
+                && frame.semantic_graph_selected_path == frame.semantic_graph_requested_path)
+    });
+    let semantic_graph_path_counts = frames.iter().fold(BTreeMap::new(), |mut counts, frame| {
+        *counts
+            .entry(frame.semantic_graph_selected_path.as_str().to_owned())
+            .or_insert(0) += 1;
+        counts
+    });
     let manifest = CaptureManifest {
         sample_hz: SAMPLE_HZ,
-        pipeline: "shared tactical player, scene, camera, authoritative locomotion projection, authored FK, and final procedural passes",
+        pipeline: "shared tactical player, scene, camera, authoritative locomotion projection, dependency-backed semantic graph, authored FK, and final procedural passes",
         views: VIEWS,
         validation: CaptureValidation {
             finite_transforms,
@@ -2584,6 +2614,7 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
             hard_stop_height_continuity_valid,
             repeated_evaluation_valid,
             attack_footwork_valid,
+            semantic_graph_paths_exercised,
             views_are_distinct,
             duplicate_view_frames: sequence.duplicate_view_frames.clone(),
             note: "Continuity metrics are regression signals, not biomechanical proof; review index.html at normal and slow speed.",
@@ -2591,6 +2622,7 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         scenarios,
         frames,
         presentation_events,
+        semantic_graph_path_counts,
     };
     let manifest_path = sequence.output.join("manifest.json");
     fs::write(
@@ -2626,6 +2658,7 @@ fn finish_capture(sequence: &mut CaptureSequence, exit: &mut MessageWriter<AppEx
         && hard_stop_height_continuity_valid
         && repeated_evaluation_valid
         && attack_footwork_valid
+        && semantic_graph_paths_exercised
         && views_are_distinct
     {
         exit.write(AppExit::Success);
@@ -3952,6 +3985,9 @@ mod tests {
             attack_constrained_right_foot_target: None,
             attack_support_handoffs: 0,
             attack_maximum_reach_yield_metres: 0.0,
+            semantic_graph_requested_path: SemanticGraphPath::LegacyFallback,
+            semantic_graph_selected_path: SemanticGraphPath::LegacyFallback,
+            semantic_graph_runtime_evaluated: false,
             screenshots,
             bones: BTreeMap::new(),
         };
@@ -4309,6 +4345,9 @@ mod tests {
             attack_constrained_right_foot_target: None,
             attack_support_handoffs: 0,
             attack_maximum_reach_yield_metres: 0.0,
+            semantic_graph_requested_path: SemanticGraphPath::LegacyFallback,
+            semantic_graph_selected_path: SemanticGraphPath::LegacyFallback,
+            semantic_graph_runtime_evaluated: false,
             screenshots: BTreeMap::new(),
             bones,
         };
@@ -4422,6 +4461,9 @@ mod tests {
             attack_constrained_right_foot_target: None,
             attack_support_handoffs: 0,
             attack_maximum_reach_yield_metres: 0.0,
+            semantic_graph_requested_path: SemanticGraphPath::LegacyFallback,
+            semantic_graph_selected_path: SemanticGraphPath::LegacyFallback,
+            semantic_graph_runtime_evaluated: false,
             screenshots: BTreeMap::new(),
             bones: BTreeMap::from([
                 ("left_foot".into(), foot(left_x, left_terrain_height)),

--- a/crates/adventuresim-tactical-client/src/animation_viewer_main.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer_main.rs
@@ -1,6 +1,7 @@
 //! Deterministic native animation capture utility.
 
 mod animation;
+mod animation_graph_nodes;
 mod animation_viewer;
 mod camera;
 mod player;

--- a/crates/adventuresim-tactical-client/src/main.rs
+++ b/crates/adventuresim-tactical-client/src/main.rs
@@ -26,6 +26,7 @@ use console_error_panic_hook;
 use wasm_bindgen::prelude::*;
 
 mod animation;
+mod animation_graph_nodes;
 mod camera;
 #[cfg(feature = "debug")]
 mod debug;

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -141,6 +141,34 @@ The animation evaluator consumes skeleton state in this order:
    and head/torso look. Body facing is already present on the replicated root.
 7. Apply optional secondary animation.
 
+The dependency-backed semantic bridge routes ordinary grounded locomotion and
+raised-guard/attack evaluation through real dependency `AnimationGraph`
+queries. Its inputs are a read-only snapshot of
+`PresentedSkeleton` plus `AnimationEvaluation`: speed, local direction,
+gait/action phase, crouch/airborne state, attack height, lead and support feet,
+contact sequence, effective pack, and the attack's captured step
+direction/speed. The bridge flattens anchor samples directly and span samples
+into separate start/end contributions. A chain of dependency pose-blend nodes
+composes those weights; the graph-returned start/end weights atomically
+reconstruct each `PoseSample` total and span progress before driving the existing
+effective-pack resolver. Persistent contexts are keyed by player and route and
+seek meaningful gait/action phase; despawned-player contexts are pruned. A
+missing, malformed, non-finite, out-of-range, or non-normalized graph output
+discards the entire temporary decode and selects the untouched legacy
+evaluation. Resolution
+therefore remains exact pose, same-pack mirrored counterpart, then parent
+fallback, independently for each requested semantic. Specialized packs can
+continue overriding only a subset.
+
+The existing authored FK player remains ordered before bind restoration,
+whole-body mirroring, body response, terrain IK/attack footwork, and weapon
+constraints. Gait endpoint parity still selects binary pre-mirrored clips;
+guard/action fallback still chooses one coherent whole-body mirror. The bridge
+does not consume root motion, emit gameplay events, choose actions or contacts,
+advance authoritative phases, displace the controller, add a second
+inertializer, or add another IK pass. The existing 0.18-second presentation
+crossfade remains the sole transition smoothing.
+
 Overgrowth similarly supplies named blend coordinates such as movement speed,
 ground speed, crouch height, and attack height from AngelScript, then evaluates
 nested synchronized animation groups against the same normalized time in

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1879)
+## Files (1881)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1292,7 +1292,9 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-client/src/animation/procedural/ik/mod.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/procedural/ik/solver.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/procedural/rig.rs` — Rust source module.
+- `crates/adventuresim-tactical-client/src/animation/semantic_graph.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/tests.rs` — Rust source module.
+- `crates/adventuresim-tactical-client/src/animation_graph_nodes.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/animation_viewer.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/animation_viewer_main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/camera.rs` — Rust source module for this component.


### PR DESCRIPTION
Part of #451. Stacked on the pinned dependency.

Routes ordinary locomotion and raised-guard attacks through persistent dependency-backed semantic graphs. Sparse anchor/span contributions are encoded into real Pose blends, decoded back into authoritative FK weights, and fall back exactly to the legacy evaluator on missing or malformed graph output.

The graph is presentation-only: no authority, persistence, root motion, or gameplay events move into the dependency. Existing procedural ordering remains FK first, then mirroring, body response, grounding/terrain IK, attack footwork, and weapon constraints.

Evidence:
- semantic graph tests pass, including non-identity FK effects and exact fallback
- focused walk manifest: `ordinary_locomotion` evaluated for 159/159 frames
- focused attack manifest: `raised_guard_attack` evaluated for 48/48 frames
- attack footwork, biomechanics, and distinct-view gates pass
