### PR TITLE
Add native semantic animation graph editor

### DIFF
--- a/crates/adventuresim-tactical-client/Cargo.toml
+++ b/crates/adventuresim-tactical-client/Cargo.toml
@@ -63,3 +63,9 @@ name = "animation-viewer"
 path = "src/animation_viewer_main.rs"
 doc = false
 required-features = ["debug"]
+
+[[bin]]
+name = "animation-graph-editor"
+path = "src/animation_graph_editor_main.rs"
+doc = false
+required-features = ["animation-graph-editor"]

--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -67,6 +67,28 @@ mirroring, body response, terrain IK/attack footwork, and weapon constraints
 still run after FK; graph root motion, events, inertialization, and IK remain
 unused.
 
+The visual graph editor is an opt-in native authoring tool, not a shipping
+client feature:
+
+```powershell
+just animation-graph-editor assets
+just animation-graph-preview steady-walk-2.0 target/animation-captures/graph-preview
+```
+
+Editor startup reports every code-owned missing motion, validates anchor frames,
+resolves the deterministic ordinary and raised/right-attack catalog routes, and
+prints exact or same-pack mirrored fallback choices. It then validates and
+queries the same centralized sparse-blend graph assets used by gameplay for a
+representative ordinary stride and right-lead attack before opening the upstream editor.
+Missing optional catalog motions are warnings; an invalid anchor or a missing
+motion required by either deterministic route is fatal; graph asset, schema, or
+query failure is also fatal. It registers Adventure Simulator's sparse semantic
+blend node. The preview recipe uses
+the real deterministic gameplay viewer and its `manifest.json`/`failure.txt`
+gates; editor clip preview is useful for authoring but is not acceptance
+evidence. `animation-graph-editor` is disabled by default, native-target-only,
+and absent from server and ordinary Wasm dependency graphs.
+
 ## Animation export contract
 
 The humanoid base rig is independent from authored motions:

--- a/crates/adventuresim-tactical-client/src/animation/catalog.rs
+++ b/crates/adventuresim-tactical-client/src/animation/catalog.rs
@@ -1,5 +1,8 @@
 use std::{collections::BTreeMap, str::FromStr};
 
+#[cfg(any(test, feature = "animation-graph-editor"))]
+use std::path::{Path, PathBuf};
+
 use adventuresim_tactical_core::prelude::*;
 use bevy::prelude::*;
 
@@ -293,5 +296,201 @@ impl AnimationPackCatalog {
         Ok(Self {
             packs: BTreeMap::from([(id, pack)]),
         })
+    }
+}
+
+#[cfg(any(test, feature = "animation-graph-editor"))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EditorRouteResolution {
+    pub route: &'static str,
+    pub requested: SemanticPose,
+    pub resolved_pack: String,
+    pub resolved_pose: SemanticPose,
+    pub mirrored: bool,
+    pub motion_path: PathBuf,
+    pub frame: u16,
+}
+
+#[cfg(any(test, feature = "animation-graph-editor"))]
+#[derive(Debug, Clone)]
+pub(crate) struct EditorValidationReport {
+    pub pack_count: usize,
+    pub motion_count: usize,
+    pub missing_motion_count: usize,
+    pub warnings: Vec<String>,
+    pub route_resolutions: Vec<EditorRouteResolution>,
+}
+
+/// Validate the code-owned semantic catalog against an editor asset root and
+/// resolve the same deterministic ordinary and raised/attack samples used by
+/// the capture viewer. Errors are returned together so the native tool can
+/// print a complete actionable preflight instead of failing at the first file.
+#[cfg(any(test, feature = "animation-graph-editor"))]
+pub(crate) fn validate_editor_asset_root(
+    asset_root: &Path,
+) -> Result<EditorValidationReport, Vec<String>> {
+    let catalog = AnimationPackCatalog::default();
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+    let mut motion_count = 0;
+    let mut missing_motion_count = 0;
+
+    for (pack_id, pack) in &catalog.packs {
+        motion_count += pack.motions.len();
+        for (motion_id, motion) in &pack.motions {
+            let full_path = asset_root.join(&motion.path);
+            if !full_path.is_file() {
+                missing_motion_count += 1;
+                warnings.push(format!(
+                    "pack {pack_id} motion {motion_id} is missing {}",
+                    full_path.display()
+                ));
+            }
+        }
+        for (pose, anchor) in &pack.poses {
+            match pack.motions.get(&anchor.motion) {
+                Some(motion) if anchor.frame <= motion.last_frame => {}
+                Some(motion) => errors.push(format!(
+                    "pack {pack_id} pose {} frame {} exceeds {} frame {}",
+                    pose.as_str(),
+                    anchor.frame,
+                    anchor.motion,
+                    motion.last_frame
+                )),
+                None => errors.push(format!(
+                    "pack {pack_id} pose {} references unknown motion {}",
+                    pose.as_str(),
+                    anchor.motion
+                )),
+            }
+        }
+    }
+
+    let ordinary = SkeletonState::default()
+        .with_local_velocity(Vec3::NEG_Z * 2.0)
+        .with_world_velocity(Vec3::NEG_Z * 2.0);
+    let mut raised_attack = SkeletonState::default().with_lead_foot(LeadFoot::Right);
+    raised_attack.begin_attack(AttackSpec::default(), 10, 20);
+    raised_attack.advance_action(20);
+
+    let mut route_resolutions = Vec::new();
+    for (route, state) in [
+        ("ordinary_locomotion", ordinary),
+        ("raised_guard_attack", raised_attack),
+    ] {
+        let evaluation = AnimationEvaluation::from_skeleton(&state);
+        let samples = if evaluation.action.is_empty() {
+            &evaluation.base
+        } else {
+            &evaluation.action
+        };
+        if samples.is_empty() {
+            errors.push(format!("route {route} produced no semantic samples"));
+            continue;
+        }
+        for sample in samples {
+            match resolve_editor_pose(&catalog, HUMANOID_UNARMED_PACK, sample.pose, asset_root) {
+                Some(resolution) => {
+                    if !resolution.motion_path.is_file() {
+                        errors.push(format!(
+                            "required route {route} resolves {} to missing {}",
+                            sample.pose.as_str(),
+                            resolution.motion_path.display()
+                        ));
+                    }
+                    route_resolutions.push(EditorRouteResolution {
+                        route,
+                        requested: sample.pose,
+                        ..resolution
+                    });
+                }
+                None => errors.push(format!(
+                    "route {route} cannot resolve semantic pose {} from pack {HUMANOID_UNARMED_PACK}",
+                    sample.pose.as_str()
+                )),
+            }
+            if let PoseSampling::Span { end, progress } = sample.sampling
+                && progress > f32::EPSILON
+            {
+                match resolve_editor_pose(&catalog, HUMANOID_UNARMED_PACK, end, asset_root) {
+                    Some(resolution) => {
+                        if !resolution.motion_path.is_file() {
+                            errors.push(format!(
+                                "required route {route} resolves span endpoint {} to missing {}",
+                                end.as_str(),
+                                resolution.motion_path.display()
+                            ));
+                        }
+                        route_resolutions.push(EditorRouteResolution {
+                            route,
+                            requested: end,
+                            ..resolution
+                        });
+                    }
+                    None => errors.push(format!(
+                        "route {route} cannot resolve span endpoint {} from pack {HUMANOID_UNARMED_PACK}",
+                        end.as_str()
+                    )),
+                }
+            }
+        }
+    }
+
+    // The raised/right attack deliberately proves same-pack semantic mirroring
+    // because the root pack authors the left contact and resolves its right
+    // counterpart without introducing an independent authority path.
+    if !route_resolutions
+        .iter()
+        .any(|resolution| resolution.route == "raised_guard_attack" && resolution.mirrored)
+    {
+        errors.push("raised_guard_attack did not exercise mirrored fallback resolution".into());
+    }
+
+    if errors.is_empty() {
+        Ok(EditorValidationReport {
+            pack_count: catalog.packs.len(),
+            motion_count,
+            missing_motion_count,
+            warnings,
+            route_resolutions,
+        })
+    } else {
+        Err(errors)
+    }
+}
+
+#[cfg(any(test, feature = "animation-graph-editor"))]
+fn resolve_editor_pose(
+    catalog: &AnimationPackCatalog,
+    requested_pack: &str,
+    requested_pose: SemanticPose,
+    asset_root: &Path,
+) -> Option<EditorRouteResolution> {
+    let mut pack_id = requested_pack;
+    loop {
+        let pack = catalog.packs.get(pack_id)?;
+        let resolved = pack
+            .poses
+            .get(&requested_pose)
+            .map(|anchor| (requested_pose, anchor, false))
+            .or_else(|| {
+                let counterpart = requested_pose.mirrored_counterpart()?;
+                pack.poses
+                    .get(&counterpart)
+                    .map(|anchor| (counterpart, anchor, true))
+            });
+        if let Some((resolved_pose, anchor, mirrored)) = resolved {
+            let motion = pack.motions.get(&anchor.motion)?;
+            return Some(EditorRouteResolution {
+                route: "",
+                requested: requested_pose,
+                resolved_pack: pack_id.to_owned(),
+                resolved_pose,
+                mirrored,
+                motion_path: asset_root.join(&motion.path),
+                frame: anchor.frame,
+            });
+        }
+        pack_id = pack.fallback.as_deref()?;
     }
 }

--- a/crates/adventuresim-tactical-client/src/animation/mod.rs
+++ b/crates/adventuresim-tactical-client/src/animation/mod.rs
@@ -65,7 +65,7 @@ impl Default for TerrainIkEnabled {
     }
 }
 
-mod catalog;
+pub(crate) mod catalog;
 pub use catalog::AnimationPackCatalog;
 use catalog::*;
 

--- a/crates/adventuresim-tactical-client/src/animation/semantic_graph.rs
+++ b/crates/adventuresim-tactical-client/src/animation/semantic_graph.rs
@@ -116,7 +116,7 @@ pub(crate) struct SemanticGraphTelemetry {
 }
 
 #[derive(Resource)]
-pub(super) struct SemanticGraphLibrary {
+pub(crate) struct SemanticGraphLibrary {
     pub(super) ordinary: Handle<DependencyAnimationGraph>,
     pub(super) raised: Handle<DependencyAnimationGraph>,
     contexts: HashMap<(Entity, SemanticGraphPath), GraphContextArena>,
@@ -501,4 +501,102 @@ pub(super) fn route_semantic_graph_for_test(
     resources: SystemResources,
 ) -> SemanticGraphTrace {
     route_semantic_graph(&mut graphs, &resources, entity, &skeleton)
+}
+
+#[cfg(any(test, feature = "animation-graph-editor"))]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct EditorGraphPreflightRoute {
+    pub(crate) label: &'static str,
+    pub(crate) requested_path: SemanticGraphPath,
+    pub(crate) selected_path: SemanticGraphPath,
+    pub(crate) sample_count: usize,
+}
+
+/// Validate and query the exact graph assets installed by
+/// `SemanticGraphLibrary`, using representative states for both migrated
+/// gameplay routes. The editor calls this before it installs its UI plugin so
+/// graph asset, schema, or query failures cannot be hidden by a successful
+/// catalog-only preflight.
+#[cfg(any(test, feature = "animation-graph-editor"))]
+pub(crate) fn editor_graph_preflight(
+    mut graphs: ResMut<SemanticGraphLibrary>,
+    resources: SystemResources,
+) -> Result<Vec<EditorGraphPreflightRoute>, Vec<String>> {
+    let graph_assets = [
+        (
+            SemanticGraphPath::OrdinaryLocomotion,
+            graphs.ordinary.clone(),
+        ),
+        (SemanticGraphPath::RaisedGuardAttack, graphs.raised.clone()),
+    ];
+    let mut errors = Vec::new();
+    for (path, handle) in &graph_assets {
+        match resources.animation_graph_assets.get(handle) {
+            Some(graph) => {
+                if let Err(error) = graph.validate() {
+                    errors.push(format!(
+                        "{} graph schema is invalid: {error}",
+                        path.as_str()
+                    ));
+                }
+            }
+            None => errors.push(format!("{} graph asset did not load", path.as_str())),
+        }
+    }
+
+    let mut ordinary = SkeletonState::default()
+        .with_local_velocity(Vec3::NEG_Z * 3.75)
+        .with_world_velocity(Vec3::NEG_Z * 3.75);
+    ordinary.gait_phase = 0.25;
+
+    let mut right_attack = SkeletonState::default()
+        .with_weapon_guard(WeaponGuardState::Raised)
+        .with_lead_foot(LeadFoot::Right);
+    right_attack.begin_attack(AttackSpec::default(), 10, 20);
+    right_attack.advance_action(15);
+
+    let cases = [
+        (
+            "ordinary locomotion at 3.75 m/s",
+            ordinary,
+            SemanticGraphPath::OrdinaryLocomotion,
+        ),
+        (
+            "raised right-lead attack at contact approach",
+            right_attack,
+            SemanticGraphPath::RaisedGuardAttack,
+        ),
+    ];
+    let mut routes = Vec::new();
+    for (label, skeleton, expected_path) in cases {
+        let presented = PresentedSkeleton::new(skeleton, None);
+        let legacy = AnimationEvaluation::from_skeleton(&presented);
+        let trace = route_semantic_graph(&mut graphs, &resources, Entity::PLACEHOLDER, &presented);
+        if trace.requested_path != expected_path
+            || trace.path != expected_path
+            || !trace.runtime_evaluated
+            || trace.evaluation != legacy
+        {
+            errors.push(format!(
+                "{label} graph query failed: requested {}, selected {}, runtime success {}, legacy parity {}",
+                trace.requested_path.as_str(),
+                trace.path.as_str(),
+                trace.runtime_evaluated,
+                trace.evaluation == legacy
+            ));
+            continue;
+        }
+        routes.push(EditorGraphPreflightRoute {
+            label,
+            requested_path: trace.requested_path,
+            selected_path: trace.path,
+            sample_count: selected_samples(&trace.evaluation).len(),
+        });
+    }
+
+    if errors.is_empty() {
+        Ok(routes)
+    } else {
+        Err(errors)
+    }
 }

--- a/crates/adventuresim-tactical-client/src/animation/tests.rs
+++ b/crates/adventuresim-tactical-client/src/animation/tests.rs
@@ -2,6 +2,8 @@ use super::*;
 
 #[cfg(test)]
 mod legacy_tests {
+    use std::path::Path;
+
     use super::*;
     use bevy_animation_graph::core::animation_graph::{DEFAULT_OUTPUT_POSE, TargetPin};
     use semantic_graph::{SemanticGraphPath, SemanticGraphTrace};
@@ -272,6 +274,41 @@ mod legacy_tests {
             resolve(production.evaluation.action[0]),
             resolve(changed.evaluation.action[0])
         );
+    }
+
+    #[test]
+    fn editor_preflight_resolves_deterministic_routes_and_mirror_fallback() {
+        let asset_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("assets");
+        let report = catalog::validate_editor_asset_root(&asset_root).unwrap();
+        assert!(report.motion_count > 0);
+        assert!(report.missing_motion_count > 0);
+        assert_eq!(report.missing_motion_count, report.warnings.len());
+        assert!(
+            report
+                .route_resolutions
+                .iter()
+                .any(|resolution| resolution.route == "ordinary_locomotion")
+        );
+        assert!(report.route_resolutions.iter().any(|resolution| {
+            resolution.route == "raised_guard_attack" && resolution.mirrored
+        }));
+
+        let mut app = graph_test_app();
+        let graph_routes = app
+            .world_mut()
+            .run_system_cached(semantic_graph::editor_graph_preflight)
+            .unwrap()
+            .unwrap();
+        assert_eq!(graph_routes.len(), 2);
+        assert!(graph_routes.iter().all(|route| {
+            route.requested_path == route.selected_path && route.sample_count > 0
+        }));
+        assert!(graph_routes.iter().any(|route| {
+            route.label.contains("right-lead")
+                && route.selected_path == SemanticGraphPath::RaisedGuardAttack
+        }));
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/animation_graph_editor_main.rs
+++ b/crates/adventuresim-tactical-client/src/animation_graph_editor_main.rs
@@ -1,0 +1,125 @@
+//! Native, opt-in Adventure Simulator animation-graph authoring tool.
+
+// This bin reuses the tactical animation/catalog modules solely for project
+// validation; their runtime systems are intentionally not installed here.
+#![allow(dead_code)]
+
+#[cfg(not(target_family = "wasm"))]
+mod native {
+    use std::path::PathBuf;
+
+    use bevy::prelude::*;
+    use bevy_animation_graph_editor::AnimationGraphEditorPlugin;
+
+    use crate::{
+        animation::catalog::validate_editor_asset_root,
+        animation::semantic_graph::{SemanticGraphLibrary, editor_graph_preflight},
+        animation_graph_nodes::SparseSemanticBlendNode,
+    };
+
+    pub(super) fn run() {
+        let asset_root = asset_source_argument().unwrap_or_else(|| {
+            eprintln!(
+                "error: Adventure Simulator's graph editor requires --asset-source <assets-dir>"
+            );
+            std::process::exit(2);
+        });
+        let report = validate_editor_asset_root(&asset_root).unwrap_or_else(|errors| {
+            eprintln!("Adventure Simulator animation graph validation failed:");
+            for error in errors {
+                eprintln!("  - {error}");
+            }
+            std::process::exit(2);
+        });
+
+        eprintln!(
+            "Validated {} semantic pack(s), {} motion source(s), and {} deterministic route endpoint(s); {} optional motion file(s) are absent.",
+            report.pack_count,
+            report.motion_count,
+            report.route_resolutions.len(),
+            report.missing_motion_count
+        );
+        for warning in &report.warnings {
+            eprintln!("  warning: {warning}");
+        }
+        for resolution in report.route_resolutions {
+            let fallback = if resolution.mirrored {
+                "same-pack mirrored fallback"
+            } else {
+                "exact"
+            };
+            eprintln!(
+                "  {}: {} -> {}:{} frame {} ({fallback}) [{}]",
+                resolution.route,
+                resolution.requested.as_str(),
+                resolution.resolved_pack,
+                resolution.resolved_pose.as_str(),
+                resolution.frame,
+                resolution.motion_path.display()
+            );
+        }
+
+        let mut graph_preflight = App::new();
+        graph_preflight
+            .add_plugins(MinimalPlugins)
+            .add_plugins(bevy::asset::AssetPlugin::default())
+            .add_plugins(bevy_animation_graph::AnimationGraphPlugin::default())
+            .register_type::<SparseSemanticBlendNode>()
+            .init_resource::<SemanticGraphLibrary>();
+        let routes = graph_preflight
+            .world_mut()
+            .run_system_cached(editor_graph_preflight)
+            .unwrap_or_else(|error| {
+                eprintln!("Adventure Simulator graph preflight system failed: {error}");
+                std::process::exit(2);
+            })
+            .unwrap_or_else(|errors| {
+                eprintln!("Adventure Simulator animation graph validation failed:");
+                for error in errors {
+                    eprintln!("  - {error}");
+                }
+                std::process::exit(2);
+            });
+        for route in routes {
+            eprintln!(
+                "  queried {}: {} -> {} ({} semantic sample(s))",
+                route.label,
+                route.requested_path.as_str(),
+                route.selected_path.as_str(),
+                route.sample_count
+            );
+        }
+
+        let mut app = App::new();
+        app.add_plugins(AnimationGraphEditorPlugin)
+            .register_type::<SparseSemanticBlendNode>();
+        app.run();
+    }
+
+    fn asset_source_argument() -> Option<PathBuf> {
+        let args = std::env::args_os().skip(1).collect::<Vec<_>>();
+        args.windows(2).find_map(|pair| {
+            matches!(pair[0].to_str(), Some("--asset-source" | "-a"))
+                .then(|| PathBuf::from(&pair[1]))
+        })
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+mod animation;
+#[cfg(not(target_family = "wasm"))]
+mod animation_graph_nodes;
+#[cfg(not(target_family = "wasm"))]
+mod camera;
+#[cfg(not(target_family = "wasm"))]
+mod player;
+#[cfg(not(target_family = "wasm"))]
+mod presentation;
+
+#[cfg(not(target_family = "wasm"))]
+fn main() {
+    native::run();
+}
+
+#[cfg(target_family = "wasm")]
+fn main() {}

--- a/justfile
+++ b/justfile
@@ -304,6 +304,14 @@ tactical-isolated profile="tactical-dev" base_port="23200" mission_id="mission:t
 tactical-play mode="animation" base_port="24920" graphics_preset="default" presentation_trace="auto" present_mode="auto-vsync" window_capture="auto" capture_source="window" render_backend="auto": preflight verify-db-client
     @{{ python_bin }} scripts/dev_stack.py tactical-play {{ quote(mode) }} {{ quote(base_port) }} --graphics-preset {{ quote(graphics_preset) }} --presentation-trace {{ quote(presentation_trace) }} --present-mode {{ quote(present_mode) }} --window-capture {{ quote(window_capture) }} --capture-source {{ quote(capture_source) }} --render-backend {{ quote(render_backend) }}
 
+# Launch the native-only graph editor after validating semantic packs and routes.
+animation-graph-editor asset_source="assets":
+    @cargo run -p adventuresim-tactical-client --no-default-features --features animation-graph-editor --bin animation-graph-editor -- --asset-source {{ quote(asset_source) }}
+
+# Capture a deterministic semantic-route preview with the gameplay viewer.
+animation-graph-preview scenario="steady-walk-2.0" output="target/animation-captures/graph-preview":
+    @cargo run -p adventuresim-tactical-client --bin animation-viewer -- --scenario {{ quote(scenario) }} --output {{ quote(output) }}
+
 # Report whether the supervised tactical database, claim, authority, listener,
 # and recorded child identities are healthy.
 tactical-status:

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -169,6 +169,40 @@ advance authoritative phases, displace the controller, add a second
 inertializer, or add another IK pass. The existing 0.18-second presentation
 crossfade remains the sole transition smoothing.
 
+### Graph authoring capability map
+
+The pinned dependency supplies generic semantic anchor nodes, 1D and 2D sparse
+blend spaces, nested reusable graphs, bone-masked linear layers,
+additive/difference layers, semantic mirroring, marker synchronization, and
+presentation-only transitions/inertialization. Adventure Simulator's initial
+bridge intentionally uses only the smallest subset: a registered custom sparse
+semantic blend node, a fixed dependency pose-blend chain, and dependency pose
+evaluation for ordinary locomotion and raised guard/attack. Existing code
+continues to own sparse 1D speed/gait-phase
+and directional selection, nested effective-pack fallback, binary gait endpoint
+mirroring, coherent whole-body guard mirroring, and the single 0.18-second
+presentation crossfade. Bone masks remain in the authored resolver. The bridge
+does not yet claim to use the dependency's 2D blend-space, nested-graph,
+additive/difference, marker-sync, or inertializer nodes.
+
+Launch the project-compatible native editor with `just animation-graph-editor
+assets`. It registers the custom sparse blend node, reports optional missing
+motion files, validates anchor frame bounds and deterministic catalog fallback,
+then validates and queries the same centralized runtime graphs for a
+representative ordinary stride and right-lead attack before opening the UI.
+Graph load, schema, or query failures are fatal. Use `just animation-graph-preview`
+for deterministic viewer/capture evidence; editor clip preview does not replace
+the viewer manifest and failure gates.
+
+Authoring stays sparse: export meaningful contact, passing/flight, guard,
+attack-contact, and recovery anchors from the canonical rig; record their frame
+indices in the code-owned catalog; use full-body masks only where the existing
+resolver requires them; and keep phase markers aligned with authoritative gait
+or action phase. Graphs and masks are presentation assets. They cannot choose
+actions or contacts, advance phase, emit authoritative gameplay events, apply
+root motion to the controller, or move server state. The editor feature and its
+large UI/preview dependencies are native-only and disabled in shipping Wasm.
+
 Overgrowth similarly supplies named blend coordinates such as movement speed,
 ground speed, crouch height, and attack height from AngelScript, then evaluates
 nested synchronized animation groups against the same normalized time in

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -623,6 +623,34 @@ For normal native tactical development, use the supervised launcher:
 just tactical-play animation
 ```
 
+For animation-graph authoring, launch the optional native editor from the
+repository root:
+
+```powershell
+just animation-graph-editor assets
+```
+
+The launcher first reports missing optional semantic motion files and validates anchor frame bounds, the
+ordinary locomotion route, the raised/right-attack route, and exact/mirrored
+catalog fallback resolution. It then validates and queries the same centralized
+runtime graph assets used by gameplay for a representative ordinary stride and
+right-lead attack. Missing optional files are warnings; invalid anchors, files
+required by either deterministic route, and graph load/schema/query failures are
+fatal. It prints catalog problems together and does not open the UI with a
+broken required route. The editor feature is disabled by default and is
+not part of the Wasm or server build.
+
+Use the gameplay capture fixture for deterministic preview evidence rather than
+treating the editor viewport as final output:
+
+```powershell
+just animation-graph-preview steady-walk-2.0 target/animation-captures/graph-preview
+```
+
+Choose any scenario accepted by `animation-viewer`; the output retains its
+scenario telemetry, semantic-route counts, `manifest.json`, `failure.txt`, PNG
+sequences, and HTML review surface.
+
 Use `just tactical-play diagnostic` to run the same native gameplay client
 with a bounded analogue-input script and a per-render-frame animation-state
 JSONL log. The generated script, `animation-state-<session>.jsonl`, and process

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1881)
+## Files (1882)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1294,6 +1294,7 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-client/src/animation/procedural/rig.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/semantic_graph.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/tests.rs` — Rust source module.
+- `crates/adventuresim-tactical-client/src/animation_graph_editor_main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/animation_graph_nodes.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/animation_viewer.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/animation_viewer_main.rs` — Rust source module for this component.


### PR DESCRIPTION
Closes #451. Stacked on the semantic graph runtime.

Adds a native-only project graph editor entry point and shared sparse semantic blend node. Preflight validates the animation catalog/assets/fallbacks and evaluates the same centralized runtime graphs for blended locomotion and partial attack before launching the upstream editor.

Also documents the deterministic viewer handoff and updates the generated project map.

Verification:
- editor preflight tests in both native binaries
- no-default native editor check
- final workspace, Wasm, formatting, project-map, and diff checks
- independent correctness and maintainability reviews approved after remediation

The stack remains draft while the Bevy 0.19 repeated-camera capture drift and private-repository CI credential are made explicit.
