### PR TITLE
feat(tactical): add passive humanoid ragdoll foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ version = "0.1.0"
 dependencies = [
  "adventuresim-tactical-core",
  "adventuresim-tactical-netcode",
+ "avian3d",
  "bevy",
  "bevy_animation_graph",
  "bevy_animation_graph_editor",

--- a/crates/adventuresim-tactical-client/Cargo.toml
+++ b/crates/adventuresim-tactical-client/Cargo.toml
@@ -11,12 +11,13 @@ default = ["debug"]
 debug = ["bevy/debug", "adventuresim-tactical-core/avian_debug"]
 tracy = ["bevy/trace_tracy", "dep:tracing-tracy", "dep:tracing-subscriber", "dep:tracy-client-sys"]
 animation-graph-editor = ["dep:bevy_animation_graph_editor"]
-animation-graph-physics = ["bevy_animation_graph/physics_avian"]
+animation-graph-physics = ["bevy_animation_graph/physics_avian", "dep:avian3d"]
 
 [dependencies]
 bevy.workspace = true
 bevy_flair.workspace = true
 bevy_animation_graph.workspace = true
+avian3d = { workspace = true, optional = true }
 adventuresim-tactical-core = { workspace = true, features = ["meshgen"] }
 adventuresim-tactical-netcode = { workspace = true, features = ["client"] }
 clap.workspace = true
@@ -69,3 +70,9 @@ name = "animation-graph-editor"
 path = "src/animation_graph_editor_main.rs"
 doc = false
 required-features = ["animation-graph-editor"]
+
+[[bin]]
+name = "ragdoll-viewer"
+path = "src/ragdoll_viewer_main.rs"
+doc = false
+required-features = ["debug", "animation-graph-physics"]

--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -160,6 +160,23 @@ measured for upright, lowered-guard `humanoid_unarmed` locomotion only;
 crouching, guard movement, and specialized packs receive no inferred
 compensation.
 
+## Native ragdoll fixture
+
+`just ragdoll-viewer` launches the existing Cascadeur `humanoid_unarmed` rig
+over a complete Avian solver. Press `T` to switch between animated kinematic
+bodies and a passive ragdoll, and `R` to reset to animation. A deterministic
+three-quarter camera follows the client-only solved pelvis, keeping the
+rendered rig and passive fall in frame without requiring a gameplay controller
+or collider. The fixture maps pelvis, chest, head, major limbs, hands, and
+feet. Twist bones, toes, clavicles, neck intermediates, and weapon sockets stay
+under authored hierarchy control rather than receiving duplicate rigid bodies.
+
+This is a native presentation fixture, not a new gameplay authority. Its
+solver bodies collide with terrain but not one another, never replace the
+replicated player root or gameplay hitbox, and are discarded with the client.
+The ordinary live client deliberately retains its collider-query-only physics
+configuration.
+
 ## Deterministic animation capture
 
 Regenerate the mirrored endpoint clips after changing `walk.glb` or `run.glb`

--- a/crates/adventuresim-tactical-client/src/animation/mod.rs
+++ b/crates/adventuresim-tactical-client/src/animation/mod.rs
@@ -14,6 +14,8 @@ use bevy::{
 };
 
 mod procedural;
+#[cfg(all(not(target_family = "wasm"), feature = "animation-graph-physics"))]
+pub(crate) mod ragdoll;
 
 #[allow(unused_imports)]
 pub(crate) use procedural::{

--- a/crates/adventuresim-tactical-client/src/animation/procedural/rig.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural/rig.rs
@@ -27,7 +27,7 @@ impl Default for HumanoidRig {
 }
 
 impl HumanoidRig {
-    pub(super) fn get(&self, role: &BoneRole) -> Option<&Entity> {
+    pub(crate) fn get(&self, role: &BoneRole) -> Option<&Entity> {
         self.bones[role.index()].as_ref()
     }
 
@@ -118,7 +118,7 @@ impl BoneRole {
         Self::WeaponRight,
     ];
 
-    pub(super) fn index(self) -> usize {
+    pub(crate) fn index(self) -> usize {
         self as usize
     }
 

--- a/crates/adventuresim-tactical-client/src/animation/ragdoll.rs
+++ b/crates/adventuresim-tactical-client/src/animation/ragdoll.rs
@@ -1,0 +1,652 @@
+//! Client-presentational humanoid ragdolls for the focused native viewer.
+//!
+//! This module intentionally does not attach physics bodies to the replicated
+//! player root or gameplay collider. The solver-owned bodies are transient
+//! presentation state and only write back to rendered rig bones.
+
+use std::collections::{BTreeMap, HashMap};
+
+use avian3d::prelude::{
+    AngularVelocity, JointFrame, LinearVelocity, PhysicsSystems, Position,
+    RevoluteJoint as AvianRevoluteJoint, RigidBody, Rotation,
+    SphericalJoint as AvianSphericalJoint,
+};
+use bevy::{app::AnimationSystems, math::Isometry3d, prelude::*};
+use bevy_animation_graph::core::ragdoll::relative_kinematic_body::{
+    RelativeKinematicBody, RelativeKinematicBodyPositionBased,
+};
+use bevy_animation_graph::core::ragdoll::{
+    definition::{
+        Body, BodyId, BodyMode, Collider, ColliderMassMode, ColliderShape, Joint, JointVariant,
+        Ragdoll, RevoluteJoint, SphericalJoint,
+    },
+    spawning::spawn_ragdoll_avian,
+};
+
+use super::procedural::{self, BoneRole, HumanoidRig};
+
+pub(crate) const RAGDOLL_LAYER: u32 = 1 << 1;
+pub(crate) const TERRAIN_LAYER: u32 = 1;
+
+const BODY_SPECS: [(BoneRole, f32, f32); 15] = [
+    (BoneRole::Pelvis, 0.18, 0.24),
+    (BoneRole::Chest, 0.18, 0.28),
+    (BoneRole::Head, 0.15, 0.16),
+    (BoneRole::ThighLeft, 0.10, 0.36),
+    (BoneRole::ShinLeft, 0.085, 0.34),
+    (BoneRole::FootLeft, 0.09, 0.20),
+    (BoneRole::ThighRight, 0.10, 0.36),
+    (BoneRole::ShinRight, 0.085, 0.34),
+    (BoneRole::FootRight, 0.09, 0.20),
+    (BoneRole::UpperArmLeft, 0.075, 0.27),
+    (BoneRole::ForearmLeft, 0.065, 0.25),
+    (BoneRole::HandLeft, 0.07, 0.14),
+    (BoneRole::UpperArmRight, 0.075, 0.27),
+    (BoneRole::ForearmRight, 0.065, 0.25),
+    (BoneRole::HandRight, 0.07, 0.14),
+];
+
+const SPHERICAL_LINKS: [(BoneRole, BoneRole); 6] = [
+    (BoneRole::Pelvis, BoneRole::Chest),
+    (BoneRole::Chest, BoneRole::Head),
+    (BoneRole::Pelvis, BoneRole::ThighLeft),
+    (BoneRole::Pelvis, BoneRole::ThighRight),
+    (BoneRole::Chest, BoneRole::UpperArmLeft),
+    (BoneRole::Chest, BoneRole::UpperArmRight),
+];
+
+const HINGE_LINKS: [(BoneRole, BoneRole); 6] = [
+    (BoneRole::ThighLeft, BoneRole::ShinLeft),
+    (BoneRole::ShinLeft, BoneRole::FootLeft),
+    (BoneRole::ThighRight, BoneRole::ShinRight),
+    (BoneRole::ShinRight, BoneRole::FootRight),
+    (BoneRole::UpperArmLeft, BoneRole::ForearmLeft),
+    (BoneRole::UpperArmRight, BoneRole::ForearmRight),
+];
+
+#[derive(Resource, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum RagdollMode {
+    #[default]
+    Animated,
+    Passive,
+}
+
+impl RagdollMode {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Animated => "animated",
+            Self::Passive => "passive ragdoll",
+        }
+    }
+}
+
+#[derive(Resource, Default)]
+pub(crate) struct RagdollReset(pub(crate) bool);
+
+#[derive(Component)]
+struct RagdollOwnedBone;
+
+/// Client-only camera/presentation focus following the solved pelvis. It does
+/// not affect the replicated player root, controller, or gameplay hitboxes.
+#[derive(Component, Debug, Clone, Copy)]
+pub(crate) struct RagdollPresentationFocus(pub(crate) Vec3);
+
+/// Marks bodies owned by this bridge rather than BAG's AnimatedScene target
+/// writer. Such bodies must not retain either relative-kinematic component.
+#[derive(Component)]
+struct ManuallyOwnedRagdollBody;
+
+#[derive(Debug, Clone, Copy)]
+struct BodyBinding {
+    bone: Entity,
+    body: Entity,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct JointFrameBinding {
+    joint: Entity,
+    body1: Entity,
+    body2: Entity,
+    pivot_world: Vec3,
+    basis_world: Quat,
+}
+
+#[derive(Component)]
+struct JointFramesConfigured;
+
+#[derive(Component)]
+struct RagdollRootOwner(Entity);
+
+#[derive(Component, Default)]
+struct CapturedRagdollPose(HashMap<Entity, Transform>);
+
+#[derive(Component)]
+struct HumanoidRagdoll {
+    root: Entity,
+    bindings: Vec<BodyBinding>,
+    joint_frames: Vec<JointFrameBinding>,
+    focus_body: Option<Entity>,
+}
+
+pub(crate) struct HumanoidRagdollPlugin;
+
+impl Plugin for HumanoidRagdollPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<RagdollMode>()
+            .init_resource::<RagdollReset>()
+            .add_systems(
+                Update,
+                (
+                    spawn_missing_humanoid_ragdolls.after(procedural::cache_humanoid_rigs),
+                    cleanup_orphaned_ragdolls,
+                ),
+            )
+            .add_systems(
+                FixedPostUpdate,
+                (configure_joint_frames, drive_or_release_bodies)
+                    .chain()
+                    .before(PhysicsSystems::First),
+            )
+            .add_systems(
+                FixedPostUpdate,
+                capture_solved_body_poses.after(PhysicsSystems::Last),
+            )
+            .add_systems(
+                PostUpdate,
+                read_passive_pose_to_rendered_bones
+                    .after(AnimationSystems)
+                    .after(bevy_animation_graph::core::plugin::AnimationGraphSet::Final)
+                    .before(TransformSystems::Propagate),
+            );
+    }
+}
+
+fn complete_topology(rig: &HumanoidRig) -> bool {
+    BODY_SPECS
+        .iter()
+        .all(|(role, _, _)| rig.get(role).is_some())
+}
+
+fn spawn_missing_humanoid_ragdolls(
+    mut commands: Commands,
+    rigs: Query<(Entity, &HumanoidRig), Without<HumanoidRagdoll>>,
+    globals: Query<&GlobalTransform>,
+) {
+    for (owner, rig) in &rigs {
+        if !complete_topology(rig) {
+            continue;
+        }
+        let Some((definition, body_roles, joint_roles)) = build_definition(rig, &globals) else {
+            continue;
+        };
+        let spawned = spawn_ragdoll_avian(
+            owner,
+            &definition,
+            Isometry3d::IDENTITY,
+            None,
+            &mut commands,
+        );
+        let mut bindings = Vec::with_capacity(body_roles.len());
+        let mut focus_body = None;
+        let mut focus_position = None;
+        for (body_id, role, bone, global) in body_roles {
+            let Some(body) = spawned.bodies.get(&body_id).copied() else {
+                continue;
+            };
+            commands
+                .entity(body)
+                .insert((
+                    ManuallyOwnedRagdollBody,
+                    Transform::from_translation(global.translation())
+                        .with_rotation(global.rotation()),
+                    Position(global.translation()),
+                    Rotation(global.rotation()),
+                    LinearVelocity::ZERO,
+                    AngularVelocity::ZERO,
+                ))
+                // `spawn_ragdoll_avian` inserts the position-based target and
+                // its required velocity target. These queued removals follow
+                // that spawn command, preventing BAG's update systems from
+                // driving manually simulated dynamic bodies toward identity.
+                .remove::<RelativeKinematicBodyPositionBased>()
+                .remove::<RelativeKinematicBody>();
+            bindings.push(BodyBinding { bone, body });
+            if role == BoneRole::Pelvis {
+                focus_body = Some(body);
+                focus_position = Some(global.translation());
+            }
+        }
+        let joint_frames = joint_roles
+            .into_iter()
+            .filter_map(|binding| {
+                Some(JointFrameBinding {
+                    joint: *spawned.joints.get(&binding.joint)?,
+                    body1: *spawned.bodies.get(&binding.body1)?,
+                    body2: *spawned.bodies.get(&binding.body2)?,
+                    pivot_world: binding.pivot_world,
+                    basis_world: binding.basis_world,
+                })
+            })
+            .collect();
+        commands
+            .entity(spawned.root)
+            .insert(RagdollRootOwner(owner));
+        commands.entity(owner).insert((
+            HumanoidRagdoll {
+                root: spawned.root,
+                bindings,
+                joint_frames,
+                focus_body,
+            },
+            CapturedRagdollPose::default(),
+            RagdollPresentationFocus(focus_position.unwrap_or_default()),
+        ));
+    }
+}
+
+type DefinitionBinding = (BodyId, BoneRole, Entity, GlobalTransform);
+
+struct JointDefinitionBinding {
+    joint: bevy_animation_graph::core::ragdoll::definition::JointId,
+    body1: BodyId,
+    body2: BodyId,
+    pivot_world: Vec3,
+    basis_world: Quat,
+}
+
+fn build_definition(
+    rig: &HumanoidRig,
+    globals: &Query<&GlobalTransform>,
+) -> Option<(Ragdoll, Vec<DefinitionBinding>, Vec<JointDefinitionBinding>)> {
+    let mut ragdoll = Ragdoll {
+        total_mass: 72.0,
+        ..default()
+    };
+    let mut ids = BTreeMap::new();
+    let mut bindings = Vec::with_capacity(BODY_SPECS.len());
+    for (role, radius, length) in BODY_SPECS {
+        let bone = *rig.get(&role)?;
+        let global = *globals.get(bone).ok()?;
+        let mut collider = Collider::new();
+        collider.label = format!("{role:?} collider");
+        collider.shape = ColliderShape::Capsule(Capsule3d::new(radius, length));
+        collider.layer_membership = RAGDOLL_LAYER;
+        collider.layer_filter = TERRAIN_LAYER;
+        collider.override_layers = true;
+        collider.mass_mode = ColliderMassMode::ByVolume;
+        let mut body = Body::new();
+        body.label = format!("{role:?}");
+        body.offset = global.translation();
+        body.colliders.push(collider.id);
+        body.default_mode = BodyMode::Kinematic;
+        ids.insert(role, body.id);
+        bindings.push((body.id, role, bone, global));
+        ragdoll.add_collider(collider);
+        ragdoll.add_body(body);
+    }
+    let mut joint_bindings = Vec::new();
+    for (parent, child) in SPHERICAL_LINKS {
+        let child_global = globals.get(*rig.get(&child)?).ok()?;
+        let position = child_global.translation();
+        let mut joint = Joint::new();
+        joint.label = format!("{parent:?} -> {child:?}");
+        joint.variant = JointVariant::Spherical(SphericalJoint {
+            body1: ids[&parent],
+            body2: ids[&child],
+            position,
+            twist_axis: Vec3::Y,
+            swing_limit: Some(
+                bevy_animation_graph::core::ragdoll::definition::AngleLimit {
+                    min: -0.8,
+                    max: 0.8,
+                },
+            ),
+            twist_limit: Some(
+                bevy_animation_graph::core::ragdoll::definition::AngleLimit {
+                    min: -0.6,
+                    max: 0.6,
+                },
+            ),
+            ..default()
+        });
+        joint_bindings.push(JointDefinitionBinding {
+            joint: joint.id,
+            body1: ids[&parent],
+            body2: ids[&child],
+            pivot_world: position,
+            basis_world: child_global.rotation(),
+        });
+        ragdoll.add_joint(joint);
+    }
+    for (parent, child) in HINGE_LINKS {
+        let child_global = globals.get(*rig.get(&child)?).ok()?;
+        let position = child_global.translation();
+        let mut joint = Joint::new();
+        joint.label = format!("{parent:?} -> {child:?}");
+        joint.variant = JointVariant::Revolute(RevoluteJoint {
+            body1: ids[&parent],
+            body2: ids[&child],
+            position,
+            hinge_axis: Vec3::X,
+            angle_limit: Some(
+                bevy_animation_graph::core::ragdoll::definition::AngleLimit {
+                    min: -0.15,
+                    max: 2.5,
+                },
+            ),
+            ..default()
+        });
+        joint_bindings.push(JointDefinitionBinding {
+            joint: joint.id,
+            body1: ids[&parent],
+            body2: ids[&child],
+            pivot_world: position,
+            basis_world: child_global.rotation(),
+        });
+        ragdoll.add_joint(joint);
+    }
+    Some((ragdoll, bindings, joint_bindings))
+}
+
+fn local_joint_frame(body: Transform, pivot_world: Vec3, basis_world: Quat) -> JointFrame {
+    let local_anchor = body.rotation.inverse() * (pivot_world - body.translation);
+    let local_basis = body.rotation.inverse() * basis_world;
+    JointFrame::local(Isometry3d::new(local_anchor, local_basis))
+}
+
+fn configure_joint_frames(
+    mut commands: Commands,
+    ragdolls: Query<&HumanoidRagdoll>,
+    configured: Query<(), With<JointFramesConfigured>>,
+    body_poses: Query<(&Position, &Rotation)>,
+    mut joints: ParamSet<(
+        Query<&mut AvianSphericalJoint>,
+        Query<&mut AvianRevoluteJoint>,
+    )>,
+) {
+    for ragdoll in &ragdolls {
+        for binding in &ragdoll.joint_frames {
+            if configured.contains(binding.joint) {
+                continue;
+            }
+            let (Ok((position1, rotation1)), Ok((position2, rotation2))) =
+                (body_poses.get(binding.body1), body_poses.get(binding.body2))
+            else {
+                continue;
+            };
+            let frame1 = local_joint_frame(
+                Transform::from_translation(position1.0).with_rotation(rotation1.0),
+                binding.pivot_world,
+                binding.basis_world,
+            );
+            let frame2 = local_joint_frame(
+                Transform::from_translation(position2.0).with_rotation(rotation2.0),
+                binding.pivot_world,
+                binding.basis_world,
+            );
+            let mut applied = false;
+            if let Ok(mut joint) = joints.p0().get_mut(binding.joint) {
+                joint.frame1 = frame1;
+                joint.frame2 = frame2;
+                applied = true;
+            } else if let Ok(mut joint) = joints.p1().get_mut(binding.joint) {
+                joint.frame1 = frame1;
+                joint.frame2 = frame2;
+                applied = true;
+            }
+            if applied {
+                commands.entity(binding.joint).insert(JointFramesConfigured);
+            }
+        }
+    }
+}
+
+fn cleanup_orphaned_ragdolls(
+    mut commands: Commands,
+    roots: Query<(Entity, &RagdollRootOwner)>,
+    owners: Query<(), With<HumanoidRagdoll>>,
+) {
+    for (root, owner) in &roots {
+        if owners.get(owner.0).is_err() {
+            commands.entity(root).despawn();
+        }
+    }
+}
+
+fn drive_or_release_bodies(
+    mut commands: Commands,
+    mode: Res<RagdollMode>,
+    mut reset: ResMut<RagdollReset>,
+    ragdolls: Query<&HumanoidRagdoll>,
+    globals: Query<&GlobalTransform>,
+    mut bodies: Query<(
+        &RigidBody,
+        &mut Position,
+        &mut Rotation,
+        &mut LinearVelocity,
+        &mut AngularVelocity,
+    )>,
+) {
+    let reset_now = std::mem::take(&mut reset.0);
+    for ragdoll in &ragdolls {
+        for binding in &ragdoll.bindings {
+            let Ok((rigid_body, mut position, mut rotation, mut linear, mut angular)) =
+                bodies.get_mut(binding.body)
+            else {
+                continue;
+            };
+            let animate = *mode == RagdollMode::Animated || reset_now;
+            let target_body = if animate {
+                RigidBody::Kinematic
+            } else {
+                RigidBody::Dynamic
+            };
+            if *rigid_body != target_body {
+                commands.entity(binding.body).insert(target_body);
+            }
+            if animate && let Ok(global) = globals.get(binding.bone) {
+                position.0 = global.translation();
+                rotation.0 = global.rotation();
+                linear.0 = Vec3::ZERO;
+                angular.0 = Vec3::ZERO;
+            }
+        }
+    }
+}
+
+fn capture_solved_body_poses(
+    mut ragdolls: Query<(
+        &HumanoidRagdoll,
+        &mut CapturedRagdollPose,
+        &mut RagdollPresentationFocus,
+    )>,
+    body_poses: Query<(&Position, &Rotation)>,
+) {
+    for (ragdoll, mut captured, mut focus) in &mut ragdolls {
+        captured.0.clear();
+        if let Some(focus_body) = ragdoll.focus_body
+            && let Ok((position, _)) = body_poses.get(focus_body)
+        {
+            focus.0 = position.0;
+        }
+        for binding in &ragdoll.bindings {
+            if let Ok((position, rotation)) = body_poses.get(binding.body) {
+                captured.0.insert(
+                    binding.bone,
+                    Transform::from_translation(position.0).with_rotation(rotation.0),
+                );
+            }
+        }
+    }
+}
+
+fn read_passive_pose_to_rendered_bones(
+    mode: Res<RagdollMode>,
+    mut commands: Commands,
+    ragdolls: Query<(&HumanoidRagdoll, &CapturedRagdollPose)>,
+    parents: Query<&ChildOf>,
+    globals: Query<&GlobalTransform>,
+    mut bone_transforms: ParamSet<(Query<(Entity, &Transform)>, Query<&mut Transform>)>,
+) {
+    let local_snapshot = bone_transforms
+        .p0()
+        .iter()
+        .map(|(entity, transform)| (entity, *transform))
+        .collect::<HashMap<_, _>>();
+    let mut writable_bones = bone_transforms.p1();
+    for (ragdoll, captured) in &ragdolls {
+        let _root_is_kept_for_lifecycle = ragdoll.root;
+        for binding in &ragdoll.bindings {
+            if *mode == RagdollMode::Animated {
+                commands.entity(binding.bone).remove::<RagdollOwnedBone>();
+                continue;
+            }
+            let Ok(parent) = parents.get(binding.bone) else {
+                continue;
+            };
+            let Some(parent_world) = resolved_world_transform(
+                parent.parent(),
+                &captured.0,
+                &local_snapshot,
+                &parents,
+                &globals,
+                0,
+            ) else {
+                continue;
+            };
+            let Some(desired_world) = captured.0.get(&binding.bone).copied() else {
+                continue;
+            };
+            let Ok(mut local) = writable_bones.get_mut(binding.bone) else {
+                continue;
+            };
+            *local = local_from_world(parent_world, desired_world);
+            commands.entity(binding.bone).insert(RagdollOwnedBone);
+        }
+    }
+}
+
+fn resolved_world_transform(
+    entity: Entity,
+    desired: &HashMap<Entity, Transform>,
+    locals: &HashMap<Entity, Transform>,
+    parents: &Query<&ChildOf>,
+    globals: &Query<&GlobalTransform>,
+    depth: usize,
+) -> Option<Transform> {
+    if let Some(transform) = desired.get(&entity) {
+        return Some(*transform);
+    }
+    if depth >= 64 {
+        return None;
+    }
+    if let (Some(local), Ok(parent)) = (locals.get(&entity), parents.get(entity)) {
+        let parent_world = resolved_world_transform(
+            parent.parent(),
+            desired,
+            locals,
+            parents,
+            globals,
+            depth + 1,
+        )?;
+        return Some(parent_world.mul_transform(*local));
+    }
+    globals
+        .get(entity)
+        .ok()
+        .map(GlobalTransform::compute_transform)
+}
+
+fn local_from_world(parent_world: Transform, desired_world: Transform) -> Transform {
+    Transform::from_matrix(parent_world.to_matrix().inverse() * desired_world.to_matrix())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conservative_topology_excludes_twist_toe_and_weapon_bones() {
+        assert_eq!(BODY_SPECS.len(), 15);
+        assert!(!BODY_SPECS.iter().any(|(role, _, _)| matches!(
+            role,
+            BoneRole::ThighTwistLeft
+                | BoneRole::ShinTwistLeft
+                | BoneRole::ToeLeft
+                | BoneRole::WeaponLeft
+                | BoneRole::ThighTwistRight
+                | BoneRole::ShinTwistRight
+                | BoneRole::ToeRight
+                | BoneRole::WeaponRight
+        )));
+    }
+
+    #[test]
+    fn topology_has_one_body_per_role_and_expected_hinges() {
+        let unique = BODY_SPECS
+            .iter()
+            .map(|(role, _, _)| *role)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(unique.len(), BODY_SPECS.len());
+        assert!(HINGE_LINKS.contains(&(BoneRole::ThighLeft, BoneRole::ShinLeft)));
+        assert!(HINGE_LINKS.contains(&(BoneRole::UpperArmRight, BoneRole::ForearmRight)));
+    }
+
+    #[test]
+    fn rotated_body_joint_frame_reconstructs_world_anchor_and_basis() {
+        let body = Transform::from_xyz(2.0, 1.0, -3.0).with_rotation(Quat::from_rotation_y(0.7));
+        let pivot = Vec3::new(2.4, 1.3, -2.8);
+        let basis = Quat::from_rotation_x(0.4);
+        let frame = local_joint_frame(body, pivot, basis)
+            .get_local_isometry()
+            .expect("helper always creates a local frame");
+        let reconstructed = body.mul_transform(
+            Transform::from_translation(frame.translation.into()).with_rotation(frame.rotation),
+        );
+        assert!(reconstructed.translation.distance(pivot) < 1.0e-5);
+        assert!(reconstructed.rotation.angle_between(basis) < 1.0e-5);
+    }
+
+    #[test]
+    fn parent_and_child_readback_preserve_both_world_poses() {
+        let desired_parent =
+            Transform::from_xyz(1.0, 2.0, 3.0).with_rotation(Quat::from_rotation_z(0.4));
+        let desired_child =
+            Transform::from_xyz(1.2, 2.7, 3.1).with_rotation(Quat::from_rotation_y(-0.3));
+        let child_local = local_from_world(desired_parent, desired_child);
+        let reconstructed = desired_parent.mul_transform(child_local);
+        assert!(
+            reconstructed
+                .translation
+                .distance(desired_child.translation)
+                < 1.0e-5
+        );
+        assert!(reconstructed.rotation.angle_between(desired_child.rotation) < 1.0e-5);
+    }
+
+    #[test]
+    fn manual_body_contract_removes_both_graph_kinematic_targets() {
+        let mut world = World::new();
+        let body = world
+            .spawn(RelativeKinematicBodyPositionBased::default())
+            .id();
+        assert!(
+            world
+                .entity(body)
+                .contains::<RelativeKinematicBodyPositionBased>()
+        );
+        assert!(world.entity(body).contains::<RelativeKinematicBody>());
+        world
+            .entity_mut(body)
+            .remove::<RelativeKinematicBodyPositionBased>()
+            .remove::<RelativeKinematicBody>()
+            .insert(ManuallyOwnedRagdollBody);
+        assert!(
+            !world
+                .entity(body)
+                .contains::<RelativeKinematicBodyPositionBased>()
+        );
+        assert!(!world.entity(body).contains::<RelativeKinematicBody>());
+        assert!(world.entity(body).contains::<ManuallyOwnedRagdollBody>());
+    }
+}

--- a/crates/adventuresim-tactical-client/src/ragdoll_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/ragdoll_viewer.rs
@@ -1,0 +1,190 @@
+use std::path::PathBuf;
+
+use adventuresim_tactical_core::{physics::AdventureSimulatorPhysicsPlugin, prelude::*};
+use adventuresim_tactical_netcode::client::WeaponGuardInputState;
+use bevy::{asset::io::AssetSourceBuilder, prelude::*, window::PresentMode};
+
+use crate::{
+    animation::{
+        TacticalAnimationPlugin,
+        ragdoll::{
+            HumanoidRagdollPlugin, RAGDOLL_LAYER, RagdollMode, RagdollPresentationFocus,
+            RagdollReset, TERRAIN_LAYER,
+        },
+    },
+    camera::{CameraMode, TacticalCameraPlugin, TacticalCameraSet},
+    player::{LocalCharacterId, PlayerPlugin},
+    presentation::TacticalPresentationPlugin,
+};
+
+#[derive(Component)]
+struct RagdollViewerSubject;
+
+#[derive(Component)]
+struct RagdollViewerLabel;
+
+pub(crate) fn run(asset_root: PathBuf) {
+    let source = AssetSourceBuilder::platform_default(&asset_root.to_string_lossy(), None);
+    App::new()
+        .register_asset_source("workspace", source)
+        .register_required_components_with::<Collider, _>(DebugRender::none)
+        .add_plugins(
+            DefaultPlugins
+                .set(AssetPlugin {
+                    file_path: asset_root.to_string_lossy().into_owned(),
+                    ..default()
+                })
+                .set(WindowPlugin {
+                    primary_window: Some(Window {
+                        title: "Adventure Simulator Ragdoll Viewer".into(),
+                        resolution: (960, 720).into(),
+                        present_mode: PresentMode::AutoVsync,
+                        ..default()
+                    }),
+                    ..default()
+                }),
+        )
+        .add_plugins((
+            AdventureSimulatorCorePlugins
+                .build()
+                .set(AdventureSimulatorPhysicsPlugin {
+                    enable_simulation: true,
+                }),
+            EnhancedInputPlugin,
+        ))
+        .add_plugins((
+            PlayerPlugin,
+            TacticalAnimationPlugin,
+            HumanoidRagdollPlugin,
+            TacticalCameraPlugin,
+            TacticalPresentationPlugin::default(),
+        ))
+        .insert_resource(LocalCharacterId(0))
+        .insert_resource(CameraMode { third_person: true })
+        .insert_resource(WeaponGuardInputState::default())
+        .insert_resource(ClearColor(Color::srgb(0.08, 0.1, 0.13)))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (keyboard_controls, update_label))
+        .add_systems(
+            PostUpdate,
+            position_viewer_camera
+                .after(TacticalCameraSet::Offset)
+                .before(TransformSystems::Propagate),
+        )
+        .run();
+}
+
+fn viewer_camera_transform(focus: Vec3) -> Transform {
+    let target = focus + Vec3::new(0.0, -0.15, 0.0);
+    Transform::from_translation(focus + Vec3::new(2.0, 1.0, 3.2)).looking_at(target, Vec3::Y)
+}
+
+fn position_viewer_camera(
+    subject: Single<(&Transform, Option<&RagdollPresentationFocus>), With<RagdollViewerSubject>>,
+    mut cameras: Query<&mut Transform, (With<Camera3d>, Without<RagdollViewerSubject>)>,
+) {
+    let focus = subject.1.map_or(subject.0.translation, |focus| focus.0);
+    let framed = viewer_camera_transform(focus);
+    for mut camera in &mut cameras {
+        *camera = framed;
+    }
+}
+
+fn setup(mut commands: Commands) {
+    // Keep the focused physics fixture level so capture measures ragdoll
+    // settling rather than downhill travel on the gameplay hills profile.
+    let terrain = TerrainGenerator::new(0xA11C_E5E1).generate(80, 0, 80);
+    let height = terrain.height_at(Vec2::ZERO).unwrap_or_default() + 0.95;
+    let terrain_collider = terrain.collider();
+    commands.spawn((
+        Name::new("Ragdoll viewer terrain"),
+        SceneId("hills".to_owned()),
+        terrain,
+        RigidBody::Static,
+        terrain_collider,
+        terrain_collision_layers(),
+        Transform::default(),
+    ));
+    commands.spawn((
+        Name::new("Ragdoll viewer subject"),
+        RagdollViewerSubject,
+        Player {
+            name: "Ragdoll review".into(),
+        },
+        CharacterId(0),
+        CharacterLook::default(),
+        SkeletonState::default(),
+        Transform::from_xyz(0.0, height, 0.0),
+    ));
+    commands.spawn((
+        RagdollViewerLabel,
+        Text::new("Loading Cascadeur humanoid..."),
+        TextFont::from_font_size(22.0),
+        TextColor(Color::WHITE),
+        Node {
+            position_type: PositionType::Absolute,
+            top: px(16),
+            left: px(16),
+            ..default()
+        },
+    ));
+}
+
+fn terrain_collision_layers() -> CollisionLayers {
+    CollisionLayers::new(TERRAIN_LAYER, RAGDOLL_LAYER)
+}
+
+fn keyboard_controls(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    mut mode: ResMut<RagdollMode>,
+    mut reset: ResMut<RagdollReset>,
+) {
+    if keyboard.just_pressed(KeyCode::KeyT) {
+        *mode = match *mode {
+            RagdollMode::Animated => RagdollMode::Passive,
+            RagdollMode::Passive => RagdollMode::Animated,
+        };
+    }
+    if keyboard.just_pressed(KeyCode::KeyR) {
+        reset.0 = true;
+        *mode = RagdollMode::Animated;
+    }
+}
+
+fn update_label(mode: Res<RagdollMode>, mut labels: Query<&mut Text, With<RagdollViewerLabel>>) {
+    if !mode.is_changed() {
+        return;
+    }
+    for mut label in &mut labels {
+        label.0 = format!("Mode: {}\nT: animated/passive | R: reset", mode.label());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{terrain_collision_layers, viewer_camera_transform};
+    use crate::animation::ragdoll::{RAGDOLL_LAYER, TERRAIN_LAYER};
+    use avian3d::prelude::CollisionLayers;
+    use bevy::prelude::*;
+
+    #[test]
+    fn fixture_terrain_and_ragdoll_layers_interact_bidirectionally() {
+        let terrain = terrain_collision_layers();
+        let ragdoll = CollisionLayers::new(RAGDOLL_LAYER, TERRAIN_LAYER);
+
+        assert!(terrain.interacts_with(ragdoll));
+        assert!(!terrain.interacts_with(terrain));
+        assert!(!ragdoll.interacts_with(ragdoll));
+    }
+
+    #[test]
+    fn deterministic_camera_faces_subject_from_stable_three_quarter_offset() {
+        let subject = Vec3::new(1.0, 2.0, -3.0);
+        let camera = viewer_camera_transform(subject);
+        let target = subject + Vec3::new(0.0, -0.15, 0.0);
+        let expected = (target - camera.translation).normalize();
+        assert!(camera.forward().as_vec3().dot(expected) > 0.9999);
+        let distance = (camera.translation - subject).length();
+        assert!(distance > 3.5 && distance < 4.0);
+    }
+}

--- a/crates/adventuresim-tactical-client/src/ragdoll_viewer_main.rs
+++ b/crates/adventuresim-tactical-client/src/ragdoll_viewer_main.rs
@@ -1,0 +1,46 @@
+//! Focused native presentation/physics fixture for the Cascadeur humanoid.
+
+#[cfg(not(target_family = "wasm"))]
+mod animation;
+#[cfg(not(target_family = "wasm"))]
+mod animation_graph_nodes;
+#[cfg(not(target_family = "wasm"))]
+mod camera;
+#[cfg(not(target_family = "wasm"))]
+mod player;
+#[cfg(not(target_family = "wasm"))]
+mod presentation;
+#[cfg(not(target_family = "wasm"))]
+mod ragdoll_viewer;
+
+#[cfg(not(target_family = "wasm"))]
+use std::path::PathBuf;
+
+#[cfg(not(target_family = "wasm"))]
+use clap::Parser;
+
+#[cfg(not(target_family = "wasm"))]
+#[derive(Debug, Parser)]
+#[command(version, about = "Review the Adventure Simulator humanoid ragdoll")]
+struct Args {
+    #[arg(long, default_value = "assets")]
+    asset_root: PathBuf,
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn main() {
+    let args = Args::parse();
+    let asset_root = if args.asset_root.is_absolute() {
+        args.asset_root
+    } else {
+        std::env::current_dir()
+            .expect("ragdoll viewer needs a working directory")
+            .join(args.asset_root)
+    };
+    ragdoll_viewer::run(asset_root);
+}
+
+#[cfg(target_family = "wasm")]
+fn main() {
+    panic!("ragdoll-viewer is a native-only Avian physics fixture");
+}

--- a/justfile
+++ b/justfile
@@ -312,6 +312,11 @@ animation-graph-editor asset_source="assets":
 animation-graph-preview scenario="steady-walk-2.0" output="target/animation-captures/graph-preview":
     @cargo run -p adventuresim-tactical-client --bin animation-viewer -- --scenario {{ quote(scenario) }} --output {{ quote(output) }}
 
+# Launch the focused native Cascadeur-humanoid ragdoll fixture with a complete
+# Avian solver. This does not change the live client's query-only physics path.
+ragdoll-viewer asset_source="assets":
+    @cargo run -p adventuresim-tactical-client --features animation-graph-physics --bin ragdoll-viewer -- --asset-root {{ quote(asset_source) }}
+
 # Report whether the supervised tactical database, claim, authority, listener,
 # and recorded child identities are healthy.
 tactical-status:

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -1123,16 +1123,27 @@ semantics.
 
 ## Secondary animation
 
-Clients may eventually use joint motors or other procedural dynamics to give
-bones inertia and react to movement, collisions, weapons, clothing, and
-equipment. Overgrowth can mix authored animation with active-ragdoll physics;
+The native `ragdoll-viewer` now provides a deliberately isolated passive
+ragdoll for the existing Cascadeur humanoid. It maps a conservative set of
+major bones through reusable `bevy_animation_graph` ragdoll definitions and
+runs a complete Avian solver without changing the live client's query-only
+physics setup. Twist bones, toes, clavicles, neck intermediates, and weapon
+sockets remain excluded from the rigid-body topology. The ragdoll owns only
+rendered bone transforms while active; it never moves the replicated player
+root, gameplay collider, hitboxes, or persistent strategic state.
+
+Clients may also use joint motors or other procedural dynamics to give bones
+inertia and react to movement, collisions, weapons, clothing, and equipment.
+Overgrowth can mix authored animation with active-ragdoll physics;
 its animation output carries per-bone physics weights through
 [`animation.cpp`](https://github.com/WolfireGames/overgrowth/blob/245fe4828631c84c0023d29d1525f5716ccb6106/Source/Asset/Asset/animation.cpp#L1269-L1425)
 and `RiggedObject` applies them to joint strength.
 
-Secondary animation is not in scope for the MVP. The base evaluator should
-nevertheless preserve a clean final-pose stage so it can be added without
-changing skeleton state or authored pack semantics.
+The focused fixture is an engineering/review capability rather than an MVP
+combat or death mechanic. Integrating ragdoll state with authoritative combat,
+network replication, recovery, or get-up behavior remains future work. The
+base evaluator preserves a clean final-pose stage so those decisions do not
+change authored pack semantics.
 
 ## Stylistic principles
 

--- a/wiki/reference/llm/project-map.md
+++ b/wiki/reference/llm/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (1882)
+## Files (1885)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -1292,6 +1292,7 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-client/src/animation/procedural/ik/mod.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/procedural/ik/solver.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/procedural/rig.rs` — Rust source module.
+- `crates/adventuresim-tactical-client/src/animation/ragdoll.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/semantic_graph.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation/tests.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/animation_graph_editor_main.rs` — Rust source module for this component.
@@ -1304,6 +1305,8 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-client/src/main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/player.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/presentation.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-client/src/ragdoll_viewer.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-client/src/ragdoll_viewer_main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/ui.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-core/Cargo.toml` — Cargo package/workspace manifest.
 - `crates/adventuresim-tactical-core/src/animation/evaluation.rs` — Rust source module.


### PR DESCRIPTION
Stacked on #456. Adds a native-only, client-presentational Cascadeur-humanoid ragdoll fixture using the pinned animation-graph fork's reusable ragdoll primitives. It runs a full Avian solver only in the focused viewer, isolates bodies from authoritative player and hitbox collisions, fixes rotated body-local joint frames, reads solved poses through the hierarchy, removes graph kinematic adapters from manually owned bodies, cleans up lifecycle state, and follows the solved pelvis for review.

The focused fixture now creates a real static Avian collider from the same generated terrain surface used for rendering. Reciprocal terrain/ragdoll masks allow those bodies to contact the floor without enabling ragdoll self-collision or coupling physics back into the player root. The review surface is level so capture measures settling rather than downhill travel.

No tactical physics is persisted or used as combat authority. Verification: 122 focused ragdoll-viewer tests; native animated/active/passive capture; visual screenshot inspection; rustfmt, project-map, and diff checks.