### PR TITLE
feat(tactical): demonstrate active ragdoll joint motors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation_graph"
 version = "0.11.0"
-source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=07cc881457c1f9a1f843e0f4b95cbfe28b71c921#07cc881457c1f9a1f843e0f4b95cbfe28b71c921"
+source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88#dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88"
 dependencies = [
  "avian3d",
  "bevy",
@@ -1239,7 +1239,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation_graph_builtin_nodes"
 version = "0.11.0"
-source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=07cc881457c1f9a1f843e0f4b95cbfe28b71c921#07cc881457c1f9a1f843e0f4b95cbfe28b71c921"
+source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88#dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88"
 dependencies = [
  "avian3d",
  "bevy",
@@ -1257,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation_graph_core"
 version = "0.11.0"
-source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=07cc881457c1f9a1f843e0f4b95cbfe28b71c921#07cc881457c1f9a1f843e0f4b95cbfe28b71c921"
+source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88#dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88"
 dependencies = [
  "avian3d",
  "bevy",
@@ -1274,7 +1274,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation_graph_editor"
 version = "0.11.0"
-source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=07cc881457c1f9a1f843e0f4b95cbfe28b71c921#07cc881457c1f9a1f843e0f4b95cbfe28b71c921"
+source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88#dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88"
 dependencies = [
  "bevy",
  "bevy-inspector-egui",
@@ -1296,7 +1296,7 @@ dependencies = [
 [[package]]
 name = "bevy_animation_graph_proc_macros"
 version = "0.11.0"
-source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=07cc881457c1f9a1f843e0f4b95cbfe28b71c921#07cc881457c1f9a1f843e0f4b95cbfe28b71c921"
+source = "git+https://github.com/adventure-simulator-group/bevy_animation_graph?rev=dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88#dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88"
 dependencies = [
  "quote",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ bevy_ahoy = { version = "0.2.0", default-features = false, features = ["serializ
 bevy_enhanced_input = { version = "0.26.0", default-features = false }
 bevy_flair = "0.8.0"
 noiz = "0.5.0"
-bevy_animation_graph = { git = "https://github.com/adventure-simulator-group/bevy_animation_graph", rev = "07cc881457c1f9a1f843e0f4b95cbfe28b71c921", default-features = false }
-bevy_animation_graph_editor = { git = "https://github.com/adventure-simulator-group/bevy_animation_graph", rev = "07cc881457c1f9a1f843e0f4b95cbfe28b71c921", default-features = false }
+bevy_animation_graph = { git = "https://github.com/adventure-simulator-group/bevy_animation_graph", rev = "dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88", default-features = false }
+bevy_animation_graph_editor = { git = "https://github.com/adventure-simulator-group/bevy_animation_graph", rev = "dbd9801ce08a5794a7ebc8fe35470cbe5bbe5a88", default-features = false }
 
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
 serde_json = "1"

--- a/crates/adventuresim-tactical-client/README.md
+++ b/crates/adventuresim-tactical-client/README.md
@@ -163,12 +163,13 @@ compensation.
 ## Native ragdoll fixture
 
 `just ragdoll-viewer` launches the existing Cascadeur `humanoid_unarmed` rig
-over a complete Avian solver. Press `T` to switch between animated kinematic
-bodies and a passive ragdoll, and `R` to reset to animation. A deterministic
-three-quarter camera follows the client-only solved pelvis, keeping the
-rendered rig and passive fall in frame without requiring a gameplay controller
-or collider. The fixture maps pelvis, chest, head, major limbs, hands, and
-feet. Twist bones, toes, clavicles, neck intermediates, and weapon sockets stay
+over a complete Avian solver. Press `T` to cycle animated, active-motor, and
+zero-strength passive modes, and `R` to reset to animation. A deterministic
+three-quarter camera follows the client-only solved pelvis, keeping the rig and
+passive fall in frame without requiring a gameplay controller or collider. The active profile drives the revolute knee and elbow hinges;
+Avian does not expose an equivalent spherical-joint motor, so hips, shoulders,
+spine, and neck remain limit-only. The fixture maps pelvis, chest, head, major
+limbs, hands, and feet. Twist bones, toes, clavicles, neck intermediates, and weapon sockets stay
 under authored hierarchy control rather than receiving duplicate rigid bodies.
 
 This is a native presentation fixture, not a new gameplay authority. Its
@@ -176,6 +177,13 @@ solver bodies collide with terrain but not one another, never replace the
 replicated player root or gameplay hitbox, and are discarded with the client.
 The ordinary live client deliberately retains its collider-query-only physics
 configuration.
+
+`just ragdoll-capture` deterministically settles each mode for an exact number
+of fixed solver ticks, independent of render-frame cadence, and captures it. It
+writes three screenshots and `manifest.json`, including bounded motor strength,
+driven-hinge count, finite/convergence error metrics, and the explicit passive
+zero-strength gate. A failed gate leaves `failure.txt`; screenshots still need
+visual review.
 
 ## Deterministic animation capture
 

--- a/crates/adventuresim-tactical-client/src/animation/ragdoll.rs
+++ b/crates/adventuresim-tactical-client/src/animation/ragdoll.rs
@@ -16,9 +16,10 @@ use bevy_animation_graph::core::ragdoll::relative_kinematic_body::{
     RelativeKinematicBody, RelativeKinematicBodyPositionBased,
 };
 use bevy_animation_graph::core::ragdoll::{
+    active_motor_avian::apply_active_motor,
     definition::{
-        Body, BodyId, BodyMode, Collider, ColliderMassMode, ColliderShape, Joint, JointVariant,
-        Ragdoll, RevoluteJoint, SphericalJoint,
+        ActiveRevoluteMotor, Body, BodyId, BodyMode, Collider, ColliderMassMode, ColliderShape,
+        Joint, JointVariant, Ragdoll, RevoluteJoint, SphericalJoint,
     },
     spawning::spawn_ragdoll_avian,
 };
@@ -55,19 +56,43 @@ const SPHERICAL_LINKS: [(BoneRole, BoneRole); 6] = [
     (BoneRole::Chest, BoneRole::UpperArmRight),
 ];
 
-const HINGE_LINKS: [(BoneRole, BoneRole); 6] = [
-    (BoneRole::ThighLeft, BoneRole::ShinLeft),
-    (BoneRole::ShinLeft, BoneRole::FootLeft),
-    (BoneRole::ThighRight, BoneRole::ShinRight),
-    (BoneRole::ShinRight, BoneRole::FootRight),
-    (BoneRole::UpperArmLeft, BoneRole::ForearmLeft),
-    (BoneRole::UpperArmRight, BoneRole::ForearmRight),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HingeKind {
+    Knee,
+    Elbow,
+    PassiveAnkle,
+}
+
+const HINGE_LINKS: [(BoneRole, BoneRole, HingeKind); 6] = [
+    (BoneRole::ThighLeft, BoneRole::ShinLeft, HingeKind::Knee),
+    (
+        BoneRole::ShinLeft,
+        BoneRole::FootLeft,
+        HingeKind::PassiveAnkle,
+    ),
+    (BoneRole::ThighRight, BoneRole::ShinRight, HingeKind::Knee),
+    (
+        BoneRole::ShinRight,
+        BoneRole::FootRight,
+        HingeKind::PassiveAnkle,
+    ),
+    (
+        BoneRole::UpperArmLeft,
+        BoneRole::ForearmLeft,
+        HingeKind::Elbow,
+    ),
+    (
+        BoneRole::UpperArmRight,
+        BoneRole::ForearmRight,
+        HingeKind::Elbow,
+    ),
 ];
 
 #[derive(Resource, Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) enum RagdollMode {
     #[default]
     Animated,
+    Active,
     Passive,
 }
 
@@ -75,7 +100,16 @@ impl RagdollMode {
     pub(crate) fn label(self) -> &'static str {
         match self {
             Self::Animated => "animated",
+            Self::Active => "active motors",
             Self::Passive => "passive ragdoll",
+        }
+    }
+
+    pub(crate) fn next(self) -> Self {
+        match self {
+            Self::Animated => Self::Active,
+            Self::Active => Self::Passive,
+            Self::Passive => Self::Animated,
         }
     }
 }
@@ -83,18 +117,65 @@ impl RagdollMode {
 #[derive(Resource, Default)]
 pub(crate) struct RagdollReset(pub(crate) bool);
 
+#[derive(Resource, Debug, Clone)]
+pub(crate) struct ActiveMotorProfile {
+    pub(crate) strength: f32,
+    pub(crate) target_knee_radians: f32,
+    pub(crate) target_elbow_radians: f32,
+    pub(crate) max_torque: f32,
+}
+
+impl Default for ActiveMotorProfile {
+    fn default() -> Self {
+        Self {
+            strength: 1.0,
+            target_knee_radians: 0.35,
+            target_elbow_radians: 0.25,
+            max_torque: 140.0,
+        }
+    }
+}
+
+#[derive(Resource, Debug, Clone, Default, serde::Serialize)]
+pub(crate) struct RagdollMotorTelemetry {
+    pub(crate) samples: Vec<MotorTelemetrySample>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct MotorTelemetrySample {
+    pub(crate) tick: u64,
+    pub(crate) strength: f32,
+    pub(crate) driven_hinges: usize,
+    pub(crate) mean_error_radians: f32,
+    pub(crate) maximum_error_radians: f32,
+    pub(crate) pelvis_speed: f32,
+    pub(crate) finite: bool,
+}
+
+#[derive(Resource, Default)]
+struct ActiveMotorBlend {
+    strength: f32,
+    tick: u64,
+}
+
 #[derive(Component)]
 struct RagdollOwnedBone;
 
 /// Client-only camera/presentation focus following the solved pelvis. It does
 /// not affect the replicated player root, controller, or gameplay hitboxes.
 #[derive(Component, Debug, Clone, Copy)]
-pub(crate) struct RagdollPresentationFocus(pub(crate) Vec3);
+pub(crate) struct RagdollPresentationFocus {
+    pub(crate) position: Vec3,
+    pub(crate) linear_velocity: Vec3,
+}
 
 /// Marks bodies owned by this bridge rather than BAG's AnimatedScene target
 /// writer. Such bodies must not retain either relative-kinematic component.
 #[derive(Component)]
 struct ManuallyOwnedRagdollBody;
+
+#[derive(Component)]
+pub(crate) struct RagdollPresentationReady;
 
 #[derive(Debug, Clone, Copy)]
 struct BodyBinding {
@@ -111,6 +192,15 @@ struct JointFrameBinding {
     basis_world: Quat,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct HingeBinding {
+    joint: Entity,
+    body1: Entity,
+    body2: Entity,
+    kind: HingeKind,
+    axis_sign: f32,
+}
+
 #[derive(Component)]
 struct JointFramesConfigured;
 
@@ -125,6 +215,7 @@ struct HumanoidRagdoll {
     root: Entity,
     bindings: Vec<BodyBinding>,
     joint_frames: Vec<JointFrameBinding>,
+    hinges: Vec<HingeBinding>,
     focus_body: Option<Entity>,
 }
 
@@ -134,6 +225,9 @@ impl Plugin for HumanoidRagdollPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<RagdollMode>()
             .init_resource::<RagdollReset>()
+            .init_resource::<ActiveMotorProfile>()
+            .init_resource::<ActiveMotorBlend>()
+            .init_resource::<RagdollMotorTelemetry>()
             .add_systems(
                 Update,
                 (
@@ -143,13 +237,19 @@ impl Plugin for HumanoidRagdollPlugin {
             )
             .add_systems(
                 FixedPostUpdate,
-                (configure_joint_frames, drive_or_release_bodies)
+                (
+                    configure_joint_frames,
+                    drive_or_release_bodies,
+                    apply_active_motors,
+                )
                     .chain()
                     .before(PhysicsSystems::First),
             )
             .add_systems(
                 FixedPostUpdate,
-                capture_solved_body_poses.after(PhysicsSystems::Last),
+                (sample_motor_telemetry, capture_solved_body_poses)
+                    .chain()
+                    .after(PhysicsSystems::Last),
             )
             .add_systems(
                 PostUpdate,
@@ -217,7 +317,7 @@ fn spawn_missing_humanoid_ragdolls(
             }
         }
         let joint_frames = joint_roles
-            .into_iter()
+            .iter()
             .filter_map(|binding| {
                 Some(JointFrameBinding {
                     joint: *spawned.joints.get(&binding.joint)?,
@@ -225,6 +325,18 @@ fn spawn_missing_humanoid_ragdolls(
                     body2: *spawned.bodies.get(&binding.body2)?,
                     pivot_world: binding.pivot_world,
                     basis_world: binding.basis_world,
+                })
+            })
+            .collect();
+        let hinges = joint_roles
+            .iter()
+            .filter_map(|binding| {
+                Some(HingeBinding {
+                    joint: *spawned.joints.get(&binding.joint)?,
+                    body1: *spawned.bodies.get(&binding.body1)?,
+                    body2: *spawned.bodies.get(&binding.body2)?,
+                    kind: binding.hinge_kind?,
+                    axis_sign: 1.0,
                 })
             })
             .collect();
@@ -236,10 +348,15 @@ fn spawn_missing_humanoid_ragdolls(
                 root: spawned.root,
                 bindings,
                 joint_frames,
+                hinges,
                 focus_body,
             },
             CapturedRagdollPose::default(),
-            RagdollPresentationFocus(focus_position.unwrap_or_default()),
+            RagdollPresentationFocus {
+                position: focus_position.unwrap_or_default(),
+                linear_velocity: Vec3::ZERO,
+            },
+            RagdollPresentationReady,
         ));
     }
 }
@@ -252,6 +369,7 @@ struct JointDefinitionBinding {
     body2: BodyId,
     pivot_world: Vec3,
     basis_world: Quat,
+    hinge_kind: Option<HingeKind>,
 }
 
 fn build_definition(
@@ -315,10 +433,11 @@ fn build_definition(
             body2: ids[&child],
             pivot_world: position,
             basis_world: child_global.rotation(),
+            hinge_kind: None,
         });
         ragdoll.add_joint(joint);
     }
-    for (parent, child) in HINGE_LINKS {
+    for (parent, child, kind) in HINGE_LINKS {
         let child_global = globals.get(*rig.get(&child)?).ok()?;
         let position = child_global.translation();
         let mut joint = Joint::new();
@@ -342,6 +461,7 @@ fn build_definition(
             body2: ids[&child],
             pivot_world: position,
             basis_world: child_global.rotation(),
+            hinge_kind: Some(kind),
         });
         ragdoll.add_joint(joint);
     }
@@ -454,23 +574,162 @@ fn drive_or_release_bodies(
     }
 }
 
+fn motor_target(kind: HingeKind, profile: &ActiveMotorProfile) -> Option<f32> {
+    match kind {
+        HingeKind::Knee => Some(profile.target_knee_radians),
+        HingeKind::Elbow => Some(profile.target_elbow_radians),
+        HingeKind::PassiveAnkle => None,
+    }
+}
+
+fn apply_active_motors(
+    mode: Res<RagdollMode>,
+    profile: Res<ActiveMotorProfile>,
+    time: Res<Time<Fixed>>,
+    mut blend: ResMut<ActiveMotorBlend>,
+    ragdolls: Query<&HumanoidRagdoll>,
+    mut joints: Query<&mut AvianRevoluteJoint>,
+) {
+    let requested = if *mode == RagdollMode::Active {
+        profile.strength.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    let max_step = 4.0 * time.delta_secs();
+    blend.strength += (requested - blend.strength).clamp(-max_step, max_step);
+    blend.tick = blend.tick.saturating_add(1);
+
+    for ragdoll in &ragdolls {
+        for hinge in &ragdoll.hinges {
+            let Some(target) = motor_target(hinge.kind, &profile) else {
+                if let Ok(mut joint) = joints.get_mut(hinge.joint) {
+                    let _ = apply_active_motor(
+                        &mut joint,
+                        ActiveRevoluteMotor::default(),
+                        hinge.axis_sign,
+                    );
+                }
+                continue;
+            };
+            let settings = ActiveRevoluteMotor {
+                enabled: blend.strength > f32::EPSILON,
+                target_position: target,
+                target_velocity: 0.0,
+                max_torque: profile.max_torque * blend.strength,
+                frequency_hz: 6.0 * blend.strength,
+                damping_ratio: 1.0,
+            };
+            if let Ok(mut joint) = joints.get_mut(hinge.joint) {
+                let _ = apply_active_motor(&mut joint, settings, hinge.axis_sign);
+            }
+        }
+    }
+}
+
+fn wrapped_angle(angle: f32) -> f32 {
+    (angle + std::f32::consts::PI).rem_euclid(std::f32::consts::TAU) - std::f32::consts::PI
+}
+
+fn revolute_angle(joint: &AvianRevoluteJoint, rotation1: Quat, rotation2: Quat) -> Option<f32> {
+    let basis1 = joint.local_basis1()?;
+    let basis2 = joint.local_basis2()?;
+    let axis = joint.hinge_axis.try_normalize()?;
+    let orthogonal = axis.any_orthonormal_vector();
+    let a1 = rotation1 * basis1 * axis;
+    let b1 = rotation1 * basis1 * orthogonal;
+    let b2 = rotation2 * basis2 * orthogonal;
+    Some(b1.cross(b2).dot(a1).atan2(b1.dot(b2)))
+}
+
+fn sample_motor_telemetry(
+    profile: Res<ActiveMotorProfile>,
+    blend: Res<ActiveMotorBlend>,
+    ragdolls: Query<&HumanoidRagdoll>,
+    joints: Query<&AvianRevoluteJoint>,
+    rotations: Query<&Rotation>,
+    linear_velocities: Query<&LinearVelocity>,
+    mut telemetry: ResMut<RagdollMotorTelemetry>,
+) {
+    for ragdoll in &ragdolls {
+        let mut driven = 0;
+        let mut error_sum = 0.0;
+        let mut maximum_error = 0.0_f32;
+        let mut finite = true;
+        for hinge in &ragdoll.hinges {
+            let Some(target) = motor_target(hinge.kind, &profile) else {
+                continue;
+            };
+            let (Ok(joint), Ok(rotation1), Ok(rotation2)) = (
+                joints.get(hinge.joint),
+                rotations.get(hinge.body1),
+                rotations.get(hinge.body2),
+            ) else {
+                finite = false;
+                continue;
+            };
+            if joint.motor.enabled {
+                driven += 1;
+            }
+            let Some(angle) = revolute_angle(joint, rotation1.0, rotation2.0) else {
+                finite = false;
+                continue;
+            };
+            let error = wrapped_angle(target * hinge.axis_sign - angle).abs();
+            finite &= error.is_finite();
+            if error.is_finite() {
+                error_sum += error;
+                maximum_error = maximum_error.max(error);
+            }
+        }
+        let driven_contract_count = ragdoll
+            .hinges
+            .iter()
+            .filter(|hinge| motor_target(hinge.kind, &profile).is_some())
+            .count();
+        let pelvis_speed = ragdoll
+            .focus_body
+            .and_then(|body| linear_velocities.get(body).ok())
+            .map_or(f32::NAN, |velocity| velocity.0.length());
+        finite &= pelvis_speed.is_finite();
+        telemetry.samples.push(MotorTelemetrySample {
+            tick: blend.tick,
+            strength: blend.strength,
+            driven_hinges: driven,
+            mean_error_radians: if driven_contract_count == 0 {
+                0.0
+            } else {
+                error_sum / driven_contract_count as f32
+            },
+            maximum_error_radians: maximum_error,
+            pelvis_speed,
+            finite,
+        });
+        const MAX_TELEMETRY_SAMPLES: usize = 256;
+        if telemetry.samples.len() > MAX_TELEMETRY_SAMPLES {
+            let excess = telemetry.samples.len() - MAX_TELEMETRY_SAMPLES;
+            telemetry.samples.drain(..excess);
+        }
+    }
+}
+
 fn capture_solved_body_poses(
     mut ragdolls: Query<(
         &HumanoidRagdoll,
         &mut CapturedRagdollPose,
         &mut RagdollPresentationFocus,
     )>,
-    body_poses: Query<(&Position, &Rotation)>,
+    body_poses: Query<(&Position, &Rotation, &LinearVelocity)>,
 ) {
     for (ragdoll, mut captured, mut focus) in &mut ragdolls {
         captured.0.clear();
         if let Some(focus_body) = ragdoll.focus_body
-            && let Ok((position, _)) = body_poses.get(focus_body)
+            && let Ok((position, _, linear_velocity)) = body_poses.get(focus_body)
         {
-            focus.0 = position.0;
+            focus.position = position.0;
+            focus.linear_velocity = linear_velocity.0;
         }
         for binding in &ragdoll.bindings {
-            if let Ok((position, rotation)) = body_poses.get(binding.body) {
+            if let Ok((position, rotation, _)) = body_poses.get(binding.body) {
                 captured.0.insert(
                     binding.bone,
                     Transform::from_translation(position.0).with_rotation(rotation.0),
@@ -588,8 +847,12 @@ mod tests {
             .map(|(role, _, _)| *role)
             .collect::<std::collections::BTreeSet<_>>();
         assert_eq!(unique.len(), BODY_SPECS.len());
-        assert!(HINGE_LINKS.contains(&(BoneRole::ThighLeft, BoneRole::ShinLeft)));
-        assert!(HINGE_LINKS.contains(&(BoneRole::UpperArmRight, BoneRole::ForearmRight)));
+        assert!(HINGE_LINKS.contains(&(BoneRole::ThighLeft, BoneRole::ShinLeft, HingeKind::Knee)));
+        assert!(HINGE_LINKS.contains(&(
+            BoneRole::UpperArmRight,
+            BoneRole::ForearmRight,
+            HingeKind::Elbow
+        )));
     }
 
     #[test]
@@ -648,5 +911,30 @@ mod tests {
         );
         assert!(!world.entity(body).contains::<RelativeKinematicBody>());
         assert!(world.entity(body).contains::<ManuallyOwnedRagdollBody>());
+    }
+
+    #[test]
+    fn mode_cycle_is_animated_active_passive() {
+        assert_eq!(RagdollMode::Animated.next(), RagdollMode::Active);
+        assert_eq!(RagdollMode::Active.next(), RagdollMode::Passive);
+        assert_eq!(RagdollMode::Passive.next(), RagdollMode::Animated);
+    }
+
+    #[test]
+    fn ankle_hinges_are_explicitly_not_driven() {
+        let profile = ActiveMotorProfile::default();
+        assert_eq!(motor_target(HingeKind::PassiveAnkle, &profile), None);
+        assert!(motor_target(HingeKind::Knee, &profile).is_some());
+        assert!(motor_target(HingeKind::Elbow, &profile).is_some());
+    }
+
+    #[test]
+    fn revolute_metric_matches_joint_frame_signed_angle() {
+        let joint = AvianRevoluteJoint::new(Entity::PLACEHOLDER, Entity::PLACEHOLDER)
+            .with_hinge_axis(Vec3::X);
+        let expected = 0.6;
+        let measured = revolute_angle(&joint, Quat::IDENTITY, Quat::from_rotation_x(expected))
+            .expect("local joint frames yield an angle");
+        assert!((wrapped_angle(expected - measured)).abs() < 1.0e-5);
     }
 }

--- a/crates/adventuresim-tactical-client/src/ragdoll_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/ragdoll_viewer.rs
@@ -1,14 +1,21 @@
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 use adventuresim_tactical_core::{physics::AdventureSimulatorPhysicsPlugin, prelude::*};
 use adventuresim_tactical_netcode::client::WeaponGuardInputState;
-use bevy::{asset::io::AssetSourceBuilder, prelude::*, window::PresentMode};
+use bevy::{
+    asset::io::AssetSourceBuilder,
+    prelude::*,
+    render::view::screenshot::{Screenshot, ScreenshotCaptured, save_to_disk},
+    window::PresentMode,
+};
+use serde::Serialize;
 
 use crate::{
     animation::{
         TacticalAnimationPlugin,
         ragdoll::{
-            HumanoidRagdollPlugin, RAGDOLL_LAYER, RagdollMode, RagdollPresentationFocus,
+            HumanoidRagdollPlugin, MotorTelemetrySample, RAGDOLL_LAYER, RagdollMode,
+            RagdollMotorTelemetry, RagdollPresentationFocus, RagdollPresentationReady,
             RagdollReset, TERRAIN_LAYER,
         },
     },
@@ -23,7 +30,19 @@ struct RagdollViewerSubject;
 #[derive(Component)]
 struct RagdollViewerLabel;
 
-pub(crate) fn run(asset_root: PathBuf) {
+pub(crate) fn run(asset_root: PathBuf, output: Option<PathBuf>) {
+    if let Some(output) = &output {
+        fs::create_dir_all(output)
+            .unwrap_or_else(|error| panic!("failed to create {output:?}: {error}"));
+        for name in ["manifest.json", "failure.txt"] {
+            let path = output.join(name);
+            if let Err(error) = fs::remove_file(&path)
+                && error.kind() != std::io::ErrorKind::NotFound
+            {
+                panic!("failed to invalidate {path:?}: {error}");
+            }
+        }
+    }
     let source = AssetSourceBuilder::platform_default(&asset_root.to_string_lossy(), None);
     App::new()
         .register_asset_source("workspace", source)
@@ -63,6 +82,7 @@ pub(crate) fn run(asset_root: PathBuf) {
         .insert_resource(CameraMode { third_person: true })
         .insert_resource(WeaponGuardInputState::default())
         .insert_resource(ClearColor(Color::srgb(0.08, 0.1, 0.13)))
+        .insert_resource(RagdollCapture::new(output))
         .add_systems(Startup, setup)
         .add_systems(Update, (keyboard_controls, update_label))
         .add_systems(
@@ -71,6 +91,7 @@ pub(crate) fn run(asset_root: PathBuf) {
                 .after(TacticalCameraSet::Offset)
                 .before(TransformSystems::Propagate),
         )
+        .add_systems(Last, capture_modes)
         .run();
 }
 
@@ -83,11 +104,93 @@ fn position_viewer_camera(
     subject: Single<(&Transform, Option<&RagdollPresentationFocus>), With<RagdollViewerSubject>>,
     mut cameras: Query<&mut Transform, (With<Camera3d>, Without<RagdollViewerSubject>)>,
 ) {
-    let focus = subject.1.map_or(subject.0.translation, |focus| focus.0);
+    let focus = subject
+        .1
+        .map_or(subject.0.translation, |focus| focus.position);
     let framed = viewer_camera_transform(focus);
     for mut camera in &mut cameras {
         *camera = framed;
     }
+}
+
+const CAPTURE_MODES: [(RagdollMode, &str, u32); 3] = [
+    (RagdollMode::Animated, "animated", 30),
+    (RagdollMode::Active, "active", 180),
+    (RagdollMode::Passive, "passive", 90),
+];
+const SETTLE_SPEED_WINDOW_TICKS: u64 = 30;
+
+fn fixed_steps_settled(start_tick: u64, current_tick: u64, required_steps: u32) -> bool {
+    current_tick.saturating_sub(start_tick) >= u64::from(required_steps)
+}
+
+#[derive(Resource)]
+struct RagdollCapture {
+    output: Option<PathBuf>,
+    stage: usize,
+    stage_started_tick: Option<u64>,
+    in_flight: bool,
+    captures: Vec<CaptureSample>,
+    active_initial_error: Option<f32>,
+}
+
+impl RagdollCapture {
+    fn new(output: Option<PathBuf>) -> Self {
+        Self {
+            output,
+            stage: 0,
+            stage_started_tick: None,
+            in_flight: false,
+            captures: Vec::new(),
+            active_initial_error: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CaptureSample {
+    mode: String,
+    screenshot: String,
+    telemetry: Option<MotorTelemetrySample>,
+    pelvis_position: [f32; 3],
+    terrain_height: Option<f32>,
+    pelvis_height_above_terrain: Option<f32>,
+    pelvis_speed: f32,
+    maximum_recent_pelvis_speed: f32,
+}
+
+#[derive(Serialize)]
+struct CaptureManifest {
+    pipeline: &'static str,
+    controls: &'static str,
+    captures: Vec<CaptureSample>,
+    validation: CaptureValidation,
+}
+
+#[derive(Serialize)]
+struct CaptureValidation {
+    all_modes_captured: bool,
+    finite_telemetry: bool,
+    active_hinges_driven: bool,
+    active_convergence_observed: bool,
+    passive_zero_strength: bool,
+    terrain_contact_bounded: bool,
+    pelvis_settled: bool,
+    note: &'static str,
+}
+
+fn pelvis_has_bounded_support(sample: &CaptureSample) -> bool {
+    sample
+        .pelvis_height_above_terrain
+        .is_some_and(|height| (-0.1..=0.75).contains(&height))
+}
+
+fn supported_and_settled(sample: &CaptureSample) -> bool {
+    const MAX_SETTLED_PELVIS_SPEED: f32 = 0.5;
+
+    pelvis_has_bounded_support(sample)
+        && sample.maximum_recent_pelvis_speed.is_finite()
+        && sample.maximum_recent_pelvis_speed <= MAX_SETTLED_PELVIS_SPEED
 }
 
 fn setup(mut commands: Commands) {
@@ -140,10 +243,7 @@ fn keyboard_controls(
     mut reset: ResMut<RagdollReset>,
 ) {
     if keyboard.just_pressed(KeyCode::KeyT) {
-        *mode = match *mode {
-            RagdollMode::Animated => RagdollMode::Passive,
-            RagdollMode::Passive => RagdollMode::Animated,
-        };
+        *mode = mode.next();
     }
     if keyboard.just_pressed(KeyCode::KeyR) {
         reset.0 = true;
@@ -156,13 +256,104 @@ fn update_label(mode: Res<RagdollMode>, mut labels: Query<&mut Text, With<Ragdol
         return;
     }
     for mut label in &mut labels {
-        label.0 = format!("Mode: {}\nT: animated/passive | R: reset", mode.label());
+        label.0 = format!(
+            "Mode: {}\nT: animated/active/passive | R: reset",
+            mode.label()
+        );
     }
+}
+
+fn capture_modes(
+    mut commands: Commands,
+    mut capture: ResMut<RagdollCapture>,
+    mut mode: ResMut<RagdollMode>,
+    ready: Query<&RagdollPresentationFocus, With<RagdollPresentationReady>>,
+    terrains: Query<&SceneTerrain>,
+    telemetry: Res<RagdollMotorTelemetry>,
+) {
+    let Some(output) = capture.output.clone() else {
+        return;
+    };
+    if capture.in_flight || capture.stage >= CAPTURE_MODES.len() {
+        return;
+    }
+    let Ok(focus) = ready.single() else {
+        return;
+    };
+    let Ok(terrain) = terrains.single() else {
+        return;
+    };
+    let (target_mode, slug, settle_fixed_steps) = CAPTURE_MODES[capture.stage];
+    if *mode != target_mode {
+        *mode = target_mode;
+        capture.stage_started_tick = None;
+        return;
+    }
+    let Some(current_tick) = telemetry.samples.last().map(|sample| sample.tick) else {
+        return;
+    };
+    let stage_started_tick = *capture.stage_started_tick.get_or_insert(current_tick);
+    if target_mode == RagdollMode::Active
+        && capture.active_initial_error.is_none()
+        && let Some(sample) = telemetry
+            .samples
+            .iter()
+            .find(|sample| sample.tick >= stage_started_tick && sample.strength >= 0.5)
+    {
+        capture.active_initial_error = Some(sample.mean_error_radians);
+    }
+    if !fixed_steps_settled(stage_started_tick, current_tick, settle_fixed_steps) {
+        return;
+    }
+
+    let screenshot = format!("{slug}.png");
+    let path = output.join(&screenshot);
+    let terrain_height = terrain.height_at(Vec2::new(focus.position.x, focus.position.z));
+    let recent_start_tick = current_tick
+        .saturating_sub(SETTLE_SPEED_WINDOW_TICKS)
+        .max(stage_started_tick);
+    let maximum_recent_pelvis_speed = telemetry
+        .samples
+        .iter()
+        .filter(|sample| sample.tick >= recent_start_tick)
+        .map(|sample| sample.pelvis_speed)
+        .try_fold(0.0_f32, |maximum, speed| {
+            speed.is_finite().then(|| maximum.max(speed))
+        })
+        .unwrap_or(f32::NAN);
+    let sample = CaptureSample {
+        mode: slug.to_owned(),
+        screenshot,
+        telemetry: telemetry.samples.last().cloned(),
+        pelvis_position: focus.position.to_array(),
+        terrain_height,
+        pelvis_height_above_terrain: terrain_height.map(|height| focus.position.y - height),
+        pelvis_speed: focus.linear_velocity.length(),
+        maximum_recent_pelvis_speed,
+    };
+    capture.in_flight = true;
+    commands.spawn(Screenshot::primary_window()).observe(
+        move |captured: On<ScreenshotCaptured>,
+              mut capture: ResMut<RagdollCapture>,
+              mut exit: MessageWriter<AppExit>| {
+            save_to_disk(&path)(captured);
+            capture.captures.push(sample.clone());
+            capture.stage += 1;
+            capture.stage_started_tick = None;
+            capture.in_flight = false;
+            if capture.stage == CAPTURE_MODES.len() {
+                finish_capture(&capture, &mut exit);
+            }
+        },
+    );
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{terrain_collision_layers, viewer_camera_transform};
+    use super::{
+        CaptureSample, fixed_steps_settled, pelvis_has_bounded_support, supported_and_settled,
+        terrain_collision_layers, viewer_camera_transform,
+    };
     use crate::animation::ragdoll::{RAGDOLL_LAYER, TERRAIN_LAYER};
     use avian3d::prelude::CollisionLayers;
     use bevy::prelude::*;
@@ -178,6 +369,34 @@ mod tests {
     }
 
     #[test]
+    fn capture_settle_uses_fixed_tick_delta_not_render_calls() {
+        assert!(!fixed_steps_settled(100, 129, 30));
+        assert!(fixed_steps_settled(100, 130, 30));
+        assert!(fixed_steps_settled(100, 131, 30));
+        assert!(!fixed_steps_settled(100, 99, 1));
+    }
+
+    #[test]
+    fn capture_rejects_freefall_and_accepts_supported_rest() {
+        let sample = |height, speed| CaptureSample {
+            mode: "passive".to_owned(),
+            screenshot: "passive.png".to_owned(),
+            telemetry: None,
+            pelvis_position: [0.0, height, 0.0],
+            terrain_height: Some(0.0),
+            pelvis_height_above_terrain: Some(height),
+            pelvis_speed: speed,
+            maximum_recent_pelvis_speed: speed,
+        };
+
+        assert!(supported_and_settled(&sample(0.4, 0.1)));
+        assert!(!supported_and_settled(&sample(-30.0, 24.0)));
+        assert!(!supported_and_settled(&sample(0.4, 1.0)));
+        assert!(!pelvis_has_bounded_support(&sample(1.0, 0.1)));
+        assert!(!pelvis_has_bounded_support(&sample(-0.2, 0.1)));
+    }
+
+    #[test]
     fn deterministic_camera_faces_subject_from_stable_three_quarter_offset() {
         let subject = Vec3::new(1.0, 2.0, -3.0);
         let camera = viewer_camera_transform(subject);
@@ -186,5 +405,82 @@ mod tests {
         assert!(camera.forward().as_vec3().dot(expected) > 0.9999);
         let distance = (camera.translation - subject).length();
         assert!(distance > 3.5 && distance < 4.0);
+    }
+}
+
+fn finish_capture(capture: &RagdollCapture, exit: &mut MessageWriter<AppExit>) {
+    let Some(output) = &capture.output else {
+        return;
+    };
+    let active = capture
+        .captures
+        .iter()
+        .find(|sample| sample.mode == "active");
+    let passive = capture
+        .captures
+        .iter()
+        .find(|sample| sample.mode == "passive");
+    let active_final = active
+        .and_then(|sample| sample.telemetry.as_ref())
+        .map(|sample| sample.mean_error_radians);
+    let validation = CaptureValidation {
+        all_modes_captured: capture.captures.len() == CAPTURE_MODES.len(),
+        finite_telemetry: capture
+            .captures
+            .iter()
+            .filter_map(|sample| sample.telemetry.as_ref())
+            .all(|sample| sample.finite),
+        active_hinges_driven: active
+            .and_then(|sample| sample.telemetry.as_ref())
+            .is_some_and(|sample| sample.driven_hinges == 4 && sample.strength >= 0.95),
+        active_convergence_observed: capture.active_initial_error.zip(active_final).is_some_and(
+            |(initial, final_error)| {
+                if initial <= 0.05 {
+                    final_error <= 0.05
+                } else {
+                    final_error <= initial * 0.8
+                }
+            },
+        ),
+        passive_zero_strength: passive
+            .and_then(|sample| sample.telemetry.as_ref())
+            .is_some_and(|sample| sample.strength <= 0.001 && sample.driven_hinges == 0),
+        terrain_contact_bounded: [active, passive]
+            .into_iter()
+            .flatten()
+            .all(pelvis_has_bounded_support),
+        pelvis_settled: [active, passive]
+            .into_iter()
+            .flatten()
+            .all(|sample| supported_and_settled(sample)),
+        note: "Terrain contact and settling are machine-gated; screenshots require visual review.",
+    };
+    let valid = validation.all_modes_captured
+        && validation.finite_telemetry
+        && validation.active_hinges_driven
+        && validation.active_convergence_observed
+        && validation.passive_zero_strength
+        && validation.terrain_contact_bounded
+        && validation.pelvis_settled;
+    let manifest = CaptureManifest {
+        pipeline: "cascadeur_humanoid_avian_ragdoll",
+        controls: "T cycles animated -> active -> passive; R resets",
+        captures: capture.captures.clone(),
+        validation,
+    };
+    fs::write(
+        output.join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest).expect("ragdoll manifest serializes"),
+    )
+    .unwrap_or_else(|error| panic!("failed to write ragdoll manifest: {error}"));
+    if !valid {
+        fs::write(
+            output.join("failure.txt"),
+            "Ragdoll capture validation failed; inspect manifest.json and screenshots.\n",
+        )
+        .unwrap_or_else(|error| panic!("failed to write ragdoll failure marker: {error}"));
+        exit.write(AppExit::Error(1.try_into().expect("one is non-zero")));
+    } else {
+        exit.write(AppExit::Success);
     }
 }

--- a/crates/adventuresim-tactical-client/src/ragdoll_viewer_main.rs
+++ b/crates/adventuresim-tactical-client/src/ragdoll_viewer_main.rs
@@ -25,6 +25,10 @@ use clap::Parser;
 struct Args {
     #[arg(long, default_value = "assets")]
     asset_root: PathBuf,
+
+    /// Capture animated, active, and passive review frames and exit.
+    #[arg(long)]
+    output: Option<PathBuf>,
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -37,7 +41,7 @@ fn main() {
             .expect("ragdoll viewer needs a working directory")
             .join(args.asset_root)
     };
-    ragdoll_viewer::run(asset_root);
+    ragdoll_viewer::run(asset_root, args.output);
 }
 
 #[cfg(target_family = "wasm")]

--- a/justfile
+++ b/justfile
@@ -317,6 +317,11 @@ animation-graph-preview scenario="steady-walk-2.0" output="target/animation-capt
 ragdoll-viewer asset_source="assets":
     @cargo run -p adventuresim-tactical-client --features animation-graph-physics --bin ragdoll-viewer -- --asset-root {{ quote(asset_source) }}
 
+# Capture animated, active-motor, and passive ragdoll review frames plus
+# manifest.json/failure.txt validation gates, then exit.
+ragdoll-capture output="target/animation-captures/ragdoll-review" asset_source="assets":
+    @cargo run -p adventuresim-tactical-client --features animation-graph-physics --bin ragdoll-viewer -- --asset-root {{ quote(asset_source) }} --output {{ quote(output) }}
+
 # Report whether the supervised tactical database, claim, authority, listener,
 # and recorded child identities are healthy.
 tactical-status:

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -1145,6 +1145,27 @@ network replication, recovery, or get-up behavior remains future work. The
 base evaluator preserves a clean final-pose stage so those decisions do not
 change authored pack semantics.
 
+The active fixture mode uses the fork's validated Avian adapter to drive the
+existing revolute knee and elbow joints. Strength ramps at the fixed physics
+rate; switching to passive ramps toward an explicit zero-torque, disabled
+motor rather than retaining an implicit solver default. Target, velocity,
+frequency, damping, and torque inputs are finite-checked and clamped by the
+dependency. This is hinge-only: Avian's spherical joints have limits but no
+corresponding angular motor API, so the hips, shoulders, spine, and neck are
+not claimed as actively driven.
+
+`just ragdoll-capture` advances animated, active, and passive modes for exact
+fixed-solver tick counts independent of render cadence, then records screenshots plus
+bounded telemetry in `manifest.json`. It gates finite metrics, driven hinge
+count, active error convergence, and passive zero strength, writing
+`failure.txt` on failure. The fixture terrain is also a real static physics
+collider restricted to the ragdoll layer, and capture rejects active or passive
+poses whose pelvis falls through the terrain or remains in high-speed motion.
+Settling is evaluated across the final half-second of fixed physics samples,
+not from one potentially misleading instant at the end of a bounce.
+These numeric gates catch wiring, collision, and solver regressions; the images
+remain the authority for presentation quality.
+
 ## Stylistic principles
 
 Animations should remain realistic in accordance with the


### PR DESCRIPTION
Stacked on #457 and depends on adventure-simulator-group/bevy_animation_graph#2. Pins the reviewed motor revision, adds animated -> active -> passive cycling, smoothly drives exactly four knee/elbow hinges while ankles remain passive, samples Avian-equivalent joint-frame error after physics, and captures all modes after exact fixed-solver tick counts. Controls: T cycles modes, R resets.

Capture now records global pelvis position, terrain clearance, instantaneous speed, and maximum speed across the final 30 fixed-physics ticks. It fails on non-finite telemetry, missing floor support, clearance outside -0.1 to 0.75 m, or maximum recent speed above 0.5 m/s, in addition to the existing motor/convergence/passive-strength gates. This prevents a pelvis-following camera from hiding unbounded freefall.

Final native capture passed with no failure marker: active clearance 0.184 m and max-window speed 0.165 m/s; passive clearance 0.184 m and max-window speed 0.035 m/s. All 122 focused tests passed and screenshots were visually inspected. This remains a native presentation experiment and does not move authoritative actors.