### PR TITLE
Fix tactical player transform root

### DIFF
--- a/crates/adventuresim-tactical-client/src/animation/diagnostics.rs
+++ b/crates/adventuresim-tactical-client/src/animation/diagnostics.rs
@@ -91,9 +91,11 @@ pub(super) fn log_animation_diagnostics(
     mut log: Option<ResMut<AnimationDiagnosticLog>>,
     input: Option<Res<DiagnosticInputStatus>>,
     render_schedule: Option<Res<RenderScheduleTelemetry>>,
+    terrains: Query<&SceneTerrain>,
     players: Query<
         (
             &Transform,
+            &GlobalTransform,
             &SkeletonState,
             &PresentedSkeleton,
             &AnimationPlayback,
@@ -116,7 +118,12 @@ pub(super) fn log_animation_diagnostics(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_micros().min(u64::MAX as u128) as u64)
         .unwrap_or_default();
-    for (transform, authoritative, presented, playback, semantic_graph) in &players {
+    let terrain = terrains.iter().next();
+    for (transform, global_transform, authoritative, presented, playback, semantic_graph) in
+        &players
+    {
+        let global_translation = global_transform.translation();
+        let terrain_height = terrain.and_then(|terrain| terrain.height_at(global_translation.xz()));
         let evaluation = AnimationEvaluation::from_skeleton(presented);
         let transition = playback.presentation_transition.as_ref().map(|transition| {
             serde_json::json!({
@@ -146,6 +153,13 @@ pub(super) fn log_animation_diagnostics(
                 "translation": transform.translation.to_array(),
                 "rotation_xyzw": transform.rotation.to_array(),
             },
+            "controller_global_transform": {
+                "translation": global_translation.to_array(),
+                "rotation_xyzw": global_transform.compute_transform().rotation.to_array(),
+            },
+            "terrain_height": terrain_height,
+            "controller_height_above_terrain": terrain_height
+                .map(|height| global_translation.y - height),
             "authoritative": authoritative,
             "presented": &presented.state,
             "presentation_phase_error_remaining": presented.phase_error_remaining,

--- a/crates/adventuresim-tactical-netcode/src/server.rs
+++ b/crates/adventuresim-tactical-netcode/src/server.rs
@@ -17,7 +17,10 @@ impl Plugin for AdventureSimulatorServerPlugin {
 }
 
 #[derive(Component, Debug, Clone)]
-#[require(Name::from("Server"), AeronetRepliconServer)]
+// Aeronet parents each connection entity to the server. Party players reuse their
+// connection entity, so the server must be a transform root for their world-space
+// transforms to remain valid.
+#[require(Name::from("Server"), AeronetRepliconServer, Transform)]
 pub struct AdventureSimulatorServer {
     pub addr: SocketAddr,
 }
@@ -48,4 +51,21 @@ fn websocket_config(addr: SocketAddr) -> ServerConfig {
     ServerConfig::builder()
         .with_bind_address(addr)
         .with_no_encryption()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_is_an_identity_transform_root() {
+        let mut world = World::new();
+        let server = world.spawn(AdventureSimulatorServer::default()).id();
+
+        assert_eq!(world.get::<Transform>(server), Some(&Transform::IDENTITY));
+        assert_eq!(
+            world.get::<GlobalTransform>(server),
+            Some(&GlobalTransform::IDENTITY)
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- make the Aeronet server entity an identity transform root for its child connection/player entities
- record controller global position, terrain height, and terrain-relative clearance in native animation diagnostics
- add a regression proving the server automatically receives identity local and global transforms

## Verification
- cargo test -p adventuresim-tactical-netcode --features server server_is_an_identity_transform_root
- cargo check -p adventuresim-tactical-client -p adventuresim-tactical-server
- cargo fmt --all -- --check
- git diff --check
- native just tactical-play diagnostic: 529 samples, 0 missing terrain samples, clearance 0.997-1.088 m, no B0004 hierarchy warning

Stacked on #458.