### PR TITLE
Revise tactical controls and guarded locomotion

### DIFF
--- a/crates/adventuresim-tactical-client/src/animation/loading.rs
+++ b/crates/adventuresim-tactical-client/src/animation/loading.rs
@@ -378,13 +378,7 @@ pub(super) fn bind_animation_target_paths(
     path.push(name.clone());
     let target = AnimationTargetId::from_names(path.iter());
     runtime.canonical_targets.insert(target);
-    let bone_name = name.as_str().to_ascii_lowercase();
-    let lower_body = bone_name == "skeleton"
-        || bone_name.contains("hips")
-        || bone_name.contains("thigh")
-        || bone_name.contains("shin")
-        || bone_name.contains("foot")
-        || bone_name.contains("toe");
+    let lower_body = is_lower_body_animation_target(name.as_str());
     if lower_body {
         runtime.lower_body_targets.insert(target);
     } else {
@@ -404,6 +398,18 @@ pub(super) fn bind_animation_target_paths(
             );
         }
     }
+}
+
+pub(super) fn is_lower_body_animation_target(name: &str) -> bool {
+    let bone_name = name.to_ascii_lowercase();
+    bone_name == "skeleton"
+        || bone_name == "root"
+        || bone_name == "pelvis"
+        || bone_name.contains("hips")
+        || bone_name.contains("thigh")
+        || bone_name.contains("shin")
+        || bone_name.contains("foot")
+        || bone_name.contains("toe")
 }
 
 pub(super) fn identify_animation_players(

--- a/crates/adventuresim-tactical-client/src/animation/loading.rs
+++ b/crates/adventuresim-tactical-client/src/animation/loading.rs
@@ -154,10 +154,28 @@ pub(super) fn collect_loaded_packs(
         .map(|(key, handle)| (key.clone(), handle.clone()))
         .collect::<Vec<_>>();
     let mut graph = AnimationGraph::new();
+    for target in &runtime.lower_body_targets {
+        graph.add_target_to_mask_group(*target, LOWER_BODY_MASK_GROUP);
+    }
+    for target in &runtime.upper_body_targets {
+        graph.add_target_to_mask_group(*target, UPPER_BODY_MASK_GROUP);
+    }
     runtime.clips = ordered
         .into_iter()
         .map(|(key, handle)| {
             let node = graph.add_clip(handle.clone(), 1.0, graph.root);
+            let upper_node = graph.add_clip_with_mask(
+                handle.clone(),
+                1 << LOWER_BODY_MASK_GROUP,
+                1.0,
+                graph.root,
+            );
+            let lower_node = graph.add_clip_with_mask(
+                handle.clone(),
+                1 << UPPER_BODY_MASK_GROUP,
+                1.0,
+                graph.root,
+            );
             let pack = &catalog.packs[&key.0];
             let anchor_motion = key.1.strip_suffix("_mirrored").unwrap_or(&key.1);
             let anchor_frames = pack
@@ -174,16 +192,50 @@ pub(super) fn collect_loaded_packs(
                 )
                 .collect::<BTreeSet<_>>();
             let anchor_nodes = anchor_frames
-                .into_iter()
+                .iter()
+                .copied()
                 .map(|frame| (frame, graph.add_clip(handle.clone(), 1.0, graph.root)))
                 .collect();
             let duration_seconds = clips.get(&handle).map_or(0.0, AnimationClip::duration);
+            let upper_anchor_nodes = anchor_frames
+                .iter()
+                .copied()
+                .map(|frame| {
+                    (
+                        frame,
+                        graph.add_clip_with_mask(
+                            handle.clone(),
+                            1 << LOWER_BODY_MASK_GROUP,
+                            1.0,
+                            graph.root,
+                        ),
+                    )
+                })
+                .collect();
+            let lower_anchor_nodes = anchor_frames
+                .into_iter()
+                .map(|frame| {
+                    (
+                        frame,
+                        graph.add_clip_with_mask(
+                            handle.clone(),
+                            1 << UPPER_BODY_MASK_GROUP,
+                            1.0,
+                            graph.root,
+                        ),
+                    )
+                })
+                .collect();
             (
                 key,
                 LoadedClip {
                     node,
                     duration_seconds,
                     anchor_nodes,
+                    upper_node,
+                    upper_anchor_nodes,
+                    lower_node,
+                    lower_anchor_nodes,
                 },
             )
         })
@@ -282,7 +334,7 @@ pub(super) fn establish_animation_targets(
             Vec::new(),
             &children,
             &names,
-            &mut runtime.canonical_targets,
+            &mut runtime,
         );
         commands.entity(rig_root).insert(RigAnimationTargetsBound);
     }
@@ -318,14 +370,26 @@ pub(super) fn bind_animation_target_paths(
     mut path: Vec<Name>,
     children: &Query<&Children>,
     names: &Query<&Name>,
-    canonical_targets: &mut HashSet<AnimationTargetId>,
+    runtime: &mut AnimationRuntime,
 ) {
     let Ok(name) = names.get(entity) else {
         return;
     };
     path.push(name.clone());
     let target = AnimationTargetId::from_names(path.iter());
-    canonical_targets.insert(target);
+    runtime.canonical_targets.insert(target);
+    let bone_name = name.as_str().to_ascii_lowercase();
+    let lower_body = bone_name == "skeleton"
+        || bone_name.contains("hips")
+        || bone_name.contains("thigh")
+        || bone_name.contains("shin")
+        || bone_name.contains("foot")
+        || bone_name.contains("toe");
+    if lower_body {
+        runtime.lower_body_targets.insert(target);
+    } else {
+        runtime.upper_body_targets.insert(target);
+    }
     commands.entity(entity).insert((target, AnimatedBy(player)));
     if let Ok(entity_children) = children.get(entity) {
         for child in entity_children.iter() {
@@ -336,7 +400,7 @@ pub(super) fn bind_animation_target_paths(
                 path.clone(),
                 children,
                 names,
-                canonical_targets,
+                runtime,
             );
         }
     }

--- a/crates/adventuresim-tactical-client/src/animation/mod.rs
+++ b/crates/adventuresim-tactical-client/src/animation/mod.rs
@@ -28,6 +28,8 @@ const HUMANOID_UNARMED_PACK: &str = "humanoid_unarmed";
 const BIPED_BASE_GLB: &str = "animations/biped/unarmed/base.glb";
 const ANIMATION_FPS: f32 = 30.0;
 const PRESENTATION_CROSSFADE_SECONDS: f32 = 0.18;
+const LOWER_BODY_MASK_GROUP: u32 = 0;
+const UPPER_BODY_MASK_GROUP: u32 = 1;
 // Player transforms sit at the center of the 1.9 m server collider, while
 // authored rigs use a floor-level origin. Keep visual feet on the collider's
 // lower face so the first-person camera lands at the authored head.
@@ -79,14 +81,41 @@ struct LoadedClip {
     node: AnimationNodeIndex,
     duration_seconds: f32,
     anchor_nodes: BTreeMap<u16, AnimationNodeIndex>,
+    upper_node: AnimationNodeIndex,
+    upper_anchor_nodes: BTreeMap<u16, AnimationNodeIndex>,
+    lower_node: AnimationNodeIndex,
+    lower_anchor_nodes: BTreeMap<u16, AnimationNodeIndex>,
 }
 
 impl LoadedClip {
     fn at_anchor(&self, frame: u16) -> Self {
+        self.at_anchor_layer(frame, ClipLayer::Whole)
+    }
+
+    fn at_anchor_layer(&self, frame: u16, layer: ClipLayer) -> Self {
         let mut clip = self.clone();
-        clip.node = self.anchor_nodes.get(&frame).copied().unwrap_or(self.node);
+        clip.node = match layer {
+            ClipLayer::Whole => self.anchor_nodes.get(&frame).copied().unwrap_or(self.node),
+            ClipLayer::Upper => self
+                .upper_anchor_nodes
+                .get(&frame)
+                .copied()
+                .unwrap_or(self.upper_node),
+            ClipLayer::Lower => self
+                .lower_anchor_nodes
+                .get(&frame)
+                .copied()
+                .unwrap_or(self.lower_node),
+        };
         clip
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClipLayer {
+    Whole,
+    Upper,
+    Lower,
 }
 
 #[derive(Resource, Default)]
@@ -104,6 +133,8 @@ struct AnimationRuntime {
     graph: Option<Handle<AnimationGraph>>,
     revision: u64,
     canonical_targets: HashSet<AnimationTargetId>,
+    lower_body_targets: HashSet<AnimationTargetId>,
+    upper_body_targets: HashSet<AnimationTargetId>,
 }
 
 #[derive(Component, Debug)]
@@ -249,15 +280,34 @@ fn evaluate_skeletons(
                 mirrored > exact
             });
         let mut weighted = Vec::<WeightedClip>::new();
+        let base_layer = if evaluation.action.is_empty() && !evaluation.lower_body.is_empty() {
+            ClipLayer::Upper
+        } else {
+            ClipLayer::Whole
+        };
         for sample in samples {
-            append_resolved_sample(
+            append_resolved_sample_layer(
                 &mut weighted,
                 &runtime,
                 &catalog,
                 &skeleton.animation_pack,
                 *sample,
                 coherent_guard_parity,
+                base_layer,
             );
+        }
+        if evaluation.action.is_empty() {
+            for sample in &evaluation.lower_body {
+                append_resolved_sample_layer(
+                    &mut weighted,
+                    &runtime,
+                    &catalog,
+                    &skeleton.animation_pack,
+                    *sample,
+                    None,
+                    ClipLayer::Lower,
+                );
+            }
         }
         let target = PlaybackPose {
             use_authored_bind_pose: weighted.is_empty(),
@@ -732,8 +782,9 @@ fn append_weighted_anchor(
     resolved: &ResolvedAnchor,
     frame: u16,
     weight: f32,
+    layer: ClipLayer,
 ) {
-    let clip = resolved.clip.at_anchor(frame);
+    let clip = resolved.clip.at_anchor_layer(frame, layer);
     append_weighted_clip(
         weighted,
         &clip,
@@ -778,6 +829,26 @@ fn append_resolved_sample(
     sample: PoseSample,
     forced_mirror_parity: Option<bool>,
 ) {
+    append_resolved_sample_layer(
+        weighted,
+        runtime,
+        catalog,
+        pack,
+        sample,
+        forced_mirror_parity,
+        ClipLayer::Whole,
+    );
+}
+
+fn append_resolved_sample_layer(
+    weighted: &mut Vec<WeightedClip>,
+    runtime: &AnimationRuntime,
+    catalog: &AnimationPackCatalog,
+    pack: &str,
+    sample: PoseSample,
+    forced_mirror_parity: Option<bool>,
+    layer: ClipLayer,
+) {
     let start = match forced_mirror_parity {
         Some(mirrored) => resolve_anchor_with_parity(runtime, catalog, pack, sample.pose, mirrored),
         None => resolve_anchor(runtime, catalog, pack, sample.pose),
@@ -789,7 +860,7 @@ fn append_resolved_sample(
     };
     match sample.sampling {
         PoseSampling::Anchor => {
-            append_weighted_anchor(weighted, &start, start.anchor.frame, sample.weight)
+            append_weighted_anchor(weighted, &start, start.anchor.frame, sample.weight, layer)
         }
         PoseSampling::Cycle { phase } => {
             append_weighted_clip(
@@ -810,7 +881,7 @@ fn append_resolved_sample(
                 None => resolve_anchor(runtime, catalog, pack, end_pose),
             };
             let Some(end) = end else {
-                append_weighted_anchor(weighted, &start, start.anchor.frame, sample.weight);
+                append_weighted_anchor(weighted, &start, start.anchor.frame, sample.weight, layer);
                 return;
             };
             if start.pack_id == end.pack_id && start.anchor.motion == end.anchor.motion {
@@ -819,8 +890,15 @@ fn append_resolved_sample(
                     &start,
                     start.anchor.frame,
                     sample.weight * (1.0 - progress),
+                    layer,
                 );
-                append_weighted_anchor(weighted, &end, end.anchor.frame, sample.weight * progress);
+                append_weighted_anchor(
+                    weighted,
+                    &end,
+                    end.anchor.frame,
+                    sample.weight * progress,
+                    layer,
+                );
             } else if let Some(reference) = catalog.packs[end.pack_id]
                 .references
                 .get(&end.anchor.motion)
@@ -836,8 +914,15 @@ fn append_resolved_sample(
                     &end,
                     reference.frame,
                     sample.weight * (1.0 - progress),
+                    layer,
                 );
-                append_weighted_anchor(weighted, &end, end.anchor.frame, sample.weight * progress);
+                append_weighted_anchor(
+                    weighted,
+                    &end,
+                    end.anchor.frame,
+                    sample.weight * progress,
+                    layer,
+                );
             } else if let Some(reference) = catalog.packs[start.pack_id]
                 .references
                 .get(&start.anchor.motion)
@@ -853,16 +938,30 @@ fn append_resolved_sample(
                     &start,
                     start.anchor.frame,
                     sample.weight * (1.0 - progress),
+                    layer,
                 );
-                append_weighted_anchor(weighted, &start, reference.frame, sample.weight * progress);
+                append_weighted_anchor(
+                    weighted,
+                    &start,
+                    reference.frame,
+                    sample.weight * progress,
+                    layer,
+                );
             } else {
                 append_weighted_anchor(
                     weighted,
                     &start,
                     start.anchor.frame,
                     sample.weight * (1.0 - progress),
+                    layer,
                 );
-                append_weighted_anchor(weighted, &end, end.anchor.frame, sample.weight * progress);
+                append_weighted_anchor(
+                    weighted,
+                    &end,
+                    end.anchor.frame,
+                    sample.weight * progress,
+                    layer,
+                );
             }
         }
     }

--- a/crates/adventuresim-tactical-client/src/animation/procedural/ik/locomotion.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural/ik/locomotion.rs
@@ -14,7 +14,8 @@ pub(super) fn owns(skeleton: &SkeletonState) -> bool {
     skeleton.is_grounded()
         && matches!(skeleton.posture(), Posture::Upright | Posture::Crouched)
         && skeleton.action_kind() == SkeletonAction::None
-        && skeleton.weapon_guard() == WeaponGuardState::Lowered
+        && (skeleton.weapon_guard() == WeaponGuardState::Lowered
+            || skeleton.guarded_sprint_locomotion())
 }
 
 /// Overgrowth-style ordinary locomotion IK: the graph supplies the complete
@@ -288,9 +289,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ordinary_ownership_excludes_guard_and_actions() {
+    fn ordinary_ownership_selects_guarded_sprint_but_excludes_guard_steps_and_actions() {
         let ordinary = SkeletonState::default();
         assert!(owns(&ordinary));
+
+        let guard_step = ordinary.clone().with_weapon_guard(WeaponGuardState::Raised);
+        assert!(!owns(&guard_step));
+
+        let guarded_sprint = guard_step.with_guarded_sprint_locomotion(true);
+        assert!(owns(&guarded_sprint));
 
         let mut attacking = ordinary.clone();
         attacking.begin_attack(AttackSpec::default(), 0, 1);

--- a/crates/adventuresim-tactical-client/src/animation/procedural/ik/mod.rs
+++ b/crates/adventuresim-tactical-client/src/animation/procedural/ik/mod.rs
@@ -779,6 +779,7 @@ pub(in crate::animation) fn apply_terrain_leg_ik(
         let raised_guard_follower = !attack_footwork_active
             && raised_footwork_posture_is_valid(skeleton)
             && skeleton.weapon_guard() == WeaponGuardState::Raised
+            && !skeleton.guarded_sprint_locomotion()
             && skeleton.action_kind() == SkeletonAction::None
             && skeleton.raised_locomotion().is_moving();
         let raised_footwork_was_active = raised_states

--- a/crates/adventuresim-tactical-client/src/animation/tests.rs
+++ b/crates/adventuresim-tactical-client/src/animation/tests.rs
@@ -625,7 +625,7 @@ mod legacy_tests {
             }
             let node_base = runtime.clips.len() * 256;
             let pack = &catalog.packs[HUMANOID_UNARMED_PACK];
-            let anchor_nodes = pack
+            let anchor_nodes: BTreeMap<u16, AnimationNodeIndex> = pack
                 .poses
                 .values()
                 .filter(|candidate| candidate.motion == anchor.motion)
@@ -647,7 +647,11 @@ mod legacy_tests {
                 LoadedClip {
                     node: AnimationNodeIndex::new(node_base),
                     duration_seconds: 64.0 / ANIMATION_FPS,
-                    anchor_nodes,
+                    anchor_nodes: anchor_nodes.clone(),
+                    upper_node: AnimationNodeIndex::new(node_base),
+                    upper_anchor_nodes: anchor_nodes.clone(),
+                    lower_node: AnimationNodeIndex::new(node_base),
+                    lower_anchor_nodes: anchor_nodes,
                 },
             );
         }
@@ -746,6 +750,10 @@ mod legacy_tests {
                 node: AnimationNodeIndex::new(9_000),
                 duration_seconds: 64.0 / ANIMATION_FPS,
                 anchor_nodes: BTreeMap::from([(0, mirrored_node)]),
+                upper_node: AnimationNodeIndex::new(9_000),
+                upper_anchor_nodes: BTreeMap::from([(0, mirrored_node)]),
+                lower_node: AnimationNodeIndex::new(9_000),
+                lower_anchor_nodes: BTreeMap::from([(0, mirrored_node)]),
             },
         );
         let mut weighted = Vec::new();

--- a/crates/adventuresim-tactical-client/src/animation/tests.rs
+++ b/crates/adventuresim-tactical-client/src/animation/tests.rs
@@ -821,6 +821,32 @@ mod legacy_tests {
     }
 
     #[test]
+    fn composite_mask_keeps_root_pelvis_and_legs_out_of_the_upper_body() {
+        for lower in [
+            "Skeleton",
+            "root",
+            "pelvis",
+            "thigh.L",
+            "thigh_twist.R",
+            "shin.L",
+            "foot.R",
+            "toe.L",
+        ] {
+            assert!(is_lower_body_animation_target(lower), "{lower}");
+        }
+        for upper in [
+            "stomach_01",
+            "stomach_02",
+            "chest",
+            "clavicle.L",
+            "upper_arm.R",
+            "head",
+        ] {
+            assert!(!is_lower_body_animation_target(upper), "{upper}");
+        }
+    }
+
+    #[test]
     fn authored_rig_attaches_to_a_player_with_skeleton_state() {
         let mut world = World::new();
         let mut runtime = AnimationRuntime::default();

--- a/crates/adventuresim-tactical-client/src/animation_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/animation_viewer.rs
@@ -1460,10 +1460,6 @@ fn drive_sequence(
             Quat::from_euler(EulerRot::YXZ, frame.camera_yaw, frame.camera_pitch, 0.0);
         look.yaw = frame.camera_yaw;
         look.pitch = frame.camera_pitch;
-        let wheel = match frame.weapon_guard {
-            WeaponGuardState::Raised => 1.0,
-            WeaponGuardState::Lowered => -1.0,
-        };
         let attack_start_frame = frame.scenario.starts_with("attack-step-").then_some(8);
         if frame.action != SkeletonAction::Attack
             || attack_start_frame == Some(frame.scenario_frame)
@@ -1471,7 +1467,7 @@ fn drive_sequence(
             skeleton.lead_foot = frame.lead_foot;
         }
         terrain_ik.0 = terrain_ik_enabled_for_frame(&frame);
-        guard_input.apply_controls(wheel, false);
+        guard_input.desired = frame.weapon_guard;
         set_weapon_guard(&mut skeleton, guard_input.desired);
         let grounded = metadata.kind != ScenarioKind::Landing || frame.scenario_frame >= 32;
         let vertical_velocity = if metadata.kind == ScenarioKind::Landing && !grounded {

--- a/crates/adventuresim-tactical-client/src/camera.rs
+++ b/crates/adventuresim-tactical-client/src/camera.rs
@@ -1,6 +1,6 @@
 use adventuresim_tactical_core::prelude::{
-    CharacterControllerCameraOf, CharacterControllerState, Collider, ShapeCastConfig, SpatialQuery,
-    SpatialQueryFilter, WeaponGuardState,
+    CharacterControllerCameraOf, CharacterControllerState, Collider, PlayerEquipment,
+    ShapeCastConfig, SpatialQuery, SpatialQueryFilter, TacticalPlayerViewer, WeaponGuardState,
 };
 use adventuresim_tactical_netcode::client::WeaponGuardInputState;
 use bevy::prelude::*;
@@ -382,17 +382,29 @@ fn update_camera_aim(
     spatial: SpatialQuery,
     cameras: Query<(&Transform, &CharacterControllerCameraOf)>,
     controllers: Query<&Transform, Without<CharacterControllerCameraOf>>,
+    viewer: TacticalPlayerViewer,
     mut aim: ResMut<CameraAimState>,
 ) {
-    aim.active = mode.third_person && guard.desired == WeaponGuardState::Raised;
-    if !aim.active {
+    let raised = mode.third_person && guard.desired == WeaponGuardState::Raised;
+    if !raised {
+        aim.active = false;
         aim.blocked = false;
         aim.camera_hit = None;
         aim.actual_hit = None;
         return;
     }
+    aim.active = false;
 
     for (camera, camera_of) in &cameras {
+        aim.active = viewer
+            .get(camera_of.character_controller)
+            .is_ok_and(|player| player.weapon_is_ranged());
+        if !aim.active {
+            aim.blocked = false;
+            aim.camera_hit = None;
+            aim.actual_hit = None;
+            continue;
+        }
         let Ok(controller) = controllers.get(camera_of.character_controller) else {
             continue;
         };

--- a/crates/adventuresim-tactical-client/src/diagnostics.rs
+++ b/crates/adventuresim-tactical-client/src/diagnostics.rs
@@ -333,6 +333,9 @@ fn drive_scripted_input(
             movement,
             look: script.look,
             jump: false,
+            crouch: false,
+            prone: false,
+            pace: MovementPace::Sprint,
             weapon_guard: script.weapon_guard,
         };
         input_override.0 = Some(request);

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -1,6 +1,7 @@
 use adventuresim_tactical_core::prelude::*;
 use adventuresim_tactical_netcode::{
     bevy_replicon::prelude::ClientTriggerExt,
+    client::DirectControlState,
     message::{DefendRequest, MeleeActionRequest, RangedActionRequest},
 };
 use bevy::prelude::*;
@@ -63,7 +64,10 @@ impl Plugin for PlayerPlugin {
             .add_observer(on_parry_fired)
             .add_systems(
                 Update,
-                update_attack_state_system.run_if(any_with_component::<AttackState>),
+                (
+                    apply_direct_combat_controls,
+                    update_attack_state_system.run_if(any_with_component::<AttackState>),
+                ),
             );
     }
 }
@@ -142,10 +146,6 @@ fn on_new_player_added_hook(
                     ))
                 ),
                 (
-                    Action::<input::Jump>::new(),
-                    bindings![KeyCode::Space, GamepadButton::South],
-                ),
-                (
                     Action::<input::RotateCamera>::new(),
                     Bindings::spawn((
                         Spawn((Binding::mouse_motion(), Scale::splat(0.15))),
@@ -154,14 +154,6 @@ fn on_new_player_added_hook(
                             DeadZone::default(),
                         )),
                     ))
-                ),
-                (
-                    Action::<Attack>::new(),
-                    bindings![MouseButton::Left],
-                ),
-                (
-                    Action::<Dodge>::new(),
-                    bindings![KeyCode::KeyF],
                 ),
                 (
                     Action::<Parry>::new(),
@@ -332,13 +324,23 @@ fn on_attack_fired_hook(
     viewer: TacticalPlayerViewer,
     time: Res<Time>,
 ) {
-    let Ok((attacking, mut skeleton)) = q_character.get_mut(event.context) else {
+    try_start_attack(event.context, &mut cmd, &mut q_character, &viewer, &time);
+}
+
+fn try_start_attack(
+    entity: Entity,
+    cmd: &mut Commands,
+    q_character: &mut Query<(Has<AttackState>, &mut SkeletonState)>,
+    viewer: &TacticalPlayerViewer,
+    time: &Time,
+) {
+    let Ok((attacking, mut skeleton)) = q_character.get_mut(entity) else {
         return;
     };
     if attacking {
         return;
     }
-    let Ok((reach, ranged, melee)) = viewer.get(event.context).map(|character| {
+    let Ok((reach, ranged, melee)) = viewer.get(entity).map(|character| {
         (
             character.weapon_reach(),
             character.weapon_is_ranged(),
@@ -353,7 +355,7 @@ fn on_attack_fired_hook(
         warn!("Trying to attack without a usable equipped weapon");
         return;
     }
-    cmd.entity(event.context)
+    cmd.entity(entity)
         .insert(AttackState::new(PRE_HIT_DELAY, reach, ranged));
     let start = (time.elapsed_secs_f64() * LOCOMOTION_SAMPLE_HZ as f64).round() as u64;
     let predicted = if ranged {
@@ -370,6 +372,28 @@ fn on_attack_fired_hook(
         cmd.client_trigger(RangedActionRequest::Start);
     } else {
         cmd.client_trigger(MeleeActionRequest::Start);
+    }
+}
+
+fn apply_direct_combat_controls(
+    controls: Res<DirectControlState>,
+    mut cmd: Commands,
+    players: Query<Entity, With<ControlledPlayer>>,
+    mut q_character: Query<(Has<AttackState>, &mut SkeletonState)>,
+    viewer: TacticalPlayerViewer,
+    time: Res<Time>,
+) {
+    for entity in &players {
+        if controls.attack_just_pressed {
+            try_start_attack(entity, &mut cmd, &mut q_character, &viewer, &time);
+        }
+        if controls.dodge_just_pressed {
+            if let Ok((_, mut skeleton)) = q_character.get_mut(entity) {
+                let start = (time.elapsed_secs_f64() * LOCOMOTION_SAMPLE_HZ as f64).round() as u64;
+                skeleton.begin_dodge(DodgeSpec::default(), start, start + 8);
+            }
+            cmd.client_trigger(DefendRequest::Dodge);
+        }
     }
 }
 

--- a/crates/adventuresim-tactical-client/src/player.rs
+++ b/crates/adventuresim-tactical-client/src/player.rs
@@ -57,7 +57,8 @@ impl Plugin for PlayerPlugin {
         // Replication supplies Transform but not a render hierarchy root.
         // Require visibility before Add<Player> observers attach mesh children
         // so authored rigs cannot inherit from a component-less parent.
-        app.register_required_components_with::<Player, _>(|| Visibility::Inherited)
+        app.init_resource::<DirectControlState>()
+            .register_required_components_with::<Player, _>(|| Visibility::Inherited)
             .add_observer(on_new_player_added_hook)
             .add_observer(on_attack_fired_hook)
             .add_observer(on_dodge_fired)

--- a/crates/adventuresim-tactical-client/src/ui.rs
+++ b/crates/adventuresim-tactical-client/src/ui.rs
@@ -395,15 +395,20 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 fn update_weapon_guard_ui(
     guard: Res<WeaponGuardInputState>,
+    players: Query<Entity, With<ControlledPlayer>>,
+    viewer: TacticalPlayerViewer,
     mut spans: Query<&mut TextSpan, With<WeaponGuardSpan>>,
 ) {
-    if !guard.is_changed() {
-        return;
-    }
+    let ranged = players
+        .iter()
+        .next()
+        .and_then(|entity| viewer.get(entity).ok())
+        .is_some_and(|player| player.weapon_is_ranged());
     for mut span in &mut spans {
         **span = match guard.desired {
             WeaponGuardState::Lowered => "Lowered".to_owned(),
-            WeaponGuardState::Raised => "Raised".to_owned(),
+            WeaponGuardState::Raised if ranged => "Aiming".to_owned(),
+            WeaponGuardState::Raised => "Blocking".to_owned(),
         };
     }
 }

--- a/crates/adventuresim-tactical-core/src/animation/evaluation.rs
+++ b/crates/adventuresim-tactical-core/src/animation/evaluation.rs
@@ -29,6 +29,9 @@ pub struct PoseSample {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AnimationEvaluation {
     pub base: Vec<PoseSample>,
+    /// Optional locomotion layer evaluated only on the pelvis and legs. This
+    /// lets a raised upper-body guard retain an ordinary walk/run blend.
+    pub lower_body: Vec<PoseSample>,
     pub action: Vec<PoseSample>,
     pub movement_speed: f32,
     pub gait_phase: f32,
@@ -73,9 +76,18 @@ impl AnimationEvaluation {
                 locomotion_samples(speed, gait_phase, crouch_amount)
             }
         };
+        let lower_body = if state.posture() == Posture::Upright
+            && state.weapon_guard() == WeaponGuardState::Raised
+            && speed > RAISED_GUARD_LOCOMOTION_PROFILE.reference_speed
+        {
+            locomotion_samples(speed, gait_phase, 0.0)
+        } else {
+            Vec::new()
+        };
         let action = action_samples(state);
         Self {
             base,
+            lower_body,
             action,
             movement_speed: speed,
             gait_phase,

--- a/crates/adventuresim-tactical-core/src/animation/evaluation.rs
+++ b/crates/adventuresim-tactical-core/src/animation/evaluation.rs
@@ -76,9 +76,9 @@ impl AnimationEvaluation {
                 locomotion_samples(speed, gait_phase, crouch_amount)
             }
         };
-        let lower_body = if state.posture() == Posture::Upright
-            && state.weapon_guard() == WeaponGuardState::Raised
-            && speed > RAISED_GUARD_LOCOMOTION_PROFILE.reference_speed
+        let lower_body = if state.guarded_sprint_locomotion()
+            && state.raised_locomotion().is_moving()
+            && speed > 0.05
         {
             locomotion_samples(speed, gait_phase, 0.0)
         } else {

--- a/crates/adventuresim-tactical-core/src/animation/state.rs
+++ b/crates/adventuresim-tactical-core/src/animation/state.rs
@@ -499,6 +499,7 @@ pub struct SkeletonState {
     pub landing_sequence: u64,
     pub landing_impact_speed: f32,
     pub lead_foot: LeadFoot,
+    guarded_sprint_locomotion: bool,
     stance: StanceState,
     action: ActionState,
     pub animation_pack: String,
@@ -517,6 +518,7 @@ struct SkeletonStateWire {
     landing_sequence: u64,
     landing_impact_speed: f32,
     lead_foot: LeadFoot,
+    guarded_sprint_locomotion: bool,
     stance: StanceState,
     action: ActionState,
     animation_pack: String,
@@ -549,11 +551,13 @@ impl<'de> Deserialize<'de> for SkeletonState {
                 0.0
             },
             lead_foot: wire.lead_foot,
+            guarded_sprint_locomotion: wire.guarded_sprint_locomotion,
             stance: wire.stance,
             action: wire.action,
             animation_pack: wire.animation_pack,
         };
         state.transition_body(wire.body);
+        state.set_guarded_sprint_locomotion(wire.guarded_sprint_locomotion);
         Ok(state)
     }
 }
@@ -572,6 +576,7 @@ impl Default for SkeletonState {
             landing_sequence: 0,
             landing_impact_speed: 0.0,
             lead_foot: LeadFoot::Left,
+            guarded_sprint_locomotion: false,
             stance: StanceState::Lowered,
             action: ActionState::default(),
             animation_pack: "humanoid_unarmed".to_owned(),
@@ -594,6 +599,7 @@ pub fn set_weapon_guard(skeleton: &mut SkeletonState, weapon_guard: WeaponGuardS
         (StanceState::Lowered, WeaponGuardState::Raised) => {}
         (StanceState::Raised { .. }, WeaponGuardState::Lowered) => {
             skeleton.stance = StanceState::Lowered;
+            skeleton.guarded_sprint_locomotion = false;
         }
     }
 }
@@ -646,6 +652,9 @@ impl SkeletonState {
     /// Entering a downed mode also cancels presentation actions.
     pub fn transition_body(&mut self, body: BodyState) {
         self.body = body;
+        if body != BodyState::Grounded(GroundedPosture::Upright) {
+            self.guarded_sprint_locomotion = false;
+        }
         if body.is_downed() {
             self.stance = StanceState::Lowered;
             self.action = ActionState::default();
@@ -665,6 +674,20 @@ impl SkeletonState {
     pub fn with_raised_locomotion(mut self, locomotion: RaisedLocomotionIntent) -> Self {
         self.set_raised_locomotion(locomotion);
         self
+    }
+    pub fn set_guarded_sprint_locomotion(&mut self, enabled: bool) {
+        self.guarded_sprint_locomotion = enabled
+            && self.body == BodyState::Grounded(GroundedPosture::Upright)
+            && self.weapon_guard() == WeaponGuardState::Raised;
+    }
+    pub fn with_guarded_sprint_locomotion(mut self, enabled: bool) -> Self {
+        self.set_guarded_sprint_locomotion(enabled);
+        self
+    }
+    pub fn guarded_sprint_locomotion(&self) -> bool {
+        self.guarded_sprint_locomotion
+            && self.body == BodyState::Grounded(GroundedPosture::Upright)
+            && self.weapon_guard() == WeaponGuardState::Raised
     }
     pub fn weapon_guard(&self) -> WeaponGuardState {
         match self.stance {

--- a/crates/adventuresim-tactical-core/src/animation/tests.rs
+++ b/crates/adventuresim-tactical-core/src/animation/tests.rs
@@ -643,6 +643,7 @@ mod legacy_tests {
                 .with_local_velocity(Vec3::new(0.0, 0.0, -3.75))
                 .with_gait_phase(0.25)
                 .with_weapon_guard(WeaponGuardState::Raised)
+                .with_guarded_sprint_locomotion(true)
                 .with_raised_locomotion(raised_intent(Vec3::new(0.0, 0.0, -3.75))),
         );
         assert_eq!(evaluation.base[0].pose, SemanticPose::GuardLeadLeft);
@@ -653,6 +654,21 @@ mod legacy_tests {
                 | SemanticPose::RunContact
                 | SemanticPose::RunFlight
         )));
+    }
+
+    #[test]
+    fn ordinary_guard_movement_keeps_procedural_legs_even_above_guard_speed() {
+        let evaluation = AnimationEvaluation::from_skeleton(
+            &SkeletonState::default()
+                .with_local_velocity(Vec3::new(0.0, 0.0, -3.75))
+                .with_gait_phase(0.25)
+                .with_weapon_guard(WeaponGuardState::Raised)
+                .with_raised_locomotion(raised_intent(Vec3::new(0.0, 0.0, -3.75))),
+        );
+
+        assert!(evaluation.lower_body.is_empty());
+        assert_eq!(evaluation.base.len(), 1);
+        assert_eq!(evaluation.base[0].pose, SemanticPose::GuardLeadLeft);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-core/src/animation/tests.rs
+++ b/crates/adventuresim-tactical-core/src/animation/tests.rs
@@ -637,6 +637,25 @@ mod legacy_tests {
     }
 
     #[test]
+    fn raised_guard_jog_layers_ordinary_locomotion_under_static_guard() {
+        let evaluation = AnimationEvaluation::from_skeleton(
+            &SkeletonState::default()
+                .with_local_velocity(Vec3::new(0.0, 0.0, -3.75))
+                .with_gait_phase(0.25)
+                .with_weapon_guard(WeaponGuardState::Raised)
+                .with_raised_locomotion(raised_intent(Vec3::new(0.0, 0.0, -3.75))),
+        );
+        assert_eq!(evaluation.base[0].pose, SemanticPose::GuardLeadLeft);
+        assert!(evaluation.lower_body.iter().any(|sample| matches!(
+            sample.pose,
+            SemanticPose::WalkContact
+                | SemanticPose::WalkPassing
+                | SemanticPose::RunContact
+                | SemanticPose::RunFlight
+        )));
+    }
+
+    #[test]
     fn entering_raised_guard_resets_to_static_guard_endpoint_once() {
         let mut state = SkeletonState::default()
             .with_gait_phase(0.63)

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -35,10 +35,12 @@ pub mod prelude {
         InventoryItems, ItemOf, ItemProperties, ItemQuantity, ShieldItem, WeaponItem,
     };
     pub use crate::physics::{
-        AdventureSimulatorPhysicsSet, TACTICAL_GUARD_SPEED_METRES_PER_SECOND,
-        TACTICAL_RUN_SPEED_METRES_PER_SECOND, tactical_character_controller,
+        AdventureSimulatorPhysicsSet, BREATH_PER_METRE_PER_SECOND,
+        BREATH_RECOVERY_PER_ENDURANCE_PER_SECOND, MovementPace,
+        TACTICAL_GUARD_SPEED_METRES_PER_SECOND, TACTICAL_RUN_SPEED_METRES_PER_SECOND,
+        TACTICAL_WALK_SPEED_METRES_PER_SECOND, tactical_character_controller, tactical_jog_speed,
         tactical_movement_acceleration_hz_for_guard, tactical_movement_speed,
-        tactical_movement_speed_for_guard,
+        tactical_movement_speed_for_guard, tactical_movement_speed_for_pace, tactical_sprint_speed,
     };
     pub use crate::player::{
         Attributes, BestiaryCategories, CharacterId, ControlledPlayer, Limbs, Player, Skills,

--- a/crates/adventuresim-tactical-core/src/physics.rs
+++ b/crates/adventuresim-tactical-core/src/physics.rs
@@ -1,3 +1,4 @@
+use adventuresim_core::prelude::*;
 use avian3d::{collider_tree::ColliderTreeSystems, prelude::*};
 use bevy::prelude::*;
 use bevy_ahoy::{
@@ -5,7 +6,35 @@ use bevy_ahoy::{
     input::AccumulatedInput,
 };
 
-use crate::animation::{SkeletonState, WeaponGuardState};
+use crate::{
+    animation::{SkeletonState, WeaponGuardState},
+    player::TacticalPlayerViewer,
+};
+
+#[derive(
+    Component,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    Reflect,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub enum MovementPace {
+    #[default]
+    Walk,
+    Jog,
+    Sprint,
+}
+
+pub const TACTICAL_WALK_SPEED_METRES_PER_SECOND: f32 = 2.0;
+pub const BREATH_RECOVERY_PER_ENDURANCE_PER_SECOND: f32 = 0.0031875;
+pub const BREATH_PER_METRE_PER_SECOND: f32 = 0.0034;
+const REFERENCE_LEG_STRENGTH: f32 = 3.0;
+const REFERENCE_BURDEN_KG: f32 = 70.0;
 
 /// Maximum ordinary tactical movement speed, in metres per second.
 pub const TACTICAL_RUN_SPEED_METRES_PER_SECOND: f32 = 5.5;
@@ -20,6 +49,31 @@ pub const TACTICAL_GUARD_SPEED_METRES_PER_SECOND: f32 = 2.0;
 pub const TACTICAL_RUN_ACCELERATION_HZ: f32 = 8.0;
 pub const TACTICAL_GROUND_ACCELERATION_METRES_PER_SECOND_SQUARED: f32 =
     TACTICAL_RUN_SPEED_METRES_PER_SECOND * TACTICAL_RUN_ACCELERATION_HZ;
+
+pub fn tactical_jog_speed(endurance: f32) -> f32 {
+    (endurance.max(0.0) * BREATH_RECOVERY_PER_ENDURANCE_PER_SECOND / BREATH_PER_METRE_PER_SECOND)
+        .clamp(
+            TACTICAL_WALK_SPEED_METRES_PER_SECOND,
+            TACTICAL_RUN_SPEED_METRES_PER_SECOND,
+        )
+}
+
+pub fn tactical_sprint_speed(
+    left_leg_strength: f32,
+    right_leg_strength: f32,
+    left_leg_health: f32,
+    right_leg_health: f32,
+    burden_kg: f32,
+) -> f32 {
+    let effective_strength = ((left_leg_strength * left_leg_health.max(0.0)
+        + right_leg_strength * right_leg_health.max(0.0))
+        * 0.5)
+        .max(0.0);
+    let strength_ratio = effective_strength / REFERENCE_LEG_STRENGTH;
+    let burden_ratio = REFERENCE_BURDEN_KG / burden_kg.max(1.0);
+    (TACTICAL_RUN_SPEED_METRES_PER_SECOND * (strength_ratio * burden_ratio).sqrt())
+        .clamp(TACTICAL_WALK_SPEED_METRES_PER_SECOND, 8.0)
+}
 
 /// Builds the shared tactical controller instead of inheriting Ahoy's much
 /// faster general-purpose default.
@@ -55,6 +109,29 @@ pub fn tactical_movement_speed_for_guard(
     let cap = match weapon_guard {
         WeaponGuardState::Lowered => TACTICAL_RUN_SPEED_METRES_PER_SECOND,
         WeaponGuardState::Raised => TACTICAL_GUARD_SPEED_METRES_PER_SECOND,
+    };
+    cap * movement.map_or(0.0, |movement| movement.length().clamp(0.0, 1.0))
+}
+
+pub fn tactical_movement_speed_for_pace(
+    movement: Option<Vec2>,
+    pace: MovementPace,
+    weapon_guard: WeaponGuardState,
+    jog_speed: f32,
+    sprint_speed: f32,
+) -> f32 {
+    let requested = match pace {
+        MovementPace::Walk => TACTICAL_WALK_SPEED_METRES_PER_SECOND,
+        MovementPace::Jog => jog_speed,
+        MovementPace::Sprint => sprint_speed,
+    };
+    let cap = if weapon_guard == WeaponGuardState::Raised {
+        match pace {
+            MovementPace::Sprint => jog_speed,
+            _ => requested.min(TACTICAL_GUARD_SPEED_METRES_PER_SECOND),
+        }
+    } else {
+        requested
     };
     cap * movement.map_or(0.0, |movement| movement.length().clamp(0.0, 1.0))
 }
@@ -125,15 +202,50 @@ impl Plugin for AdventureSimulatorPhysicsPlugin {
 
 fn apply_analogue_movement_speed(
     mut controllers: Query<(
+        Entity,
         &AccumulatedInput,
         &mut CharacterController,
         Option<&SkeletonState>,
+        Option<&MovementPace>,
     )>,
+    viewer: TacticalPlayerViewer,
 ) {
-    for (input, mut controller, skeleton) in &mut controllers {
+    for (entity, input, mut controller, skeleton, pace) in &mut controllers {
         let guard = skeleton.map_or(WeaponGuardState::Lowered, SkeletonState::weapon_guard);
-        controller.speed = tactical_movement_speed_for_guard(input.last_movement, guard);
-        controller.acceleration_hz = tactical_movement_acceleration_hz_for_guard(guard);
+        let Some(pace) = pace else {
+            controller.speed = tactical_movement_speed_for_guard(input.last_movement, guard);
+            controller.acceleration_hz = tactical_movement_acceleration_hz_for_guard(guard);
+            continue;
+        };
+        let (jog, sprint) =
+            viewer
+                .get(entity)
+                .map_or((3.75, TACTICAL_RUN_SPEED_METRES_PER_SECOND), |player| {
+                    let burden = player.body_weight() + player.inventory_weight();
+                    (
+                        tactical_jog_speed(
+                            player.raw_single_body_part_attr(SimpleAttribute::Endurance),
+                        ),
+                        tactical_sprint_speed(
+                            player.raw_limb_attr(LimbAttribute::Strength, BodyPart::LeftLeg),
+                            player.raw_limb_attr(LimbAttribute::Strength, BodyPart::RightLeg),
+                            player.body_part_health(BodyPart::LeftLeg),
+                            player.body_part_health(BodyPart::RightLeg),
+                            burden,
+                        ),
+                    )
+                });
+        controller.speed =
+            tactical_movement_speed_for_pace(input.last_movement, *pace, guard, jog, sprint);
+        let magnitude = input
+            .last_movement
+            .map_or(0.0, |movement| movement.length().clamp(0.0, 1.0));
+        controller.acceleration_hz = if magnitude > f32::EPSILON {
+            TACTICAL_GROUND_ACCELERATION_METRES_PER_SECOND_SQUARED
+                / (controller.speed / magnitude).max(0.01)
+        } else {
+            tactical_movement_acceleration_hz_for_guard(guard)
+        };
     }
 }
 
@@ -230,6 +342,31 @@ mod tests {
         assert_eq!(
             guarded,
             TACTICAL_GROUND_ACCELERATION_METRES_PER_SECOND_SQUARED
+        );
+    }
+
+    #[test]
+    fn character_paces_are_reference_normalized_and_guard_sprint_becomes_jog() {
+        assert!((tactical_jog_speed(4.0) - 3.75).abs() < 0.0001);
+        assert_eq!(
+            tactical_sprint_speed(
+                REFERENCE_LEG_STRENGTH,
+                REFERENCE_LEG_STRENGTH,
+                1.0,
+                1.0,
+                REFERENCE_BURDEN_KG,
+            ),
+            TACTICAL_RUN_SPEED_METRES_PER_SECOND
+        );
+        assert_eq!(
+            tactical_movement_speed_for_pace(
+                Some(Vec2::Y),
+                MovementPace::Sprint,
+                WeaponGuardState::Raised,
+                3.75,
+                6.5,
+            ),
+            3.75
         );
     }
 }

--- a/crates/adventuresim-tactical-netcode/src/client.rs
+++ b/crates/adventuresim-tactical-netcode/src/client.rs
@@ -3,7 +3,7 @@ use crate::message::{JoinRequest, PlayerInputRequest};
 use adventuresim_tactical_core::prelude::*;
 use aeronet_replicon::client::{AeronetRepliconClient, AeronetRepliconClientPlugin};
 use aeronet_websocket::client::{ClientConfig, WebSocketClient, WebSocketClientPlugin};
-use bevy::{input::mouse::AccumulatedMouseScroll, prelude::*};
+use bevy::prelude::*;
 use bevy_replicon::prelude::*;
 
 #[derive(Default)]
@@ -12,13 +12,14 @@ pub struct AdventureSimulatorClientPlugin;
 impl Plugin for AdventureSimulatorClientPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<WeaponGuardInputState>()
+            .init_resource::<DirectControlState>()
             .init_resource::<PlayerInputOverride>()
             .add_plugins((WebSocketClientPlugin, AeronetRepliconClientPlugin))
             .add_observer(on_client_added)
             .add_systems(OnEnter(ClientState::Connected), announce_join)
             .add_systems(
                 PreUpdate,
-                update_weapon_guard_input.after(bevy::input::InputSystems),
+                update_direct_control_input.after(bevy::input::InputSystems),
             )
             .add_systems(
                 FixedUpdate,
@@ -32,39 +33,151 @@ pub struct WeaponGuardInputState {
     pub desired: WeaponGuardState,
 }
 
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct DirectControlState {
+    pub pace: MovementPace,
+    pub jump: bool,
+    pub crouch: bool,
+    pub prone: bool,
+    pub attack_just_pressed: bool,
+    pub dodge_just_pressed: bool,
+    caps_jog: bool,
+    guarded_space: bool,
+    reserved_throw_chord: bool,
+}
+
+impl Default for DirectControlState {
+    fn default() -> Self {
+        Self {
+            pace: MovementPace::Walk,
+            jump: false,
+            crouch: false,
+            prone: false,
+            attack_just_pressed: false,
+            dodge_just_pressed: false,
+            caps_jog: false,
+            guarded_space: false,
+            reserved_throw_chord: false,
+        }
+    }
+}
+
 /// Optional input supplied by native diagnostic tooling. The request still
 /// crosses the ordinary client/server transport and authoritative controller;
 /// only the physical keyboard/gamepad sampling is replaced.
 #[derive(Resource, Debug, Clone, Copy, Default)]
 pub struct PlayerInputOverride(pub Option<PlayerInputRequest>);
 
-impl WeaponGuardInputState {
-    pub fn apply_controls(&mut self, wheel_y: f32, right_thumb_pressed: bool) {
-        if wheel_y > 0.0 {
-            self.desired = WeaponGuardState::Raised;
-        } else if wheel_y < 0.0 {
-            self.desired = WeaponGuardState::Lowered;
-        }
-        if right_thumb_pressed {
-            self.desired = match self.desired {
-                WeaponGuardState::Lowered => WeaponGuardState::Raised,
-                WeaponGuardState::Raised => WeaponGuardState::Lowered,
-            };
-        }
-    }
-}
-
-fn update_weapon_guard_input(
-    scroll: Res<AccumulatedMouseScroll>,
+fn update_direct_control_input(
+    keys: Res<ButtonInput<KeyCode>>,
+    mouse: Res<ButtonInput<MouseButton>>,
     gamepads: Query<&Gamepad>,
     mut guard: ResMut<WeaponGuardInputState>,
+    mut controls: ResMut<DirectControlState>,
 ) {
-    guard.apply_controls(
-        scroll.delta.y,
-        gamepads
-            .iter()
-            .any(|gamepad| gamepad.just_pressed(GamepadButton::RightThumb)),
-    );
+    if keys.just_pressed(KeyCode::CapsLock) {
+        controls.caps_jog = !controls.caps_jog;
+    }
+    let keyboard_moving = [KeyCode::KeyW, KeyCode::KeyA, KeyCode::KeyS, KeyCode::KeyD]
+        .into_iter()
+        .any(|key| keys.pressed(key));
+    let gamepad_moving = gamepads.iter().any(|gamepad| {
+        Vec2::new(
+            gamepad.get(GamepadAxis::LeftStickX).unwrap_or_default(),
+            gamepad.get(GamepadAxis::LeftStickY).unwrap_or_default(),
+        )
+        .length_squared()
+            > 0.01
+    });
+    let moving = keyboard_moving || gamepad_moving;
+    let left_trigger = gamepads
+        .iter()
+        .any(|gamepad| gamepad.pressed(GamepadButton::LeftTrigger2));
+    let left_trigger_just_pressed = gamepads
+        .iter()
+        .any(|gamepad| gamepad.just_pressed(GamepadButton::LeftTrigger2));
+    let right_bumper = gamepads
+        .iter()
+        .any(|gamepad| gamepad.pressed(GamepadButton::RightTrigger));
+    let right_bumper_just_pressed = gamepads
+        .iter()
+        .any(|gamepad| gamepad.just_pressed(GamepadButton::RightTrigger));
+    let right_trigger_just_pressed = gamepads
+        .iter()
+        .any(|gamepad| gamepad.just_pressed(GamepadButton::RightTrigger2));
+    let right_trigger = gamepads
+        .iter()
+        .any(|gamepad| gamepad.pressed(GamepadButton::RightTrigger2));
+    let left_thumb = gamepads
+        .iter()
+        .any(|gamepad| gamepad.pressed(GamepadButton::LeftThumb));
+    let left_thumb_just_pressed = gamepads
+        .iter()
+        .any(|gamepad| gamepad.just_pressed(GamepadButton::LeftThumb));
+
+    let raised = mouse.pressed(MouseButton::Right) || left_trigger;
+    if right_bumper && left_trigger_just_pressed {
+        controls.reserved_throw_chord = true;
+    }
+    if !right_bumper || !left_trigger {
+        controls.reserved_throw_chord = false;
+    }
+    guard.desired = if raised {
+        WeaponGuardState::Raised
+    } else {
+        WeaponGuardState::Lowered
+    };
+
+    let control_pressed = keys.pressed(KeyCode::ControlLeft) || keys.pressed(KeyCode::ControlRight);
+    let control_just_pressed =
+        keys.just_pressed(KeyCode::ControlLeft) || keys.just_pressed(KeyCode::ControlRight);
+    let keyboard_dive = control_pressed && keys.just_pressed(KeyCode::Space)
+        || keys.pressed(KeyCode::Space) && control_just_pressed;
+    let gamepad_dive =
+        left_thumb && right_trigger_just_pressed || right_trigger && left_thumb_just_pressed;
+    if !keyboard_dive && control_just_pressed {
+        controls.prone = !controls.prone;
+    }
+    if !gamepad_dive && left_thumb_just_pressed {
+        controls.prone = !controls.prone;
+    }
+    if keyboard_dive || gamepad_dive {
+        controls.prone = false;
+    }
+
+    if raised && keys.just_pressed(KeyCode::Space) {
+        controls.guarded_space = true;
+    }
+    let keyboard_dodge = raised && controls.guarded_space && keys.just_released(KeyCode::Space);
+    if keys.just_released(KeyCode::Space) {
+        controls.guarded_space = false;
+    }
+    controls.attack_just_pressed = raised
+        && (mouse.just_pressed(MouseButton::Left) || (left_trigger && right_trigger_just_pressed));
+    controls.dodge_just_pressed = keyboard_dodge
+        || (left_trigger && right_bumper_just_pressed && moving && !controls.reserved_throw_chord);
+    controls.crouch = raised
+        && (keys.pressed(KeyCode::Space)
+            || (keys.pressed(KeyCode::ShiftLeft) && !moving)
+            || (left_trigger && right_bumper && !moving && !controls.reserved_throw_chord));
+    controls.jump = !raised
+        && !keyboard_dive
+        && !gamepad_dive
+        && (keys.just_pressed(KeyCode::Space)
+            || (!left_trigger && !left_thumb && right_trigger_just_pressed));
+    controls.pace = if keyboard_moving {
+        if keys.pressed(KeyCode::ShiftLeft) {
+            MovementPace::Sprint
+        } else if controls.caps_jog {
+            MovementPace::Jog
+        } else {
+            MovementPace::Walk
+        }
+    } else if gamepad_moving {
+        MovementPace::Sprint
+    } else {
+        MovementPace::Walk
+    };
 }
 
 #[derive(Component, Clone, Debug)]
@@ -110,8 +223,8 @@ fn send_player_input(
     mut commands: Commands,
     players: Query<(&Actions<Player>, &CharacterLook), With<ControlledPlayer>>,
     movements: Query<&Action<input::Movement>>,
-    jumps: Query<&Action<input::Jump>>,
     guard: Res<WeaponGuardInputState>,
+    mut controls: ResMut<DirectControlState>,
     scripted: Res<PlayerInputOverride>,
 ) {
     for (actions, look) in &players {
@@ -123,47 +236,16 @@ fn send_player_input(
             .iter_many(actions)
             .next()
             .map(|movement| **movement);
-        let jump = jumps
-            .iter_many(actions)
-            .next()
-            .map(|jump| **jump)
-            .unwrap_or(false);
-
         commands.client_trigger(PlayerInputRequest {
             movement,
             look: Vec2::new(look.yaw, look.pitch),
-            jump,
+            jump: controls.jump,
+            crouch: controls.crouch,
+            prone: controls.prone,
+            pace: controls.pace,
             weapon_guard: guard.desired,
         });
-    }
-}
-
-#[cfg(test)]
-mod weapon_guard_input_tests {
-    use super::*;
-
-    #[test]
-    fn guard_defaults_lowered_and_wheel_is_idempotent() {
-        let mut state = WeaponGuardInputState::default();
-        assert_eq!(state.desired, WeaponGuardState::Lowered);
-        state.apply_controls(1.0, false);
-        state.apply_controls(1.0, false);
-        assert_eq!(state.desired, WeaponGuardState::Raised);
-        state.apply_controls(-1.0, false);
-        state.apply_controls(-1.0, false);
-        assert_eq!(state.desired, WeaponGuardState::Lowered);
-    }
-
-    #[test]
-    fn right_thumb_toggles_only_on_reported_press_edge() {
-        let mut state = WeaponGuardInputState::default();
-        state.apply_controls(0.0, true);
-        assert_eq!(state.desired, WeaponGuardState::Raised);
-        state.apply_controls(0.0, false);
-        state.apply_controls(0.0, false);
-        assert_eq!(state.desired, WeaponGuardState::Raised);
-        state.apply_controls(0.0, true);
-        assert_eq!(state.desired, WeaponGuardState::Lowered);
+        controls.jump = false;
     }
 }
 

--- a/crates/adventuresim-tactical-netcode/src/message.rs
+++ b/crates/adventuresim-tactical-netcode/src/message.rs
@@ -24,6 +24,9 @@ pub struct PlayerInputRequest {
     pub movement: Option<Vec2>,
     pub look: Vec2,
     pub jump: bool,
+    pub crouch: bool,
+    pub prone: bool,
+    pub pace: MovementPace,
     pub weapon_guard: WeaponGuardState,
 }
 

--- a/crates/adventuresim-tactical-server/src/player_projection.rs
+++ b/crates/adventuresim-tactical-server/src/player_projection.rs
@@ -38,6 +38,12 @@ pub(crate) struct LoadingPlayer {
 #[derive(Component, Debug, Clone, Copy, Default, PartialEq)]
 pub(crate) struct AuthoritativeMovementIntent(Option<Vec2>);
 
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct AuthoritativePostureIntent {
+    crouch: bool,
+    prone: bool,
+}
+
 /// Durable inventory provenance retained only on the authoritative server.
 #[derive(Component, Debug, Clone, Copy)]
 pub(crate) struct TacticalInventoryItemId(pub u64);
@@ -319,6 +325,8 @@ fn spawn_connected_player(
             tactical_character_controller(),
             CharacterLook::default(),
             AuthoritativeMovementIntent::default(),
+            AuthoritativePostureIntent::default(),
+            MovementPace::default(),
         ),
     ));
 
@@ -480,20 +488,35 @@ pub(crate) fn on_player_input(
             &TacticalCombatState,
             &mut SkeletonState,
             &mut AuthoritativeMovementIntent,
+            &mut AuthoritativePostureIntent,
+            &mut MovementPace,
         ),
         With<Player>,
     >,
 ) {
-    let Some(validated) =
-        validate_player_input(input.look, input.movement, input.jump, input.weapon_guard)
-    else {
+    let Some(validated) = validate_player_input(
+        input.look,
+        input.movement,
+        input.jump,
+        input.crouch,
+        input.prone,
+        input.pace,
+        input.weapon_guard,
+    ) else {
         return;
     };
     let Some(entity) = input.client_id.entity() else {
         return;
     };
-    let Ok((mut accumulated_input, mut look, combat_state, mut skeleton, mut movement_intent)) =
-        players.get_mut(entity)
+    let Ok((
+        mut accumulated_input,
+        mut look,
+        combat_state,
+        mut skeleton,
+        mut movement_intent,
+        mut posture_intent,
+        mut pace,
+    )) = players.get_mut(entity)
     else {
         return;
     };
@@ -501,6 +524,9 @@ pub(crate) fn on_player_input(
         accumulated_input.last_movement = None;
         movement_intent.0 = None;
         accumulated_input.jumped = None;
+        accumulated_input.crouched = false;
+        posture_intent.crouch = false;
+        posture_intent.prone = false;
         set_weapon_guard(
             &mut skeleton,
             authoritative_weapon_guard(validated.weapon_guard, true),
@@ -510,7 +536,11 @@ pub(crate) fn on_player_input(
     look.yaw = validated.yaw;
     look.pitch = validated.pitch;
     accumulated_input.last_movement = validated.movement;
+    accumulated_input.crouched = validated.crouch || validated.prone;
     movement_intent.0 = validated.movement;
+    posture_intent.crouch = validated.crouch;
+    posture_intent.prone = validated.prone;
+    *pace = validated.pace;
     set_weapon_guard(
         &mut skeleton,
         authoritative_weapon_guard(validated.weapon_guard, false),
@@ -526,6 +556,9 @@ struct ValidatedPlayerInput {
     yaw: f32,
     pitch: f32,
     jump: bool,
+    crouch: bool,
+    prone: bool,
+    pace: MovementPace,
     weapon_guard: WeaponGuardState,
 }
 
@@ -533,6 +566,9 @@ fn validate_player_input(
     look: Vec2,
     movement: Option<Vec2>,
     jump: bool,
+    crouch: bool,
+    prone: bool,
+    pace: MovementPace,
     weapon_guard: WeaponGuardState,
 ) -> Option<ValidatedPlayerInput> {
     if !look.is_finite() || movement.is_some_and(|movement| !movement.is_finite()) {
@@ -544,6 +580,9 @@ fn validate_player_input(
             - std::f32::consts::PI,
         pitch: look.y.clamp(-1.5, 1.5),
         jump,
+        crouch,
+        prone,
+        pace,
         weapon_guard,
     })
 }
@@ -567,12 +606,13 @@ pub(crate) fn restore_authoritative_movement_intent(
         (
             &AuthoritativeMovementIntent,
             &SkeletonState,
+            &AuthoritativePostureIntent,
             &mut AccumulatedInput,
         ),
         With<Player>,
     >,
 ) {
-    for (movement_intent, skeleton, mut accumulated_input) in &mut players {
+    for (movement_intent, skeleton, posture, mut accumulated_input) in &mut players {
         accumulated_input.last_movement =
             if let Some((direction, speed)) = skeleton.attack_movement() {
                 let cap = match skeleton.weapon_guard() {
@@ -588,6 +628,7 @@ pub(crate) fn restore_authoritative_movement_intent(
             } else {
                 movement_intent.0
             };
+        accumulated_input.crouched = posture.crouch || posture.prone;
     }
 }
 
@@ -602,11 +643,12 @@ pub(crate) fn update_skeleton_locomotion(
             &mut SkeletonState,
             &mut Transform,
             &TacticalCombatState,
+            &AuthoritativePostureIntent,
         ),
         With<Player>,
     >,
 ) {
-    for (controller, velocity, mut skeleton, mut transform, combat_state) in &mut players {
+    for (controller, velocity, mut skeleton, mut transform, combat_state, posture) in &mut players {
         if combat_state.is_incapacitated() {
             let lowered = authoritative_weapon_guard(skeleton.weapon_guard(), true);
             set_weapon_guard(&mut skeleton, lowered);
@@ -631,6 +673,9 @@ pub(crate) fn update_skeleton_locomotion(
                 tick,
             },
         );
+        if posture.prone && controller.grounded.is_some() {
+            skeleton.transition_body(BodyState::Prone);
+        }
     }
 }
 
@@ -675,11 +720,12 @@ fn player_spawn_offset(collider: &Collider) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        AuthoritativeMovementIntent, Player, WeaponGuardState, authoritative_weapon_guard, input,
-        mission_enemy_health_scale, mission_enemy_scale, restore_authoritative_movement_intent,
-        tactical_movement_speed_for_guard, validate_player_input,
+        AuthoritativeMovementIntent, AuthoritativePostureIntent, Player, WeaponGuardState,
+        authoritative_weapon_guard, input, mission_enemy_health_scale, mission_enemy_scale,
+        restore_authoritative_movement_intent, tactical_movement_speed_for_guard,
+        validate_player_input,
     };
-    use adventuresim_tactical_core::prelude::{AttackSpec, SkeletonState};
+    use adventuresim_tactical_core::prelude::{AttackSpec, MovementPace, SkeletonState};
     use bevy::prelude::*;
 
     #[test]
@@ -712,9 +758,15 @@ mod tests {
             (Vec2::ZERO, Some(Vec2::new(f32::NEG_INFINITY, 0.0))),
             (Vec2::ZERO, Some(Vec2::new(0.0, f32::NAN))),
         ] {
-            if let Some(validated) =
-                validate_player_input(look, movement, true, WeaponGuardState::Raised)
-            {
+            if let Some(validated) = validate_player_input(
+                look,
+                movement,
+                true,
+                false,
+                false,
+                MovementPace::Sprint,
+                WeaponGuardState::Raised,
+            ) {
                 controller_input = (
                     Vec2::new(validated.yaw, validated.pitch),
                     validated.movement,
@@ -740,6 +792,9 @@ mod tests {
             Vec2::new(std::f32::consts::TAU * 4.0 + 0.25, 99.0),
             Some(Vec2::splat(10.0)),
             true,
+            false,
+            false,
+            MovementPace::Sprint,
             WeaponGuardState::Raised,
         )
         .unwrap();
@@ -770,6 +825,7 @@ mod tests {
                 Player::default(),
                 AuthoritativeMovementIntent(Some(Vec2::X)),
                 SkeletonState::default(),
+                AuthoritativePostureIntent::default(),
                 input::AccumulatedInput::default(),
             ))
             .id();
@@ -825,6 +881,7 @@ mod tests {
                 Player::default(),
                 AuthoritativeMovementIntent(Some(Vec2::X)),
                 skeleton,
+                AuthoritativePostureIntent::default(),
                 input::AccumulatedInput::default(),
             ))
             .id();

--- a/crates/adventuresim-tactical-server/src/player_projection.rs
+++ b/crates/adventuresim-tactical-server/src/player_projection.rs
@@ -644,11 +644,14 @@ pub(crate) fn update_skeleton_locomotion(
             &mut Transform,
             &TacticalCombatState,
             &AuthoritativePostureIntent,
+            &MovementPace,
         ),
         With<Player>,
     >,
 ) {
-    for (controller, velocity, mut skeleton, mut transform, combat_state, posture) in &mut players {
+    for (controller, velocity, mut skeleton, mut transform, combat_state, posture, pace) in
+        &mut players
+    {
         if combat_state.is_incapacitated() {
             let lowered = authoritative_weapon_guard(skeleton.weapon_guard(), true);
             set_weapon_guard(&mut skeleton, lowered);
@@ -673,6 +676,7 @@ pub(crate) fn update_skeleton_locomotion(
                 tick,
             },
         );
+        skeleton.set_guarded_sprint_locomotion(*pace == MovementPace::Sprint);
         if posture.prone && controller.grounded.is_some() {
             skeleton.transition_body(BodyState::Prone);
         }

--- a/wiki/client/animation.md
+++ b/wiki/client/animation.md
@@ -968,8 +968,8 @@ diagonal direction, release during a step, and a mid-step lateral
 reversal.
 
 During lowered travel, forward walk and run continue to serve diagonal and
-lateral travel. Raised upright grounded movement freezes the current lead and
-samples only its static guard pose. A client-only procedural lower-body pass
+lateral travel. Ordinary raised upright grounded movement freezes the current
+lead and samples only its static guard pose. A client-only procedural lower-body pass
 alternates one swing foot with exactly one world-space support foot. Each
 compact step projects authoritative local velocity from the step origin,
 retains the authored guard's separated stance tracks, interpolates horizontally
@@ -990,6 +990,14 @@ entire two-step pulse. The guard lead never doubles as swing-side state and
 remains fixed across forward, backward, lateral, and diagonal motion. Authored
 guard walk and strafe files remain available for comparison but are not sampled
 by continuous raised locomotion.
+
+Raised sprint input is the sole exception. Its gameplay speed remains the
+character's endurance-neutral jog, but presentation layers the static guard on
+the upper body over the ordinary walk/run interpolation on the lower body. The
+animation graph masks the locomotion clip off `stomach_01` and every descendant
+upper-body target while masking the guard clip off `root`, `pelvis`, and every
+leg target. Ordinary locomotion terrain IK owns this composite's legs;
+procedural combat stepping owns every non-sprint raised movement.
 
 Semantic intent carries a wrapping step sequence and a swing side separate
 from guard lead. The sequence increments at every handoff, allowing a client

--- a/wiki/client/controls.md
+++ b/wiki/client/controls.md
@@ -81,7 +81,7 @@ builds, <kbd>F6</kbd> exposes rig, collision, smoothing, and aim telemetry.
 | <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> | Left Stick | Movement. | Keyboard movement walks by default, jogs while Caps Lock is on, and sprints while <kbd>Shift</kbd> is held. Analogue stick deflection selects the continuous pace up to sprint at full deflection. Jog is the character's endurance-neutral pace; sprint is limited by leg strength relative to total carried weight. |
 | Mouse | Right Stick | Look. | |
 | <kbd>F9</kbd> | | Toggle first-/third-person camera. | Third person preserves the same immediate look direction across centered and raised-weapon shoulder profiles. |
-| Hold RMB | Hold LT | Aim / block. | This state never toggles or persists: releasing the button immediately lowers the weapon. A ranged weapon aims; a melee weapon blocks. Sprint input while raised produces an endurance-neutral jog with the upper body still aiming or blocking. |
+| Hold RMB | Hold LT | Aim / block. | This state never toggles or persists: releasing the button immediately lowers the weapon. A ranged weapon aims; a melee weapon blocks. Ordinary raised movement uses procedural combat steps. Sprint input while raised instead produces an endurance-neutral jog with the upper body still aiming or blocking. |
 | <kbd>Space</kbd> | RT | Jump. | Controller South/A is deliberately unbound. |
 | RMB + LMB | LT + RT | Attack. | An attack already in progress continues if aim/block is released, then finishes with the weapon lowered. |
 | LMB | RB | Grab with the right hand. | Grabbing is not yet implemented in the tactical layer. Holding RB and then pressing LT will eventually throw a held weapon; that chord is reserved but not implemented. |

--- a/wiki/client/controls.md
+++ b/wiki/client/controls.md
@@ -78,15 +78,18 @@ builds, <kbd>F6</kbd> exposes rig, collision, smoothing, and aim telemetry.
 
 | **M+KB** | **Controller** | **Function** | **Notes** |
 |-|-|-|-|
-| <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> | Left Stick | Movement. | |
+| <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> | Left Stick | Movement. | Keyboard movement walks by default, jogs while Caps Lock is on, and sprints while <kbd>Shift</kbd> is held. Analogue stick deflection selects the continuous pace up to sprint at full deflection. Jog is the character's endurance-neutral pace; sprint is limited by leg strength relative to total carried weight. |
 | Mouse | Right Stick | Look. | |
 | <kbd>F9</kbd> | | Toggle first-/third-person camera. | Third person preserves the same immediate look direction across centered and raised-weapon shoulder profiles. |
-| LMB | RT | Attack! | |
-| Release <kbd>SPACE</kbd> | Full LT | Dodge or jump. | <ul><li>A quick tap is more like a hop or dash. Holding the button for a bit before releasing makes it a full-body jump. You can tell whether you have held long enough for a full jump by the state of your character's animation.<li>LT has to be held all the way, then released, to jump. |
-| <kbd>SHIFT</kbd> | Partial LT | Crouch or duck. | <ul><li>When crouching and attacked, your character automatically ducks in an appropriate direction, but only if you were not crouching before the attack began.<li>LT is only held partially here, so releasing it to un-crouch does not cause you to jump.
-| <kbd>CTRL</kbd> | Left Stick Click | Prone–standing toggle. | <ul><li>Jump while held to dive.<li>Crouch to orient your character in the direction the camera is facing.<li>When prone, your character automatically switches to supine based on how you look around. Looking forward, you're prone; looking at your toes, you're supine.<li>Once prone/supine, jump causes you to roll if in a lateral direction, scamper otherwise. This is a very mediocre dodge.
-| Scroll | Right Stick Click | Aim / weapon guard. | <ul><li>Aim means the weapon guard is raised. Scrolling up always raises it and scrolling down always lowers it, so repeated wheel input is idempotent.<li>Right Stick Click toggles the state once per press.<li>The default is lowered. The HUD reports the desired state immediately while the server validates and replicates it.<li>For melee weapons, stabbing without aiming = swinging.<li>For ranged weapons, shooting without aiming = bashing.<li>Aiming while pressing a [hand button](slots.md) with an item in your hand causes you to throw. When not aiming, you simply drop it.
-| MMB or RMB | LB or RB | Grab with left/right hand. | <ul><li>When there is nothing in hand, pressing this grabs whatever you're looking at; *holding* this button, then pressing a [slot button](slots.md), equips the item in that slot into the chosen hand.<li>When there is something in a hand, pressing this drops it; *holding* this button, then pressing a slot button, places the item held in that hand into the chosen slot.
+| Hold RMB | Hold LT | Aim / block. | This state never toggles or persists: releasing the button immediately lowers the weapon. A ranged weapon aims; a melee weapon blocks. Sprint input while raised produces an endurance-neutral jog with the upper body still aiming or blocking. |
+| <kbd>Space</kbd> | RT | Jump. | Controller South/A is deliberately unbound. |
+| RMB + LMB | LT + RT | Attack. | An attack already in progress continues if aim/block is released, then finishes with the weapon lowered. |
+| LMB | RB | Grab with the right hand. | Grabbing is not yet implemented in the tactical layer. Holding RB and then pressing LT will eventually throw a held weapon; that chord is reserved but not implemented. |
+| MMB | LB | Grab with the left hand. | LT + LB remains a left-hand grab. Grabbing is not yet implemented in the tactical layer. |
+| RMB + <kbd>Shift</kbd> while still, or RMB + <kbd>Space</kbd> | LT + RB while still | Duck. | Ducking is a lasting crouch while the chord is held. "Still" is determined from movement input, not current velocity. Pressing guarded <kbd>Space</kbd> begins the duck immediately. |
+| Release RMB + <kbd>Space</kbd> | LT + RB while moving | Dodge. | Releasing <kbd>Space</kbd> after a guarded duck dodges. Controller movement is determined from stick input, not current velocity. |
+| <kbd>Ctrl</kbd> | Left Stick Click | Toggle prone / standing. | This is a persistent toggle. |
+| <kbd>Ctrl</kbd> + <kbd>Space</kbd> | RT + Left Stick Click | Dive. | The chord suppresses both the ordinary jump and prone-toggle actions. |
 
 This is somewhere between a real action game and an RPG wearing an action game's skin. We aren't actually simulating everything based on hitboxes and projectile trajectories, but we still want to use some of the player's mechanical skills, specifically accuracy and reaction time.[^3]
 

--- a/wiki/tactical/combat.md
+++ b/wiki/tactical/combat.md
@@ -212,8 +212,8 @@ fn balance_damage(attacker, defender, attack_directness):
 ### Exhaustion (grey)
 Exhaustion represents how out of breath your character is. Most actions will not actually exhaust faster than it recuperates, but climbing, sprinting, and fighting with heavy weapons, shield, and armor can.
 ```rs
-const BREATH_RECOVERY_PER_ENDURANCE_PER_SECOND = 0.002
-# someone with 2 endurance (poorly fed Napoleonic soldier) can march 1.2m/s all day. Therefore a simple linear ratio between velocity and breath must be about:
+const BREATH_RECOVERY_PER_ENDURANCE_PER_SECOND = 0.0031875
+# A character with 4 endurance can jog at 3.75m/s without gaining or losing exhaustion.
 const BREATH_PER_METERS_PER_SECOND = 0.0034
  
 fn update_stamina(player):


### PR DESCRIPTION
## Summary
- replace persisted guard toggles with held RMB/LT aim-or-block controls and implement the revised keyboard, mouse, and controller chords
- add walk, endurance-neutral jog, and leg-strength-versus-burden sprint pacing while preserving full normal acceleration in guard
- keep ordinary guarded movement on procedural combat steps; use the authored walk/run lower body only for guarded sprint
- mask guarded-jog locomotion off the upper body and give its legs to ordinary terrain IK
- document the complete control and guarded-locomotion contracts

## Why
The implemented controls had drifted from the intended action layout, and guarded locomotion selected its composite from observed speed rather than sprint intent. The first composite mask also classified the authored root and pelvis as upper-body targets, allowing locomotion transforms into the guard layer.

## Impact
Players hold guard/aim instead of toggling it, use explicit walk/jog/sprint pacing, and retain responsive guard acceleration. Normal guarded travel preserves the established procedural footwork; only deliberate guarded sprint becomes a jog with a stable authored upper-body guard. Grab, dive, and future throw inputs are reserved where their tactical mechanics do not yet exist.

## Stack
- stacked on #460 (`codex/run-foot-contact`)

## Verification
- `cargo check -p adventuresim-tactical-client -p adventuresim-tactical-server`
- `cargo test -p adventuresim-tactical-core -p adventuresim-tactical-client -p adventuresim-tactical-server`
- tactical client suite: 176 passed
- tactical core suite: 72 passed
- tactical server suite: 37 passed
- native `raised-guard-forward` capture: every manifest gate true and no `failure.txt`
- supervised tactical session: database ready, claim consumed, server authority registered, listener owned, client running