### PR TITLE
Optimize procedural grass rendering

### DIFF
--- a/assets/shaders/tactical_foliage.wgsl
+++ b/assets/shaders/tactical_foliage.wgsl
@@ -9,8 +9,8 @@ struct TacticalFoliageMaterial {
     wind: vec4<f32>,
     interaction: vec4<f32>,
     interaction_motion: vec4<f32>,
-    lod: vec4<f32>,
     shading: vec4<f32>,
+    shape: vec4<f32>,
 }
 
 @group(#{MATERIAL_BIND_GROUP}) @binding(0)
@@ -32,31 +32,11 @@ fn vertex(vertex: Vertex) -> VertexOutput {
         world_from_local,
         vec4<f32>(root_local, 1.0),
     ).xyz;
-    let distance_to_camera = distance(root_world, view.lod_view_world_position.xyz);
-    let lod_amount = smoothstep(foliage.lod.x, foliage.lod.y, distance_to_camera);
-    let density = mix(1.0, foliage.lod.z, lod_amount * foliage.lod.w);
-    var survival = 1.0;
-    if foliage.lod.w > 0.5 {
-        survival = 1.0 - smoothstep(density, density + 0.035, blade_threshold);
-    }
-    let width_compensation = mix(
-        1.0,
-        min(2.25, inverseSqrt(max(density, 0.01))),
-        foliage.lod.w,
-    );
-    let adjusted_xz = root_local.xz
-        + (position.xz - root_local.xz) * width_compensation * survival;
-    position = vec3<f32>(
-        adjusted_xz.x,
-        root_local.y + (position.y - root_local.y) * survival,
-        adjusted_xz.y,
-    );
-
-    var world_position = mesh_functions::mesh_position_local_to_world(
-        world_from_local,
-        vec4<f32>(position, 1.0),
-    );
-    let bend = clamp(vertex.uv.y, 0.0, 1.0) * survival;
+    // Density is represented by genuinely smaller LOD meshes. The previous
+    // distance threshold collapsed rejected blades here, after their vertex
+    // invocations had already begun, so it did not save vertex work.
+    let width_compensation = max(foliage.shape.w, 1.0);
+    let bend = clamp(vertex.uv.y, 0.0, 1.0);
     let wind_direction = normalize(foliage.wind.xy);
     let wind_cross = vec2<f32>(-wind_direction.y, wind_direction.x);
     let spatial_noise = sin(root_world.x * 0.071 + root_world.z * 0.113)
@@ -74,14 +54,8 @@ fn vertex(vertex: Vertex) -> VertexOutput {
         wind_direction * primary_wave * gust
         + wind_cross * flutter * 0.18
     ) * foliage.wind.z;
-    let wind_bend = (natural_lean + wind_offset) * bend * bend;
-    world_position = vec4<f32>(
-        world_position.x + wind_bend.x,
-        world_position.y,
-        world_position.z + wind_bend.y,
-        world_position.w,
-    );
-
+    var interaction_offset = vec2<f32>(0.0, 0.0);
+    var interaction_droop = 0.0;
     if foliage.interaction.w > 0.0 && foliage.shading.w > 0.5 {
         let from_player = root_world.xz - foliage.interaction.xz;
         let player_distance = length(from_player);
@@ -95,24 +69,105 @@ fn vertex(vertex: Vertex) -> VertexOutput {
         let player_push = (1.0 - smoothstep(0.18, foliage.interaction.w, player_distance))
             * foliage.interaction_motion.w;
         let motion_direction = normalize(velocity_xz + push_direction * 0.15);
-        let interaction_bend = (
+        interaction_offset = (
             push_direction * 0.62 + motion_direction * min(length(velocity_xz) * 0.035, 0.28)
-        ) * player_push * bend * bend;
+        ) * player_push;
+        interaction_droop = player_push * 0.34;
+    }
+
+    let original_world_normal = normalize(mesh_functions::mesh_normal_local_to_world(
+        vertex.normal,
+        vertex.instance_index,
+    ));
+    var world_position: vec4<f32>;
+    var shaped_world_normal = original_world_normal;
+    if foliage.shape.x > 0.5 {
+        // Each grass blade is a single longitudinal ribbon. Its sampled rows
+        // follow one cubic curve, rather than translating a rigid card.
+        let t = clamp(vertex.uv.y, 0.0, 1.0);
+        let one_minus_t = 1.0 - t;
+        let curve_profile = 3.0 * one_minus_t * one_minus_t * t * 0.06
+            + 3.0 * one_minus_t * t * t * 0.5
+            + t * t * t;
+        let curve_derivative = 3.0 * one_minus_t * one_minus_t * 0.06
+            + 6.0 * one_minus_t * t * (0.5 - 0.06)
+            + 3.0 * t * t * (1.0 - 0.5);
+        let authored_facing = normalize(original_world_normal.xz + vec2<f32>(0.0001, 0.0));
+        let authored_amount = 0.72 + 0.28
+            * sin(root_world.x * 2.17 - root_world.z * 1.39 + blade_threshold * 5.7);
+        let total_curve = authored_facing * foliage.shape.z * authored_amount
+            + natural_lean
+            + wind_offset
+            + interaction_offset;
+
+        let centre_local = vec3<f32>(root_local.x, position.y, root_local.z);
+        let centre_world = mesh_functions::mesh_position_local_to_world(
+            world_from_local,
+            vec4<f32>(centre_local, 1.0),
+        );
+        let curve_offset = total_curve * curve_profile;
+
+        // Rotate a ribbon toward the camera only as it becomes edge-on. This
+        // preserves each blade's authored facing while preventing it from
+        // disappearing to sub-pixel width at glancing angles.
+        let local_side = normalize(vec2<f32>(-vertex.normal.z, vertex.normal.x));
+        let transformed_side = (world_from_local
+            * vec4<f32>(local_side.x, 0.0, local_side.y, 0.0)).xz;
+        let side_scale = length(transformed_side);
+        let original_side = normalize(transformed_side + vec2<f32>(0.0001, 0.0));
+        let to_camera = normalize(view.lod_view_world_position.xz - root_world.xz
+            + vec2<f32>(0.0001, 0.0));
+        var camera_side = vec2<f32>(-to_camera.y, to_camera.x);
+        camera_side = select(camera_side, -camera_side, dot(camera_side, original_side) < 0.0);
+        let edge_on = 1.0 - smoothstep(0.08, 0.38, abs(dot(original_world_normal.xz, to_camera)));
+        let visible_side = normalize(mix(original_side, camera_side, edge_on * foliage.shape.y));
+        let half_width = length(position.xz - root_local.xz)
+            * side_scale
+            * width_compensation;
+        let signed_side = select(-1.0, 1.0, vertex.uv.x >= 0.5);
+        let side_offset = visible_side * half_width * signed_side;
         world_position = vec4<f32>(
-            world_position.x + interaction_bend.x,
-            world_position.y - player_push * 0.34 * bend * bend,
-            world_position.z + interaction_bend.y,
+            centre_world.x + curve_offset.x + side_offset.x,
+            centre_world.y - interaction_droop * t * t,
+            centre_world.z + curve_offset.y + side_offset.y,
+            centre_world.w,
+        );
+
+        let world_up = (world_from_local * vec4<f32>(0.0, 1.0, 0.0, 0.0)).xyz;
+        let tangent = vec3<f32>(
+            world_up.x + total_curve.x * curve_derivative,
+            world_up.y - interaction_droop * 2.0 * t,
+            world_up.z + total_curve.y * curve_derivative,
+        );
+        shaped_world_normal = normalize(cross(tangent, vec3<f32>(visible_side.x, 0.0, visible_side.y)));
+    } else {
+        let adjusted_xz = root_local.xz
+            + (position.xz - root_local.xz) * width_compensation;
+        position = vec3<f32>(
+            adjusted_xz.x,
+            position.y,
+            adjusted_xz.y,
+        );
+        world_position = mesh_functions::mesh_position_local_to_world(
+            world_from_local,
+            vec4<f32>(position, 1.0),
+        );
+        let card_bend = (natural_lean + wind_offset + interaction_offset) * bend * bend;
+        world_position = vec4<f32>(
+            world_position.x + card_bend.x,
+            world_position.y - interaction_droop * bend * bend,
+            world_position.z + card_bend.y,
             world_position.w,
         );
     }
 
     out.world_position = world_position;
     out.position = position_world_to_clip(out.world_position.xyz);
-    let world_normal = mesh_functions::mesh_normal_local_to_world(
-        vertex.normal,
-        vertex.instance_index,
-    );
-    out.world_normal = normalize(mix(world_normal, vec3<f32>(0.0, 1.0, 0.0), foliage.shading.z));
+    out.world_normal = normalize(mix(
+        shaped_world_normal,
+        vec3<f32>(0.0, 1.0, 0.0),
+        foliage.shading.z,
+    ));
     out.uv = vertex.uv;
 #ifdef VERTEX_UVS_B
     out.uv_b = vertex.uv_b;

--- a/assets/shaders/tactical_terrain.wgsl
+++ b/assets/shaders/tactical_terrain.wgsl
@@ -1,6 +1,7 @@
 #import bevy_pbr::{
     pbr_fragment::pbr_input_from_standard_material,
     pbr_functions::alpha_discard,
+    mesh_view_bindings::view,
 }
 #ifdef PREPASS_PIPELINE
 #import bevy_pbr::{
@@ -19,6 +20,7 @@ struct TacticalTerrainMaterial {
     cover: vec4<f32>,
     weather: vec4<f32>,
     variation: vec4<f32>,
+    far_sward: vec4<f32>,
 }
 
 @group(#{MATERIAL_BIND_GROUP}) @binding(100)
@@ -67,10 +69,26 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     color = mix(color, stone, slope * (0.48 + hilly * 0.42));
     color = mix(color, vec3<f32>(0.09, 0.18, 0.22), water * 0.78);
     color *= 0.94 + detail * terrain.variation.y;
+
+    // Past the geometric LOD, represent the aggregate colour and normal
+    // response of a sward directly on the terrain. Frequencies stay low enough
+    // to remain stable when minified in a WebGPU browser canvas.
+    let camera_distance = distance(position.xz, view.lod_view_world_position.xz);
+    let sward_fade = smoothstep(terrain.far_sward.x, terrain.far_sward.y, camera_distance);
+    let sward_amount = sward_fade
+        * terrain.far_sward.z
+        * (1.0 - water)
+        * (1.0 - slope * 0.72);
+    let sward_pattern = sin(position.x * 0.43 + position.z * 0.19 + terrain.variation.x * 17.0)
+        * cos(position.z * 0.37 - position.x * 0.13 - terrain.variation.x * 11.0);
+    let sward_color = color * vec3<f32>(0.82, 1.035, 0.72)
+        * (0.97 + sward_pattern * 0.035);
+    color = mix(color, sward_color, sward_amount * 0.44);
+
     let snow_mask = snow * smoothstep(0.3, 0.86, normal.y) * (0.91 + detail * 0.09);
     color = mix(color, vec3<f32>(0.79, 0.84, 0.86), snow_mask);
 
-    let micro = terrain.variation.z * (1.0 - snow_mask);
+    let micro = (terrain.variation.z + sward_amount * 0.012) * (1.0 - snow_mask);
     pbr_input.N = normalize(pbr_input.N + vec3<f32>(
         cos(position.x * 2.11 + position.z * 0.47),
         0.0,

--- a/crates/adventuresim-tactical-client/src/presentation/foliage.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/foliage.rs
@@ -1,15 +1,15 @@
 use super::*;
 
+const GRASS_PATCH_GRID_SIDE: usize = 27;
+const GRASS_PATCH_SPACING: f32 = 3.2;
+const GRASS_BLADE_SPACING: f32 = 0.135;
+const GRASS_FAR_GRID_COORDINATES: [usize; 12] = [0, 2, 5, 7, 9, 12, 14, 17, 19, 21, 24, 26];
+
 pub(super) fn foliage_material(wind_scale: f32, ground_foliage: bool) -> TacticalFoliageMaterial {
     TacticalFoliageMaterial {
         wind: Vec4::new(0.74, 0.67, wind_scale, 1.35),
         interaction: Vec4::ZERO,
         interaction_motion: Vec4::ZERO,
-        lod: if ground_foliage {
-            Vec4::new(24.0, 120.0, 0.18, 1.0)
-        } else {
-            Vec4::ZERO
-        },
         // Root brightness, meadow colour variation, normal up-bias, and
         // whether nearby player movement affects this material.
         shading: if ground_foliage {
@@ -17,6 +17,24 @@ pub(super) fn foliage_material(wind_scale: f32, ground_foliage: bool) -> Tactica
         } else {
             Vec4::new(0.55, 0.08, 0.28, 0.0)
         },
+        // Curved ribbon geometry, edge-on view thickening, authored lean, and
+        // reserved future shaping control. Understory cards retain the older
+        // crossed-plane deformation path.
+        shape: Vec4::ZERO,
+    }
+}
+
+fn grass_material(
+    wind_scale: f32,
+    lod: GrassMeshLod,
+    grass_density: f32,
+) -> TacticalFoliageMaterial {
+    TacticalFoliageMaterial {
+        // The far mesh retains 144 of the near mesh's 729 blades.
+        // Widening by the square root of that density ratio preserves roughly
+        // the same projected coverage without submitting collapsed geometry.
+        shape: Vec4::new(1.0, 0.88, 0.09, lod.width_compensation(grass_density)),
+        ..foliage_material(wind_scale, true)
     }
 }
 
@@ -67,6 +85,15 @@ pub(super) fn spawn_ground_foliage(
     terrain: &SceneTerrain,
     environment: &SceneEnvironment,
 ) {
+    let canopy = bps(environment.canopy_bps);
+    let water = bps(environment.water_bps);
+    let wetland = bps(environment.wetland_bps);
+    let cultivation = bps(environment.cultivation_bps);
+    let snow = bps(environment.weather.snow_cover_bps);
+    let grass_density = (0.96 - canopy * 0.16 - water * 0.88 + cultivation * 0.04)
+        .clamp(0.06, 0.98)
+        * (1.0 - snow * 0.36);
+    let understory_chance = (canopy * 0.16 + wetland * 0.22).clamp(0.0, 0.24);
     let grass_color = if environment.weather.snow_cover_bps >= 5_000 {
         Color::srgb_u8(155, 164, 137)
     } else if environment.cultivation_bps >= 4_000 {
@@ -74,7 +101,16 @@ pub(super) fn spawn_ground_foliage(
     } else {
         Color::srgb_u8(82, 119, 45)
     };
-    let grass_mesh = meshes.add(grass_patch_mesh(grass_color));
+    let grass_near_mesh = meshes.add(grass_patch_mesh(
+        grass_color,
+        GrassMeshLod::Near,
+        grass_density,
+    ));
+    let grass_far_mesh = meshes.add(grass_patch_mesh(
+        grass_color,
+        GrassMeshLod::Far,
+        grass_density,
+    ));
     let understory_mesh = meshes.add(if environment.weather.snow_cover_bps >= 5_000 {
         foliage_clump_mesh(0.72, 0.92, Color::srgb_u8(130, 144, 119), 3)
     } else if environment.wetland_bps >= 3_000 {
@@ -82,88 +118,115 @@ pub(super) fn spawn_ground_foliage(
     } else {
         foliage_clump_mesh(0.9, 1.05, Color::srgb_u8(52, 91, 43), 3)
     });
-    let grass_material = materials.add(foliage_material(
-        0.16 + bps(environment.weather.wind_speed_bps) * 0.36,
-        true,
+    let grass_wind_scale = 0.16 + bps(environment.weather.wind_speed_bps) * 0.36;
+    let grass_near_material = materials.add(grass_material(
+        grass_wind_scale,
+        GrassMeshLod::Near,
+        grass_density,
+    ));
+    let grass_far_material = materials.add(grass_material(
+        grass_wind_scale,
+        GrassMeshLod::Far,
+        grass_density,
     ));
     let understory_material = materials.add(foliage_material(
         0.1 + bps(environment.weather.wind_speed_bps) * 0.24,
         true,
     ));
     let base_seed = stable_text_seed(&environment.scene_digest) ^ stable_text_seed(&scene_id.0);
-    let canopy = bps(environment.canopy_bps);
-    let water = bps(environment.water_bps);
-    let wetland = bps(environment.wetland_bps);
-    let cultivation = bps(environment.cultivation_bps);
-    let snow = bps(environment.weather.snow_cover_bps);
-    let grass_chance = (0.96 - canopy * 0.16 - water * 0.88 + cultivation * 0.04).clamp(0.06, 0.98)
-        * (1.0 - snow * 0.36);
-    let understory_chance = (canopy * 0.16 + wetland * 0.22).clamp(0.0, 0.24);
     let half_x = terrain.width() * 0.5;
     let half_z = terrain.depth() * 0.5;
-    // Each instance is a forty-nine-blade patch whose footprint overlaps its
-    // neighbours. This keeps the entity count bounded while producing the
-    // near-continuous oblique coverage expected from grassland.
-    let spacing = 1.0;
-    let count_x = (terrain.width() / spacing).floor() as i32;
-    let count_z = (terrain.depth() / spacing).floor() as i32;
+    // Grass uses a macro patch whose internal blade spacing matches the old
+    // one-metre patch. A roughly ten-times larger footprint therefore retains
+    // density while cutting extraction, visibility, and instance entities by
+    // an order of magnitude. Aligning each patch to the sampled terrain normal
+    // keeps the larger shared plane seated on slopes.
+    let count_x = (terrain.width() / GRASS_PATCH_SPACING).ceil() as i32;
+    let count_z = (terrain.depth() / GRASS_PATCH_SPACING).ceil() as i32;
     for z in 0..count_z {
         for x in 0..count_x {
             let cell = ((x as u32 as u64) << 32) | z as u32 as u64;
             let hash = splitmix64(base_seed ^ cell);
-            let choose = unit_hash(hash);
-            let layer = if choose < understory_chance {
-                Some(FoliageLayer::Understory)
-            } else if choose < understory_chance + grass_chance {
-                Some(FoliageLayer::Grass)
-            } else {
-                None
-            };
-            let Some(layer) = layer else { continue };
             let jitter_x = unit_hash(splitmix64(hash ^ 0x39bd_7f21)) - 0.5;
             let jitter_z = unit_hash(splitmix64(hash ^ 0xe651_34aa)) - 0.5;
-            let world_x = -half_x + (x as f32 + 0.5 + jitter_x * 0.72) * spacing;
-            let world_z = -half_z + (z as f32 + 0.5 + jitter_z * 0.72) * spacing;
-            let Some(height) = terrain.height_at(Vec2::new(world_x, world_z)) else {
+            let world_x = -half_x + (x as f32 + 0.5 + jitter_x * 0.24) * GRASS_PATCH_SPACING;
+            let world_z = -half_z + (z as f32 + 0.5 + jitter_z * 0.24) * GRASS_PATCH_SPACING;
+            let Some(transform) = foliage_transform(terrain, world_x, world_z, hash) else {
                 continue;
-            };
-            if terrain
-                .normal_at(Vec2::new(world_x, world_z))
-                .is_none_or(|normal| normal.y < 0.72)
-            {
-                continue;
-            }
-            let scale = 0.72 + unit_hash(splitmix64(hash ^ 0x8c0a_3c95)) * 0.58;
-            let (mesh, material) = match layer {
-                FoliageLayer::Grass => (grass_mesh.clone(), grass_material.clone()),
-                FoliageLayer::Understory => (understory_mesh.clone(), understory_material.clone()),
             };
             commands.spawn((
-                Name::new(match layer {
-                    FoliageLayer::Grass => "Tactical grass clump",
-                    FoliageLayer::Understory => "Tactical understory clump",
-                }),
+                Name::new("Tactical grass near ribbons"),
                 FoliageOf(source),
-                layer,
+                FoliageLayer::Grass,
                 NotShadowCaster,
-                Mesh3d(mesh),
-                MeshMaterial3d(material),
-                VisibilityRange::abrupt(
-                    0.0,
-                    if layer == FoliageLayer::Grass {
-                        130.0
-                    } else {
-                        92.0
-                    },
-                ),
-                Transform::from_xyz(world_x, height, world_z)
-                    .with_rotation(Quat::from_rotation_y(
-                        unit_hash(hash) * core::f32::consts::TAU,
-                    ))
-                    .with_scale(Vec3::splat(scale)),
+                Mesh3d(grass_near_mesh.clone()),
+                MeshMaterial3d(grass_near_material.clone()),
+                grass_lod_visibility(GrassMeshLod::Near),
+                transform,
+            ));
+            commands.spawn((
+                Name::new("Tactical grass far ribbons"),
+                FoliageOf(source),
+                NotShadowCaster,
+                Mesh3d(grass_far_mesh.clone()),
+                MeshMaterial3d(grass_far_material.clone()),
+                grass_lod_visibility(GrassMeshLod::Far),
+                transform,
             ));
         }
     }
+
+    let understory_spacing = 1.0;
+    let understory_count_x = (terrain.width() / understory_spacing).floor() as i32;
+    let understory_count_z = (terrain.depth() / understory_spacing).floor() as i32;
+    for z in 0..understory_count_z {
+        for x in 0..understory_count_x {
+            let cell = ((x as u32 as u64) << 32) | z as u32 as u64;
+            let hash = splitmix64(base_seed ^ cell ^ 0xa04f_63d2_719b_e850);
+            if unit_hash(hash) >= understory_chance {
+                continue;
+            }
+            let jitter_x = unit_hash(splitmix64(hash ^ 0x39bd_7f21)) - 0.5;
+            let jitter_z = unit_hash(splitmix64(hash ^ 0xe651_34aa)) - 0.5;
+            let world_x = -half_x + (x as f32 + 0.5 + jitter_x * 0.72) * understory_spacing;
+            let world_z = -half_z + (z as f32 + 0.5 + jitter_z * 0.72) * understory_spacing;
+            let Some(transform) = foliage_transform(terrain, world_x, world_z, hash) else {
+                continue;
+            };
+            commands.spawn((
+                Name::new("Tactical understory clump"),
+                FoliageOf(source),
+                FoliageLayer::Understory,
+                NotShadowCaster,
+                Mesh3d(understory_mesh.clone()),
+                MeshMaterial3d(understory_material.clone()),
+                VisibilityRange::abrupt(0.0, 92.0),
+                transform,
+            ));
+        }
+    }
+}
+
+fn foliage_transform(
+    terrain: &SceneTerrain,
+    world_x: f32,
+    world_z: f32,
+    hash: u64,
+) -> Option<Transform> {
+    let sample = Vec2::new(world_x, world_z);
+    let height = terrain.height_at(sample)?;
+    let normal = terrain.normal_at(sample)?;
+    if normal.y < 0.72 {
+        return None;
+    }
+    let terrain_rotation = Quat::from_rotation_arc(Vec3::Y, normal);
+    let yaw = Quat::from_rotation_y(unit_hash(hash) * core::f32::consts::TAU);
+    let scale = 0.72 + unit_hash(splitmix64(hash ^ 0x8c0a_3c95)) * 0.58;
+    Some(
+        Transform::from_xyz(world_x, height, world_z)
+            .with_rotation(terrain_rotation * yaw)
+            .with_scale(Vec3::splat(scale)),
+    )
 }
 
 pub(super) fn on_environment_added(
@@ -192,23 +255,157 @@ pub(super) fn on_environment_added(
     Ok(())
 }
 
-pub(super) fn grass_patch_mesh(color: Color) -> Mesh {
-    let blades = (0..49)
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum GrassMeshLod {
+    Near,
+    Far,
+}
+
+impl GrassMeshLod {
+    fn row_heights(self) -> &'static [f32] {
+        match self {
+            // Seven paired rows plus a shared tip: the same fifteen-vertex
+            // near ribbon used by Ghost of Tsushima's published grass design.
+            Self::Near => &[0.0, 0.14, 0.29, 0.45, 0.61, 0.76, 0.9],
+            // Three paired rows plus a shared tip: seven vertices at distance.
+            Self::Far => &[0.0, 0.45, 0.82],
+        }
+    }
+
+    fn blade_grid_indices(self, grass_density: f32) -> impl Iterator<Item = usize> {
+        let coordinates: &[usize] = match self {
+            Self::Near => &[],
+            Self::Far => &GRASS_FAR_GRID_COORDINATES,
+        };
+        (0..GRASS_PATCH_GRID_SIDE * GRASS_PATCH_GRID_SIDE).filter(move |index| {
+            let selected_for_lod = if coordinates.is_empty() {
+                true
+            } else {
+                let row = index / GRASS_PATCH_GRID_SIDE;
+                let column = index % GRASS_PATCH_GRID_SIDE;
+                coordinates.contains(&row) && coordinates.contains(&column)
+            };
+            selected_for_lod
+                && (grass_density >= 1.0
+                    || unit_hash(splitmix64(*index as u64 ^ 0x24e8_51c6_9a37_b40d)) < grass_density)
+        })
+    }
+
+    fn blade_count(self, grass_density: f32) -> usize {
+        self.blade_grid_indices(grass_density).count()
+    }
+
+    fn width_compensation(self, grass_density: f32) -> f32 {
+        let near_count = Self::Near.blade_count(grass_density).max(1) as f32;
+        let lod_count = self.blade_count(grass_density).max(1) as f32;
+        (near_count / lod_count).sqrt()
+    }
+}
+
+pub(super) fn grass_lod_visibility(lod: GrassMeshLod) -> VisibilityRange {
+    match lod {
+        GrassMeshLod::Near => VisibilityRange {
+            start_margin: 0.0..0.0,
+            end_margin: 34.0..44.0,
+            use_aabb: false,
+        },
+        GrassMeshLod::Far => VisibilityRange {
+            start_margin: 34.0..44.0,
+            end_margin: 124.0..132.0,
+            use_aabb: false,
+        },
+    }
+}
+
+pub(super) fn grass_patch_mesh(color: Color, lod: GrassMeshLod, grass_density: f32) -> Mesh {
+    let grid_side = GRASS_PATCH_GRID_SIDE;
+    let centre = (grid_side - 1) as f32 * 0.5;
+    let blade_spacing = GRASS_BLADE_SPACING;
+    let blades = lod
+        .blade_grid_indices(grass_density)
         .map(|index| {
-            let row = index / 7;
-            let column = index % 7;
+            let row = index / grid_side;
+            let column = index % grid_side;
             let hash = splitmix64(index as u64 ^ 0x8d12_6f4a_0bc3_7791);
-            let jitter_x = (unit_hash(hash) - 0.5) * 0.07;
-            let jitter_z = (unit_hash(splitmix64(hash)) - 0.5) * 0.07;
+            let jitter_x = (unit_hash(hash) - 0.5) * blade_spacing * 0.39;
+            let jitter_z = (unit_hash(splitmix64(hash)) - 0.5) * blade_spacing * 0.39;
             let scale = 0.68 + unit_hash(splitmix64(hash ^ 0x52a9_f131)) * 0.36;
             (
-                (column as f32 - 3.0) * 0.18 + jitter_x,
-                (row as f32 - 3.0) * 0.18 + jitter_z,
+                (column as f32 - centre) * blade_spacing + jitter_x,
+                (row as f32 - centre) * blade_spacing + jitter_z,
                 scale,
+                index as u64,
             )
         })
         .collect::<Vec<_>>();
-    foliage_patch_mesh(0.045, 0.82, color, 2, &blades)
+    grass_ribbon_patch_mesh(0.045, 0.82, color, lod, &blades)
+}
+
+fn grass_ribbon_patch_mesh(
+    width: f32,
+    height: f32,
+    color: Color,
+    lod: GrassMeshLod,
+    blades: &[(f32, f32, f32, u64)],
+) -> Mesh {
+    let rows = lod.row_heights();
+    let vertices_per_blade = rows.len() * 2 + 1;
+    let triangles_per_blade = (rows.len() - 1) * 2 + 1;
+    let mut positions = Vec::with_capacity(blades.len() * vertices_per_blade);
+    let mut normals = Vec::with_capacity(blades.len() * vertices_per_blade);
+    let mut uvs = Vec::with_capacity(blades.len() * vertices_per_blade);
+    let mut blade_roots = Vec::with_capacity(blades.len() * vertices_per_blade);
+    let mut colors = Vec::with_capacity(blades.len() * vertices_per_blade);
+    let mut indices = Vec::with_capacity(blades.len() * triangles_per_blade * 3);
+    let linear = color.to_linear().to_f32_array();
+
+    for &(offset_x, offset_z, blade_scale, blade_seed) in blades {
+        let root = Vec3::new(offset_x, 0.0, offset_z);
+        let hash = splitmix64(blade_seed ^ 0x6c8e_9cf5_701a_d30b);
+        let angle = unit_hash(hash) * core::f32::consts::TAU;
+        let half_width = Vec3::new(angle.cos(), 0.0, angle.sin()) * width * blade_scale * 0.5;
+        let normal = Vec3::Y.cross(half_width).normalize_or_zero().to_array();
+        let blade_threshold = unit_hash(splitmix64(hash ^ 0x3d91_02ea_61b8_7c45));
+        let blade_color = [linear[0], linear[1], linear[2], blade_threshold];
+        let base = positions.len() as u32;
+
+        for &height_fraction in rows {
+            let taper = (1.0 - height_fraction).powf(0.72);
+            let side = half_width * taper;
+            let centre = root + Vec3::Y * height * blade_scale * height_fraction;
+            positions.extend_from_slice(&[(centre - side).to_array(), (centre + side).to_array()]);
+            normals.extend_from_slice(&[normal; 2]);
+            uvs.extend_from_slice(&[[0.0, height_fraction], [1.0, height_fraction]]);
+            blade_roots.extend_from_slice(&[[offset_x, offset_z]; 2]);
+            colors.extend_from_slice(&[blade_color; 2]);
+        }
+        positions.push((root + Vec3::Y * height * blade_scale).to_array());
+        normals.push(normal);
+        uvs.push([0.5, 1.0]);
+        blade_roots.push([offset_x, offset_z]);
+        colors.push(blade_color);
+
+        for row in 0..rows.len() - 1 {
+            let lower = base + (row * 2) as u32;
+            let upper = lower + 2;
+            indices.extend_from_slice(&[lower, lower + 1, upper + 1, lower, upper + 1, upper]);
+        }
+        let shoulder = base + ((rows.len() - 1) * 2) as u32;
+        let tip = base + (vertices_per_blade - 1) as u32;
+        indices.extend_from_slice(&[shoulder, shoulder + 1, tip]);
+    }
+
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::RENDER_WORLD,
+    );
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_1, blade_roots);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+    mesh.insert_indices(Indices::U32(indices));
+    mesh
 }
 
 pub(super) fn foliage_clump_mesh(width: f32, height: f32, color: Color, planes: usize) -> Mesh {
@@ -292,9 +489,9 @@ pub(in crate::presentation) struct TacticalFoliageMaterial {
     #[uniform(0)]
     interaction_motion: Vec4,
     #[uniform(0)]
-    lod: Vec4,
-    #[uniform(0)]
     shading: Vec4,
+    #[uniform(0)]
+    shape: Vec4,
 }
 
 impl Material for TacticalFoliageMaterial {
@@ -363,19 +560,40 @@ mod tests {
     }
 
     #[test]
-    fn grass_patches_pack_forty_nine_thin_blades_into_each_instance() {
-        let mesh = grass_patch_mesh(Color::WHITE);
-        let positions = mesh
+    fn grass_patches_use_a_stable_reduced_far_subset() {
+        let near = grass_patch_mesh(Color::WHITE, GrassMeshLod::Near, 1.0);
+        let far = grass_patch_mesh(Color::WHITE, GrassMeshLod::Far, 1.0);
+        let sparse = grass_patch_mesh(Color::WHITE, GrassMeshLod::Near, 0.25);
+        let near_positions = near
             .attribute(Mesh::ATTRIBUTE_POSITION)
             .and_then(VertexAttributeValues::as_float3)
             .unwrap();
-        assert_eq!(positions.len(), 49 * 2 * 5);
-        let Some(VertexAttributeValues::Float32x2(roots)) = mesh.attribute(Mesh::ATTRIBUTE_UV_1)
+        let far_positions = far
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .and_then(VertexAttributeValues::as_float3)
+            .unwrap();
+        assert_eq!(near_positions.len(), 729 * 15);
+        assert_eq!(far_positions.len(), 144 * 7);
+        assert!(near_positions.len() > far_positions.len());
+        let sparse_positions = sparse
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .and_then(VertexAttributeValues::as_float3)
+            .unwrap();
+        assert!(!sparse_positions.is_empty());
+        assert!(sparse_positions.len() < near_positions.len());
+        let Some(VertexAttributeValues::Float32x2(near_roots)) =
+            near.attribute(Mesh::ATTRIBUTE_UV_1)
         else {
             panic!("grass mesh must carry stable blade roots");
         };
-        assert_eq!(roots.len(), positions.len());
-        let Some(VertexAttributeValues::Float32x4(colors)) = mesh.attribute(Mesh::ATTRIBUTE_COLOR)
+        let Some(VertexAttributeValues::Float32x2(far_roots)) = far.attribute(Mesh::ATTRIBUTE_UV_1)
+        else {
+            panic!("far grass mesh must carry stable blade roots");
+        };
+        assert_eq!(near_roots.len(), near_positions.len());
+        assert_eq!(far_roots.len(), far_positions.len());
+        assert!(far_roots.iter().all(|root| near_roots.contains(root)));
+        let Some(VertexAttributeValues::Float32x4(colors)) = near.attribute(Mesh::ATTRIBUTE_COLOR)
         else {
             panic!("grass mesh must carry stable blade thresholds");
         };
@@ -385,13 +603,29 @@ mod tests {
     }
 
     #[test]
+    fn grass_lods_crossfade_across_the_same_distance_interval() {
+        let near = grass_lod_visibility(GrassMeshLod::Near);
+        let far = grass_lod_visibility(GrassMeshLod::Far);
+        assert_eq!(near.end_margin, far.start_margin);
+        assert!(!near.is_abrupt());
+        assert!(!far.is_abrupt());
+    }
+
+    #[test]
     fn ground_foliage_enables_continuous_lod_and_interaction() {
         let grass = foliage_material(0.3, true);
         let crown = foliage_material(0.3, false);
-        assert_eq!(grass.lod, Vec4::new(24.0, 120.0, 0.18, 1.0));
         assert_eq!(grass.shading.w, 1.0);
-        assert_eq!(crown.lod, Vec4::ZERO);
         assert_eq!(crown.shading.w, 0.0);
+        assert_eq!(grass.shape, Vec4::ZERO);
+        assert_eq!(
+            grass_material(0.3, GrassMeshLod::Near, 1.0).shape,
+            Vec4::new(1.0, 0.88, 0.09, 1.0)
+        );
+        assert_eq!(
+            grass_material(0.3, GrassMeshLod::Far, 1.0).shape,
+            Vec4::new(1.0, 0.88, 0.09, 2.25)
+        );
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/presentation/terrain.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/terrain.rs
@@ -37,6 +37,8 @@ pub(in crate::presentation) struct TacticalTerrainExtension {
     weather: Vec4,
     #[uniform(100)]
     variation: Vec4,
+    #[uniform(100)]
+    far_sward: Vec4,
 }
 
 impl MaterialExtension for TacticalTerrainExtension {
@@ -109,6 +111,18 @@ pub(in crate::presentation) fn terrain_material(
                 0.055,
                 0.032,
                 environment.generation_version as f32,
+            ),
+            // Beyond the geometric grass range, retain a band-limited sward
+            // response in the terrain material instead of paying for blades
+            // that project to less than a pixel. x/y are the fade interval;
+            // z is environment-dependent coverage and w is reserved.
+            far_sward: Vec4::new(
+                104.0,
+                132.0,
+                (1.0 - bps(environment.water_bps) * 0.9
+                    - bps(environment.weather.snow_cover_bps) * 0.8)
+                    .clamp(0.0, 1.0),
+                0.0,
             ),
         },
     }

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -299,8 +299,18 @@ camera-facing whole-tree billboard. Impostor bounds come from the actual
 descendant branch groups rather than an unrelated generic crown, preserving
 the generated tree's silhouette across levels. Those visual levels do not
 change the server-owned trunk collider.
-Non-colliding grass and understory use shared meshes with continuous,
-hash-stable distance thinning, layered shader wind, and root-to-tip shading.
+Non-colliding grass and understory use automatically instanced shared meshes,
+layered shader wind, and root-to-tip shading. Grass cross-fades from an
+729-blade, fifteen-vertex macro patch to a stable 144-blade,
+seven-vertex subset at distance; rejected blades are absent from the far mesh
+rather than collapsed after vertex shading. The 3.2-metre patch spacing cuts
+grass render entities by roughly an order of magnitude while retaining the
+original internal blade spacing. Environment coverage selects stable blades
+inside that shared mesh instead of omitting whole macro patches. Beyond the geometric range, the
+terrain material retains only the band-limited aggregate colour and normal
+response of the sward. Bevy's standard mesh path supplies WebGPU-compatible
+GPU preprocessing, culling, and indirect batches when the adapter supports
+them, with its normal fallback on more limited browser devices.
 The local player transform drives nearby blade bending on the client only; this
 cosmetic interaction is neither replicated nor included in collision or
 tactical authority. The immutable environment and weather snapshots control the procedural ground

--- a/wiki/shared/terrain.md
+++ b/wiki/shared/terrain.md
@@ -44,13 +44,23 @@ bole. This value is part of deterministic generation rather than a query over
 spawned neighbors, preserving parallel tree construction.
 
 Grass, shrubs, and reeds are deterministic shared-mesh foliage with no gameplay
-collider. Grass uses overlapping shared patches of forty-nine narrow crossed
-blades across the full playable view distance: covered ground reads as a
-continuous sward from normal camera angles while remaining legible from
-overhead. Stable per-blade thresholds continuously reduce distant density and
-compensate surviving blade width without visible LOD rings. Layered spatial
-wind bends tips more than roots, while the locally controlled player's position
-and velocity flatten and push nearby grass as a presentation-only effect.
+collider. Grass uses overlapping 3.2-metre shared macro patches containing 729 individually
+oriented ribbons: each nearby blade samples a cubic longitudinal curve with
+fifteen vertices, then cross-fades beyond 34 metres to a stable 144-blade
+subset using seven vertices per ribbon. The retained blades widen by the square
+root of the density ratio, preserving aggregate coverage while eliminating
+the rejected blades before vertex shading. Internal blade spacing matches the
+former one-metre patch, so the larger footprint cuts grass render entities by
+roughly an order of magnitude without reducing near-field density. Canopy,
+water, cultivation, and snow select stable blades within the shared mesh rather
+than opening macro-patch-sized holes.
+Both representations evaluate the same authored lean, layered spatial wind,
+and player displacement curve, and an edge-on ribbon turns partially toward
+the view so it retains useful screen width without becoming a full billboard.
+The geometric sward ends by 132 metres; beyond it, band-limited terrain colour
+and normal variation carries the far-field grass response without sub-pixel
+blade geometry. The locally controlled player's position and velocity flatten
+and push nearby grass as a presentation-only effect.
 Root self-shadow, broad colour variation, a darker centre rib, and softened
 upward normals keep the dense field readable without making individual cards
 look heavily lit. A procedural terrain material blends forest floor, dry


### PR DESCRIPTION
## Summary

- replace metre-scale grass clumps with shared 3.2 m macro patches while preserving near-field blade spacing
- render curved 15-vertex near blades and a stable, width-compensated 7-vertex far subset with cross-faded LODs
- carry the far sward beyond geometric grass using band-limited terrain color and normal variation
- align patches to terrain slopes and retain deterministic density, wind, and player interaction
- document the grass rendering and WebGPU-compatible GPU preprocessing path

## Why

The earlier procedural grass spent most of its time on CPU-side render-item and entity overhead. Larger shared patches reduce those submissions by roughly an order of magnitude, while explicit geometry LOD and a terrain-based far field keep individual blades useful only where they contribute visible detail.

On the RX 9070 XT test machine at 4K, the fixed scene viewer improved from a 11.25 ms median frame/CPU-busy time to 3.18 ms. Relative to a no-grass control, grass-specific CPU overhead fell from about 8.54 ms to 0.46 ms (about 18x), while marginal GPU-busy cost was about 0.10 ms. The viewer now fits within the 4.17 ms frame budget used as a 240 Hz pipeline-headroom target.

The implementation remains compatible with Bevy's WebGPU rendering path: it uses standard materials and meshes, allowing supported adapters to use Bevy's GPU preprocessing, culling, and indirect drawing without requiring geometry shaders or a bespoke compute-only path.

## Validation

- `cargo test --target-dir C:\Users\adler\Projects\adventure-simulator\target\codex-build -p adventuresim-tactical-client --no-default-features` (218 passed after rebasing onto the current parent)
- `cargo clippy --target-dir C:\Users\adler\Projects\adventure-simulator\target\codex-build -p adventuresim-tactical-client --no-default-features -- -D warnings`
- `cargo check --target-dir C:\Users\adler\Projects\adventure-simulator\target\codex-build-wasm --target wasm32-unknown-unknown -p adventuresim-tactical-client --no-default-features`
- `just fmt`
- native flat and steep tactical scene capture gates
- PresentMon 4K fixed-camera benchmark and no-grass control
- `git diff --check`
- clean merge-tree check against `codex/tactical-world-scenes`
