### PR TITLE
Add authoritative tactical ground surfaces

### DIFF
--- a/assets/shaders/tactical_terrain.wgsl
+++ b/assets/shaders/tactical_terrain.wgsl
@@ -25,6 +25,10 @@ struct TacticalTerrainMaterial {
 
 @group(#{MATERIAL_BIND_GROUP}) @binding(100)
 var<uniform> terrain: TacticalTerrainMaterial;
+@group(#{MATERIAL_BIND_GROUP}) @binding(101)
+var ground_map: texture_2d<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(102)
+var ground_map_sampler: sampler;
 
 fn detail_noise(position: vec3<f32>, normal: vec3<f32>) -> f32 {
     let weights = abs(normal) / max(dot(abs(normal), vec3<f32>(1.0)), 0.001);
@@ -57,16 +61,22 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     let snow = terrain.weather.y;
     let hilly = terrain.weather.z;
     let slope = smoothstep(0.16, 0.68, 1.0 - abs(normal.y));
+    let ground_sample = textureSample(ground_map, ground_map_sampler, in.uv);
+    let cover_kind = round(ground_sample.r * 255.0);
+    let tall_grass = 1.0 - step(0.5, abs(cover_kind - 1.0));
+    let leaf_litter = 1.0 - step(0.5, abs(cover_kind - 2.0));
 
     var color = terrain.base_color.rgb;
     let forest_floor = vec3<f32>(0.105, 0.175, 0.072) * (0.91 + detail * 0.09);
     let mud = vec3<f32>(0.18, 0.16, 0.105) * (0.94 + detail * 0.06);
     let tilled = vec3<f32>(0.33, 0.285, 0.105) * (0.92 + detail * 0.08);
     let stone = vec3<f32>(0.31, 0.30, 0.275) * (0.9 + detail * 0.1);
+    let leaf_floor = vec3<f32>(0.255, 0.16, 0.065) * (0.9 + detail * 0.1);
     color = mix(color, forest_floor, canopy * 0.74);
     color = mix(color, mud, max(wetland, wetness) * 0.68);
     color = mix(color, tilled, cultivation * 0.72);
     color = mix(color, stone, slope * (0.48 + hilly * 0.42));
+    color = mix(color, leaf_floor, leaf_litter * 0.88);
     color = mix(color, vec3<f32>(0.09, 0.18, 0.22), water * 0.78);
     color *= 0.94 + detail * terrain.variation.y;
 
@@ -77,6 +87,7 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     let sward_fade = smoothstep(terrain.far_sward.x, terrain.far_sward.y, camera_distance);
     let sward_amount = sward_fade
         * terrain.far_sward.z
+        * tall_grass
         * (1.0 - water)
         * (1.0 - slope * 0.72);
     let sward_pattern = sin(position.x * 0.43 + position.z * 0.19 + terrain.variation.x * 17.0)

--- a/assets/tactical-scenes/cultivated-roadside.json
+++ b/assets/tactical-scenes/cultivated-roadside.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47106,
   "scene_key": "roadside",
   "source": {

--- a/assets/tactical-scenes/dense-woodland.json
+++ b/assets/tactical-scenes/dense-woodland.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 42,
   "scene_key": "woodland",
   "source": {

--- a/assets/tactical-scenes/flat-dry-grassland.json
+++ b/assets/tactical-scenes/flat-dry-grassland.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47101,
   "scene_key": "grassland",
   "source": {

--- a/assets/tactical-scenes/heavy-rain-high-wind.json
+++ b/assets/tactical-scenes/heavy-rain-high-wind.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47108,
   "scene_key": "storm",
   "source": {

--- a/assets/tactical-scenes/narrow-peak-lod-boundary.json
+++ b/assets/tactical-scenes/narrow-peak-lod-boundary.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47110,
   "scene_key": "mountain",
   "source": {

--- a/assets/tactical-scenes/playability-repair-required.json
+++ b/assets/tactical-scenes/playability-repair-required.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47111,
   "scene_key": "floodplain",
   "source": {

--- a/assets/tactical-scenes/saturated-wetland.json
+++ b/assets/tactical-scenes/saturated-wetland.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47105,
   "scene_key": "wetland",
   "source": {

--- a/assets/tactical-scenes/snow-covered-ground.json
+++ b/assets/tactical-scenes/snow-covered-ground.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47107,
   "scene_key": "snowfield",
   "source": {

--- a/assets/tactical-scenes/sparse-woodland.json
+++ b/assets/tactical-scenes/sparse-woodland.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47104,
   "scene_key": "woodland",
   "source": {

--- a/assets/tactical-scenes/steep-open-hillside.json
+++ b/assets/tactical-scenes/steep-open-hillside.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47102,
   "scene_key": "hillside",
   "source": {

--- a/assets/tactical-scenes/valley-distant-ridge.json
+++ b/assets/tactical-scenes/valley-distant-ridge.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generation_version": 3,
+  "generation_version": 4,
   "seed": 47109,
   "scene_key": "valley",
   "source": {

--- a/crates/adventuresim-tactical-client/src/presentation/foliage.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/foliage.rs
@@ -80,9 +80,9 @@ pub(super) fn spawn_ground_foliage(
     commands: &mut Commands,
     meshes: &mut Assets<Mesh>,
     materials: &mut Assets<TacticalFoliageMaterial>,
-    source: Entity,
     scene_id: &SceneId,
     terrain: &SceneTerrain,
+    ground: &SceneGround,
     environment: &SceneEnvironment,
 ) {
     let canopy = bps(environment.canopy_bps);
@@ -133,6 +133,8 @@ pub(super) fn spawn_ground_foliage(
         0.1 + bps(environment.weather.wind_speed_bps) * 0.24,
         true,
     ));
+    let litter_mesh = meshes.add(ground_litter_patch_mesh());
+    let litter_material = materials.add(foliage_material(0.015, false));
     let base_seed = stable_text_seed(&environment.scene_digest) ^ stable_text_seed(&scene_id.0);
     let half_x = terrain.width() * 0.5;
     let half_z = terrain.depth() * 0.5;
@@ -151,12 +153,15 @@ pub(super) fn spawn_ground_foliage(
             let jitter_z = unit_hash(splitmix64(hash ^ 0xe651_34aa)) - 0.5;
             let world_x = -half_x + (x as f32 + 0.5 + jitter_x * 0.24) * GRASS_PATCH_SPACING;
             let world_z = -half_z + (z as f32 + 0.5 + jitter_z * 0.24) * GRASS_PATCH_SPACING;
+            let ground_position = Vec2::new(world_x, world_z);
+            if !ground_allows_grass_patch(ground, ground_position) {
+                continue;
+            }
             let Some(transform) = foliage_transform(terrain, world_x, world_z, hash) else {
                 continue;
             };
             commands.spawn((
                 Name::new("Tactical grass near ribbons"),
-                FoliageOf(source),
                 FoliageLayer::Grass,
                 NotShadowCaster,
                 Mesh3d(grass_near_mesh.clone()),
@@ -166,7 +171,6 @@ pub(super) fn spawn_ground_foliage(
             ));
             commands.spawn((
                 Name::new("Tactical grass far ribbons"),
-                FoliageOf(source),
                 NotShadowCaster,
                 Mesh3d(grass_far_mesh.clone()),
                 MeshMaterial3d(grass_far_material.clone()),
@@ -190,12 +194,17 @@ pub(super) fn spawn_ground_foliage(
             let jitter_z = unit_hash(splitmix64(hash ^ 0xe651_34aa)) - 0.5;
             let world_x = -half_x + (x as f32 + 0.5 + jitter_x * 0.72) * understory_spacing;
             let world_z = -half_z + (z as f32 + 0.5 + jitter_z * 0.72) * understory_spacing;
+            if ground
+                .ground_at(Vec2::new(world_x, world_z))
+                .is_none_or(|sample| sample.cover == GroundCover::LeafLitter)
+            {
+                continue;
+            }
             let Some(transform) = foliage_transform(terrain, world_x, world_z, hash) else {
                 continue;
             };
             commands.spawn((
                 Name::new("Tactical understory clump"),
-                FoliageOf(source),
                 FoliageLayer::Understory,
                 NotShadowCaster,
                 Mesh3d(understory_mesh.clone()),
@@ -205,6 +214,48 @@ pub(super) fn spawn_ground_foliage(
             ));
         }
     }
+
+    for (index, sample) in ground.samples().iter().enumerate() {
+        if sample.cover != GroundCover::LeafLitter {
+            continue;
+        }
+        let hash = splitmix64(base_seed ^ index as u64 ^ 0x2b6f_5dd9_81aa_9135);
+        if unit_hash(hash) >= bps(sample.cover_density_bps) * 0.58 {
+            continue;
+        }
+        let grid_x = index % ground.grid_width();
+        let grid_z = index / ground.grid_width();
+        let jitter = ground.grid_scale() * 0.28;
+        let world_x = grid_x as f32 * ground.grid_scale() - ground.width() * 0.5
+            + (unit_hash(splitmix64(hash ^ 0x672a_1f04)) - 0.5) * jitter;
+        let world_z = grid_z as f32 * ground.grid_scale() - ground.depth() * 0.5
+            + (unit_hash(splitmix64(hash ^ 0xeeb0_31cd)) - 0.5) * jitter;
+        let Some(mut transform) = foliage_transform(terrain, world_x, world_z, hash) else {
+            continue;
+        };
+        transform.translation.y += 0.018;
+        transform.scale *= 0.72;
+        commands.spawn((
+            Name::new("Tactical dry leaves and twigs"),
+            FoliageLayer::LeafLitter,
+            NotShadowCaster,
+            Mesh3d(litter_mesh.clone()),
+            MeshMaterial3d(litter_material.clone()),
+            VisibilityRange::abrupt(0.0, 72.0),
+            transform,
+        ));
+    }
+}
+
+fn ground_allows_grass_patch(ground: &SceneGround, centre: Vec2) -> bool {
+    ground
+        .ground_at(centre)
+        .is_some_and(|sample| sample.cover == GroundCover::TallGrass)
+        && !ground.cover_intersects_square(
+            centre,
+            GRASS_PATCH_SPACING * 0.58,
+            GroundCover::LeafLitter,
+        )
 }
 
 fn foliage_transform(
@@ -229,30 +280,33 @@ fn foliage_transform(
     )
 }
 
-pub(super) fn on_environment_added(
-    event: On<Add, SceneEnvironment>,
-    environments: Query<&SceneEnvironment>,
-    scenes: Query<(&SceneId, &SceneTerrain)>,
-    foliage: Query<&FoliageOf>,
+pub(super) fn present_ground_scatter(
+    scenes: Query<
+        (
+            Entity,
+            &SceneId,
+            &SceneTerrain,
+            &SceneGround,
+            &SceneEnvironment,
+        ),
+        Without<GroundScatterPresented>,
+    >,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut foliage_materials: ResMut<Assets<TacticalFoliageMaterial>>,
-) -> Result {
-    if foliage.iter().any(|source| source.0 == event.entity) {
-        return Ok(());
+) {
+    for (entity, scene_id, terrain, ground, environment) in &scenes {
+        spawn_ground_foliage(
+            &mut commands,
+            &mut meshes,
+            &mut foliage_materials,
+            scene_id,
+            terrain,
+            ground,
+            environment,
+        );
+        commands.entity(entity).insert(GroundScatterPresented);
     }
-    let environment = environments.get(event.entity)?;
-    let (scene_id, terrain) = scenes.get(event.entity)?;
-    spawn_ground_foliage(
-        &mut commands,
-        &mut meshes,
-        &mut foliage_materials,
-        event.entity,
-        scene_id,
-        terrain,
-        environment,
-    );
-    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -412,6 +466,92 @@ pub(super) fn foliage_clump_mesh(width: f32, height: f32, color: Color, planes: 
     foliage_patch_mesh(width, height, color, planes, &[(0.0, 0.0, 1.0)])
 }
 
+/// Shared proof-of-concept forest-floor patch. Flat ochre leaf diamonds and
+/// narrow brown twig quads keep the mesh deliberately cheap while making the
+/// exclusive leaf-litter profile visually unmistakable.
+fn ground_litter_patch_mesh() -> Mesh {
+    let mut data = GroundLitterMeshData::default();
+    let leaf_colors = [
+        Color::srgb_u8(151, 82, 30),
+        Color::srgb_u8(184, 116, 38),
+        Color::srgb_u8(116, 67, 30),
+        Color::srgb_u8(201, 145, 54),
+    ];
+    for leaf in 0..10_u64 {
+        let hash = splitmix64(leaf ^ 0x5ec4_57d2_bf90_1c37);
+        let centre = Vec2::new(unit_hash(hash) - 0.5, unit_hash(splitmix64(hash ^ 1)) - 0.5) * 0.82;
+        let angle = unit_hash(splitmix64(hash ^ 2)) * core::f32::consts::TAU;
+        let long =
+            Vec2::new(angle.cos(), angle.sin()) * (0.08 + unit_hash(splitmix64(hash ^ 3)) * 0.045);
+        let side = Vec2::new(-long.y, long.x) * 0.42;
+        data.append_quad(
+            centre,
+            long,
+            side,
+            0.004 + leaf as f32 * 0.0004,
+            leaf_colors[leaf as usize % leaf_colors.len()],
+        );
+    }
+    for twig in 0..5_u64 {
+        let hash = splitmix64(twig ^ 0xa773_9fe2_410c_862d);
+        let centre = Vec2::new(unit_hash(hash) - 0.5, unit_hash(splitmix64(hash ^ 1)) - 0.5) * 0.76;
+        let angle = unit_hash(splitmix64(hash ^ 2)) * core::f32::consts::TAU;
+        let long =
+            Vec2::new(angle.cos(), angle.sin()) * (0.16 + unit_hash(splitmix64(hash ^ 3)) * 0.08);
+        let side = Vec2::new(-long.y, long.x) * 0.065;
+        data.append_quad(
+            centre,
+            long,
+            side,
+            0.012 + twig as f32 * 0.0006,
+            Color::srgb_u8(79, 47, 24),
+        );
+    }
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::RENDER_WORLD,
+    );
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, data.positions);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, data.normals);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, data.uvs);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_1, data.roots);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, data.colors);
+    mesh.insert_indices(Indices::U32(data.indices));
+    mesh
+}
+
+#[derive(Default)]
+struct GroundLitterMeshData {
+    positions: Vec<[f32; 3]>,
+    normals: Vec<[f32; 3]>,
+    uvs: Vec<[f32; 2]>,
+    roots: Vec<[f32; 2]>,
+    colors: Vec<[f32; 4]>,
+    indices: Vec<u32>,
+}
+
+impl GroundLitterMeshData {
+    fn append_quad(&mut self, centre: Vec2, long: Vec2, side: Vec2, height: f32, color: Color) {
+        let base = self.positions.len() as u32;
+        for point in [
+            centre - long - side,
+            centre + long - side,
+            centre + long + side,
+            centre - long + side,
+        ] {
+            self.positions.push([point.x, height, point.y]);
+            self.normals.push(Vec3::Y.to_array());
+            self.roots.push(centre.to_array());
+        }
+        self.uvs
+            .extend_from_slice(&[[0.0, 0.85], [1.0, 0.85], [1.0, 1.0], [0.0, 1.0]]);
+        let color = color.to_linear().to_f32_array();
+        self.colors.extend_from_slice(&[color; 4]);
+        self.indices
+            .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
+}
+
 pub(super) fn foliage_patch_mesh(
     width: f32,
     height: f32,
@@ -526,7 +666,11 @@ impl Material for TacticalFoliageMaterial {
 pub(crate) enum FoliageLayer {
     Grass,
     Understory,
+    LeafLitter,
 }
+
+#[derive(Component)]
+pub(in crate::presentation) struct GroundScatterPresented;
 
 /// Marks the locally controlled character whose movement bends nearby grass.
 #[derive(Component)]
@@ -537,9 +681,6 @@ pub(in crate::presentation) struct GrassInteractionState {
     previous_position: Option<Vec3>,
     smoothed_velocity: Vec3,
 }
-
-#[derive(Component)]
-pub(in crate::presentation) struct FoliageOf(pub(in crate::presentation) Entity);
 
 const FOLIAGE_SHADER: &str = "shaders/tactical_foliage.wgsl";
 
@@ -656,5 +797,26 @@ mod tests {
             Vec4::new(3.0, 1.0, -2.0, 1.35)
         );
         assert_eq!(materials.get(&crown).unwrap().interaction, Vec4::ZERO);
+    }
+
+    #[test]
+    fn leaf_litter_conservatively_excludes_overlapping_grass_patches() {
+        let mut samples = vec![GroundSurface::default(); 81];
+        samples[40].cover = GroundCover::LeafLitter;
+        let ground = SceneGround::from_samples(9, 9, 1.0, samples).unwrap();
+        assert!(!ground_allows_grass_patch(&ground, Vec2::ZERO));
+        assert!(ground_allows_grass_patch(&ground, Vec2::new(-4.0, -4.0)));
+    }
+
+    #[test]
+    fn proof_litter_mesh_contains_separate_leaf_and_twig_quads() {
+        let mesh = ground_litter_patch_mesh();
+        let positions = mesh
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .and_then(VertexAttributeValues::as_float3)
+            .unwrap();
+        assert_eq!(positions.len(), (10 + 5) * 4);
+        assert!(mesh.attribute(Mesh::ATTRIBUTE_COLOR).is_some());
+        assert!(mesh.attribute(Mesh::ATTRIBUTE_UV_1).is_some());
     }
 }

--- a/crates/adventuresim-tactical-client/src/presentation/foliage.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/foliage.rs
@@ -4,6 +4,10 @@ const GRASS_PATCH_GRID_SIDE: usize = 27;
 const GRASS_PATCH_SPACING: f32 = 3.2;
 const GRASS_BLADE_SPACING: f32 = 0.135;
 const GRASS_FAR_GRID_COORDINATES: [usize; 12] = [0, 2, 5, 7, 9, 12, 14, 17, 19, 21, 24, 26];
+const DRY_LEAF_PASSES_PER_SAMPLE: u64 = 3;
+const TWIG_PASSES_PER_SAMPLE: u64 = 2;
+const DRY_LEAF_MESH_VARIANTS: u64 = 4;
+const TWIG_MESH_VARIANTS: u64 = 3;
 
 pub(super) fn foliage_material(wind_scale: f32, ground_foliage: bool) -> TacticalFoliageMaterial {
     TacticalFoliageMaterial {
@@ -133,8 +137,14 @@ pub(super) fn spawn_ground_foliage(
         0.1 + bps(environment.weather.wind_speed_bps) * 0.24,
         true,
     ));
-    let litter_mesh = meshes.add(ground_litter_patch_mesh());
-    let litter_material = materials.add(foliage_material(0.015, false));
+    let dry_leaf_meshes = (0..DRY_LEAF_MESH_VARIANTS)
+        .map(|variant| meshes.add(dry_leaf_patch_mesh(variant)))
+        .collect::<Vec<_>>();
+    let twig_meshes = (0..TWIG_MESH_VARIANTS)
+        .map(|variant| meshes.add(twig_patch_mesh(variant)))
+        .collect::<Vec<_>>();
+    let dry_leaf_material = materials.add(foliage_material(0.008, false));
+    let twig_material = materials.add(foliage_material(0.004, false));
     let base_seed = stable_text_seed(&environment.scene_digest) ^ stable_text_seed(&scene_id.0);
     let half_x = terrain.width() * 0.5;
     let half_z = terrain.depth() * 0.5;
@@ -219,32 +229,96 @@ pub(super) fn spawn_ground_foliage(
         if sample.cover != GroundCover::LeafLitter {
             continue;
         }
-        let hash = splitmix64(base_seed ^ index as u64 ^ 0x2b6f_5dd9_81aa_9135);
-        if unit_hash(hash) >= bps(sample.cover_density_bps) * 0.58 {
-            continue;
-        }
         let grid_x = index % ground.grid_width();
         let grid_z = index / ground.grid_width();
-        let jitter = ground.grid_scale() * 0.28;
-        let world_x = grid_x as f32 * ground.grid_scale() - ground.width() * 0.5
-            + (unit_hash(splitmix64(hash ^ 0x672a_1f04)) - 0.5) * jitter;
-        let world_z = grid_z as f32 * ground.grid_scale() - ground.depth() * 0.5
-            + (unit_hash(splitmix64(hash ^ 0xeeb0_31cd)) - 0.5) * jitter;
-        let Some(mut transform) = foliage_transform(terrain, world_x, world_z, hash) else {
-            continue;
-        };
-        transform.translation.y += 0.018;
-        transform.scale *= 0.72;
-        commands.spawn((
-            Name::new("Tactical dry leaves and twigs"),
-            FoliageLayer::LeafLitter,
-            NotShadowCaster,
-            Mesh3d(litter_mesh.clone()),
-            MeshMaterial3d(litter_material.clone()),
-            VisibilityRange::abrupt(0.0, 72.0),
-            transform,
-        ));
+        let cell_origin = Vec2::new(
+            grid_x as f32 * ground.grid_scale() - ground.width() * 0.5,
+            grid_z as f32 * ground.grid_scale() - ground.depth() * 0.5,
+        );
+        let density = bps(sample.cover_density_bps);
+        for pass in 0..DRY_LEAF_PASSES_PER_SAMPLE {
+            let hash =
+                splitmix64(base_seed ^ index as u64 ^ pass.rotate_left(19) ^ 0x2b6f_5dd9_81aa_9135);
+            if unit_hash(hash) >= density * 0.92 {
+                continue;
+            }
+            spawn_forest_floor_patch(
+                commands,
+                terrain,
+                ground,
+                cell_origin,
+                hash,
+                "Tactical dry-leaf patch",
+                FoliageLayer::DryLeaves,
+                &dry_leaf_meshes[(hash % dry_leaf_meshes.len() as u64) as usize],
+                &dry_leaf_material,
+                0.8,
+                0.012,
+            );
+        }
+        for pass in 0..TWIG_PASSES_PER_SAMPLE {
+            let hash =
+                splitmix64(base_seed ^ index as u64 ^ pass.rotate_left(23) ^ 0xc41b_b83e_3a70_f965);
+            if unit_hash(hash) >= density * 0.62 {
+                continue;
+            }
+            spawn_forest_floor_patch(
+                commands,
+                terrain,
+                ground,
+                cell_origin,
+                hash,
+                "Tactical twig patch",
+                FoliageLayer::Twigs,
+                &twig_meshes[(hash % twig_meshes.len() as u64) as usize],
+                &twig_material,
+                0.72,
+                0.02,
+            );
+        }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_forest_floor_patch(
+    commands: &mut Commands,
+    terrain: &SceneTerrain,
+    ground: &SceneGround,
+    cell_origin: Vec2,
+    hash: u64,
+    name: &'static str,
+    layer: FoliageLayer,
+    mesh: &Handle<Mesh>,
+    material: &Handle<TacticalFoliageMaterial>,
+    scale: f32,
+    height_offset: f32,
+) {
+    let jitter = ground.grid_scale() * 0.78;
+    let position = cell_origin
+        + Vec2::new(
+            unit_hash(splitmix64(hash ^ 0x672a_1f04)) - 0.5,
+            unit_hash(splitmix64(hash ^ 0xeeb0_31cd)) - 0.5,
+        ) * jitter;
+    if ground
+        .ground_at(position)
+        .is_none_or(|sample| sample.cover != GroundCover::LeafLitter)
+    {
+        return;
+    }
+    let Some(mut transform) = foliage_transform(terrain, position.x, position.y, hash) else {
+        return;
+    };
+    transform.translation.y += height_offset;
+    transform.scale *= scale;
+    commands.spawn((
+        Name::new(name),
+        layer,
+        NotShadowCaster,
+        Mesh3d(mesh.clone()),
+        MeshMaterial3d(material.clone()),
+        VisibilityRange::abrupt(0.0, 72.0),
+        transform,
+    ));
 }
 
 fn ground_allows_grass_patch(ground: &SceneGround, centre: Vec2) -> bool {
@@ -466,58 +540,76 @@ pub(super) fn foliage_clump_mesh(width: f32, height: f32, color: Color, planes: 
     foliage_patch_mesh(width, height, color, planes, &[(0.0, 0.0, 1.0)])
 }
 
-/// Shared proof-of-concept forest-floor patch. Flat ochre leaf diamonds and
-/// narrow brown twig quads keep the mesh deliberately cheap while making the
-/// exclusive leaf-litter profile visually unmistakable.
-fn ground_litter_patch_mesh() -> Mesh {
+/// Dense dry-leaf carpet with enough colour, size, and orientation variation
+/// to avoid reading as a repeated decal when its shared mesh is instanced.
+fn dry_leaf_patch_mesh(variant: u64) -> Mesh {
     let mut data = GroundLitterMeshData::default();
     let leaf_colors = [
         Color::srgb_u8(151, 82, 30),
         Color::srgb_u8(184, 116, 38),
         Color::srgb_u8(116, 67, 30),
         Color::srgb_u8(201, 145, 54),
+        Color::srgb_u8(128, 91, 42),
     ];
-    for leaf in 0..10_u64 {
-        let hash = splitmix64(leaf ^ 0x5ec4_57d2_bf90_1c37);
-        let centre = Vec2::new(unit_hash(hash) - 0.5, unit_hash(splitmix64(hash ^ 1)) - 0.5) * 0.82;
+    for leaf in 0..24_u64 {
+        let hash = splitmix64(leaf ^ variant.rotate_left(29) ^ 0x5ec4_57d2_bf90_1c37);
+        let centre = Vec2::new(unit_hash(hash) - 0.5, unit_hash(splitmix64(hash ^ 1)) - 0.5) * 1.08;
         let angle = unit_hash(splitmix64(hash ^ 2)) * core::f32::consts::TAU;
         let long =
-            Vec2::new(angle.cos(), angle.sin()) * (0.08 + unit_hash(splitmix64(hash ^ 3)) * 0.045);
-        let side = Vec2::new(-long.y, long.x) * 0.42;
-        data.append_quad(
+            Vec2::new(angle.cos(), angle.sin()) * (0.065 + unit_hash(splitmix64(hash ^ 3)) * 0.045);
+        let side = Vec2::new(-long.y, long.x) * (0.34 + unit_hash(splitmix64(hash ^ 4)) * 0.16);
+        data.append_diamond(
             centre,
             long,
             side,
-            0.004 + leaf as f32 * 0.0004,
+            0.003 + (leaf % 7) as f32 * 0.00045,
             leaf_colors[leaf as usize % leaf_colors.len()],
         );
     }
-    for twig in 0..5_u64 {
-        let hash = splitmix64(twig ^ 0xa773_9fe2_410c_862d);
-        let centre = Vec2::new(unit_hash(hash) - 0.5, unit_hash(splitmix64(hash ^ 1)) - 0.5) * 0.76;
+    data.into_mesh()
+}
+
+/// Independent twig mesh. Longer, thinner pieces and a lower spawn density
+/// let twigs form irregular accents over the denser dry-leaf carpet.
+fn twig_patch_mesh(variant: u64) -> Mesh {
+    let mut data = GroundLitterMeshData::default();
+    let twig_colors = [
+        Color::srgb_u8(79, 47, 24),
+        Color::srgb_u8(102, 62, 29),
+        Color::srgb_u8(62, 40, 25),
+    ];
+    for twig in 0..9_u64 {
+        let hash = splitmix64(twig ^ variant.rotate_left(31) ^ 0xa773_9fe2_410c_862d);
+        let centre = Vec2::new(unit_hash(hash) - 0.5, unit_hash(splitmix64(hash ^ 1)) - 0.5) * 1.02;
         let angle = unit_hash(splitmix64(hash ^ 2)) * core::f32::consts::TAU;
         let long =
-            Vec2::new(angle.cos(), angle.sin()) * (0.16 + unit_hash(splitmix64(hash ^ 3)) * 0.08);
-        let side = Vec2::new(-long.y, long.x) * 0.065;
+            Vec2::new(angle.cos(), angle.sin()) * (0.14 + unit_hash(splitmix64(hash ^ 3)) * 0.13);
+        let side = Vec2::new(-long.y, long.x) * (0.045 + unit_hash(splitmix64(hash ^ 4)) * 0.025);
         data.append_quad(
             centre,
             long,
             side,
-            0.012 + twig as f32 * 0.0006,
-            Color::srgb_u8(79, 47, 24),
+            0.008 + (twig % 5) as f32 * 0.0008,
+            twig_colors[twig as usize % twig_colors.len()],
         );
     }
-    let mut mesh = Mesh::new(
-        PrimitiveTopology::TriangleList,
-        RenderAssetUsages::RENDER_WORLD,
-    );
-    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, data.positions);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, data.normals);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, data.uvs);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_1, data.roots);
-    mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, data.colors);
-    mesh.insert_indices(Indices::U32(data.indices));
-    mesh
+    data.into_mesh()
+}
+
+impl GroundLitterMeshData {
+    fn into_mesh(self) -> Mesh {
+        let mut mesh = Mesh::new(
+            PrimitiveTopology::TriangleList,
+            RenderAssetUsages::RENDER_WORLD,
+        );
+        mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, self.positions);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, self.normals);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, self.uvs);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_UV_1, self.roots);
+        mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, self.colors);
+        mesh.insert_indices(Indices::U32(self.indices));
+        mesh
+    }
 }
 
 #[derive(Default)]
@@ -545,6 +637,21 @@ impl GroundLitterMeshData {
         }
         self.uvs
             .extend_from_slice(&[[0.0, 0.85], [1.0, 0.85], [1.0, 1.0], [0.0, 1.0]]);
+        let color = color.to_linear().to_f32_array();
+        self.colors.extend_from_slice(&[color; 4]);
+        self.indices
+            .extend_from_slice(&[base, base + 1, base + 2, base, base + 2, base + 3]);
+    }
+
+    fn append_diamond(&mut self, centre: Vec2, long: Vec2, side: Vec2, height: f32, color: Color) {
+        let base = self.positions.len() as u32;
+        for point in [centre - long, centre + side, centre + long, centre - side] {
+            self.positions.push([point.x, height, point.y]);
+            self.normals.push(Vec3::Y.to_array());
+            self.roots.push(centre.to_array());
+        }
+        self.uvs
+            .extend_from_slice(&[[0.5, 0.85], [1.0, 0.925], [0.5, 1.0], [0.0, 0.925]]);
         let color = color.to_linear().to_f32_array();
         self.colors.extend_from_slice(&[color; 4]);
         self.indices
@@ -666,7 +773,8 @@ impl Material for TacticalFoliageMaterial {
 pub(crate) enum FoliageLayer {
     Grass,
     Understory,
-    LeafLitter,
+    DryLeaves,
+    Twigs,
 }
 
 #[derive(Component)]
@@ -809,14 +917,27 @@ mod tests {
     }
 
     #[test]
-    fn proof_litter_mesh_contains_separate_leaf_and_twig_quads() {
-        let mesh = ground_litter_patch_mesh();
-        let positions = mesh
+    fn proof_litter_uses_separate_dense_leaf_and_twig_meshes() {
+        let leaves = dry_leaf_patch_mesh(0);
+        let alternate_leaves = dry_leaf_patch_mesh(1);
+        let twigs = twig_patch_mesh(0);
+        let leaf_positions = leaves
             .attribute(Mesh::ATTRIBUTE_POSITION)
             .and_then(VertexAttributeValues::as_float3)
             .unwrap();
-        assert_eq!(positions.len(), (10 + 5) * 4);
-        assert!(mesh.attribute(Mesh::ATTRIBUTE_COLOR).is_some());
-        assert!(mesh.attribute(Mesh::ATTRIBUTE_UV_1).is_some());
+        let twig_positions = twigs
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .and_then(VertexAttributeValues::as_float3)
+            .unwrap();
+        assert_eq!(leaf_positions.len(), 24 * 4);
+        assert_eq!(twig_positions.len(), 9 * 4);
+        assert_ne!(
+            leaves.attribute(Mesh::ATTRIBUTE_POSITION),
+            alternate_leaves.attribute(Mesh::ATTRIBUTE_POSITION)
+        );
+        for mesh in [&leaves, &twigs] {
+            assert!(mesh.attribute(Mesh::ATTRIBUTE_COLOR).is_some());
+            assert!(mesh.attribute(Mesh::ATTRIBUTE_UV_1).is_some());
+        }
     }
 }

--- a/crates/adventuresim-tactical-client/src/presentation/mod.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/mod.rs
@@ -50,6 +50,7 @@ use bevy::{
     asset::RenderAssetUsages,
     camera::{Exposure, visibility::VisibilityRange},
     core_pipeline::tonemapping::Tonemapping,
+    image::ImageSampler,
     light::{
         Atmosphere, AtmosphereEnvironmentMapLight, NotShadowCaster, atmosphere::ScatteringMedium,
         light_consts::lux,
@@ -124,6 +125,7 @@ impl Plugin for TacticalPresentationPlugin {
             (
                 advance_weather_particles,
                 update_grass_interaction,
+                present_ground_scatter,
                 (present_pending_trees, update_tree_projected_lod_ranges).chain(),
                 keep_celestial_visuals_centered,
             ),
@@ -132,7 +134,7 @@ impl Plugin for TacticalPresentationPlugin {
         .add_observer(environment::on_environment_added)
         .add_observer(sky::on_environment_added)
         .add_observer(terrain::on_environment_added)
-        .add_observer(foliage::on_environment_added)
+        .add_observer(terrain::on_ground_added)
         .add_observer(weather::on_environment_added)
         .add_observer(on_scene_obstacle_added)
         .add_observer(on_scene_vista_bundle);

--- a/crates/adventuresim-tactical-client/src/presentation/terrain.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/terrain.rs
@@ -39,6 +39,9 @@ pub(in crate::presentation) struct TacticalTerrainExtension {
     variation: Vec4,
     #[uniform(100)]
     far_sward: Vec4,
+    #[texture(101)]
+    #[sampler(102)]
+    ground_map: Handle<Image>,
 }
 
 impl MaterialExtension for TacticalTerrainExtension {
@@ -57,11 +60,17 @@ pub(in crate::presentation) type TacticalTerrainMaterial =
 pub(in crate::presentation) fn on_game_scene_added(
     event: On<Add, SceneId>,
     mut commands: Commands,
-    query: Query<(&SceneId, &SceneTerrain, Option<&SceneEnvironment>)>,
+    query: Query<(
+        &SceneId,
+        &SceneTerrain,
+        Option<&SceneEnvironment>,
+        Option<&SceneGround>,
+    )>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<TacticalTerrainMaterial>>,
+    mut images: ResMut<Assets<Image>>,
 ) -> Result {
-    let (id, terrain, environment) = query.get(event.entity)?;
+    let (id, terrain, environment, ground) = query.get(event.entity)?;
     info!(entity = ?event.entity, "Spawning a scene {id:?}");
 
     let legacy_environment;
@@ -77,13 +86,15 @@ pub(in crate::presentation) fn on_game_scene_added(
         ScenePresentationOf(event.entity),
         TerrainMaterialPresentation,
         Mesh3d(meshes.add(terrain.mesh())),
-        MeshMaterial3d(materials.add(terrain_material(environment))),
+        MeshMaterial3d(materials.add(terrain_material(environment, ground, &mut images))),
     ));
     Ok(())
 }
 
 pub(in crate::presentation) fn terrain_material(
     environment: &SceneEnvironment,
+    ground: Option<&SceneGround>,
+    images: &mut Assets<Image>,
 ) -> TacticalTerrainMaterial {
     TacticalTerrainMaterial {
         base: StandardMaterial {
@@ -124,8 +135,62 @@ pub(in crate::presentation) fn terrain_material(
                     .clamp(0.0, 1.0),
                 0.0,
             ),
+            ground_map: images.add(ground_map_image(ground)),
         },
     }
+}
+
+fn ground_map_image(ground: Option<&SceneGround>) -> Image {
+    let (width, height, pixels) = ground.map_or_else(
+        || (1, 1, vec![0, 0, 0, 0]),
+        |ground| {
+            let pixels = ground
+                .samples()
+                .iter()
+                .flat_map(|sample| {
+                    let cover = match sample.cover {
+                        GroundCover::Bare => 0,
+                        GroundCover::TallGrass => 1,
+                        GroundCover::LeafLitter => 2,
+                        GroundCover::LooseStone => 3,
+                        GroundCover::Reeds => 4,
+                    };
+                    let substrate = match sample.substrate {
+                        GroundSubstrate::Soil => 0,
+                        GroundSubstrate::Stone => 1,
+                        GroundSubstrate::Gravel => 2,
+                        GroundSubstrate::Mud => 3,
+                        GroundSubstrate::Road => 4,
+                        GroundSubstrate::Water => 5,
+                    };
+                    [
+                        cover,
+                        substrate,
+                        (u32::from(sample.cover_density_bps) * 255 / 10_000) as u8,
+                        sample.cover_height_cm.min(255) as u8,
+                    ]
+                })
+                .collect();
+            (
+                ground.grid_width() as u32,
+                ground.grid_depth() as u32,
+                pixels,
+            )
+        },
+    );
+    let mut image = Image::new(
+        Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        pixels,
+        TextureFormat::Rgba8Unorm,
+        RenderAssetUsages::RENDER_WORLD,
+    );
+    image.sampler = ImageSampler::nearest();
+    image
 }
 
 pub(in crate::presentation) fn legacy_scene_environment(id: &SceneId) -> SceneEnvironment {
@@ -171,14 +236,40 @@ pub(super) fn on_environment_added(
         &ScenePresentationOf,
         &MeshMaterial3d<TacticalTerrainMaterial>,
     )>,
+    ground: Query<&SceneGround>,
     mut terrain_materials: ResMut<Assets<TacticalTerrainMaterial>>,
+    mut images: ResMut<Assets<Image>>,
 ) -> Result {
+    let environment = environments.get(event.entity)?;
+    let ground = ground.get(event.entity).ok();
+    for (source, material) in &presentations {
+        if source.0 == event.entity
+            && let Some(mut material) = terrain_materials.get_mut(&material.0)
+        {
+            *material = terrain_material(environment, ground, &mut images);
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn on_ground_added(
+    event: On<Add, SceneGround>,
+    grounds: Query<&SceneGround>,
+    environments: Query<&SceneEnvironment>,
+    presentations: Query<(
+        &ScenePresentationOf,
+        &MeshMaterial3d<TacticalTerrainMaterial>,
+    )>,
+    mut terrain_materials: ResMut<Assets<TacticalTerrainMaterial>>,
+    mut images: ResMut<Assets<Image>>,
+) -> Result {
+    let ground = grounds.get(event.entity)?;
     let environment = environments.get(event.entity)?;
     for (source, material) in &presentations {
         if source.0 == event.entity
             && let Some(mut material) = terrain_materials.get_mut(&material.0)
         {
-            *material = terrain_material(environment);
+            *material = terrain_material(environment, Some(ground), &mut images);
         }
     }
     Ok(())

--- a/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
@@ -213,7 +213,8 @@ struct ObstacleSummary {
 struct FoliageSummary {
     grass_clumps: usize,
     understory_clumps: usize,
-    leaf_litter_patches: usize,
+    dry_leaf_patches: usize,
+    twig_patches: usize,
 }
 
 #[derive(Serialize)]
@@ -271,7 +272,7 @@ struct ValidationSummary {
     coarse_source_terrain_upsampled: bool,
     microrelief_present: bool,
     grass_present: bool,
-    leaf_litter_present_when_trees: bool,
+    forest_floor_scatter_present_when_trees: bool,
     understory_present_when_expected: bool,
     vista_has_three_lods: bool,
     vista_reaches_fifty_kilometres: bool,
@@ -1162,18 +1163,21 @@ fn build_manifest(
     };
     let mut grass_clumps = 0;
     let mut understory_clumps = 0;
-    let mut leaf_litter_patches = 0;
+    let mut dry_leaf_patches = 0;
+    let mut twig_patches = 0;
     for layer in foliage {
         match layer {
             FoliageLayer::Grass => grass_clumps += 1,
             FoliageLayer::Understory => understory_clumps += 1,
-            FoliageLayer::LeafLitter => leaf_litter_patches += 1,
+            FoliageLayer::DryLeaves => dry_leaf_patches += 1,
+            FoliageLayer::Twigs => twig_patches += 1,
         }
     }
     let foliage_summary = FoliageSummary {
         grass_clumps,
         understory_clumps,
-        leaf_litter_patches,
+        dry_leaf_patches,
+        twig_patches,
     };
     let tree_impostor_bakes = tree_bakes
         .iter()
@@ -1274,7 +1278,8 @@ fn build_manifest(
                 && state.terrain.generated_samples > state.terrain.source_samples),
         microrelief_present: state.repairs.microrelief_adjusted_samples > 0,
         grass_present: grass_clumps > 0,
-        leaf_litter_present_when_trees: state.expected_trees == 0 || leaf_litter_patches > 0,
+        forest_floor_scatter_present_when_trees: state.expected_trees == 0
+            || (dry_leaf_patches > 0 && twig_patches > 0),
         understory_present_when_expected: !expects_understory || understory_clumps > 0,
         vista_has_three_lods: vista_summary.presented_lods.len() >= 3,
         vista_reaches_fifty_kilometres: vista_summary.diameter_metres >= 50_000.0,
@@ -1327,7 +1332,7 @@ fn validation_passes(validation: &ValidationSummary) -> bool {
         && validation.coarse_source_terrain_upsampled
         && validation.microrelief_present
         && validation.grass_present
-        && validation.leaf_litter_present_when_trees
+        && validation.forest_floor_scatter_present_when_trees
         && validation.understory_present_when_expected
         && validation.vista_has_three_lods
         && validation.vista_reaches_fifty_kilometres

--- a/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
@@ -91,7 +91,7 @@ struct CaptureView {
     overlay: bool,
 }
 
-const CAPTURE_VIEWS: [CaptureView; 13] = [
+const CAPTURE_VIEWS: [CaptureView; 14] = [
     CaptureView {
         slug: "warmup",
         label: "Render-pipeline warmup",
@@ -110,6 +110,11 @@ const CAPTURE_VIEWS: [CaptureView; 13] = [
     CaptureView {
         slug: "tree-recursive-lod",
         label: "Mixed recursive tree LOD view",
+        overlay: false,
+    },
+    CaptureView {
+        slug: "ground-cover",
+        label: "Tree-canopy leaf-litter and grass boundary",
         overlay: false,
     },
     CaptureView {
@@ -208,6 +213,7 @@ struct ObstacleSummary {
 struct FoliageSummary {
     grass_clumps: usize,
     understory_clumps: usize,
+    leaf_litter_patches: usize,
 }
 
 #[derive(Serialize)]
@@ -265,6 +271,7 @@ struct ValidationSummary {
     coarse_source_terrain_upsampled: bool,
     microrelief_present: bool,
     grass_present: bool,
+    leaf_litter_present_when_trees: bool,
     understory_present_when_expected: bool,
     vista_has_three_lods: bool,
     vista_reaches_fifty_kilometres: bool,
@@ -447,6 +454,7 @@ fn setup_scene(
     let GeneratedTacticalScene {
         digest,
         terrain,
+        ground,
         obstacles,
         repairs,
     } = generated;
@@ -683,6 +691,7 @@ fn setup_scene(
         Name::new("Captured tactical terrain"),
         SceneId(input.scene_key.clone()),
         environment,
+        ground,
         RigidBody::Static,
         CollisionLayers::new(TACTICAL_TERRAIN_LAYER, LayerMask::ALL),
         terrain_collider,
@@ -1035,6 +1044,16 @@ fn camera_for_view(slug: &str, state: &CaptureState) -> (Transform, Vec3) {
                 )
             },
         ),
+        "ground-cover" => state.tree_focus.map_or(
+            (state.ground_eye_position, state.ground_eye_target, Vec3::Y),
+            |tree| {
+                (
+                    tree + Vec3::new(5.5, -0.4, 5.5),
+                    tree + Vec3::new(0.0, -2.25, 0.0),
+                    Vec3::Y,
+                )
+            },
+        ),
         "tree-leaf-detail" => state.tree_leaf_focus.map_or(
             (state.ground_eye_position, state.ground_eye_target, Vec3::Y),
             |focus| {
@@ -1143,15 +1162,18 @@ fn build_manifest(
     };
     let mut grass_clumps = 0;
     let mut understory_clumps = 0;
+    let mut leaf_litter_patches = 0;
     for layer in foliage {
         match layer {
             FoliageLayer::Grass => grass_clumps += 1,
             FoliageLayer::Understory => understory_clumps += 1,
+            FoliageLayer::LeafLitter => leaf_litter_patches += 1,
         }
     }
     let foliage_summary = FoliageSummary {
         grass_clumps,
         understory_clumps,
+        leaf_litter_patches,
     };
     let tree_impostor_bakes = tree_bakes
         .iter()
@@ -1234,6 +1256,7 @@ fn build_manifest(
             || [
                 "tree-detail",
                 "tree-recursive-lod",
+                "ground-cover",
                 "tree-leaf-detail",
                 "tree-twig-lod",
                 "tree-small-branch-lod",
@@ -1251,6 +1274,7 @@ fn build_manifest(
                 && state.terrain.generated_samples > state.terrain.source_samples),
         microrelief_present: state.repairs.microrelief_adjusted_samples > 0,
         grass_present: grass_clumps > 0,
+        leaf_litter_present_when_trees: state.expected_trees == 0 || leaf_litter_patches > 0,
         understory_present_when_expected: !expects_understory || understory_clumps > 0,
         vista_has_three_lods: vista_summary.presented_lods.len() >= 3,
         vista_reaches_fifty_kilometres: vista_summary.diameter_metres >= 50_000.0,
@@ -1303,6 +1327,7 @@ fn validation_passes(validation: &ValidationSummary) -> bool {
         && validation.coarse_source_terrain_upsampled
         && validation.microrelief_present
         && validation.grass_present
+        && validation.leaf_litter_present_when_trees
         && validation.understory_present_when_expected
         && validation.vista_has_three_lods
         && validation.vista_reaches_fifty_kilometres

--- a/crates/adventuresim-tactical-core/src/lib.rs
+++ b/crates/adventuresim-tactical-core/src/lib.rs
@@ -56,13 +56,16 @@ pub mod prelude {
         Stats, TacticalCombatState, TacticalIncapacitationSources, TacticalPlayerView,
         TacticalPlayerViewer,
     };
-    pub use crate::scene::{SceneId, SceneTerrain, TerrainGenerator};
+    pub use crate::scene::{
+        GroundCover, GroundSubstrate, GroundSurface, SceneGround, SceneId, SceneTerrain,
+        TerrainGenerator,
+    };
     pub use crate::scene_input::{
         EnvironmentalSample, GeneratedObstacle, GeneratedTacticalScene, ROCK_RADIUS_METRES,
         SceneEnvironment, SceneInputError, SceneObstacle, SceneRepairReport, SceneSource,
-        TACTICAL_SCENE_GENERATION_VERSION, TACTICAL_SCENE_SCHEMA_VERSION, TREE_TRUNK_HEIGHT_METRES,
-        TREE_TRUNK_RADIUS_METRES, TacticalSceneInput, TacticalSurface, TerrainSampleGrid, VistaLod,
-        VistaSample,
+        TACTICAL_SCENE_GENERATION_VERSION, TACTICAL_SCENE_SCHEMA_VERSION,
+        TREE_CANOPY_GROUND_RADIUS_METRES, TREE_TRUNK_HEIGHT_METRES, TREE_TRUNK_RADIUS_METRES,
+        TacticalSceneInput, TacticalSurface, TerrainSampleGrid, VistaLod, VistaSample,
     };
     pub use adventuresim_core::item_catalog;
     pub use adventuresim_core::item_catalog::{EquipmentChannel, EquipmentLocation};

--- a/crates/adventuresim-tactical-core/src/scene.rs
+++ b/crates/adventuresim-tactical-core/src/scene.rs
@@ -60,6 +60,174 @@ impl TerrainGenerator {
 #[component(immutable)]
 pub struct SceneId(pub String);
 
+/// Physical material below a tactical ground-cover layer.
+///
+/// This is authoritative semantic data rather than a render-material index so
+/// server gameplay can query it without depending on client asset catalogs.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, Reflect)]
+#[serde(rename_all = "snake_case")]
+pub enum GroundSubstrate {
+    #[default]
+    Soil,
+    Stone,
+    Gravel,
+    Mud,
+    Road,
+    Water,
+}
+
+/// Mutually exclusive ground-cover profile at one tactical surface sample.
+///
+/// A profile can render several compatible details (for example leaves and
+/// twigs), but a location never simultaneously claims two cover profiles.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, Reflect)]
+#[serde(rename_all = "snake_case")]
+pub enum GroundCover {
+    Bare,
+    #[default]
+    TallGrass,
+    LeafLitter,
+    LooseStone,
+    Reeds,
+}
+
+/// Compact server-queryable description of one ground sample.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, Reflect)]
+#[serde(deny_unknown_fields)]
+pub struct GroundSurface {
+    pub substrate: GroundSubstrate,
+    pub cover: GroundCover,
+    pub cover_density_bps: u16,
+    pub cover_height_cm: u16,
+}
+
+/// Authoritative spatial ground semantics shared by the tactical server and
+/// clients. Samples use the same centered row-major grid convention as
+/// [`SceneTerrain`], allowing presentation and future gameplay systems to ask
+/// the same world-position question.
+#[derive(Component, Serialize, Deserialize, Debug, Reflect, Clone, PartialEq)]
+#[component(immutable)]
+pub struct SceneGround {
+    samples: Vec<GroundSurface>,
+    width: usize,
+    scale: f32,
+}
+
+impl SceneGround {
+    pub fn uniform_for_terrain(terrain: &SceneTerrain, surface: GroundSurface) -> Self {
+        Self {
+            samples: vec![surface; terrain.grid_width() * terrain.grid_depth()],
+            width: terrain.grid_width(),
+            scale: terrain.grid_scale(),
+        }
+    }
+
+    pub fn from_samples(
+        grid_width: usize,
+        grid_depth: usize,
+        scale: f32,
+        samples: Vec<GroundSurface>,
+    ) -> Option<Self> {
+        if grid_width < 2
+            || grid_depth < 2
+            || !scale.is_finite()
+            || scale <= 0.0
+            || samples.len() != grid_width.checked_mul(grid_depth)?
+            || samples
+                .iter()
+                .any(|sample| sample.cover_density_bps > 10_000 || sample.cover_height_cm > 1_000)
+        {
+            return None;
+        }
+        Some(Self {
+            samples,
+            width: grid_width,
+            scale,
+        })
+    }
+
+    pub fn grid_width(&self) -> usize {
+        self.width
+    }
+
+    pub fn grid_depth(&self) -> usize {
+        self.samples.len() / self.width
+    }
+
+    pub fn width(&self) -> f32 {
+        self.grid_width().saturating_sub(1) as f32 * self.scale
+    }
+
+    pub fn depth(&self) -> f32 {
+        self.grid_depth().saturating_sub(1) as f32 * self.scale
+    }
+
+    pub fn grid_scale(&self) -> f32 {
+        self.scale
+    }
+
+    pub fn samples(&self) -> &[GroundSurface] {
+        &self.samples
+    }
+
+    /// Returns the owning discrete ground sample for a centered world point.
+    /// Enum values are intentionally not interpolated across boundaries.
+    pub fn ground_at(&self, pos: Vec2) -> Option<GroundSurface> {
+        let grid = (pos + Vec2::new(self.width(), self.depth()) * 0.5) / self.scale;
+        if grid.x < 0.0
+            || grid.y < 0.0
+            || grid.x > (self.grid_width() - 1) as f32
+            || grid.y > (self.grid_depth() - 1) as f32
+        {
+            return None;
+        }
+        let x = (grid.x.floor() as usize).min(self.grid_width() - 1);
+        let z = (grid.y.floor() as usize).min(self.grid_depth() - 1);
+        self.samples.get(z * self.width + x).copied()
+    }
+
+    /// Conservatively checks a square scatter footprint. Macro grass patches
+    /// use this to avoid extending blades across a leaf-litter boundary.
+    pub fn cover_intersects_square(
+        &self,
+        centre: Vec2,
+        half_extent: f32,
+        cover: GroundCover,
+    ) -> bool {
+        if !half_extent.is_finite() || half_extent < 0.0 {
+            return false;
+        }
+        let half_size = Vec2::new(self.width(), self.depth()) * 0.5;
+        let minimum = ((centre - Vec2::splat(half_extent) + half_size) / self.scale)
+            .floor()
+            .max(Vec2::ZERO);
+        let maximum = ((centre + Vec2::splat(half_extent) + half_size) / self.scale)
+            .ceil()
+            .min(Vec2::new(
+                (self.grid_width() - 1) as f32,
+                (self.grid_depth() - 1) as f32,
+            ));
+        if minimum.x > maximum.x || minimum.y > maximum.y {
+            return false;
+        }
+        for z in minimum.y as usize..=maximum.y as usize {
+            for x in minimum.x as usize..=maximum.x as usize {
+                if self.samples[z * self.width + x].cover == cover {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    pub fn cover_count(&self, cover: GroundCover) -> usize {
+        self.samples
+            .iter()
+            .filter(|sample| sample.cover == cover)
+            .count()
+    }
+}
+
 #[derive(Component, Serialize, Deserialize, Default, Debug, Reflect, Clone, PartialEq)]
 pub struct SceneTerrain {
     heightmap: Vec<f32>,
@@ -275,6 +443,25 @@ impl SceneTerrain {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ground_grid_queries_discrete_centered_samples_and_rejects_invalid_data() {
+        let mut samples = vec![GroundSurface::default(); 9];
+        samples[4] = GroundSurface {
+            substrate: GroundSubstrate::Soil,
+            cover: GroundCover::LeafLitter,
+            cover_density_bps: 8_500,
+            cover_height_cm: 6,
+        };
+        let ground = SceneGround::from_samples(3, 3, 2.0, samples).unwrap();
+        assert_eq!(
+            ground.ground_at(Vec2::ZERO).unwrap().cover,
+            GroundCover::LeafLitter
+        );
+        assert!(ground.cover_intersects_square(Vec2::new(1.8, 0.0), 0.3, GroundCover::LeafLitter));
+        assert!(ground.ground_at(Vec2::new(2.01, 0.0)).is_none());
+        assert!(SceneGround::from_samples(1, 3, 1.0, vec![GroundSurface::default(); 3]).is_none());
+    }
 
     #[test]
     fn height_interpolation_respects_non_unit_grid_scale() {

--- a/crates/adventuresim-tactical-core/src/scene_input.rs
+++ b/crates/adventuresim-tactical-core/src/scene_input.rs
@@ -13,13 +13,15 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-use crate::scene::SceneTerrain;
+use crate::scene::{GroundCover, GroundSubstrate, GroundSurface, SceneGround, SceneTerrain};
 
 pub const TACTICAL_SCENE_SCHEMA_VERSION: u16 = 1;
-pub const TACTICAL_SCENE_GENERATION_VERSION: u16 = 3;
+pub const TACTICAL_SCENE_GENERATION_VERSION: u16 = 4;
 pub const MAX_SCENE_INPUT_BYTES: u64 = 32 * 1024 * 1024;
 pub const TREE_TRUNK_RADIUS_METRES: f32 = 0.35;
 pub const TREE_TRUNK_HEIGHT_METRES: f32 = 5.0;
+/// Conservative ground footprint of the generated English-oak crown.
+pub const TREE_CANOPY_GROUND_RADIUS_METRES: f32 = 5.75;
 pub const ROCK_RADIUS_METRES: f32 = 0.75;
 const MAX_PLAYABLE_SIDE: usize = 601;
 const MAX_VISTA_LEVELS: usize = 8;
@@ -155,6 +157,7 @@ pub enum GeneratedObstacle {
 pub struct GeneratedTacticalScene {
     pub digest: String,
     pub terrain: SceneTerrain,
+    pub ground: SceneGround,
     pub obstacles: Vec<GeneratedObstacle>,
     pub repairs: SceneRepairReport,
 }
@@ -329,9 +332,19 @@ impl TacticalSceneInput {
             )
         });
         repairs.removed_corridor_obstacles = (before - obstacles.len()) as u32;
+        let ground = build_scene_ground(
+            grid_width,
+            grid_depth,
+            grid_spacing,
+            &environment,
+            &terrain,
+            &obstacles,
+            self.playable.spacing_metres,
+        )?;
         Ok(GeneratedTacticalScene {
             digest: self.digest()?,
             terrain,
+            ground,
             obstacles,
             repairs,
         })
@@ -365,6 +378,102 @@ impl TacticalSceneInput {
             water_bps: (sum[3] / count) as u16,
             hilly_bps: (sum[4] / count) as u16,
         }
+    }
+}
+
+fn build_scene_ground(
+    width: usize,
+    depth: usize,
+    spacing: f32,
+    environment: &[EnvironmentalSample],
+    terrain: &SceneTerrain,
+    obstacles: &[GeneratedObstacle],
+    obstacle_spacing: f32,
+) -> Result<SceneGround, SceneInputError> {
+    let mut samples = environment
+        .iter()
+        .copied()
+        .map(base_ground_surface)
+        .collect::<Vec<_>>();
+    let half_width = terrain.width() * 0.5;
+    let half_depth = terrain.depth() * 0.5;
+    let canopy_radius_squared = TREE_CANOPY_GROUND_RADIUS_METRES.powi(2);
+    for obstacle in obstacles {
+        let GeneratedObstacle::Tree { x, z } = *obstacle else {
+            continue;
+        };
+        let tree = bevy::math::Vec2::new(
+            f32::from(x) * obstacle_spacing - half_width,
+            f32::from(z) * obstacle_spacing - half_depth,
+        );
+        for sample_z in 0..depth {
+            for sample_x in 0..width {
+                let position = bevy::math::Vec2::new(
+                    sample_x as f32 * spacing - half_width,
+                    sample_z as f32 * spacing - half_depth,
+                );
+                if position.distance_squared(tree) > canopy_radius_squared {
+                    continue;
+                }
+                let sample = &mut samples[sample_z * width + sample_x];
+                if !matches!(
+                    sample.substrate,
+                    GroundSubstrate::Water | GroundSubstrate::Road
+                ) {
+                    sample.cover = GroundCover::LeafLitter;
+                    sample.cover_density_bps = 9_200;
+                    sample.cover_height_cm = 6;
+                }
+            }
+        }
+    }
+    SceneGround::from_samples(width, depth, spacing, samples).ok_or_else(|| {
+        SceneInputError::Validation("generated ground-surface grid is invalid".into())
+    })
+}
+
+fn base_ground_surface(sample: EnvironmentalSample) -> GroundSurface {
+    if sample.crossing_bps >= 5_000 || matches!(sample.surface, TacticalSurface::Road) {
+        return GroundSurface {
+            substrate: GroundSubstrate::Road,
+            cover: GroundCover::Bare,
+            cover_density_bps: 0,
+            cover_height_cm: 0,
+        };
+    }
+    if sample.water_bps >= 5_000 || matches!(sample.surface, TacticalSurface::Water) {
+        return GroundSurface {
+            substrate: GroundSubstrate::Water,
+            cover: GroundCover::Bare,
+            cover_density_bps: 0,
+            cover_height_cm: 0,
+        };
+    }
+    if sample.wetland_bps >= 5_000 || matches!(sample.surface, TacticalSurface::Wetland) {
+        return GroundSurface {
+            substrate: GroundSubstrate::Mud,
+            cover: GroundCover::Reeds,
+            cover_density_bps: sample.wetland_bps.max(5_000),
+            cover_height_cm: 110,
+        };
+    }
+    if sample.hilly_bps >= 6_500 {
+        return GroundSurface {
+            substrate: if sample.hilly_bps >= 8_500 {
+                GroundSubstrate::Stone
+            } else {
+                GroundSubstrate::Gravel
+            },
+            cover: GroundCover::LooseStone,
+            cover_density_bps: (sample.hilly_bps / 2).clamp(3_250, 5_000),
+            cover_height_cm: 4,
+        };
+    }
+    GroundSurface {
+        substrate: GroundSubstrate::Soil,
+        cover: GroundCover::TallGrass,
+        cover_density_bps: 9_600u16.saturating_sub(sample.canopy_bps / 5),
+        cover_height_cm: 82,
     }
 }
 
@@ -823,10 +932,9 @@ mod tests {
             .unwrap()
             .generate()
             .unwrap();
-        let sparse = TacticalSceneInput::load(&root.join("sparse-woodland.json"))
-            .unwrap()
-            .generate()
-            .unwrap();
+        let sparse_input = TacticalSceneInput::load(&root.join("sparse-woodland.json")).unwrap();
+        let sparse_spacing = sparse_input.playable.spacing_metres;
+        let sparse = sparse_input.generate().unwrap();
         let hillside = TacticalSceneInput::load(&root.join("steep-open-hillside.json"))
             .unwrap()
             .generate()
@@ -844,6 +952,24 @@ mod tests {
                 .iter()
                 .any(|obstacle| matches!(obstacle, GeneratedObstacle::Rock { .. }))
         );
+        assert!(
+            flat.ground.cover_count(GroundCover::TallGrass)
+                > flat.ground.cover_count(GroundCover::LeafLitter)
+        );
+        for obstacle in &sparse.obstacles {
+            let GeneratedObstacle::Tree { x, z } = *obstacle else {
+                continue;
+            };
+            let position = bevy::math::Vec2::new(
+                f32::from(x) * sparse_spacing - sparse.terrain.width() * 0.5,
+                f32::from(z) * sparse_spacing - sparse.terrain.depth() * 0.5,
+            );
+            assert_eq!(
+                sparse.ground.ground_at(position).unwrap().cover,
+                GroundCover::LeafLitter
+            );
+        }
+        assert!(sparse.ground.cover_count(GroundCover::LeafLitter) > 0);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-netcode/src/replication.rs
+++ b/crates/adventuresim-tactical-netcode/src/replication.rs
@@ -44,6 +44,7 @@ impl Plugin for AdventureSimulatorReplicationPlugin {
             .replicate::<ItemOf>()
             .replicate::<SceneId>()
             .replicate::<SceneTerrain>()
+            .replicate::<SceneGround>()
             .replicate::<SceneEnvironment>()
             .replicate::<SceneObstacle>()
             .add_client_event::<JoinRequest>(Channel::Ordered)

--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -205,7 +205,7 @@ fn on_server_started(
 ) -> Result {
     info!("Server opened on {:?}", **server_addr);
     info!("Creating a game scene for {}", args.scene_key);
-    let (scene_id, terrain, environment, obstacles, obstacle_spacing) =
+    let (scene_id, terrain, ground, environment, obstacles, obstacle_spacing) =
         if let Some(input) = &scene_input.0 {
             let generated = input.generate()?;
             info!(
@@ -224,6 +224,7 @@ fn on_server_started(
             (
                 input.scene_key.clone(),
                 generated.terrain,
+                generated.ground,
                 Some(input.environment_snapshot(generated.digest)),
                 generated.obstacles,
                 input.playable.spacing_metres,
@@ -240,9 +241,20 @@ fn on_server_started(
                 }
             };
             generator.period = gen_period;
+            let terrain = generator.generate(args.scene_width, scene_height, args.scene_depth);
+            let ground = SceneGround::uniform_for_terrain(
+                &terrain,
+                GroundSurface {
+                    substrate: GroundSubstrate::Soil,
+                    cover: GroundCover::TallGrass,
+                    cover_density_bps: 9_000,
+                    cover_height_cm: 82,
+                },
+            );
             (
                 args.scene_key.clone(),
-                generator.generate(args.scene_width, scene_height, args.scene_depth),
+                terrain,
+                ground,
                 None,
                 Vec::new(),
                 1.0,
@@ -285,6 +297,7 @@ fn on_server_started(
         Replicated,
         SceneId(scene_id),
         terrain,
+        ground,
         RigidBody::Static,
         CollisionLayers::new(TACTICAL_TERRAIN_LAYER, LayerMask::ALL),
         terrain_collider,

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -791,15 +791,17 @@ just tactical-tree-canopy-series target/tactical-scene-captures/oak-canopy-revie
 The native viewer writes standing-eye-height (1.65 m above the sampled local
 terrain), overhead, horizon, and collider-overlay PNGs alongside the exact
 `input.json`, a browsable `index.html`, and a
-machine-readable `manifest.json`. Seven focused views target the nearest tree,
-when present: a complete individual-leaf tree, a neutral silhouette plate, an
+machine-readable `manifest.json`. Eight focused views target the nearest tree,
+when present: a complete individual-leaf tree, a canopy-ground view proving the
+leaf-litter/grass boundary, a neutral silhouette plate, an
 isolated terminal-shoot close-up with a 10 cm scale marker, and matched-scale
 leafed-twig, small-branch, crown-branch, and whole-tree-billboard views. The
 terminal plate uses the exact production branch and leaf geometry for that
 seed rather than a separately authored review prop. They fall back to the ordinary ground view
 for treeless fixtures. The viewer waits for custom material pipelines before
 capturing, then exits unsuccessfully and writes `failure.txt` when
-presentation/collider counts, collider-bounded procedural rocks, terrain
+presentation/collider counts, collider-bounded procedural rocks, authoritative
+leaf litter for generated trees, terrain
 material, coarse-input upsampling, microrelief, expected foliage, rendered
 overhead foliage detail in the flat sentinel fixture, all five tree
 LODs, precipitation, three vista LODs, the 50 km vista contract, non-uniform

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -791,9 +791,9 @@ just tactical-tree-canopy-series target/tactical-scene-captures/oak-canopy-revie
 The native viewer writes standing-eye-height (1.65 m above the sampled local
 terrain), overhead, horizon, and collider-overlay PNGs alongside the exact
 `input.json`, a browsable `index.html`, and a
-machine-readable `manifest.json`. Eight focused views target the nearest tree,
+machine-readable `manifest.json`. Nine focused views target the nearest tree,
 when present: a complete individual-leaf tree, a canopy-ground view proving the
-leaf-litter/grass boundary, a neutral silhouette plate, an
+leaf-litter/grass boundary, a mixed recursive-LOD view, a neutral silhouette plate, an
 isolated terminal-shoot close-up with a 10 cm scale marker, and matched-scale
 leafed-twig, small-branch, crown-branch, and whole-tree-billboard views. The
 terminal plate uses the exact production branch and leaf geometry for that
@@ -801,7 +801,7 @@ seed rather than a separately authored review prop. They fall back to the ordina
 for treeless fixtures. The viewer waits for custom material pipelines before
 capturing, then exits unsuccessfully and writes `failure.txt` when
 presentation/collider counts, collider-bounded procedural rocks, authoritative
-leaf litter for generated trees, terrain
+separate dry-leaf and twig scatter for generated trees, terrain
 material, coarse-input upsampling, microrelief, expected foliage, rendered
 overhead foliage detail in the flat sentinel fixture, all five tree
 LODs, precipitation, three vista LODs, the 50 km vista contract, non-uniform

--- a/wiki/shared/terrain.md
+++ b/wiki/shared/terrain.md
@@ -58,7 +58,25 @@ coverage yields taller trees whose first scaffold branches sit above the clear
 bole. This value is part of deterministic generation rather than a query over
 spawned neighbors, preserving parallel tree construction.
 
-Grass, shrubs, and reeds are deterministic shared-mesh foliage with no gameplay
+Playable terrain also carries a replicated, authoritative `SceneGround` grid
+aligned with its height samples. Each location has one semantic substrate, one
+mutually exclusive cover profile, bounded cover density, and cover height. The
+tactical server retains the CPU grid and exposes world-position queries; this
+is the future boundary for concealment, footsteps, tracks, and traversal, but
+those gameplay consumers are not implemented yet. The client uploads a packed
+copy as the terrain material map and uses the same values for deterministic
+scatter. Texture asset identifiers are presentation details and never become
+server authority.
+
+Generated tree crowns stamp leaf-litter cover into this grid. Grass macro
+patches conservatively reject any footprint intersecting those cells, while a
+shared proof-of-concept mesh scatters dry leaves and twigs over the warmer
+forest-floor material. Open soil remains tall grass, wet ground selects reeds,
+and sufficiently hilly samples select loose stone; these profiles are mutually
+exclusive at a location even when one profile renders several compatible
+details.
+
+Grass, shrubs, reeds, leaves, and twigs are deterministic shared-mesh foliage with no gameplay
 collider. Grass uses overlapping 3.2-metre shared macro patches containing 729 individually
 oriented ribbons: each nearby blade samples a cubic longitudinal curve with
 fifteen vertices, then cross-fades beyond 34 metres to a stable 144-blade

--- a/wiki/shared/terrain.md
+++ b/wiki/shared/terrain.md
@@ -69,9 +69,10 @@ scatter. Texture asset identifiers are presentation details and never become
 server authority.
 
 Generated tree crowns stamp leaf-litter cover into this grid. Grass macro
-patches conservatively reject any footprint intersecting those cells, while a
-shared proof-of-concept mesh scatters dry leaves and twigs over the warmer
-forest-floor material. Open soil remains tall grass, wet ground selects reeds,
+patches conservatively reject any footprint intersecting those cells. Separate
+shared meshes scatter a dense dry-leaf carpet and a looser layer of longer
+twigs with independent deterministic placement over the warmer forest-floor
+material. Open soil remains tall grass, wet ground selects reeds,
 and sufficiently hilly samples select loose stone; these profiles are mutually
 exclusive at a location even when one profile renders several compatible
 details.


### PR DESCRIPTION
## Summary

- add an authoritative replicated `SceneGround` grid with substrate, mutually exclusive cover, density, and height metadata
- keep the same CPU-readable surface data on the tactical server for future concealment, footstep-noise, tracking, and traversal rules
- stamp generated tree canopies as leaf litter, suppress grass across those footprints, and render separate dense dry-leaf and twig mesh layers
- upload the semantic ground map to the terrain shader so distant grass and ground tint follow the same cover classification
- add fixture, query, mesh, and native-capture validation plus architecture/development documentation

This is stacked on `codex/tactical-world-scenes` and establishes a prerequisite for #475. It intentionally does not implement stealth yet; it exposes the authoritative query contract that stealth and gravel-footstep systems can consume later.

## Validation

- `cargo fmt --all -- --check`
- `cargo run -p adventuresim-tactical-core --bin generate-scene-fixtures -- --check`
- `cargo check -p adventuresim-tactical-core -p adventuresim-tactical-netcode -p adventuresim-tactical-server -p adventuresim-tactical-client`
- `cargo test -p adventuresim-tactical-core` (106 passed)
- `cargo test -p adventuresim-tactical-client --bin tactical-scene-viewer` (23 passed)
- native dense-woodland capture: all semantic gates passed; 377 dry-leaf patches and 173 twig patches; visually inspected the grass-free canopy boundary and the independently scattered mesh layers
