### PR TITLE
Default tactical development to dense woodland

### DIFF
--- a/crates/adventuresim-tactical-server/src/main.rs
+++ b/crates/adventuresim-tactical-server/src/main.rs
@@ -40,7 +40,7 @@ use crate::{
 };
 
 const MISSION_TIMEOUT_SECS: f32 = 300.0;
-const TERRAIN_SIZE: usize = 100;
+const DEFAULT_SCENE_INPUT: &str = "assets/tactical-scenes/dense-woodland.json";
 
 #[derive(Parser, Debug, Clone, Resource)]
 #[command(name = "adventuresim-tactical-server")]
@@ -52,16 +52,12 @@ struct Args {
     mission_id: String,
     #[arg(long, env = "ADVENTURESIM_TACTICAL_CLAIM", hide_env_values = true)]
     tactical_claim: String,
-    #[arg(long)]
+    #[arg(long, default_value = "woodland")]
     scene_key: String,
-    /// Exact versioned scene input. When omitted, the legacy synthetic scene
-    /// remains available only for existing tactical development commands.
+    /// Exact versioned scene input. Defaults to the committed dense woodland
+    /// fixture for standalone tactical development.
     #[arg(long)]
     scene_input: Option<PathBuf>,
-    #[arg(long, default_value_t = TERRAIN_SIZE)]
-    scene_width: usize,
-    #[arg(long, default_value_t = TERRAIN_SIZE)]
-    scene_depth: usize,
     #[arg(long)]
     required_enemy_kills: u32,
     #[arg(long, value_parser = clap::value_parser!(u32).range(1..))]
@@ -78,19 +74,51 @@ struct Args {
     no_timeout: bool,
 }
 
+fn default_scene_input_path() -> PathBuf {
+    let working_directory_path = PathBuf::from(DEFAULT_SCENE_INPUT);
+    if working_directory_path.is_file() {
+        return working_directory_path;
+    }
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(DEFAULT_SCENE_INPUT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standalone_default_is_the_dense_woodland_fixture() {
+        let input = TacticalSceneInput::load(&default_scene_input_path())
+            .expect("default tactical scene input should remain valid");
+
+        assert_eq!(input.scene_key, "woodland");
+        assert_eq!(
+            input.source,
+            SceneSource::SyntheticFixture("dense-woodland".into())
+        );
+    }
+}
+
 fn main() {
     let args = Args::parse();
-    let loaded_scene_input = match args.scene_input.as_deref().map(TacticalSceneInput::load) {
-        Some(Ok(input)) => Some(input),
-        Some(Err(error)) => {
+    let scene_input_path = args
+        .scene_input
+        .clone()
+        .unwrap_or_else(default_scene_input_path);
+    let loaded_scene_input = match TacticalSceneInput::load(&scene_input_path) {
+        Ok(input) => input,
+        Err(error) => {
             eprintln!("refusing invalid tactical scene input: {error}");
             std::process::exit(2);
         }
-        None => None,
     };
-    let scene_vista_bundle = loaded_scene_input.as_ref().map(|input| SceneVistaBundle {
-        scene_digest: input.digest().expect("loaded scene input was validated"),
-        lods: input.vista.lods.clone(),
+    let scene_vista_bundle = Some(SceneVistaBundle {
+        scene_digest: loaded_scene_input
+            .digest()
+            .expect("loaded scene input was validated"),
+        lods: loaded_scene_input.vista.lods.clone(),
     });
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
@@ -161,7 +189,7 @@ fn main() {
 }
 
 #[derive(Resource)]
-struct LoadedSceneInput(Option<TacticalSceneInput>);
+struct LoadedSceneInput(TacticalSceneInput);
 
 #[derive(Resource)]
 pub(crate) struct SceneVistaBundleResource(pub(crate) Option<SceneVistaBundle>);
@@ -205,61 +233,27 @@ fn on_server_started(
 ) -> Result {
     info!("Server opened on {:?}", **server_addr);
     info!("Creating a game scene for {}", args.scene_key);
-    let (scene_id, terrain, ground, environment, obstacles, obstacle_spacing) =
-        if let Some(input) = &scene_input.0 {
-            let generated = input.generate()?;
-            info!(
-                scene_digest = %generated.digest,
-                schema_version = input.schema_version,
-                generation_version = input.generation_version,
-                source = ?input.source,
-                obstacles = generated.obstacles.len(),
-                upsampled_height_samples = generated.repairs.upsampled_height_samples,
-                microrelief_adjusted_samples = generated.repairs.microrelief_adjusted_samples,
-                adjusted_height_samples = generated.repairs.adjusted_height_samples,
-                repaired_water_samples = generated.repairs.repaired_water_samples,
-                removed_corridor_obstacles = generated.repairs.removed_corridor_obstacles,
-                "Loaded deterministic tactical scene input"
-            );
-            (
-                input.scene_key.clone(),
-                generated.terrain,
-                generated.ground,
-                Some(input.environment_snapshot(generated.digest)),
-                generated.obstacles,
-                input.playable.spacing_metres,
-            )
-        } else {
-            warn!("No --scene-input supplied; using legacy synthetic development terrain");
-            let mut generator = TerrainGenerator::from_hash((&args.mission_id, &args.scene_key));
-            let (scene_height, gen_period) = match args.scene_key.as_str() {
-                "hills" => (30, 200.0),
-                "desert" => (2, 30.0),
-                id => {
-                    warn!("Unknown scene: {id}");
-                    (0, 1.0)
-                }
-            };
-            generator.period = gen_period;
-            let terrain = generator.generate(args.scene_width, scene_height, args.scene_depth);
-            let ground = SceneGround::uniform_for_terrain(
-                &terrain,
-                GroundSurface {
-                    substrate: GroundSubstrate::Soil,
-                    cover: GroundCover::TallGrass,
-                    cover_density_bps: 9_000,
-                    cover_height_cm: 82,
-                },
-            );
-            (
-                args.scene_key.clone(),
-                terrain,
-                ground,
-                None,
-                Vec::new(),
-                1.0,
-            )
-        };
+    let input = &scene_input.0;
+    let generated = input.generate()?;
+    info!(
+        scene_digest = %generated.digest,
+        schema_version = input.schema_version,
+        generation_version = input.generation_version,
+        source = ?input.source,
+        obstacles = generated.obstacles.len(),
+        upsampled_height_samples = generated.repairs.upsampled_height_samples,
+        microrelief_adjusted_samples = generated.repairs.microrelief_adjusted_samples,
+        adjusted_height_samples = generated.repairs.adjusted_height_samples,
+        repaired_water_samples = generated.repairs.repaired_water_samples,
+        removed_corridor_obstacles = generated.repairs.removed_corridor_obstacles,
+        "Loaded deterministic tactical scene input"
+    );
+    let scene_id = input.scene_key.clone();
+    let terrain = generated.terrain;
+    let ground = generated.ground;
+    let environment = input.environment_snapshot(generated.digest);
+    let obstacles = generated.obstacles;
+    let obstacle_spacing = input.playable.spacing_metres;
     for obstacle in obstacles {
         let (grid_x, grid_z, kind, collider, height_offset, label) = match obstacle {
             GeneratedObstacle::Tree { x, z } => (
@@ -303,21 +297,11 @@ fn on_server_started(
         terrain_collider,
         Transform::default(),
     ));
-    if let Some(environment) = environment {
-        scene.insert(environment);
-    }
-    let scene_width = scene_input
-        .0
-        .as_ref()
-        .map_or(args.scene_width as f32, |input| {
-            f32::from(input.playable.width.saturating_sub(1)) * input.playable.spacing_metres
-        });
-    let scene_depth = scene_input
-        .0
-        .as_ref()
-        .map_or(args.scene_depth as f32, |input| {
-            f32::from(input.playable.depth.saturating_sub(1)) * input.playable.spacing_metres
-        });
+    scene.insert(environment);
+    let scene_width =
+        f32::from(input.playable.width.saturating_sub(1)) * input.playable.spacing_metres;
+    let scene_depth =
+        f32::from(input.playable.depth.saturating_sub(1)) * input.playable.spacing_metres;
     commands.spawn((
         RigidBody::Static,
         CollisionLayers::new(TACTICAL_TERRAIN_LAYER, LayerMask::ALL),

--- a/justfile
+++ b/justfile
@@ -282,8 +282,8 @@ _spawner-stop:
 # Run a single tactical server (for testing). Defaults come from `.env.tactical`
 # (written by `tactical-isolated`) when present, otherwise from the canonical
 # stack - so a bare `just tactical` targets whichever is currently running.
-tactical mission_id=env_var_or_default("TACTICAL_MISSION_ID", "test-mission") scene_key=env_var_or_default("TACTICAL_SCENE_KEY", "hills") bots=env_var_or_default("TACTICAL_BOTS", "3") port=env_var_or_default("TACTICAL_PORT", tactical_port) url=env_var_or_default("TACTICAL_SPACETIMEDB_URL", spacetime_url) module=env_var_or_default("TACTICAL_SPACETIMEDB_MODULE", spacetime_module) enemy_combat_scale_bps=env_var_or_default("TACTICAL_ENEMY_COMBAT_SCALE_BPS", "10000") scene_input=env_var_or_default("TACTICAL_SCENE_INPUT", ""):
-    @if ("{{ scene_input }}") { cargo run --package adventuresim-tactical-server --features "debug" -- --addr "0.0.0.0:{{ port }}" --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --scene-input {{ quote(scene_input) }} --spacetimedb-url {{ url }} --spacetimedb-module {{ module }} --expected-party-members 1 --required-enemy-kills {{ bots }} --enemy-combat-scale-bps {{ enemy_combat_scale_bps }} --no-timeout } else { cargo run --package adventuresim-tactical-server --features "debug" -- --addr "0.0.0.0:{{ port }}" --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --spacetimedb-url {{ url }} --spacetimedb-module {{ module }} --expected-party-members 1 --required-enemy-kills {{ bots }} --enemy-combat-scale-bps {{ enemy_combat_scale_bps }} --no-timeout }
+tactical mission_id=env_var_or_default("TACTICAL_MISSION_ID", "test-mission") scene_key=env_var_or_default("TACTICAL_SCENE_KEY", "woodland") bots=env_var_or_default("TACTICAL_BOTS", "3") port=env_var_or_default("TACTICAL_PORT", tactical_port) url=env_var_or_default("TACTICAL_SPACETIMEDB_URL", spacetime_url) module=env_var_or_default("TACTICAL_SPACETIMEDB_MODULE", spacetime_module) enemy_combat_scale_bps=env_var_or_default("TACTICAL_ENEMY_COMBAT_SCALE_BPS", "10000") scene_input=env_var_or_default("TACTICAL_SCENE_INPUT", "assets/tactical-scenes/dense-woodland.json"):
+    @cargo run --package adventuresim-tactical-server --features "debug" -- --addr "0.0.0.0:{{ port }}" --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --scene-input {{ quote(scene_input) }} --spacetimedb-url {{ url }} --spacetimedb-module {{ module }} --expected-party-members 1 --required-enemy-kills {{ bots }} --enemy-combat-scale-bps {{ enemy_combat_scale_bps }} --no-timeout
 
 # Run a native tactical client (for testing `just tactical`). Defaults come
 # from `.env.tactical` when present, same as `tactical` above.
@@ -294,15 +294,15 @@ client id=env_var_or_default("TACTICAL_CHARACTER_ID", "0") port=env_var_or_defau
 # No strategic layer, no WASM build - just the DB plus a mission. Writes
 # .env.tactical so a bare `just tactical` / `just client` (no arguments) in
 # other terminals targets it automatically.
-tactical-isolated profile="tactical-dev" base_port="23200" mission_id="mission:test-mission" scene_key="hills" character_id="0" bots="3" scene_input="": preflight verify-db-client build-tactical
-    @{{ python_bin }} scripts/dev_stack.py run-profile --mode tactical {{ quote(profile) }} {{ quote(base_port) }} --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --character-id {{ quote(character_id) }} --enemy-count {{ quote(bots) }} {{ if scene_input != "" { "--scene-input " + quote(scene_input) } else { "" } }}
+tactical-isolated profile="tactical-dev" base_port="23200" mission_id="mission:test-mission" scene_key="woodland" character_id="0" bots="3" scene_input="assets/tactical-scenes/dense-woodland.json": preflight verify-db-client build-tactical
+    @{{ python_bin }} scripts/dev_stack.py run-profile --mode tactical {{ quote(profile) }} {{ quote(base_port) }} --mission-id {{ quote(mission_id) }} --scene-key {{ quote(scene_key) }} --character-id {{ quote(character_id) }} --enemy-count {{ quote(bots) }} --scene-input {{ quote(scene_input) }}
 
 # Build and supervise a complete disposable native tactical test session.
 # animation disables combat, diagnostic runs scripted real-client input and
 # records every animation frame, combat uses normal enemies, and networking
 # omits the client while retaining the validated database/server fixture.
-tactical-play mode="animation" base_port="24920" graphics_preset="default" presentation_trace="auto" present_mode="auto-vsync" window_capture="auto" capture_source="window" render_backend="auto" scene_input="": preflight verify-db-client
-    @{{ python_bin }} scripts/dev_stack.py tactical-play {{ quote(mode) }} {{ quote(base_port) }} --graphics-preset {{ quote(graphics_preset) }} --presentation-trace {{ quote(presentation_trace) }} --present-mode {{ quote(present_mode) }} --window-capture {{ quote(window_capture) }} --capture-source {{ quote(capture_source) }} --render-backend {{ quote(render_backend) }} {{ if scene_input != "" { "--scene-input " + quote(scene_input) } else { "" } }}
+tactical-play mode="animation" base_port="24920" graphics_preset="default" presentation_trace="auto" present_mode="auto-vsync" window_capture="auto" capture_source="window" render_backend="auto" scene_input="assets/tactical-scenes/dense-woodland.json": preflight verify-db-client
+    @{{ python_bin }} scripts/dev_stack.py tactical-play {{ quote(mode) }} {{ quote(base_port) }} --graphics-preset {{ quote(graphics_preset) }} --presentation-trace {{ quote(presentation_trace) }} --present-mode {{ quote(present_mode) }} --window-capture {{ quote(window_capture) }} --capture-source {{ quote(capture_source) }} --render-backend {{ quote(render_backend) }} --scene-input {{ quote(scene_input) }}
 
 # Capture one deterministic tactical environment from fixed ground, overhead,
 # horizon, and collider-overlay cameras. Output must be a fresh directory when set.

--- a/scripts/dev_stack.py
+++ b/scripts/dev_stack.py
@@ -1171,7 +1171,7 @@ def run_profile(
     mode: ProfileMode = ProfileMode.STRATEGIC,
     verify_http: bool = False,
     mission_id: str = "mission:test-mission",
-    scene_key: str = "hills",
+    scene_key: str = "woodland",
     character_id: int = 0,
     enemy_count: int = 3,
     scene_input: str | None = None,
@@ -2058,7 +2058,7 @@ def tactical_play(
             result = run_checked([
                 "spacetime", "call", "--server", server_url, database,
                 "seed_standalone_tactical_mission", bootstrap_token,
-                str(character_id), mission_id, "hills", str(enemy_count), tactical_claim,
+                str(character_id), mission_id, "woodland", str(enemy_count), tactical_claim,
             ])
             if result.returncode:
                 write_console(result.stdout)
@@ -2068,7 +2068,7 @@ def tactical_play(
                 database=database,
                 port=int(values["tactical_port"]),
                 mission_id=mission_id,
-                scene_key="hills",
+                scene_key="woodland",
                 character_id=character_id,
                 enemy_count=enemy_count,
                 tactical_claim=None,
@@ -2098,7 +2098,7 @@ def tactical_play(
             server_metadata = run_dir / "server.identity.json"
             server_command = [
                 str(server_executable), "--addr", f"0.0.0.0:{values['tactical_port']}",
-                "--mission-id", mission_id, "--scene-key", "hills",
+                "--mission-id", mission_id, "--scene-key", "woodland",
                 "--spacetimedb-url", server_url, "--spacetimedb-module", database,
                 "--expected-party-members", "1", "--required-enemy-kills", str(enemy_count),
                 "--enemy-combat-scale-bps", str(combat_scale), "--no-timeout",
@@ -2362,8 +2362,8 @@ def create_parser() -> argparse.ArgumentParser:
     runner = sub.add_parser("run-profile")
     runner.add_argument("--mode", choices=[m.value for m in ProfileMode], default=ProfileMode.STRATEGIC.value)
     runner.add_argument("--mission-id", default="mission:test-mission")
-    runner.add_argument("--scene-key", default="hills")
-    runner.add_argument("--scene-input")
+    runner.add_argument("--scene-key", default="woodland")
+    runner.add_argument("--scene-input", default="assets/tactical-scenes/dense-woodland.json")
     runner.add_argument("--character-id", type=int, default=0)
     runner.add_argument("--enemy-count", type=int, default=3)
     runner.add_argument("name")
@@ -2411,7 +2411,9 @@ def create_parser() -> argparse.ArgumentParser:
     tactical_play_parser.add_argument(
         "--render-backend", choices=("auto", "vulkan", "dx12"), default="auto"
     )
-    tactical_play_parser.add_argument("--scene-input")
+    tactical_play_parser.add_argument(
+        "--scene-input", default="assets/tactical-scenes/dense-woodland.json"
+    )
     sub.add_parser("tactical-status")
     sub.add_parser("tactical-client")
     return parser

--- a/scripts/just_tasks.py
+++ b/scripts/just_tasks.py
@@ -528,7 +528,7 @@ def win_dev() -> int:
             sync_tree(assets, stage / "assets", clear=False)
         server = subprocess.Popen([
             str(stage / "adventuresim-tactical-server.exe"), "--addr", "0.0.0.0:6000",
-            "--mission-id", "test-mission", "--scene-key", "hills", "--spacetimedb-url",
+            "--mission-id", "test-mission", "--scene-key", "woodland", "--spacetimedb-url",
             SPACETIME_URL, "--spacetimedb-module", SPACETIME_DATABASE,
             "--expected-party-members", "1", "--bots", "3", "--no-timeout",
         ], cwd=stage)

--- a/scripts/tests/test_dev_stack.py
+++ b/scripts/tests/test_dev_stack.py
@@ -240,7 +240,8 @@ class WorkflowTests(unittest.TestCase):
         ])
         self.assertEqual(args.mode, "tactical")
         self.assertEqual(args.mission_id, "mission:test-mission")
-        self.assertEqual(args.scene_key, "hills")
+        self.assertEqual(args.scene_key, "woodland")
+        self.assertEqual(args.scene_input, "assets/tactical-scenes/dense-woodland.json")
         self.assertEqual(args.character_id, 0)
         self.assertEqual(args.enemy_count, 3)
 

--- a/wiki/reference/architecture.md
+++ b/wiki/reference/architecture.md
@@ -323,6 +323,9 @@ at the request's authoritative case-site coordinates and character minute,
 materializes the validated document atomically, and passes only its path to the
 child. A tactical-only workflow may instead supply the identical format with
 `--scene-input`, so tactical processes never load the continental pack.
+Standalone tactical development defaults to the committed `dense-woodland`
+input when no path is supplied; the server has no alternate noise-terrain
+fallback.
 
 A running tactical client receives a private, server-generated 256-bit
 reconnect capability after enrollment. The client retains it in process across

--- a/wiki/reference/developing.md
+++ b/wiki/reference/developing.md
@@ -744,11 +744,13 @@ debugging. It exposes more lifecycle details and therefore more footguns.
 For testing without the spawner:
 
 ```bash
-just tactical mission_id="test-123" scene_key="hills"
+just tactical mission_id="test-123"
 ```
 
-To exercise the versioned tactical scene boundary with bounded synthetic world
-data, pass the committed fixture (or set `TACTICAL_SCENE_INPUT`):
+Standalone tactical development defaults to the committed `dense-woodland`
+fixture. To exercise the versioned tactical scene boundary with a different
+bounded synthetic world input, pass another fixture (or set
+`TACTICAL_SCENE_INPUT`):
 
 ```powershell
 $env:TACTICAL_MISSION_ID = "test-123"
@@ -761,8 +763,9 @@ The server validates schema/generation versions, dimensions, sample counts,
 finite values, geographic and environmental bounds, weather consistency, and
 the 32 MiB file cap before opening its game listener. It deterministically
 repairs impassable deployment pads and the central encounter corridor, then
-logs the stable scene digest and repair counts. With no scene input, the old
-`hills`/`desert` noise generator remains a tactical development fallback.
+logs the stable scene digest and repair counts. If `--scene-input` is omitted,
+the server loads `assets/tactical-scenes/dense-woodland.json`; there is no
+separate synthetic terrain fallback.
 
 The committed catalog under `assets/tactical-scenes/` covers flat grassland,
 steep slopes, dense and sparse woodland, wetlands, cultivated roadside, snow,
@@ -863,7 +866,7 @@ development database, use three terminals from the repository root. First,
 create and seed the disposable mission profile (leave it running):
 
 ```bash
-just tactical-isolated presentation-demo 23200 mission:presentation-demo hills 0 1
+just tactical-isolated presentation-demo 23200 mission:presentation-demo woodland 0 1
 ```
 
 Then start the seeded mission server using the generated `.env.tactical`:


### PR DESCRIPTION
## What changed

- Remove the tactical server legacy `hills`/`desert` noise-generation fallback.
- Load the committed `dense-woodland` `TacticalSceneInput` when no scene input is specified.
- Remove the obsolete standalone scene width/depth controls.
- Align `just`, supervised tactical workflows, tests, and documentation with the woodland default.

## Why

Tactical scenes should always flow through the validated, deterministic scene-input boundary. Keeping a separate noise-terrain fallback made standalone development exercise a different level path than world-derived and fixture-driven scenes.

## Impact

Production dispatch remains unchanged and continues to pass an explicit world-derived scene input. Standalone tactical development now defaults to `assets/tactical-scenes/dense-woodland.json`, while explicit scene inputs continue to override it.

## Verification

- `just fmt`
- `cargo test -p adventuresim-tactical-server` — 72 passed
- `python -m unittest scripts.tests.test_dev_stack scripts.tests.test_just_tasks` — 76 passed
- `python scripts/update_project_map.py --check`
- `git diff --check`