### PR TITLE
Prevent tactical lighting from shining through terrain at night

### DIFF
--- a/crates/adventuresim-tactical-client/src/presentation/environment.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/environment.rs
@@ -1,13 +1,18 @@
 use super::*;
 
-pub(super) fn scene_sunlight_illuminance(environment: &SceneEnvironment) -> f32 {
+pub(super) fn scene_sunlight_illuminance(
+    environment: &SceneEnvironment,
+    sun_altitude_degrees: f32,
+) -> f32 {
     let intensity = f32::from(environment.weather.intensity_bps) / 10_000.0;
     let transmission = match environment.weather.precipitation {
         Precipitation::Clear => 1.0,
         Precipitation::Rain => 0.62 - intensity * 0.27,
         Precipitation::Snow => 0.72 - intensity * 0.22,
     };
-    lux::RAW_SUNLIGHT * transmission.clamp(0.25, 1.0)
+    let altitude = (sun_altitude_degrees / 8.0).clamp(0.0, 1.0);
+    let altitude_transmission = altitude * altitude * (3.0 - 2.0 * altitude);
+    lux::RAW_SUNLIGHT * transmission.clamp(0.25, 1.0) * altitude_transmission
 }
 
 pub(super) fn scene_distance_fog(environment: &SceneEnvironment) -> DistanceFog {
@@ -124,12 +129,26 @@ mod tests {
     }
 
     #[test]
-    fn precipitation_dims_but_never_extinguishes_sunlight() {
-        let clear = scene_sunlight_illuminance(&environment(Precipitation::Clear, 0));
-        let rain = scene_sunlight_illuminance(&environment(Precipitation::Rain, 10_000));
-        let snow = scene_sunlight_illuminance(&environment(Precipitation::Snow, 10_000));
+    fn daylight_precipitation_dims_but_never_extinguishes_sunlight() {
+        let clear = scene_sunlight_illuminance(&environment(Precipitation::Clear, 0), 30.0);
+        let rain = scene_sunlight_illuminance(&environment(Precipitation::Rain, 10_000), 30.0);
+        let snow = scene_sunlight_illuminance(&environment(Precipitation::Snow, 10_000), 30.0);
         assert!(rain < snow && snow < clear);
         assert!(rain >= lux::RAW_SUNLIGHT * 0.25);
+    }
+
+    #[test]
+    fn direct_sunlight_never_shines_upward_from_below_the_horizon() {
+        let clear = environment(Precipitation::Clear, 0);
+        assert_eq!(scene_sunlight_illuminance(&clear, -45.0), 0.0);
+        assert_eq!(scene_sunlight_illuminance(&clear, -0.01), 0.0);
+        assert_eq!(scene_sunlight_illuminance(&clear, 0.0), 0.0);
+
+        let low = scene_sunlight_illuminance(&clear, 2.0);
+        let risen = scene_sunlight_illuminance(&clear, 6.0);
+        let daylight = scene_sunlight_illuminance(&clear, 8.0);
+        assert!(0.0 < low && low < risen && risen < daylight);
+        assert_eq!(daylight, lux::RAW_SUNLIGHT);
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/presentation/sky/mod.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/sky/mod.rs
@@ -104,8 +104,8 @@ pub(in crate::presentation) fn setup_tactical_sky(
         SunDisk::EARTH,
         Transform::from_xyz(200.0, 1000.0, 100.0).looking_at(Vec3::ZERO, Vec3::Y),
         DirectionalLight {
-            shadow_maps_enabled: settings.shadows_enabled,
-            illuminance: lux::RAW_SUNLIGHT,
+            shadow_maps_enabled: false,
+            illuminance: 0.0,
             ..default()
         },
     ));
@@ -182,8 +182,8 @@ pub(super) fn on_environment_added(
     let weather_transmission = sky_weather_transmission(environment);
 
     let (mut sun, mut sun_transform) = sunlight.into_inner();
-    sun.illuminance = scene_sunlight_illuminance(environment);
-    sun.shadow_maps_enabled = settings.shadows_enabled && sun_altitude > -2.0;
+    sun.illuminance = scene_sunlight_illuminance(environment, sun_altitude);
+    sun.shadow_maps_enabled = settings.shadows_enabled && sun_altitude > 0.0;
     *sun_transform = light_transform(sun_direction);
 
     let (mut moon_light, mut moon_transform) = moonlight.into_inner();

--- a/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
@@ -434,6 +434,7 @@ pub(crate) fn run(
     if let Some(absolute_minute) = absolute_minute {
         environment.absolute_minute = absolute_minute;
     }
+    let ambient_brightness = capture_ambient_brightness(&environment);
     let output = output.map_or_else(
         || default_output(&repository_root, &fixture, &generated.digest),
         absolute_from_current,
@@ -485,7 +486,7 @@ pub(crate) fn run(
     .insert_resource(ClearColor(Color::srgb_u8(158, 181, 195)))
     .insert_resource(GlobalAmbientLight {
         color: Color::WHITE,
-        brightness: 30_000.0,
+        brightness: ambient_brightness,
         ..default()
     })
     .insert_resource(SceneSetup(Some(setup)))
@@ -498,6 +499,56 @@ pub(crate) fn run(
     let exit = app.run();
     if exit != AppExit::Success {
         std::process::exit(1);
+    }
+}
+
+fn capture_ambient_brightness(environment: &SceneEnvironment) -> f32 {
+    let celestial = celestial_directions(
+        environment.absolute_minute,
+        environment.latitude_microdegrees,
+        environment.longitude_microdegrees,
+    );
+    let sun_altitude = celestial.sun[1].asin().to_degrees();
+    let moon_altitude = celestial.moon[1].asin().to_degrees();
+    capture_ambient_brightness_for_altitudes(
+        sun_altitude,
+        moon_altitude,
+        celestial.lunar_illumination,
+    )
+}
+
+fn capture_ambient_brightness_for_altitudes(
+    sun_altitude_degrees: f32,
+    moon_altitude_degrees: f32,
+    lunar_illumination: f32,
+) -> f32 {
+    let smoothstep = |edge0: f32, edge1: f32, value: f32| {
+        let t = ((value - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+        t * t * (3.0 - 2.0 * t)
+    };
+    let daylight = 30_000.0 * smoothstep(0.0, 8.0, sun_altitude_degrees);
+    let moonlight = 0.025 * lunar_illumination * smoothstep(-2.0, 4.0, moon_altitude_degrees);
+    daylight + moonlight
+}
+
+#[cfg(test)]
+mod capture_lighting_tests {
+    use super::*;
+
+    #[test]
+    fn capture_fill_light_respects_sun_and_moon_horizons() {
+        assert_eq!(
+            capture_ambient_brightness_for_altitudes(-25.0, -24.0, 1.0),
+            0.0
+        );
+        assert_eq!(
+            capture_ambient_brightness_for_altitudes(30.0, -25.0, 0.0),
+            30_000.0
+        );
+        assert_eq!(
+            capture_ambient_brightness_for_altitudes(-25.0, 30.0, 1.0),
+            0.025
+        );
     }
 }
 

--- a/wiki/tactical/sky.md
+++ b/wiki/tactical/sky.md
@@ -16,7 +16,10 @@ move from daylight through twilight to moonlight without auto-exposure pumping.
 The Sun is Bevy's angular `SunDisk` paired with the scene's directional light.
 A shared analytical ephemeris resolves its direction from time, season,
 latitude, and longitude. It intentionally favours stable, inexpensive outdoor
-lighting over high-precision astronomical coordinates.
+lighting over high-precision astronomical coordinates. Direct illuminance
+fades in over the first eight degrees above the horizon and is zero whenever
+the Sun is below it, so the directional light can never shine upward through
+terrain or illuminate the back side of PBR materials at night.
 
 The Moon uses the strategic layer's canonical lunar phase and illumination.
 Its shader draws the phase terminator across a constant-angular-size sphere,
@@ -56,4 +59,7 @@ These deterministic native views run the production presentation plugin. The
 Moon view uses a narrow verification field of view so the first-quarter
 terminator remains inspectable; gameplay retains the physically scaled disc.
 Together the views cover horizon colour, exposure, lunar phase, and
-resolution-independent star rendering.
+resolution-independent star rendering. Native scene captures disable the
+atmosphere environment map for determinism, so their substitute ambient fill
+tracks the same Sun and Moon altitudes instead of remaining at its daylight
+brightness overnight and washing out every side of PBR materials.


### PR DESCRIPTION
## Summary

- keep direct sunlight at zero whenever the Sun is at or below the horizon, then fade it smoothly to full daylight over the first eight degrees of altitude
- initialize the tactical directional Sun dark until authoritative scene time and location have been applied
- replace the native scene viewer's fixed 30,000-brightness ambient fill with Sun/Moon-altitude-aware fill, preventing night exposure from washing out every side of PBR terrain and bark
- document the horizon contract and add focused direct-light and capture-fill tests

This follows merged PR #476. Investigation confirmed two overlapping causes in its white midnight capture: the production Sun did not account for altitude, while the deterministic viewer also supplied a large omnidirectional daylight fill overnight.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p adventuresim-tactical-client`
- `cargo test -p adventuresim-tactical-client --bin tactical-scene-viewer` (25 passed)
- midnight dense-woodland native capture: all gates passed; terrain and bark are dark rather than white with both celestial lights below the horizon
- noon dense-woodland native capture: all gates passed; forest-floor colour, bark texture, and directional shadows remain intact
