### PR TITLE
Wrap prose around short Markdown links

### DIFF
--- a/scripts/format_wiki_markdown.py
+++ b/scripts/format_wiki_markdown.py
@@ -52,7 +52,10 @@ def _restore_inline_atoms(text: str, atoms: list[str]) -> str:
 
 
 def _wrap_paragraph(lines: list[str], width: int) -> list[str]:
-    if all(len(line) <= width or INLINE_ATOM.search(line) for line in lines):
+    if all(
+        len(line) <= width or len(INLINE_ATOM.sub("x", line)) <= width
+        for line in lines
+    ):
         return lines
     if any(line.endswith("  ") for line in lines):
         return lines

--- a/scripts/test_format_wiki_markdown.py
+++ b/scripts/test_format_wiki_markdown.py
@@ -33,6 +33,16 @@ class FormatWikiMarkdownTests(unittest.TestCase):
             rendered,
         )
 
+    def test_wraps_long_prose_around_short_link(self) -> None:
+        source = (
+            "Read [this](https://example.com) because the surrounding prose is "
+            "deliberately much too long for this narrow test width.\n"
+        )
+        rendered = format_markdown(source, width=48)
+        self.assertEqual(source.split(), rendered.split())
+        self.assertGreater(len(rendered.splitlines()), 1)
+        self.assertTrue(all(len(line) <= 48 for line in rendered.splitlines()))
+
     def test_preserves_intentionally_wrapped_prose(self) -> None:
         source = "This paragraph is already wrapped\nwithin the requested width.\n"
         self.assertEqual(source, format_markdown(source, width=40))


### PR DESCRIPTION
Fix the wiki prose formatter so a short Markdown link does not exempt an otherwise overlong line from wrapping. Long link atoms remain intact and exempt, as required by the Google-derived style policy.

Verification:
- 11 wiki-tooling unit tests pass
- formatting, navigation, project-map, and mdBook checks pass