### PR TITLE
Add procedural tactical clouds

### DIFF
--- a/assets/shaders/tactical_clouds.wgsl
+++ b/assets/shaders/tactical_clouds.wgsl
@@ -1,0 +1,168 @@
+#import bevy_pbr::{
+    forward_io::{Vertex, VertexOutput},
+    mesh_functions,
+    mesh_view_bindings::view,
+    view_transformations::position_world_to_clip,
+}
+
+@group(#{MATERIAL_BIND_GROUP}) @binding(0)
+var<uniform> cloud_lighting: vec4<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(1)
+var<uniform> cloud_shape: vec4<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(2)
+var<uniform> cloud_layer: vec4<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(3)
+var<uniform> cloud_motion: vec4<f32>;
+
+fn hash13(position: vec3<f32>) -> f32 {
+    var p = fract(position * 0.1031);
+    p += dot(p, p.yzx + vec3<f32>(33.33));
+    return fract((p.x + p.y) * p.z);
+}
+
+fn value_noise_3d(position: vec3<f32>) -> f32 {
+    let cell = floor(position);
+    let local = fract(position);
+    let blend = local * local * (vec3<f32>(3.0) - 2.0 * local);
+    let n000 = hash13(cell + vec3<f32>(0.0, 0.0, 0.0));
+    let n100 = hash13(cell + vec3<f32>(1.0, 0.0, 0.0));
+    let n010 = hash13(cell + vec3<f32>(0.0, 1.0, 0.0));
+    let n110 = hash13(cell + vec3<f32>(1.0, 1.0, 0.0));
+    let n001 = hash13(cell + vec3<f32>(0.0, 0.0, 1.0));
+    let n101 = hash13(cell + vec3<f32>(1.0, 0.0, 1.0));
+    let n011 = hash13(cell + vec3<f32>(0.0, 1.0, 1.0));
+    let n111 = hash13(cell + vec3<f32>(1.0, 1.0, 1.0));
+    let z0 = mix(mix(n000, n100, blend.x), mix(n010, n110, blend.x), blend.y);
+    let z1 = mix(mix(n001, n101, blend.x), mix(n011, n111, blend.x), blend.y);
+    return mix(z0, z1, blend.z);
+}
+
+fn fbm(position: vec3<f32>) -> f32 {
+    let first = value_noise_3d(position);
+    let second = value_noise_3d(position * 2.03 + vec3<f32>(17.1, 3.7, 11.9));
+    let third = value_noise_3d(position * 4.01 + vec3<f32>(7.3, 19.1, 2.9));
+    return first * 0.57 + second * 0.29 + third * 0.14;
+}
+
+fn cloud_profile(height: f32, family: f32, noise_value: f32) -> f32 {
+    if family < 0.5 {
+        let bottom = smoothstep(0.0, 0.08, height);
+        let top = 1.0 - smoothstep(0.58 + noise_value * 0.2, 1.0, height);
+        return bottom * top;
+    }
+    if family < 1.5 {
+        return smoothstep(0.0, 0.13, height) * (1.0 - smoothstep(0.72, 1.0, height));
+    }
+    if family < 2.5 {
+        let ribbon = 1.0 - smoothstep(0.08, 0.34, abs(height - 0.52));
+        return ribbon * (0.55 + noise_value * 0.45);
+    }
+    let bottom = smoothstep(0.0, 0.035, height);
+    let top = 1.0 - smoothstep(0.68 + noise_value * 0.12, 1.0, height);
+    return bottom * top;
+}
+
+fn sample_density(world_position: vec3<f32>) -> f32 {
+    let height = (world_position.y - cloud_layer.x) / cloud_layer.y;
+    if height <= 0.0 || height >= 1.0 {
+        return 0.0;
+    }
+    let wind_position = world_position.xz + cloud_motion.xy;
+    let seed = cloud_shape.w;
+    var coordinate = vec3<f32>(
+        wind_position.x * cloud_layer.z + seed * 0.013,
+        height * 1.8 + seed * 0.007,
+        wind_position.y * cloud_layer.z - seed * 0.011,
+    );
+    if cloud_shape.z > 1.5 && cloud_shape.z < 2.5 {
+        coordinate.x *= 0.32;
+        coordinate.z *= 1.8;
+    }
+    let broad = fbm(coordinate * vec3<f32>(0.62, 0.45, 0.62));
+    let detail = fbm(coordinate * 2.15 + vec3<f32>(9.7, 1.3, 4.1));
+    let profile = cloud_profile(height, cloud_shape.z, broad);
+    let threshold = 0.82 - cloud_shape.x * 0.38;
+    let body = smoothstep(threshold, threshold + 0.16, broad * 0.72 + detail * 0.28);
+    let edge_erosion = mix(0.72, 1.0, smoothstep(0.2, 0.8, detail));
+    return body * profile * edge_erosion * cloud_shape.y;
+}
+
+fn henyey_greenstein(cosine: f32, eccentricity: f32) -> f32 {
+    let g2 = eccentricity * eccentricity;
+    let denominator = pow(max(1.0 + g2 - 2.0 * eccentricity * cosine, 0.04), 1.5);
+    return (1.0 - g2) / denominator;
+}
+
+@vertex
+fn vertex(vertex: Vertex) -> VertexOutput {
+    var out: VertexOutput;
+    let world_from_local = mesh_functions::get_world_from_local(vertex.instance_index);
+    out.world_position = mesh_functions::mesh_position_local_to_world(
+        world_from_local,
+        vec4<f32>(vertex.position, 1.0),
+    );
+    out.position = position_world_to_clip(out.world_position.xyz);
+    out.world_normal = mesh_functions::mesh_normal_local_to_world(
+        vertex.normal,
+        vertex.instance_index,
+    );
+    out.uv = vertex.uv;
+#ifdef VERTEX_OUTPUT_INSTANCE_INDEX
+    out.instance_index = vertex.instance_index;
+#endif
+    return out;
+}
+
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    let ray_origin = view.world_position;
+    let ray_direction = normalize(in.world_position.xyz - ray_origin);
+    if ray_direction.y <= 0.008 {
+        discard;
+    }
+    let layer_top = cloud_layer.x + cloud_layer.y;
+    var trace_start = max((cloud_layer.x - ray_origin.y) / ray_direction.y, 0.0);
+    var trace_end = (layer_top - ray_origin.y) / ray_direction.y;
+    trace_end = min(trace_end, cloud_layer.w);
+    if trace_end <= trace_start {
+        discard;
+    }
+    let step_length = (trace_end - trace_start) / 12.0;
+    var distance = trace_start + step_length * 0.5;
+    var optical_depth = 0.0;
+    let sun_direction = normalize(cloud_lighting.xyz);
+    let forward_phase = min(henyey_greenstein(dot(ray_direction, sun_direction), 0.55), 4.0);
+
+    for (var step = 0u; step < 12u; step += 1u) {
+        let position = ray_origin + ray_direction * distance;
+        let density = sample_density(position);
+        if density > 0.002 {
+            optical_depth += density * step_length * 0.00165;
+            if optical_depth > 5.0 {
+                break;
+            }
+        }
+        distance += step_length;
+    }
+
+    let opacity = 1.0 - exp(-min(optical_depth, 8.0));
+    if opacity < 0.002 {
+        discard;
+    }
+    let storminess = smoothstep(2.5, 3.0, cloud_shape.z);
+    let underside = 1.0 - smoothstep(0.04, 0.55, ray_direction.y);
+    let body_color = mix(
+        vec3<f32>(0.78, 0.83, 0.89),
+        vec3<f32>(0.22, 0.25, 0.30),
+        clamp(underside * (0.5 + opacity * 0.42) + storminess * 0.28, 0.0, 0.9),
+    );
+    let silver_lining = pow(1.0 - opacity, 2.2)
+        * forward_phase
+        * cloud_motion.z
+        * cloud_motion.w;
+    let sun_color = vec3<f32>(1.0, 0.88, 0.68);
+    let cloud_color = body_color + sun_color * silver_lining * 0.42;
+    // Premultiplied output preserves soft cloud edges over the atmosphere and
+    // avoids the dark fringe produced by straight-alpha filtering.
+    return vec4<f32>(cloud_color * opacity * cloud_lighting.w, opacity);
+}

--- a/crates/adventuresim-tactical-client/src/main.rs
+++ b/crates/adventuresim-tactical-client/src/main.rs
@@ -245,6 +245,7 @@ fn native_asset_root() -> std::path::PathBuf {
 fn validate_native_presentation_assets(asset_root: &std::path::Path) -> Result<(), String> {
     const REQUIRED_ASSETS: &[&str] = &[
         "shaders/tactical_foliage.wgsl",
+        "shaders/tactical_clouds.wgsl",
         "shaders/tactical_moon.wgsl",
         "shaders/tactical_stars.wgsl",
         "shaders/tactical_terrain.wgsl",

--- a/crates/adventuresim-tactical-client/src/presentation/clouds.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/clouds.rs
@@ -1,0 +1,375 @@
+//! Bounded procedural cloud slab for the grounded tactical camera.
+
+use super::*;
+
+const CLOUD_SHADER: &str = "shaders/tactical_clouds.wgsl";
+const CLOUD_DOME_DISTANCE_METRES: f32 = 20_000.0;
+
+#[derive(Component)]
+pub(crate) struct TacticalCloudLayer;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[allow(dead_code)] // Named variants are consumed by the native capture binary.
+pub(crate) enum TacticalCloudCaptureProfile {
+    #[default]
+    Cumulus,
+    Clear,
+    Stratocumulus,
+    Cirrus,
+    Overcast,
+    Storm,
+}
+
+#[derive(Resource, Clone, Copy, Debug, Default)]
+pub(crate) struct TacticalCloudCaptureOverride(pub(crate) Option<TacticalCloudCaptureProfile>);
+
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone)]
+pub(in crate::presentation) struct TacticalCloudMaterial {
+    /// Direction toward the Sun and scene-referred cloud luminance.
+    #[uniform(0)]
+    lighting: Vec4,
+    /// Coverage, density, profile family, deterministic noise seed.
+    #[uniform(1)]
+    shape: Vec4,
+    /// Bottom altitude, thickness, horizontal noise scale, trace distance.
+    #[uniform(2)]
+    layer: Vec4,
+    /// Wind offset in metres, direct-light fraction, weather transmission.
+    #[uniform(3)]
+    motion: Vec4,
+}
+
+impl Material for TacticalCloudMaterial {
+    fn vertex_shader() -> ShaderRef {
+        CLOUD_SHADER.into()
+    }
+
+    fn fragment_shader() -> ShaderRef {
+        CLOUD_SHADER.into()
+    }
+
+    fn alpha_mode(&self) -> AlphaMode {
+        AlphaMode::Premultiplied
+    }
+
+    fn specialize(
+        _pipeline: &bevy::pbr::MaterialPipeline,
+        descriptor: &mut RenderPipelineDescriptor,
+        _layout: &bevy::mesh::MeshVertexBufferLayoutRef,
+        _key: bevy::pbr::MaterialPipelineKey<Self>,
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        // The camera remains inside this shell. Disabling culling also avoids
+        // depending on a second inside-out mesh asset in the browser bundle.
+        descriptor.primitive.cull_mode = None;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct CloudLayerParameters {
+    coverage: f32,
+    density: f32,
+    profile: f32,
+    seed: f32,
+    bottom_metres: f32,
+    thickness_metres: f32,
+    horizontal_scale: f32,
+}
+
+impl CloudLayerParameters {
+    fn from_environment(
+        environment: &SceneEnvironment,
+        capture: Option<TacticalCloudCaptureProfile>,
+    ) -> Self {
+        if let Some(profile) = capture {
+            return Self::capture(profile);
+        }
+
+        let seed = cloud_seed(environment);
+        let random = ((seed >> 16) & 0xffff) as f32 / 65_535.0;
+        let clear_profile = (seed % 3) as f32;
+        match environment.weather.precipitation {
+            Precipitation::Clear => {
+                let coverage = 0.28 + random * 0.34;
+                Self::for_profile(clear_profile, coverage, 0.82, seed)
+            }
+            Precipitation::Rain => {
+                let intensity = f32::from(environment.weather.intensity_bps) / 10_000.0;
+                Self::for_profile(3.0, 0.78 + intensity * 0.18, 1.0 + intensity * 0.35, seed)
+            }
+            Precipitation::Snow => {
+                let intensity = f32::from(environment.weather.intensity_bps) / 10_000.0;
+                Self::for_profile(1.0, 0.76 + intensity * 0.18, 0.92 + intensity * 0.2, seed)
+            }
+        }
+    }
+
+    fn capture(profile: TacticalCloudCaptureProfile) -> Self {
+        let seed = match profile {
+            TacticalCloudCaptureProfile::Clear => 0,
+            TacticalCloudCaptureProfile::Cumulus => 117,
+            TacticalCloudCaptureProfile::Stratocumulus => 283,
+            TacticalCloudCaptureProfile::Cirrus => 419,
+            TacticalCloudCaptureProfile::Overcast => 631,
+            TacticalCloudCaptureProfile::Storm => 887,
+        };
+        match profile {
+            TacticalCloudCaptureProfile::Clear => Self::for_profile(0.0, 0.0, 0.0, seed),
+            TacticalCloudCaptureProfile::Cumulus => Self::for_profile(0.0, 0.48, 0.9, seed),
+            TacticalCloudCaptureProfile::Stratocumulus => Self::for_profile(1.0, 0.68, 0.9, seed),
+            TacticalCloudCaptureProfile::Cirrus => Self::for_profile(2.0, 0.42, 0.64, seed),
+            TacticalCloudCaptureProfile::Overcast => Self::for_profile(1.0, 0.94, 1.1, seed),
+            TacticalCloudCaptureProfile::Storm => Self::for_profile(3.0, 0.91, 1.32, seed),
+        }
+    }
+
+    fn for_profile(profile: f32, coverage: f32, density: f32, seed: u64) -> Self {
+        let (bottom_metres, thickness_metres, horizontal_scale) = match profile as u32 {
+            0 => (1_250.0, 1_850.0, 0.000_34),
+            1 => (1_050.0, 900.0, 0.000_25),
+            2 => (5_500.0, 520.0, 0.000_18),
+            _ => (720.0, 2_600.0, 0.000_28),
+        };
+        Self {
+            coverage: coverage.clamp(0.0, 1.0),
+            density,
+            profile,
+            seed: (seed % 4_096) as f32,
+            bottom_metres,
+            thickness_metres,
+            horizontal_scale,
+        }
+    }
+}
+
+pub(in crate::presentation) fn setup_tactical_clouds(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<TacticalCloudMaterial>>,
+) {
+    commands.spawn((
+        Name::new("Procedural tactical cloud slab"),
+        TacticalCloudLayer,
+        NoFrustumCulling,
+        NotShadowCaster,
+        Mesh3d(meshes.add(cloud_hemisphere_mesh())),
+        MeshMaterial3d(materials.add(TacticalCloudMaterial {
+            lighting: Vec4::new(0.0, 1.0, 0.0, 1.43),
+            shape: Vec4::new(0.45, 0.9, 0.0, 0.0),
+            layer: Vec4::new(1_250.0, 1_850.0, 0.000_34, 48_000.0),
+            motion: Vec4::new(0.0, 0.0, 1.0, 1.0),
+        })),
+        Transform::default(),
+    ));
+}
+
+fn cloud_hemisphere_mesh() -> Mesh {
+    const AZIMUTH_SEGMENTS: u32 = 64;
+    const ELEVATION_SEGMENTS: u32 = 20;
+    let mut positions =
+        Vec::with_capacity(((AZIMUTH_SEGMENTS + 1) * (ELEVATION_SEGMENTS + 1)) as usize);
+    let mut normals = Vec::with_capacity(positions.capacity());
+    let mut uvs = Vec::with_capacity(positions.capacity());
+    for elevation_index in 0..=ELEVATION_SEGMENTS {
+        let elevation =
+            elevation_index as f32 / ELEVATION_SEGMENTS as f32 * core::f32::consts::FRAC_PI_2;
+        let horizontal = elevation.cos();
+        let y = elevation.sin();
+        for azimuth_index in 0..=AZIMUTH_SEGMENTS {
+            let azimuth = azimuth_index as f32 / AZIMUTH_SEGMENTS as f32 * core::f32::consts::TAU;
+            let direction = Vec3::new(horizontal * azimuth.cos(), y, horizontal * azimuth.sin());
+            positions.push((direction * CLOUD_DOME_DISTANCE_METRES).to_array());
+            normals.push(direction.to_array());
+            uvs.push([
+                azimuth_index as f32 / AZIMUTH_SEGMENTS as f32,
+                elevation_index as f32 / ELEVATION_SEGMENTS as f32,
+            ]);
+        }
+    }
+    let mut indices = Vec::with_capacity((AZIMUTH_SEGMENTS * ELEVATION_SEGMENTS * 6) as usize);
+    let stride = AZIMUTH_SEGMENTS + 1;
+    for elevation_index in 0..ELEVATION_SEGMENTS {
+        for azimuth_index in 0..AZIMUTH_SEGMENTS {
+            let lower_left = elevation_index * stride + azimuth_index;
+            let lower_right = lower_left + 1;
+            let upper_left = lower_left + stride;
+            let upper_right = upper_left + 1;
+            indices.extend_from_slice(&[
+                lower_left,
+                upper_left,
+                lower_right,
+                lower_right,
+                upper_left,
+                upper_right,
+            ]);
+        }
+    }
+    let mut mesh = Mesh::new(
+        PrimitiveTopology::TriangleList,
+        RenderAssetUsages::RENDER_WORLD | RenderAssetUsages::MAIN_WORLD,
+    );
+    mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
+    mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
+    mesh.insert_indices(Indices::U32(indices));
+    mesh
+}
+
+pub(in crate::presentation) fn update_tactical_clouds(
+    time: Res<Time>,
+    active: Res<ActiveTacticalScene>,
+    environments: Query<&SceneEnvironment>,
+    celestial: Res<PresentedCelestialLighting>,
+    capture: Res<TacticalCloudCaptureOverride>,
+    camera: Single<&GlobalTransform, With<Camera3d>>,
+    mut clouds: Single<
+        (
+            &MeshMaterial3d<TacticalCloudMaterial>,
+            &mut Transform,
+            &mut Visibility,
+        ),
+        With<TacticalCloudLayer>,
+    >,
+    mut materials: ResMut<Assets<TacticalCloudMaterial>>,
+) {
+    clouds.1.translation = camera.translation();
+    let Some(environment) = active
+        .entity
+        .and_then(|entity| environments.get(entity).ok())
+    else {
+        *clouds.2 = Visibility::Hidden;
+        return;
+    };
+    let Some(celestial) = celestial.snapshot.as_ref() else {
+        *clouds.2 = Visibility::Hidden;
+        return;
+    };
+    let Some(mut material) = materials.get_mut(&clouds.0.0) else {
+        return;
+    };
+
+    let parameters = CloudLayerParameters::from_environment(environment, capture.0);
+    if parameters.coverage <= 0.001 || parameters.density <= 0.001 {
+        *clouds.2 = Visibility::Hidden;
+        return;
+    }
+    let seed = cloud_seed(environment);
+    let wind_angle = ((seed >> 32) as f32 / u32::MAX as f32) * core::f32::consts::TAU;
+    let wind_speed = 2.0 + f32::from(environment.weather.wind_speed_bps) / 10_000.0 * 16.0;
+    let elapsed =
+        time.elapsed_secs() + (environment.absolute_minute % (7 * MINUTES_PER_DAY)) as f32 * 60.0;
+    let wind_offset = Vec2::from_angle(wind_angle) * wind_speed * elapsed;
+    let daylight = smoothstep(-8.0, 8.0, celestial.sun_altitude_degrees);
+    let scene_luminance = 0.08 + daylight * 1.35;
+
+    material.lighting = celestial.sun_direction.extend(scene_luminance);
+    material.shape = Vec4::new(
+        parameters.coverage,
+        parameters.density,
+        parameters.profile,
+        parameters.seed,
+    );
+    material.layer = Vec4::new(
+        parameters.bottom_metres,
+        parameters.thickness_metres,
+        parameters.horizontal_scale,
+        48_000.0,
+    );
+    material.motion = Vec4::new(
+        wind_offset.x,
+        wind_offset.y,
+        daylight,
+        celestial.weather_transmission,
+    );
+    *clouds.2 = Visibility::Inherited;
+}
+
+fn cloud_seed(environment: &SceneEnvironment) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in environment.scene_digest.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash ^= environment.absolute_minute / 360;
+    hash ^= (environment.latitude_microdegrees as u32 as u64) << 32;
+    hash ^= environment.longitude_microdegrees as u32 as u64;
+    hash
+}
+
+fn smoothstep(edge0: f32, edge1: f32, value: f32) -> f32 {
+    let t = ((value - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn environment(precipitation: Precipitation, intensity_bps: u16) -> SceneEnvironment {
+        SceneEnvironment {
+            scene_digest: "cloud-parameter-test".into(),
+            generation_version: TACTICAL_SCENE_GENERATION_VERSION,
+            latitude_microdegrees: 53_500_000,
+            longitude_microdegrees: 10_000_000,
+            absolute_minute: 100_000,
+            absolute_elevation_metres: 20,
+            weather: WeatherSnapshot {
+                rules_version: WEATHER_RULES_VERSION,
+                interval_start_minute: 100_000,
+                cell_latitude: 0,
+                cell_longitude: 0,
+                temperature_deci_c: 150,
+                wind_speed_bps: 2_000,
+                precipitation,
+                intensity_bps,
+                ground_moisture_bps: 0,
+                snow_cover_bps: 0,
+            },
+            canopy_bps: 0,
+            wetland_bps: 0,
+            cultivation_bps: 0,
+            water_bps: 0,
+            hilly_bps: 0,
+        }
+    }
+
+    #[test]
+    fn precipitation_produces_dense_low_clouds() {
+        let clear =
+            CloudLayerParameters::from_environment(&environment(Precipitation::Clear, 0), None);
+        let rain =
+            CloudLayerParameters::from_environment(&environment(Precipitation::Rain, 8_000), None);
+        assert!(rain.coverage > clear.coverage);
+        assert!(rain.density > clear.density);
+        assert_eq!(rain.profile, 3.0);
+        assert!(rain.bottom_metres < clear.bottom_metres);
+    }
+
+    #[test]
+    fn capture_profiles_cover_distinct_altitude_and_density_families() {
+        let cumulus = CloudLayerParameters::capture(TacticalCloudCaptureProfile::Cumulus);
+        let cirrus = CloudLayerParameters::capture(TacticalCloudCaptureProfile::Cirrus);
+        let storm = CloudLayerParameters::capture(TacticalCloudCaptureProfile::Storm);
+        assert!(cirrus.bottom_metres > cumulus.bottom_metres);
+        assert!(cirrus.thickness_metres < cumulus.thickness_metres);
+        assert!(storm.density > cumulus.density);
+        assert!(storm.coverage > cumulus.coverage);
+    }
+
+    #[test]
+    fn raster_shell_contains_only_the_upper_hemisphere() {
+        let mesh = cloud_hemisphere_mesh();
+        let Some(bevy::mesh::VertexAttributeValues::Float32x3(positions)) =
+            mesh.attribute(Mesh::ATTRIBUTE_POSITION)
+        else {
+            panic!("cloud shell must contain float positions");
+        };
+        assert!(!positions.is_empty());
+        assert!(positions.iter().all(|position| position[1] >= -0.001));
+        assert!(
+            positions
+                .iter()
+                .any(|position| position[1] >= CLOUD_DOME_DISTANCE_METRES * 0.99)
+        );
+    }
+}

--- a/crates/adventuresim-tactical-client/src/presentation/mod.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/mod.rs
@@ -4,6 +4,7 @@
 //! plugin so screenshots cannot drift to a different camera, terrain mesh,
 //! lighting, or post-processing setup.
 
+mod clouds;
 mod environment;
 mod ground_scatter;
 mod obstacles;
@@ -15,6 +16,7 @@ mod vista;
 mod volumetric;
 mod weather;
 
+use clouds::*;
 use environment::*;
 use ground_scatter::*;
 use obstacles::on_scene_obstacle_added;
@@ -32,6 +34,8 @@ use weather::*;
 
 // This facade is compiled independently by several binaries, so each binary
 // uses only the subset of the stable presentation interface that it needs.
+#[allow(unused_imports)]
+pub(crate) use clouds::{TacticalCloudCaptureOverride, TacticalCloudCaptureProfile};
 #[allow(unused_imports)]
 pub(crate) use environment::{
     TacticalCameraSetup, scene_ambient_light, scene_ibl_visibility_floor,
@@ -127,6 +131,7 @@ impl Plugin for TacticalPresentationPlugin {
             MaterialPlugin::<TacticalTreeImpostorMaterial>::default(),
             MaterialPlugin::<TacticalMoonMaterial>::default(),
             MaterialPlugin::<TacticalStarMaterial>::default(),
+            MaterialPlugin::<TacticalCloudMaterial>::default(),
         ))
         .insert_resource(TacticalGraphicsSettings {
             shadows_enabled: self.shadows_enabled,
@@ -151,6 +156,7 @@ impl Plugin for TacticalPresentationPlugin {
                 setup_procedural_environment_assets,
                 setup_tactical_presentation,
                 setup_tactical_sky,
+                setup_tactical_clouds,
             )
                 .chain(),
         )
@@ -165,6 +171,7 @@ impl Plugin for TacticalPresentationPlugin {
         .init_resource::<ActiveTacticalScene>()
         .init_resource::<PresentedCelestialLighting>()
         .init_resource::<AtmosphereIblAmbientHandoff>()
+        .init_resource::<TacticalCloudCaptureOverride>()
         .add_systems(
             Update,
             (
@@ -190,6 +197,7 @@ impl Plugin for TacticalPresentationPlugin {
                 )
                     .chain(),
                 keep_celestial_visuals_centered.after(update_presented_celestial_lighting),
+                update_tactical_clouds.after(update_presented_celestial_lighting),
                 update_global_ambient_policy.after(apply_presented_celestial_lighting),
                 apply_active_environment_fog.after(refresh_active_tactical_scene),
                 (apply_active_scene_weather, advance_weather_particles)

--- a/crates/adventuresim-tactical-client/src/presentation/sky/mod.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/sky/mod.rs
@@ -171,7 +171,7 @@ pub(in crate::presentation) struct CelestialLightingSnapshot {
     pub(in crate::presentation) moon_altitude_degrees: f32,
     pub(in crate::presentation) lunar_illumination: f32,
     lunar_phase: f32,
-    weather_transmission: f32,
+    pub(in crate::presentation) weather_transmission: f32,
     equatorial_to_world: Mat4,
     exposure_ev100: f32,
     pub(in crate::presentation) ambient_color: Vec3,

--- a/crates/adventuresim-tactical-client/src/tactical_sky_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_sky_viewer.rs
@@ -26,7 +26,10 @@ use serde::Serialize;
 
 use crate::{
     SkyView,
-    presentation::{TacticalCameraSetup, TacticalPresentationPlugin},
+    presentation::{
+        TacticalCameraSetup, TacticalCloudCaptureOverride, TacticalCloudCaptureProfile,
+        TacticalPresentationPlugin,
+    },
 };
 
 const VIEW_WIDTH: u32 = 1600;
@@ -113,6 +116,7 @@ struct SkyManifest {
     horizon_sky_red_blue_delta: f32,
     sun_disk_angular_diameter_degrees: f32,
     diagnostic_magnification: bool,
+    cloud_profile: Option<&'static str>,
     exposure_ev100: f32,
     solar_source_illuminance_lux: f32,
     atmosphere_enabled: bool,
@@ -123,6 +127,11 @@ struct SkyManifest {
 }
 
 pub(super) fn run(view: SkyView, output: PathBuf, settle_frames: u32) {
+    let settle_frames = if is_cloud_view(view) {
+        settle_frames.max(60)
+    } else {
+        settle_frames
+    };
     if let Some(parent) = output.parent() {
         fs::create_dir_all(parent).expect("create sky capture output directory");
     }
@@ -167,6 +176,9 @@ pub(super) fn run(view: SkyView, output: PathBuf, settle_frames: u32) {
         bloom_enabled: true,
         max_vista_lods: 0,
     })
+    .insert_resource(TacticalCloudCaptureOverride(Some(cloud_capture_profile(
+        view,
+    ))))
     .insert_resource(ClearColor(Color::BLACK))
     .insert_resource(CaptureState {
         output,
@@ -211,6 +223,11 @@ fn sky_view_configuration(view: SkyView) -> SkyViewConfiguration {
         SkyView::Moon => 359_940,
         // Canonical new moon at 23:00 on day 77.
         SkyView::Stars => 637_860,
+        SkyView::CloudCumulus
+        | SkyView::CloudStratocumulus
+        | SkyView::CloudCirrus
+        | SkyView::CloudOvercast
+        | SkyView::CloudStorm => 172 * MINUTES_PER_DAY + 15 * 60,
     };
     let celestial = celestial_directions(
         absolute_minute,
@@ -225,6 +242,11 @@ fn sky_view_configuration(view: SkyView) -> SkyViewConfiguration {
         SkyView::Twilight => horizon_view(sun, 0.03),
         SkyView::Moon => moon,
         SkyView::Stars => Vec3::new(0.15, 0.55, -0.82).normalize(),
+        SkyView::CloudCumulus
+        | SkyView::CloudStratocumulus
+        | SkyView::CloudCirrus
+        | SkyView::CloudOvercast
+        | SkyView::CloudStorm => horizon_view(sun, 0.34),
     };
     SkyViewConfiguration {
         absolute_minute,
@@ -237,6 +259,8 @@ fn sky_view_configuration(view: SkyView) -> SkyViewConfiguration {
             12.0
         } else if matches!(view, SkyView::SunDetail) {
             20.0
+        } else if is_cloud_view(view) {
+            72.0
         } else {
             80.0
         },
@@ -442,6 +466,11 @@ fn capture_view(
                 }
                 SkyView::Twilight => twilight_subject_content(&metrics),
                 SkyView::Stars => metrics.bright_pixel_count >= 8,
+                SkyView::CloudCumulus
+                | SkyView::CloudStratocumulus
+                | SkyView::CloudCirrus
+                | SkyView::CloudOvercast
+                | SkyView::CloudStorm => metrics.upper_sky_luma_variance >= 12.0,
             };
             let validation = SkyValidation {
                 expected_dimensions,
@@ -460,7 +489,7 @@ fn capture_view(
                 render_observations: 0,
             });
             let manifest = SkyManifest {
-                pipeline: "tactical_sky_native_capture_v3",
+                pipeline: "tactical_sky_native_capture_v4",
                 view: sky_view_slug(state.view),
                 absolute_minute: state.absolute_minute,
                 resolution: [VIEW_WIDTH, VIEW_HEIGHT],
@@ -487,6 +516,7 @@ fn capture_view(
                 horizon_sky_red_blue_delta: metrics.horizon_sky_red_blue_delta,
                 sun_disk_angular_diameter_degrees: SunDisk::EARTH.angular_size.to_degrees(),
                 diagnostic_magnification: matches!(state.view, SkyView::SunDetail),
+                cloud_profile: cloud_profile_slug(state.view),
                 exposure_ev100,
                 solar_source_illuminance_lux,
                 atmosphere_enabled: true,
@@ -612,6 +642,44 @@ fn sky_view_slug(view: SkyView) -> &'static str {
         SkyView::Twilight => "twilight",
         SkyView::Moon => "moon",
         SkyView::Stars => "stars",
+        SkyView::CloudCumulus => "cloud-cumulus",
+        SkyView::CloudStratocumulus => "cloud-stratocumulus",
+        SkyView::CloudCirrus => "cloud-cirrus",
+        SkyView::CloudOvercast => "cloud-overcast",
+        SkyView::CloudStorm => "cloud-storm",
+    }
+}
+
+fn is_cloud_view(view: SkyView) -> bool {
+    matches!(
+        view,
+        SkyView::CloudCumulus
+            | SkyView::CloudStratocumulus
+            | SkyView::CloudCirrus
+            | SkyView::CloudOvercast
+            | SkyView::CloudStorm
+    )
+}
+
+fn cloud_capture_profile(view: SkyView) -> TacticalCloudCaptureProfile {
+    match view {
+        SkyView::CloudCumulus => TacticalCloudCaptureProfile::Cumulus,
+        SkyView::CloudStratocumulus => TacticalCloudCaptureProfile::Stratocumulus,
+        SkyView::CloudCirrus => TacticalCloudCaptureProfile::Cirrus,
+        SkyView::CloudOvercast => TacticalCloudCaptureProfile::Overcast,
+        SkyView::CloudStorm => TacticalCloudCaptureProfile::Storm,
+        _ => TacticalCloudCaptureProfile::Clear,
+    }
+}
+
+fn cloud_profile_slug(view: SkyView) -> Option<&'static str> {
+    match view {
+        SkyView::CloudCumulus => Some("cumulus"),
+        SkyView::CloudStratocumulus => Some("stratocumulus"),
+        SkyView::CloudCirrus => Some("cirrus"),
+        SkyView::CloudOvercast => Some("overcast"),
+        SkyView::CloudStorm => Some("storm"),
+        _ => None,
     }
 }
 

--- a/crates/adventuresim-tactical-client/src/tactical_sky_viewer_main.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_sky_viewer_main.rs
@@ -21,6 +21,11 @@ enum SkyView {
     Twilight,
     Moon,
     Stars,
+    CloudCumulus,
+    CloudStratocumulus,
+    CloudCirrus,
+    CloudOvercast,
+    CloudStorm,
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/wiki/engineering/developing.md
+++ b/wiki/engineering/developing.md
@@ -1053,6 +1053,11 @@ just tactical-sky-capture sun-detail target/tactical-sky-captures/sun-detail.png
 just tactical-sky-capture twilight target/tactical-sky-captures/twilight.png
 just tactical-sky-capture moon target/tactical-sky-captures/moon.png
 just tactical-sky-capture stars target/tactical-sky-captures/stars.png
+just tactical-sky-capture cloud-cumulus target/tactical-sky-captures/cloud-cumulus.png
+just tactical-sky-capture cloud-stratocumulus target/tactical-sky-captures/cloud-stratocumulus.png
+just tactical-sky-capture cloud-cirrus target/tactical-sky-captures/cloud-cirrus.png
+just tactical-sky-capture cloud-overcast target/tactical-sky-captures/cloud-overcast.png
+just tactical-sky-capture cloud-storm target/tactical-sky-captures/cloud-storm.png
 ```
 
 Each capture primes one disposable GPU readback after its settle interval,

--- a/wiki/generated/project-map.md
+++ b/wiki/generated/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (2010)
+## Files (2012)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.
@@ -63,6 +63,7 @@ development, or other wiki document before changing a subsystem.
 - `assets/animations/biped/unarmed/walk.glb` — Binary game or UI asset.
 - `assets/animations/biped/unarmed/walk_mirrored.glb` — Binary game or UI asset.
 - `assets/data/hipparcos-bright-stars.csv` — Repository support file.
+- `assets/shaders/tactical_clouds.wgsl` — Repository support file.
 - `assets/shaders/tactical_foliage.wgsl` — Repository support file.
 - `assets/shaders/tactical_moon.wgsl` — Repository support file.
 - `assets/shaders/tactical_pebble_billboard.wgsl` — Repository support file.
@@ -1369,6 +1370,7 @@ development, or other wiki document before changing a subsystem.
 - `crates/adventuresim-tactical-client/src/equipment.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/main.rs` — Rust source module for this component.
 - `crates/adventuresim-tactical-client/src/player.rs` — Rust source module for this component.
+- `crates/adventuresim-tactical-client/src/presentation/clouds.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/presentation/environment.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/presentation/ground_scatter/grass.rs` — Rust source module.
 - `crates/adventuresim-tactical-client/src/presentation/ground_scatter/litter.rs` — Rust source module.

--- a/wiki/tactical/sky.md
+++ b/wiki/tactical/sky.md
@@ -59,21 +59,38 @@ Regenerate the catalog from the official CDS VizieR endpoint with:
 python scripts/import_hipparcos_stars.py
 ```
 
-## Deferred clouds
+## Procedural clouds
 
-Clouds remain deliberately separate from this module while terrain foliage is
-under parallel development. The intended quality path is volumetric clouds,
-with a later browser fallback using a lower-cost procedural sky layer. Both
-paths should consume the same normalized coverage, density, wind, and lighting
-inputs so graphics presets can switch implementations without changing the
-amount or broad silhouette of cloud cover. Clouds should not be baked into an
-environment map.
+The default tactical presentation renders clouds as a bounded atmospheric
+slab. A camera-centred hemisphere supplies rasterization geometry, but the
+fragment shader intersects each view ray with the cloud layer and integrates
+twelve procedural density samples through it. Height profiles distinguish
+cumulus, stratocumulus, cirrus, and storm clouds. Wind moves the density field
+without simulating tactical fluid state.
+
+Strategic precipitation, intensity, time, and location determine the broad
+coverage and profile. Clear-weather variation is derived deterministically
+from the scene digest and weather interval because the strategic weather
+snapshot does not yet carry an authoritative cloud-cover measurement. Rain and
+snow force denser, lower layers. These values remain transient presentation
+state and are never written back to SpacetimeDB.
+
+Cloud lighting reuses the production Sun direction, exposure, and weather
+transmission. The shader uses bounded optical depth, an inexpensive
+forward-scattering approximation, and denser undersides instead of secondary
+shadow rays. Clouds remain separate from the atmosphere-generated environment
+map; they neither trigger environment-map regeneration nor bake their moving
+shape into image-based lighting.
 
 ## Verification
 
-Use `just tactical-sky-capture` with `sun`, `sun-detail`, `twilight`, `moon`, or
-`stars`. `sun-detail` is a clearly labeled 20-degree-FOV diagnostic of the same
-unchanged production `SunDisk::EARTH` and natural bloom at low solar altitude;
+Use `just tactical-sky-capture` with `sun`, `sun-detail`, `twilight`, `moon`,
+`stars`, `cloud-cumulus`, `cloud-stratocumulus`, `cloud-cirrus`,
+`cloud-overcast`, or `cloud-storm`. Cloud captures use a diagnostics-only
+profile override and a longer warm-up so shader and atmosphere pipelines have
+settled before validation. `sun-detail` remains a clearly labeled 20-degree-FOV
+diagnostic of the unchanged production `SunDisk::EARTH` and natural bloom at
+low solar altitude;
 it must not be interpreted as gameplay-scale disc size.
 These deterministic native views run the production presentation plugin. The
 Moon view uses a narrow verification field of view so the first-quarter


### PR DESCRIPTION
## Summary

- add a deterministic, bounded procedural cloud slab to the tactical presentation
- derive the default cloud profile, coverage, wind, lighting, and atmosphere integration from scene weather
- add diagnostic captures for cumulus, stratocumulus, cirrus, overcast, and storm profiles
- document the renderer, capture workflow, and laptop-oriented performance tradeoffs

## Why

The tactical sky needed clouds with more depth and variation than a skybox while keeping render cost predictable on integrated GPUs such as the Radeon 780M. The default implementation uses a fixed 12-sample shader rather than an unconstrained volumetric march.

## Validation

- `cargo test -p adventuresim-tactical-client --bin tactical-sky-viewer` (157 passed)
- `cargo test -p adventuresim-tactical-client --bin adventuresim-tactical-client graphics_preset_tests::native_asset_root_contains_required_presentation_assets`
- `cargo check -p adventuresim-tactical-client --bin adventuresim-tactical-client --target wasm32-unknown-unknown`
- semantic capture checks for all five cloud profiles
- project-map check, wiki formatting/unit/summary checks, Prettier check, and `git diff --check`

`mdbook build` was not run because `mdbook` is not installed in the local environment.
