### PR TITLE
Curve tactical cloud layers into horizon

### DIFF
--- a/assets/shaders/tactical_clouds.wgsl
+++ b/assets/shaders/tactical_clouds.wgsl
@@ -16,6 +16,9 @@ var<uniform> cloud_motion: vec4<f32>;
 /// Solar chroma derived from altitude; kept separate from scalar illuminance.
 @group(#{MATERIAL_BIND_GROUP}) @binding(4)
 var<uniform> cloud_spectral: vec4<f32>;
+/// Fixed scene anchor X/Z, shell curvature radius, aerial extinction.
+@group(#{MATERIAL_BIND_GROUP}) @binding(5)
+var<uniform> cloud_geometry: vec4<f32>;
 
 fn hash13(position: vec3<f32>) -> f32 {
     var p = fract(position * 0.1031);
@@ -93,8 +96,36 @@ fn cloud_profile(height: f32, family: f32, noise_value: f32) -> f32 {
     return bottom * top;
 }
 
+fn shell_center() -> vec3<f32> {
+    return vec3<f32>(
+        cloud_geometry.x,
+        -cloud_geometry.z,
+        cloud_geometry.y,
+    );
+}
+
+fn altitude_in_shell(world_position: vec3<f32>) -> f32 {
+    return length(world_position - shell_center()) - cloud_geometry.z;
+}
+
+fn ray_sphere_roots(
+    ray_origin: vec3<f32>,
+    ray_direction: vec3<f32>,
+    radius: f32,
+) -> vec2<f32> {
+    let relative_origin = ray_origin - shell_center();
+    let projected = dot(relative_origin, ray_direction);
+    let discriminant = projected * projected
+        - (dot(relative_origin, relative_origin) - radius * radius);
+    if discriminant < 0.0 {
+        return vec2<f32>(-1.0, -1.0);
+    }
+    let root = sqrt(discriminant);
+    return vec2<f32>(-projected - root, -projected + root);
+}
+
 fn sample_density(world_position: vec3<f32>) -> f32 {
-    let height = (world_position.y - cloud_layer.x) / cloud_layer.y;
+    let height = (altitude_in_shell(world_position) - cloud_layer.x) / cloud_layer.y;
     if height <= 0.0 || height >= 1.0 {
         return 0.0;
     }
@@ -196,31 +227,77 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let ray_origin = view.world_position;
     let ray_direction = normalize(in.world_position.xyz - ray_origin);
-    if ray_direction.y <= 0.008 {
+    if ray_direction.y < -0.001 {
         discard;
     }
-    let layer_top = cloud_layer.x + cloud_layer.y;
-    var trace_start = max((cloud_layer.x - ray_origin.y) / ray_direction.y, 0.0);
-    var trace_end = (layer_top - ray_origin.y) / ray_direction.y;
+
+    let centre = shell_center();
+    let origin_radius = length(ray_origin - centre);
+    let inner_radius = cloud_geometry.z + cloud_layer.x;
+    let outer_radius = inner_radius + cloud_layer.y;
+    let outer_roots = ray_sphere_roots(ray_origin, ray_direction, outer_radius);
+    if outer_roots.y <= 0.0 {
+        discard;
+    }
+
+    var trace_start = 0.0;
+    var trace_end = outer_roots.y;
+    if origin_radius < inner_radius {
+        // The ordinary grounded-camera case: begin where the ray exits the
+        // empty space below the cloud shell.
+        let inner_roots = ray_sphere_roots(ray_origin, ray_direction, inner_radius);
+        trace_start = max(inner_roots.y, 0.0);
+    } else if origin_radius > outer_radius {
+        // Retain a well-defined interval for diagnostic cameras outside the
+        // shell, even though tactical play normally remains below it.
+        trace_start = max(outer_roots.x, 0.0);
+        let inner_roots = ray_sphere_roots(ray_origin, ray_direction, inner_radius);
+        if inner_roots.x > trace_start {
+            trace_end = inner_roots.x;
+        }
+    }
     trace_end = min(trace_end, cloud_layer.w);
     if trace_end <= trace_start {
         discard;
     }
-    let step_length = (trace_end - trace_start) / 64.0;
-    var distance = trace_start + step_length * 0.5;
+
+    // Empty air is searched in large steps. Once density is found, backtrack
+    // and integrate in quarter-sized steps until the ray is clear again.
+    // Pixel-stable jitter prevents the curved shell from resolving into
+    // coherent marching bands without requiring more samples everywhere.
+    let coarse_step = (trace_end - trace_start) / 40.0;
+    let fine_step = coarse_step * 0.25;
+    let ray_jitter = hash13(vec3<f32>(floor(in.position.xy), cloud_shape.w));
+    var step_length = coarse_step;
+    var distance = trace_start + coarse_step * ray_jitter;
+    var fine_marching = false;
+    var fine_empty_steps = 0u;
     var transmittance = 1.0;
+    var visible_opacity = 0.0;
     var radiance = vec3<f32>(0.0);
     let sun_direction = normalize(cloud_lighting.xyz);
     let forward_phase = min(henyey_greenstein(dot(ray_direction, sun_direction), 0.55), 4.0);
     let kind = u32(cloud_shape.z + 0.5);
     let storminess = select(0.0, 1.0, kind == 3u || kind == 7u);
     let sun_color = cloud_spectral.xyz;
+    let horizon_haze = 1.0 - smoothstep(0.02, 0.22, ray_direction.y);
+    let aerial_extinction = cloud_geometry.w * mix(0.65, 4.5, horizon_haze);
 
-    for (var step = 0u; step < 64u; step += 1u) {
+    for (var step = 0u; step < 80u; step += 1u) {
+        if distance >= trace_end {
+            break;
+        }
         let position = ray_origin + ray_direction * distance;
         let distance_fade = 1.0 - smoothstep(cloud_layer.w * 0.68, cloud_layer.w, distance);
         let density = sample_density(position) * distance_fade;
         if density > 0.002 {
+            if !fine_marching {
+                fine_marching = true;
+                fine_empty_steps = 0u;
+                step_length = fine_step;
+                distance = max(distance - coarse_step, trace_start) + fine_step * ray_jitter;
+                continue;
+            }
             // Deep precipitating clouds extinguish the warm atmospheric
             // aureole behind them. Without this storm-specific optical-depth
             // boost, a physically neutral core could still appear olive from
@@ -228,7 +305,11 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
             let extinction_scale = mix(1.0, 1.65, storminess);
             let sample_opacity = 1.0
                 - exp(-density * step_length * 0.00142 * extinction_scale);
-            let height = clamp((position.y - cloud_layer.x) / cloud_layer.y, 0.0, 1.0);
+            let height = clamp(
+                (altitude_in_shell(position) - cloud_layer.x) / cloud_layer.y,
+                0.0,
+                1.0,
+            );
             let sun_visibility = sunlight_transmittance(position, sun_direction);
             let powder = 1.0 - exp(-density * 2.4);
             let clear_ambient = mix(
@@ -265,20 +346,31 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
                 * storm_direct;
             let sample_color = ambient_color * ambient_variation + direct_light;
             let weight = transmittance * sample_opacity;
-            radiance += sample_color * weight;
+            let aerial_transmission = exp(-distance * aerial_extinction);
+            radiance += sample_color * weight * aerial_transmission;
+            visible_opacity += weight * aerial_transmission;
             transmittance *= 1.0 - sample_opacity;
+            fine_empty_steps = 0u;
             if transmittance < 0.012 {
                 break;
+            }
+        } else if fine_marching {
+            fine_empty_steps += 1u;
+            if fine_empty_steps >= 3u {
+                fine_marching = false;
+                fine_empty_steps = 0u;
+                step_length = coarse_step;
             }
         }
         distance += step_length;
     }
 
-    let opacity = 1.0 - transmittance;
+    let cloud_opacity = 1.0 - transmittance;
+    let opacity = clamp(visible_opacity, 0.0, 1.0);
     if opacity < 0.002 {
         discard;
     }
-    let silver_lining = pow(1.0 - opacity, 2.2)
+    let silver_lining = pow(1.0 - cloud_opacity, 2.2)
         * forward_phase
         * cloud_motion.z
         * cloud_motion.w

--- a/crates/adventuresim-tactical-client/src/presentation/clouds.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/clouds.rs
@@ -1,9 +1,13 @@
-//! Bounded procedural cloud slab for the grounded tactical camera.
+//! Bounded procedural cloud shells for the grounded tactical camera.
 
 use super::*;
 
 const CLOUD_SHADER: &str = "shaders/tactical_clouds.wgsl";
 const CLOUD_DOME_DISTANCE_METRES: f32 = 20_000.0;
+/// Deliberately smaller than Earth's radius so cloud decks bend into the
+/// tactical horizon within the renderer's bounded trace distance.
+const CLOUD_CURVATURE_RADIUS_METRES: f32 = 180_000.0;
+const CLOUD_AERIAL_EXTINCTION_PER_METRE: f32 = 0.000_025;
 
 #[derive(Component)]
 pub(crate) struct TacticalCloudLayer {
@@ -43,6 +47,9 @@ pub(in crate::presentation) struct TacticalCloudMaterial {
     /// Solar RGB chroma derived from altitude; alpha is reserved.
     #[uniform(4)]
     spectral: Vec4,
+    /// Fixed scene anchor X/Z, curvature radius, aerial extinction.
+    #[uniform(5)]
+    geometry: Vec4,
 }
 
 impl Material for TacticalCloudMaterial {
@@ -203,6 +210,7 @@ pub(in crate::presentation) fn setup_tactical_clouds(
                 layer: Vec4::new(1_250.0, 1_850.0, 0.000_34, 24_000.0),
                 motion: Vec4::new(0.0, 0.0, 1.0, 1.0),
                 spectral: Vec4::ONE,
+                geometry: cloud_shell_geometry(),
             })),
             Transform::default(),
         ));
@@ -353,8 +361,30 @@ pub(in crate::presentation) fn update_tactical_clouds(
             celestial.weather_transmission,
         );
         material.spectral = solar_color.extend(1.0);
+        material.geometry = cloud_shell_geometry();
         *visibility = Visibility::Inherited;
     }
+}
+
+fn cloud_shell_geometry() -> Vec4 {
+    // Tactical world coordinates are local to the scene. Anchoring the shell
+    // below that origin keeps its curvature stable as the camera crosses the
+    // playable area; the camera-following mesh remains only a raster proxy.
+    Vec4::new(
+        0.0,
+        0.0,
+        CLOUD_CURVATURE_RADIUS_METRES,
+        CLOUD_AERIAL_EXTINCTION_PER_METRE,
+    )
+}
+
+#[cfg(test)]
+fn cloud_shell_altitude_at_distance(base_metres: f32, horizontal_metres: f32) -> f32 {
+    let radius = CLOUD_CURVATURE_RADIUS_METRES + base_metres;
+    (radius * radius - horizontal_metres * horizontal_metres)
+        .max(0.0)
+        .sqrt()
+        - CLOUD_CURVATURE_RADIUS_METRES
 }
 
 fn cloud_seed(environment: &SceneEnvironment) -> u64 {
@@ -529,5 +559,28 @@ mod tests {
     fn cloud_decks_composite_high_to_low() {
         assert!(cloud_sort_bias(2) < cloud_sort_bias(1));
         assert!(cloud_sort_bias(1) < cloud_sort_bias(0));
+    }
+
+    #[test]
+    fn cloud_shell_is_locally_flat_but_bends_into_the_horizon() {
+        let base_metres = 1_250.0;
+        let nearby = cloud_shell_altitude_at_distance(base_metres, 1_000.0);
+        let distant = cloud_shell_altitude_at_distance(base_metres, 20_000.0);
+
+        assert!((nearby - base_metres).abs() < 4.0);
+        assert!(distant < base_metres - 1_000.0);
+        assert!(distant > 0.0);
+        assert_eq!(cloud_shell_geometry().xy(), Vec2::ZERO);
+    }
+
+    #[test]
+    fn cloud_shader_intersects_shells_and_adapts_its_sampling() {
+        let shader = include_str!("../../../../assets/shaders/tactical_clouds.wgsl");
+
+        assert!(shader.contains("ray_sphere_roots"));
+        assert!(shader.contains("altitude_in_shell"));
+        assert!(shader.contains("let ray_jitter"));
+        assert!(shader.contains("var fine_marching = false"));
+        assert!(!shader.contains("(cloud_layer.x - ray_origin.y) / ray_direction.y"));
     }
 }

--- a/wiki/tactical/sky.md
+++ b/wiki/tactical/sky.md
@@ -63,14 +63,23 @@ python scripts/import_hipparcos_stars.py
 
 The default tactical presentation renders up to three bounded atmospheric
 decks. Camera-centred hemispheres supply rasterization geometry, but the
-fragment shader intersects each view ray with the corresponding cloud layer
-and integrates sixty-four procedural density samples through it. Short
-sun-facing shadow probes provide internal self-shadowing, while multi-scale
-edge erosion and distance fading preserve cloud detail without a hard horizon
-cutoff. Solar chroma follows Sun altitude rather than applying a permanent
-gold cast; dense storm cores converge toward neutral gray-blue multiple
-scattering while low-Sun cloud edges can remain warm. Distinct profiles
-cover cirrus, cirrocumulus, cirrostratus, altocumulus, altostratus,
+fragment shader intersects each view ray with scene-anchored concentric
+spherical shells. Their deliberately exaggerated local curvature is negligible
+across the playable area but bends distant clouds into the tactical horizon.
+The shells remain stationary; wind and vertical shear advect each procedural
+density field through its layer instead of moving a finite volume past the
+camera.
+
+The ray marcher searches empty air in coarse steps, backtracks and switches to
+quarter-sized steps after finding density, and returns to coarse search after
+leaving a cloud. A deterministic per-pixel starting offset prevents coherent
+sampling bands along the curved shell. Short sun-facing shadow probes provide
+internal self-shadowing, while multi-scale edge erosion, bounded trace distance,
+and stronger grazing-angle aerial extinction keep distant layers from forming
+a hard horizon cutoff. Solar chroma follows Sun altitude rather than applying a
+permanent gold cast; dense storm cores converge toward neutral gray-blue
+multiple scattering while low-Sun cloud edges can remain warm. Distinct
+profiles cover cirrus, cirrocumulus, cirrostratus, altocumulus, altostratus,
 nimbostratus, stratocumulus, stratus, cumulus, cumulus congestus, and
 cumulonimbus. The decks can coexist, so high ice cloud need not disappear when
 lower cloud develops.


### PR DESCRIPTION
## What changed

- replaces flat cloud-deck intersections with scene-anchored concentric spherical shells
- retains the camera-centered hemisphere only as rasterization geometry
- keeps the shells stationary while existing per-deck wind and shear advect procedural density through them
- adds analytic ray-sphere bounds, deterministic per-pixel ray jitter, coarse-to-fine adaptive marching, and grazing-angle aerial extinction
- documents the curved-volume behavior and adds geometry and shader-contract regression tests

## Why

Flat horizontal slabs made distant cloud layers and their grazing-angle sampling structure conspicuous near the horizon. Curved shells let distant clouds bend naturally into the tactical horizon while remaining effectively flat across the roughly two-kilometre playable area.

The shell radius is intentionally smaller than Earth’s radius to make that improvement visible within the renderer’s bounded 24 km trace distance. Moving density coordinates rather than the finite shell avoids the volume drifting past the player during a tactical session.

## Impact

Nearby cloud bases retain their authoritative meteorological altitude, while distant cumulus, overcast, cirrus, and storm layers transition into the horizon more naturally. Empty rays use fewer density evaluations; occupied edges receive finer sampling to suppress marching bands without increasing detail cost everywhere.

## Validation

- 32 focused cloud-test executions across all tactical-client binaries
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- wiki formatter and 11 wiki tooling tests
- wiki summary and generated project-map checks
- `mdbook build`
- focused cumulus, cirrus, overcast, and storm native captures
- full heavy-rain production semantic capture
- shader-error and image-stability gates
- `git diff --check`
