### PR TITLE
Refresh generated project map count

### DIFF
--- a/wiki/generated/project-map.md
+++ b/wiki/generated/project-map.md
@@ -9,7 +9,7 @@ Build output, Git internals, dependency directories, and generated browser artif
 Start with `AGENTS.md`, then read the root README and the relevant architecture,
 development, or other wiki document before changing a subsystem.
 
-## Files (2017)
+## Files (2020)
 
 - `.cargo/config.toml` — Tooling or build configuration.
 - `.codex/hooks.json` — Repository support file.


### PR DESCRIPTION
## What changed

- Refresh the generated project map file count from 2017 to 2020.

## Why

The Pages workflow failed in `Check generated project map` because the file entries had been updated for the latest additions, but the generated heading retained the old count.

## Impact

The generated project-map check is current again, allowing the mdBook Pages workflow to continue.

## Validation

- Repository tooling formatting check
- 11 wiki tooling unit tests
- Generated wiki navigation check
- Generated project map check from a clean tree
- `mdbook build`
- `git diff --check`

Fixes the failure in https://github.com/adventure-simulator-group/fabelgeist/actions/runs/31976738579
