### PR TITLE
Refine grass material highlights

### DIFF
--- a/assets/shaders/tactical_foliage.wgsl
+++ b/assets/shaders/tactical_foliage.wgsl
@@ -354,7 +354,14 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
         in.color.rgb,
         lod_coverage,
     );
-    pbr_input.material.perceptual_roughness = 0.86;
+    // Ground foliage is grass. Its waxy cuticle produces a tighter highlight
+    // than the shared dry-twig and woodland-plant response, allowing the
+    // differently oriented blade normals to separate without albedo noise.
+    pbr_input.material.perceptual_roughness = select(
+        0.86,
+        0.60,
+        foliage.shading.w > 0.5,
+    );
     pbr_input.material.metallic = 0.0;
     pbr_input.material.reflectance = vec3<f32>(0.16);
     // Living blades are thin enough for broad diffuse transmission. This is

--- a/crates/adventuresim-tactical-client/src/presentation/ground_scatter/grass.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/ground_scatter/grass.rs
@@ -640,24 +640,14 @@ fn grass_ribbon_patch_mesh(
         let normal = Vec3::Y.cross(half_width).normalize_or_zero().to_array();
         let blade_threshold = unit_hash(splitmix64(hash ^ 0x3d91_02ea_61b8_7c45));
         let age = unit_hash(splitmix64(hash ^ 0x1b47_c95a_622d_41e3));
-        // Each blade is one molded pigment. Variation is categorical rather
-        // than continuous noise, and senescent tips use a hard color region.
-        let pigment = splitmix64(hash ^ 0x76b3_144d) % 3;
-        let cohort_scale = match pigment {
-            0 => [0.82, 0.90, 0.78],
-            1 => [1.0, 1.0, 1.0],
-            _ => [1.08, 1.02, 0.82],
-        };
+        // Healthy blades share their species pigment. Senescent tips retain a
+        // hard straw region, while blade separation comes from the material's
+        // specular response rather than randomized albedo.
         let species_scale = species.pigment_scale();
-        let pigment_scale = [
-            cohort_scale[0] * species_scale[0],
-            cohort_scale[1] * species_scale[1],
-            cohort_scale[2] * species_scale[2],
-        ];
         let blade_color = [
-            (linear[0] * pigment_scale[0]).clamp(0.0, 1.0),
-            (linear[1] * pigment_scale[1]).clamp(0.0, 1.0),
-            (linear[2] * pigment_scale[2]).clamp(0.0, 1.0),
+            (linear[0] * species_scale[0]).clamp(0.0, 1.0),
+            (linear[1] * species_scale[1]).clamp(0.0, 1.0),
+            (linear[2] * species_scale[2]).clamp(0.0, 1.0),
             blade_threshold,
         ];
         let luminance = blade_color[0] * 0.2126 + blade_color[1] * 0.7152 + blade_color[2] * 0.0722;
@@ -1217,7 +1207,7 @@ mod tests {
             .iter()
             .map(|color| [color[0].to_bits(), color[1].to_bits(), color[2].to_bits()])
             .collect::<BTreeSet<_>>();
-        assert!(distinct_pigments.len() <= 12);
+        assert!(distinct_pigments.len() <= 4);
         assert!(distinct_pigments.len() >= 3);
     }
 
@@ -1353,6 +1343,8 @@ mod tests {
         assert!(shader.contains("abs(f32(in.visibility_range_dither)) / 16.0"));
         assert!(!shader.contains("visibility_range_dither(in.position"));
         assert!(shader.contains("vec4<f32>(root_world, 1.0)"));
+        assert!(shader.contains("0.60,"));
+        assert!(shader.contains("foliage.shading.w > 0.5"));
 
         let near = grass_patch_mesh(
             Color::WHITE,

--- a/wiki/engineering/architecture.md
+++ b/wiki/engineering/architecture.md
@@ -465,20 +465,22 @@ per patch. Macro patches remain unit-scale and nearly gridded, with boundary
 blade rows constrained to wander outward to mitigate square seams on near-flat
 and ordinary sloped terrain. This is a continuity mitigation rather than a
 guarantee across sharp terrain-normal discontinuities. Within the unchanged
-topology, deterministic mixed-age height, independent width, clumping,
-three-class pigment, lean, and curvature variation avoids a repeated
-vertical-curtain silhouette. A shared world-space meadow field keeps the full
+topology, deterministic mixed-age height, independent width, clumping, lean,
+and curvature variation avoids a repeated vertical-curtain silhouette. A shared
+world-space meadow field keeps the full
 authored density within seven metres, then introduces short juvenile pockets and
 irregular occupancy before the 18--26 metre cross-fade. The authoritative
 grass-side mask uses a broader nonlinear feather, and surviving boundary blades
 shorten with coverage, so dirt and leaf-litter transitions do not terminate as a
 same-height wall. This composition also derives a stable age cohort from the
 existing per-blade LOD threshold: a bounded minority of mature blades develops
-one hard-edged, desaturated straw-tip region while juvenile cohorts retain one
-of three green pigments. Root shading and rib definition are occlusion responses
-rather than albedo gradients. Near and far LODs therefore preserve the same age
-identity without another vertex attribute, texture read, transcendental
-evaluation, mesh, entity, material, or draw. Beneath and beyond the geometric
+one hard-edged, desaturated straw-tip region while healthy blades share their
+species pigment. A 0.60 perceptual roughness gives the differently oriented
+blades a waxy, view-dependent highlight instead of randomized albedo. Root
+shading and rib definition remain occlusion responses rather than color
+gradients. Near and far LODs therefore preserve the same age identity without
+another vertex attribute, texture read, transcendental evaluation, mesh,
+entity, material, or draw. Beneath and beyond the geometric
 range, tall-grass terrain uses an optical-average solid albedo derived from the
 same environment pigment as the blades. The compensation accounts for
 categorical blade darkening, occlusion, and thin-foliage lighting; copying the


### PR DESCRIPTION
## Summary

- lower grass perceptual roughness from 0.86 to 0.60 so blade orientation produces view-dependent highlights
- remove randomized three-cohort blade pigments while preserving species tinting and senescent straw tips
- keep the shared twig and woodland-plant roughness at 0.86
- update the architecture documentation and rendering invariants

## Why

Grass blades previously relied on randomized albedo to remain visually distinct. A moderately waxy PBR response separates differently oriented blades through lighting instead, producing a more coherent sward color without losing close-range definition.

## Validation

- `cargo test -p adventuresim-tactical-client grass_` — 11 matching tests passed in each of four tactical binaries (44 executions total)
- native `grass-seam-detail` captures passed all semantic validation gates for `flat-dry-grassland` and `sparse-woodland`
- wiki formatter and 11 wiki tooling unit tests passed
- wiki summary check passed
- `git diff --check` passed

The aggregate `just wiki-check` could not run completely in the local environment because `npm` and `mdbook` were unavailable; the independent project-map check also reports the existing generated map as stale. This change adds, removes, or repurposes no files.
