### PR TITLE
Fix belt slot attachment mapping

### DIFF
--- a/content/items/catalog.yaml
+++ b/content/items/catalog.yaml
@@ -4087,10 +4087,10 @@
           ]
         }],
         "attachment_points": [
-          {"id": "left", "channel": "mount", "capacity": 1, "order": 0, "accepts_tags": ["sheath", "bag"]},
-          {"id": "right", "channel": "mount", "capacity": 1, "order": 1, "accepts_tags": ["sheath", "bag"]},
-          {"id": "front", "channel": "mount", "capacity": 1, "order": 2, "accepts_tags": ["bag"]},
-          {"id": "back", "channel": "mount", "capacity": 1, "order": 3, "accepts_tags": ["bag"]}
+          {"id": "left", "channel": "mount", "capacity": 1, "order": 0, "locations": ["left_belt"], "accepts_tags": ["sheath", "bag"]},
+          {"id": "right", "channel": "mount", "capacity": 1, "order": 1, "locations": ["right_belt"], "accepts_tags": ["sheath", "bag"]},
+          {"id": "front", "channel": "mount", "capacity": 1, "order": 2, "locations": ["front_belt"], "accepts_tags": ["bag"]},
+          {"id": "back", "channel": "mount", "capacity": 1, "order": 3, "locations": ["back_belt"], "accepts_tags": ["bag"]}
         ]
       },
       "kind": "simple"

--- a/crates/adventuresim-core/src/item_catalog_schema.rs
+++ b/crates/adventuresim-core/src/item_catalog_schema.rs
@@ -155,6 +155,10 @@ pub struct AttachmentPointDefinition {
     pub capacity: u16,
     #[serde(default)]
     pub order: u16,
+    /// Body locations whose slot inputs may traverse this point. Empty means
+    /// the point inherits every location through which its parent is reached.
+    #[serde(default)]
+    pub locations: Vec<EquipmentLocation>,
     /// Empty accepts any equipment-authored child; otherwise at least one
     /// child's attachment tag must match.
     #[serde(default)]

--- a/crates/adventuresim-core/src/item_catalog_validation.rs
+++ b/crates/adventuresim-core/src/item_catalog_validation.rs
@@ -904,7 +904,14 @@ fn validate_equipment(
             };
             reject_unknown(
                 point,
-                &["id", "channel", "capacity", "order", "accepts_tags"],
+                &[
+                    "id",
+                    "channel",
+                    "capacity",
+                    "order",
+                    "locations",
+                    "accepts_tags",
+                ],
                 file,
                 &format!("{path}.attachment_points.{index}"),
                 errors,
@@ -933,6 +940,18 @@ fn validate_equipment(
                     "{file}: {path}.attachment_points.{index}.capacity: expected 1..={}",
                     u16::MAX
                 ));
+            }
+            if let Some(locations) = point.get("locations").and_then(Value::as_array) {
+                let mut seen = BTreeSet::new();
+                for location in locations {
+                    if !location.as_str().is_some_and(|location| {
+                        valid_locations.contains(location) && seen.insert(location)
+                    }) {
+                        errors.push(format!(
+                            "{file}: {path}.attachment_points.{index}.locations: invalid or duplicate location"
+                        ));
+                    }
+                }
             }
             if let Some(tags) = point.get("accepts_tags").and_then(Value::as_array) {
                 for tag in tags {

--- a/crates/adventuresim-tactical-client/src/equipment.rs
+++ b/crates/adventuresim-tactical-client/src/equipment.rs
@@ -458,13 +458,14 @@ fn ordered_preview_at_location(
     let mut output = Vec::new();
     let mut visited = std::collections::HashSet::new();
     for (_, entity) in found {
-        append_preview(entity, topologies, &mut visited, &mut output);
+        append_preview(entity, location, topologies, &mut visited, &mut output);
     }
     output
 }
 
 fn append_preview(
     entity: Entity,
+    location: EquipmentLocation,
     items: &Query<(Entity, &ItemOf, &EquipmentTopology, &ItemProperties)>,
     visited: &mut std::collections::HashSet<Entity>,
     output: &mut Vec<PreviewTarget>,
@@ -492,7 +493,10 @@ fn append_preview(
     };
     let mut points: Vec<_> = equipment.attachment_points.iter().collect();
     points.sort_by_key(|point| (point.order, point.id.as_str()));
-    for point in points {
+    for point in points
+        .into_iter()
+        .filter(|point| point.locations.is_empty() || point.locations.contains(&location))
+    {
         for capacity_index in 0..point.capacity {
             let child =
                 items.iter().find_map(|(child, _, topology, _)| {
@@ -507,7 +511,7 @@ fn append_preview(
                 }).then_some(child)
                 });
             if let Some(child) = child {
-                append_preview(child, items, visited, output);
+                append_preview(child, location, items, visited, output);
             } else {
                 // Empty attachment points address their mapped parent. Depth
                 // disambiguates the exact authored point/capacity on server.
@@ -569,6 +573,7 @@ fn hud_layers(
     let mut visited = std::collections::HashSet::new();
     fn append(
         entity: Entity,
+        location: EquipmentLocation,
         items: &Query<(
             Entity,
             &ItemOf,
@@ -602,7 +607,10 @@ fn hud_layers(
         };
         let mut points: Vec<_> = equipment.attachment_points.iter().collect();
         points.sort_by_key(|point| (point.order, point.id.as_str()));
-        for point in points {
+        for point in points
+            .into_iter()
+            .filter(|point| point.locations.is_empty() || point.locations.contains(&location))
+        {
             for capacity_index in 0..point.capacity {
                 let child = items.iter().find_map(|(child, _, _, _, topology)| {
                     topology.occupancies.iter().any(|occupancy| {
@@ -616,7 +624,7 @@ fn hud_layers(
                     }).then_some(child)
                 });
                 if let Some(child) = child {
-                    append(child, items, visited, output);
+                    append(child, location, items, visited, output);
                 } else {
                     output.push(PreviewTarget {
                         entity,
@@ -640,7 +648,7 @@ fn hud_layers(
         });
     }
     for (_, root) in roots {
-        append(root, items, &mut visited, &mut output);
+        append(root, location, items, &mut visited, &mut output);
     }
     output
 }
@@ -1435,7 +1443,7 @@ mod tests {
     }
 
     #[test]
-    fn preview_traversal_addresses_deepest_attachment_before_parent() {
+    fn preview_traversal_keeps_belt_attachment_points_in_their_slots() {
         let mut world = World::new();
         let actor = world.spawn_empty().id();
         let belt = world
@@ -1447,13 +1455,43 @@ mod tests {
                 },
                 EquipmentTopology {
                     placement_id: Some("worn".into()),
-                    occupancies: vec![EquipmentTopologyOccupancy {
-                        occupancy_id: "belt".into(),
-                        anchor: TacticalEquipmentAnchor::CharacterLocation(
-                            EquipmentLocation::LeftBelt,
-                        ),
+                    occupancies: [
+                        EquipmentLocation::LeftBelt,
+                        EquipmentLocation::RightBelt,
+                        EquipmentLocation::FrontBelt,
+                        EquipmentLocation::BackBelt,
+                    ]
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, location)| EquipmentTopologyOccupancy {
+                        occupancy_id: format!("belt-{index}"),
+                        anchor: TacticalEquipmentAnchor::CharacterLocation(location),
                         channel: EquipmentChannel::Accessory,
                         order: 0,
+                        requirement_index: index as u16,
+                        capacity_index: 0,
+                    })
+                    .collect(),
+                },
+            ))
+            .id();
+        let right_sheath = world
+            .spawn((
+                ItemOf(actor),
+                ItemProperties {
+                    id: "scabbard".into(),
+                    weight: 0.3,
+                },
+                EquipmentTopology {
+                    placement_id: Some("right".into()),
+                    occupancies: vec![EquipmentTopologyOccupancy {
+                        occupancy_id: "right-sheath".into(),
+                        anchor: TacticalEquipmentAnchor::ItemAttachment {
+                            parent: belt,
+                            attachment_point_id: "right".into(),
+                        },
+                        channel: EquipmentChannel::Mount,
+                        order: 1,
                         requirement_index: 0,
                         capacity_index: 0,
                     }],
@@ -1496,6 +1534,21 @@ mod tests {
             "deepest empty blade is first"
         );
         assert_eq!(preview.last().map(|target| target.entity), Some(belt));
+        let right_preview = world
+            .run_system_once(
+                move |items: Query<(Entity, &ItemOf, &EquipmentTopology, &ItemProperties)>| {
+                    ordered_preview_at_location(actor, EquipmentLocation::RightBelt, &items)
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            right_preview.first().map(|target| target.entity),
+            Some(right_sheath)
+        );
+        assert!(
+            right_preview.iter().all(|target| target.entity != sheath),
+            "the left sheath must not appear in the right belt slot"
+        );
     }
 
     #[test]

--- a/crates/adventuresim-tactical-server/src/equipment.rs
+++ b/crates/adventuresim-tactical-server/src/equipment.rs
@@ -308,7 +308,7 @@ fn ordered_at_location(
     let mut reachable = Vec::new();
     let mut visited = HashSet::new();
     for (_, entity) in found {
-        append_reachable(entity, items, &mut visited, &mut reachable);
+        append_reachable(entity, location, items, &mut visited, &mut reachable);
     }
     reachable
 }
@@ -335,6 +335,7 @@ impl ReachableTarget {
 
 fn append_reachable(
     entity: Entity,
+    location: EquipmentLocation,
     items: &Query<ItemView<'_>>,
     visited: &mut HashSet<Entity>,
     output: &mut Vec<ReachableTarget>,
@@ -354,7 +355,10 @@ fn append_reachable(
     };
     let mut points: Vec<_> = equipment.attachment_points.iter().collect();
     points.sort_by_key(|point| (point.order, point.id.as_str()));
-    for point in points {
+    for point in points
+        .into_iter()
+        .filter(|point| point.locations.is_empty() || point.locations.contains(&location))
+    {
         for capacity_index in 0..point.capacity {
             let child = items
                 .iter()
@@ -370,7 +374,7 @@ fn append_reachable(
                 }).then_some(child)
                 });
             if let Some(child) = child {
-                append_reachable(child, items, visited, output);
+                append_reachable(child, location, items, visited, output);
             } else {
                 output.push(ReachableTarget::EmptyAttachment {
                     parent: entity,
@@ -1154,7 +1158,7 @@ mod tests {
     }
 
     #[test]
-    fn nested_traversal_exposes_authored_empty_points_in_order() {
+    fn belt_locations_traverse_only_their_authored_attachment_points() {
         let mut world = World::new();
         let actor = world.spawn_empty().id();
         let belt = spawn_test_item(
@@ -1163,25 +1167,42 @@ mod tests {
             "leather_belt",
             EquipmentTopology {
                 placement_id: Some("worn".into()),
-                occupancies: vec![EquipmentTopologyOccupancy {
-                    occupancy_id: "belt".into(),
-                    anchor: TacticalEquipmentAnchor::CharacterLocation(EquipmentLocation::LeftBelt),
+                occupancies: [
+                    EquipmentLocation::LeftBelt,
+                    EquipmentLocation::RightBelt,
+                    EquipmentLocation::FrontBelt,
+                    EquipmentLocation::BackBelt,
+                ]
+                .into_iter()
+                .enumerate()
+                .map(|(index, location)| EquipmentTopologyOccupancy {
+                    occupancy_id: format!("belt-{index}"),
+                    anchor: TacticalEquipmentAnchor::CharacterLocation(location),
                     channel: EquipmentChannel::Accessory,
                     order: 0,
-                    requirement_index: 0,
+                    requirement_index: index as u16,
                     capacity_index: 0,
-                }],
+                })
+                .collect(),
             },
         );
-        let reachable = world
-            .run_system_once(move |items: Query<ItemView<'_>>| {
-                ordered_at_location(actor, EquipmentLocation::LeftBelt, &items)
-            })
-            .unwrap();
-        assert!(
-            matches!(reachable.first(), Some(ReachableTarget::EmptyAttachment { attachment_point_id, .. }) if attachment_point_id == "left")
-        );
-        assert_eq!(reachable.last(), Some(&ReachableTarget::Occupied(belt)));
+        for (location, expected_point) in [
+            (EquipmentLocation::LeftBelt, "left"),
+            (EquipmentLocation::RightBelt, "right"),
+            (EquipmentLocation::FrontBelt, "front"),
+            (EquipmentLocation::BackBelt, "back"),
+        ] {
+            let reachable = world
+                .run_system_once(move |items: Query<ItemView<'_>>| {
+                    ordered_at_location(actor, location, &items)
+                })
+                .unwrap();
+            assert!(
+                matches!(reachable.first(), Some(ReachableTarget::EmptyAttachment { attachment_point_id, .. }) if attachment_point_id == expected_point)
+            );
+            assert_eq!(reachable.len(), 2);
+            assert_eq!(reachable.last(), Some(&ReachableTarget::Occupied(belt)));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Added optional body-location addresses to authored equipment attachment points.
- Mapped the leather belt's left, right, front, and back attachment points to the corresponding belt slots.
- Filtered both authoritative server traversal and client preview/HUD traversal by the selected slot address.
- Added client and server regressions covering distinct belt attachment traversal.

## Why

Slot traversal previously reached a multi-location belt and then walked every child attachment point. As a result, John Fabelgeist's left-side rondel could appear in all four belt slots, while the right-side longsword was not independently reachable.

Attachment points without explicit location addresses still inherit their parent's selected address, preserving nested traversal such as belt to scabbard to weapon.

## Validation

- `cargo check -p adventuresim-tactical-server -p adventuresim-tactical-client`
- `cargo test -p adventuresim-tactical-server belt_locations_traverse_only_their_authored_attachment_points`
- `cargo test -p adventuresim-tactical-client preview_traversal_keeps_belt_attachment_points_in_their_slots`
- `cargo test -p adventuresim-core item_catalog` (21 passed; 2 unrelated existing hard-coded catalog-count assertions failed: 161 vs 158 total items and 67 vs 64 equipment items)
- `cargo fmt --all`
- `git diff --cached --check`
