### PR TITLE
Blend tree roots into tactical terrain

### DIFF
--- a/assets/shaders/tactical_terrain.wgsl
+++ b/assets/shaders/tactical_terrain.wgsl
@@ -81,7 +81,6 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     let readable_detail_normal = normalize(vec3<f32>(normal.x * 1.45, normal.y, normal.z * 1.45));
     let base_normal = select(readable_detail_normal, normal, terrain.detail_patch.x > 0.5);
     pbr_input.N = base_normal;
-    let canopy = terrain.cover.x;
     let wetland = terrain.cover.y;
     let cultivation = terrain.cover.z;
     let water = terrain.cover.w;
@@ -113,44 +112,19 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     let soil_response = substrate_response * upward_response * detail_distance_fade * (1.0 - snow);
     pbr_input.N = normalize(mix(base_normal, soil_normal, soil_response));
     pbr_input.diffuse_occlusion *= mix(1.0, soil_sample.g, soil_response * 0.82);
-    // Signed canopy-floor distance: 0.0 is open ground, 0.0-0.5 approaches
-    // litter from outside, and 0.5-1.0 moves into its shaded interior.
-    let canopy_floor = ground_sample.a;
     let tall_grass = 1.0 - step(0.5, abs(cover_kind - 1.0));
-    let leaf_litter = 1.0 - step(0.5, abs(cover_kind - 2.0));
 
-    // Ground uses only solid molded-material colors selected at hard gameplay
-    // boundaries. There is no sampled albedo or normal-map surface detail.
+    // Ordinary soil keeps one solid molded-material albedo regardless of
+    // grass, litter, or canopy cover. There is no sampled albedo detail.
     var color = terrain.base_color.rgb;
-    if canopy >= 0.5 { color = vec3<f32>(0.065, 0.045, 0.022); }
     if cultivation >= 0.4 { color = vec3<f32>(0.17, 0.11, 0.035); }
     if wetland >= 0.4 || substrate_kind == 3.0 { color = vec3<f32>(0.18, 0.16, 0.105); }
 
-    // Near grass-covered terrain remains visible substrate. The geometric
-    // blades provide all green until their final LOD begins to disappear.
-    // Canopy proximity may darken that substrate, but never paints a second
-    // green sward beneath the blades.
-    let shaded_substrate = select(
-        vec3<f32>(0.09, 0.065, 0.027),
-        vec3<f32>(0.067, 0.047, 0.021),
-        canopy_floor >= 0.34,
-    );
-    color = select(
-        color,
-        shaded_substrate,
-        tall_grass > 0.5 && canopy_floor >= 0.16,
-    );
+    // Near grass-covered terrain retains the scene substrate albedo. Geometric
+    // blades provide its green cover, while canopy lighting supplies shade.
     if substrate_kind == 1.0 || substrate_kind == 2.0 || slope >= 0.5 {
         color = vec3<f32>(0.31, 0.30, 0.275);
     }
-    // Shallow litter islands visually join the shaded sward. Only the deep,
-    // connected canopy core exposes dark loam.
-    let litter_color = select(
-        vec3<f32>(0.070, 0.045, 0.019),
-        vec3<f32>(0.052, 0.032, 0.017),
-        canopy_floor >= 0.78,
-    );
-    color = select(color, litter_color, leaf_litter > 0.5);
     if water >= 0.5 || substrate_kind == 5.0 { color = vec3<f32>(0.09, 0.18, 0.22); }
 
     // Use the same true camera distance that drives mesh visibility. Horizontal

--- a/assets/shaders/tactical_tree_bark.wgsl
+++ b/assets/shaders/tactical_tree_bark.wgsl
@@ -19,15 +19,183 @@
 var bark_height_ao: texture_2d<f32>;
 @group(#{MATERIAL_BIND_GROUP}) @binding(101)
 var bark_height_ao_sampler: sampler;
+@group(#{MATERIAL_BIND_GROUP}) @binding(103)
+var terrain_heightmap: texture_2d<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(104)
+var soil_height_ao: texture_2d<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(105)
+var soil_height_ao_sampler: sampler;
 
 struct TacticalTreeBarkExtension {
     relief: vec4<f32>,
     projection: vec4<f32>,
     lighting: vec4<f32>,
+    surface: vec4<f32>,
+    soil_surface: vec4<f32>,
+    deposition: vec4<f32>,
+    terrain_surface: vec4<f32>,
+    soil_response: vec4<f32>,
+    soil_optics: vec4<f32>,
 }
 
 @group(#{MATERIAL_BIND_GROUP}) @binding(102)
 var<uniform> bark: TacticalTreeBarkExtension;
+
+fn hash21(cell: vec2<f32>) -> f32 {
+    let mixed = vec3<f32>(cell.x, cell.y, cell.x) * vec3<f32>(0.1031, 0.1030, 0.0973);
+    let fractal = fract(mixed);
+    let folded = fractal + dot(fractal, fractal.yzx + vec3<f32>(33.33));
+    return fract((folded.x + folded.y) * folded.z);
+}
+
+fn hash22(cell: vec2<f32>) -> vec2<f32> {
+    return vec2<f32>(hash21(cell), hash21(cell + vec2<f32>(19.19, 47.47)));
+}
+
+fn decode_terrain_height(texel: vec4<f32>) -> f32 {
+    let encoded = round(texel.r * 255.0) + round(texel.g * 255.0) * 256.0;
+    let normalized = encoded / 65535.0;
+    return mix(bark.terrain_surface.z, bark.terrain_surface.w, normalized);
+}
+
+fn terrain_height_at(world_xz: vec2<f32>) -> f32 {
+    let dimensions = vec2<i32>(textureDimensions(terrain_heightmap));
+    let grid_maximum = vec2<f32>(dimensions - vec2<i32>(1));
+    let extent = max(bark.terrain_surface.xy * 2.0, vec2<f32>(0.001));
+    let normalized = clamp(
+        (world_xz + bark.terrain_surface.xy) / extent,
+        vec2<f32>(0.0),
+        vec2<f32>(1.0),
+    );
+    let grid = normalized * grid_maximum;
+    let cell = clamp(
+        vec2<i32>(floor(grid)),
+        vec2<i32>(0),
+        dimensions - vec2<i32>(2),
+    );
+    let fraction = grid - vec2<f32>(cell);
+    let x0y0 = decode_terrain_height(textureLoad(terrain_heightmap, cell, 0));
+    let x1y0 = decode_terrain_height(
+        textureLoad(terrain_heightmap, cell + vec2<i32>(1, 0), 0)
+    );
+    let x0y1 = decode_terrain_height(
+        textureLoad(terrain_heightmap, cell + vec2<i32>(0, 1), 0)
+    );
+    let x1y1 = decode_terrain_height(
+        textureLoad(terrain_heightmap, cell + vec2<i32>(1, 1), 0)
+    );
+    if fraction.x >= fraction.y {
+        return x0y0
+            + (x1y0 - x0y0) * fraction.x
+            + (x1y1 - x1y0) * fraction.y;
+    }
+    return x0y0
+        + (x1y1 - x0y1) * fraction.x
+        + (x0y1 - x0y0) * fraction.y;
+}
+
+fn soil_surface_sample(world_position: vec3<f32>) -> vec2<f32> {
+    let warp = vec2<f32>(
+        sin(world_position.z * 0.29 + world_position.x * 0.11),
+        sin(world_position.x * 0.23 - world_position.z * 0.17),
+    ) * 0.035;
+    let uv = world_position.xz * bark.soil_response.x + warp;
+    return textureSample(soil_height_ao, soil_height_ao_sampler, uv).rg;
+}
+
+fn dominant_projection(position: vec3<f32>, normal: vec3<f32>) -> vec2<f32> {
+    let axis = abs(normal);
+    if axis.x > axis.y && axis.x > axis.z {
+        return position.zy;
+    }
+    if axis.y > axis.z {
+        return position.xz;
+    }
+    return position.xy;
+}
+
+fn soil_speck_distance(
+    projected: vec2<f32>,
+    root_height: f32,
+    cell_size: f32,
+    layer_offset: vec2<f32>,
+    minimum_radius: f32,
+    base_occupancy: f32,
+) -> f32 {
+    let scaled = projected / cell_size + layer_offset;
+    let cell = floor(scaled);
+    let within_cell = fract(scaled);
+    let random = hash22(cell + layer_offset * 17.0);
+    let centre = vec2<f32>(0.08) + random * 0.84;
+    let delta = (within_cell - centre) * cell_size;
+    let shape_random = hash22(cell + layer_offset * 31.0 + vec2<f32>(71.7, 13.1));
+    let angle = shape_random.x * 6.2831853;
+    let major = vec2<f32>(cos(angle), sin(angle));
+    let minor = vec2<f32>(-major.y, major.x);
+    let aspect = mix(0.82, 1.22, shape_random.y);
+    let elliptical_distance = length(vec2<f32>(
+        dot(delta, major) / aspect,
+        dot(delta, minor) * aspect,
+    ));
+    let radius = mix(
+        minimum_radius,
+        cell_size * 0.38,
+        hash21(cell + layer_offset * 43.0 + vec2<f32>(29.3, 83.1)),
+    );
+
+    let height_fraction = clamp(
+        (root_height - bark.deposition.x)
+            / max(bark.deposition.y - bark.deposition.x, 0.0001),
+        0.0,
+        1.0,
+    );
+    let occupied = hash21(cell + layer_offset * 59.0 + vec2<f32>(101.3, 59.9))
+        < mix(base_occupancy, 0.025, height_fraction);
+    let bounded = min(radius - elliptical_distance, bark.deposition.y - root_height);
+    return select(-cell_size, bounded, occupied);
+}
+
+fn root_soil_signed_distance(
+    world_position: vec3<f32>,
+    macro_normal: vec3<f32>,
+    root_height: f32,
+) -> f32 {
+    let cell_size = bark.deposition.z;
+    // Keep the procedural work confined to the narrow root-contact band. The
+    // coherent branch avoids evaluating two cellular fields over the many
+    // square metres of clean trunk above it.
+    if root_height > bark.deposition.y + cell_size {
+        return -cell_size;
+    }
+    if root_height < bark.deposition.x - cell_size {
+        return cell_size;
+    }
+    let projected = dominant_projection(world_position, macro_normal);
+    let fine_specks = soil_speck_distance(
+        projected,
+        root_height,
+        cell_size,
+        vec2<f32>(3.17, 8.53),
+        bark.deposition.w,
+        0.58,
+    );
+    let coarse_specks = soil_speck_distance(
+        projected,
+        root_height,
+        cell_size * 1.73,
+        vec2<f32>(11.41, 2.79),
+        bark.deposition.w * 1.35,
+        0.34,
+    );
+    let visible_speck = max(fine_specks, coarse_specks);
+
+    // A shallow continuous contact coat seats the trunk in the ground. Its
+    // per-cell height variation prevents a mechanically level ring.
+    let contact_variation = (hash21(floor(world_position.xz / (cell_size * 1.7))) - 0.5)
+        * cell_size * 1.6;
+    let contact = bark.deposition.x + contact_variation - root_height;
+    return max(contact, visible_speck);
+}
 
 fn triplanar_weights(normal: vec3<f32>) -> vec3<f32> {
     let weighted = pow(abs(normal), vec3<f32>(bark.projection.x));
@@ -169,6 +337,7 @@ fn height_perturbed_normal(
     world_position: vec3<f32>,
     macro_normal: vec3<f32>,
     height_metres: f32,
+    strength: f32,
 ) -> vec3<f32> {
     let position_dx = dpdx(world_position);
     let position_dy = dpdy(world_position);
@@ -185,7 +354,7 @@ fn height_perturbed_normal(
     let surface_gradient = (
         reciprocal_x * height_dx + reciprocal_y * height_dy
     ) / safe_determinant;
-    return normalize(macro_normal - surface_gradient * bark.relief.z);
+    return normalize(macro_normal - surface_gradient * strength);
 }
 
 @fragment
@@ -213,6 +382,7 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
         in.world_position.xyz,
         macro_normal,
         height_metres,
+        bark.relief.z,
     );
     let parallax_shadow = 1.0 - parallax.z * 0.22;
     let directional_visibility = directional_horizon_visibility(
@@ -227,25 +397,69 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
         * directional_visibility;
     let cavity = 1.0 - sample.g;
     let micro_roughness = 0.025 * sin(dot(in.world_position.xyz, vec3<f32>(37.0, 53.0, 29.0)));
+    var soil_coverage = 0.0;
+    var soil_response_coverage = 0.0;
+    var soil_sample = vec2<f32>(0.5, 1.0);
+    var soil_normal = macro_normal;
+#ifdef VERTEX_COLORS
+    let terrain_height = terrain_height_at(in.world_position.xz);
+    let terrain_clearance = in.world_position.y - terrain_height;
+    let signed_distance = root_soil_signed_distance(
+        in.world_position.xyz,
+        macro_normal,
+        terrain_clearance,
+    );
+    // This is material selection, not translucent blending. Only the analytic
+    // coverage required to antialias the binary boundary occupies the narrow
+    // interval between zero and one.
+    let edge_width = max(fwidth(signed_distance), 0.0002);
+    soil_coverage = smoothstep(-edge_width, edge_width, signed_distance);
+    // Terrain material maps only bridge the physical contact seam. Above two
+    // inches, deposited dirt remains an albedo-only treatment over bark.
+    let contact_response = 1.0 - smoothstep(0.0381, 0.0508, max(terrain_clearance, 0.0));
+    soil_response_coverage = soil_coverage * contact_response;
+    soil_sample = soil_surface_sample(in.world_position.xyz);
+    let soil_height_metres = (soil_sample.r - 0.5) * bark.soil_response.y;
+    soil_normal = height_perturbed_normal(
+        in.world_position.xyz,
+        macro_normal,
+        soil_height_metres,
+        bark.soil_response.z,
+    );
+#endif
 
     pbr_input.world_normal = macro_normal;
-    pbr_input.N = composed_normal;
+    pbr_input.N = normalize(mix(composed_normal, soil_normal, soil_response_coverage));
+    let bark_directional_response = mix(1.0, directional_visibility, 0.62);
     pbr_input.material.base_color = vec4<f32>(
-        pbr_input.material.base_color.rgb * mix(1.0, directional_visibility, 0.62),
-        pbr_input.material.base_color.a,
+        mix(bark.surface.rgb, bark.soil_surface.rgb, soil_coverage)
+            * mix(bark_directional_response, 1.0, soil_response_coverage),
+        1.0,
     );
-    pbr_input.material.perceptual_roughness = clamp(
-        pbr_input.material.perceptual_roughness + cavity * 0.10 + micro_roughness,
+    let bark_roughness = clamp(
+        bark.surface.w + cavity * 0.10 + micro_roughness,
         0.62,
         0.94,
     );
+    pbr_input.material.perceptual_roughness = mix(
+        bark_roughness,
+        bark.soil_surface.w,
+        soil_coverage,
+    );
+    pbr_input.material.reflectance = mix(
+        pbr_input.material.reflectance,
+        vec3<f32>(bark.soil_optics.x),
+        soil_coverage,
+    );
+    let soil_visibility = mix(1.0, soil_sample.g, bark.soil_response.w);
     pbr_input.diffuse_occlusion = clamp(
-        pbr_input.diffuse_occlusion * ambient_visibility,
+        pbr_input.diffuse_occlusion
+            * mix(ambient_visibility, soil_visibility, soil_response_coverage),
         vec3<f32>(0.0),
         vec3<f32>(1.0),
     );
     pbr_input.specular_occlusion = clamp(
-        pbr_input.specular_occlusion * ambient_visibility,
+        pbr_input.specular_occlusion * mix(ambient_visibility, 1.0, soil_response_coverage),
         0.0,
         1.0,
     );

--- a/crates/adventuresim-tactical-client/src/presentation/ground_scatter/litter.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/ground_scatter/litter.rs
@@ -23,6 +23,9 @@ const DRY_LEAF_PASSES_PER_SAMPLE: u64 = 3;
 const TWIG_PASSES_PER_SAMPLE: u64 = 2;
 const WOODLAND_PLANT_PASSES_PER_SAMPLE: u64 = 1;
 const WOODLAND_FLOOR_TRANSITION_METRES: f32 = 3.2;
+const LITTER_BATCH_CELL_METRES: f32 = 64.0;
+const LITTER_BATCH_HALF_DIAGONAL_METRES: f32 =
+    LITTER_BATCH_CELL_METRES * core::f32::consts::FRAC_1_SQRT_2;
 
 pub(super) struct Assets {
     pub dry_leaf_meshes: Vec<Handle<Mesh>>,
@@ -55,7 +58,6 @@ pub(super) fn spawn(
     base_seed: u64,
     assets: &Assets,
 ) {
-    const BATCH_CELL_METRES: f32 = 64.0;
     let mut batches = BTreeMap::<(i32, i32), LitterBatch>::new();
     let mut leaf_anchors = Vec::new();
     let mut twig_anchors = Vec::new();
@@ -97,7 +99,7 @@ pub(super) fn spawn(
                 meshes,
                 &assets.dry_leaf_meshes[(hash % assets.dry_leaf_meshes.len() as u64) as usize],
                 transform,
-                BATCH_CELL_METRES,
+                LITTER_BATCH_CELL_METRES,
                 &mut batches,
                 BatchKind::Leaves,
             );
@@ -120,7 +122,7 @@ pub(super) fn spawn(
                 meshes,
                 &assets.twig_meshes[(hash % assets.twig_meshes.len() as u64) as usize],
                 transform,
-                BATCH_CELL_METRES,
+                LITTER_BATCH_CELL_METRES,
                 &mut batches,
                 BatchKind::Twigs,
             );
@@ -146,7 +148,7 @@ pub(super) fn spawn(
                 &assets.woodland_plant_meshes
                     [(hash % assets.woodland_plant_meshes.len() as u64) as usize],
                 transform,
-                BATCH_CELL_METRES,
+                LITTER_BATCH_CELL_METRES,
                 &mut batches,
                 BatchKind::Plants,
             );
@@ -161,9 +163,9 @@ pub(super) fn spawn(
     }
     for ((cell_x, cell_z), batch) in batches {
         let transform = Transform::from_xyz(
-            cell_x as f32 * BATCH_CELL_METRES,
+            cell_x as f32 * LITTER_BATCH_CELL_METRES,
             0.0,
-            cell_z as f32 * BATCH_CELL_METRES,
+            cell_z as f32 * LITTER_BATCH_CELL_METRES,
         );
         if let Some(mesh) = batch.leaves {
             commands.spawn((
@@ -172,7 +174,7 @@ pub(super) fn spawn(
                 NotShadowCaster,
                 Mesh3d(meshes.add(mesh)),
                 MeshMaterial3d(assets.dry_leaf_material.clone()),
-                VisibilityRange::abrupt(0.0, 35.0),
+                batched_litter_visibility(35.0),
                 transform,
             ));
         }
@@ -183,7 +185,7 @@ pub(super) fn spawn(
                 NotShadowCaster,
                 Mesh3d(meshes.add(mesh)),
                 MeshMaterial3d(assets.twig_material.clone()),
-                VisibilityRange::abrupt(0.0, 24.0),
+                batched_litter_visibility(24.0),
                 transform,
             ));
         }
@@ -194,10 +196,24 @@ pub(super) fn spawn(
                 NotShadowCaster,
                 Mesh3d(meshes.add(mesh)),
                 MeshMaterial3d(assets.woodland_plant_material.clone()),
-                VisibilityRange::abrupt(0.0, 28.0),
+                batched_litter_visibility(28.0),
                 transform,
             ));
         }
+    }
+}
+
+fn batched_litter_visibility(local_end_metres: f32) -> VisibilityRange {
+    // Each entity contains debris distributed across a large cell. Measuring
+    // visibility from the cell-corner entity translation can therefore hide
+    // geometry beside the camera. Use the merged mesh bounds and pad the
+    // cutoff by the greatest possible centre-to-edge distance so the range
+    // still describes distance from the debris itself.
+    let batch_end = local_end_metres + LITTER_BATCH_HALF_DIAGONAL_METRES;
+    VisibilityRange {
+        start_margin: 0.0..0.0,
+        end_margin: batch_end..batch_end,
+        use_aabb: true,
     }
 }
 
@@ -756,6 +772,15 @@ mod tests {
         mesh::VertexAttributeValues,
         prelude::{App, Image, TaskPoolPlugin, default},
     };
+
+    #[test]
+    fn batched_litter_visibility_cannot_cull_debris_inside_its_local_range() {
+        let local_end = 24.0;
+        let range = batched_litter_visibility(local_end);
+        assert!(range.use_aabb);
+        assert!(range.is_visible_at_all(LITTER_BATCH_HALF_DIAGONAL_METRES + local_end - 0.01));
+        assert!(!range.is_visible_at_all(LITTER_BATCH_HALF_DIAGONAL_METRES + local_end + 0.01));
+    }
 
     #[test]
     fn capture_anchors_preserve_distinct_placements_inside_one_batch_cell() {

--- a/crates/adventuresim-tactical-client/src/presentation/mod.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/mod.rs
@@ -62,7 +62,9 @@ pub(crate) use sky::AtmosphereIblAmbientHandoff;
 #[allow(unused_imports)]
 pub(crate) use sky::{TacticalMoon, TacticalMoonlight, TacticalStars, TacticalSunlight};
 #[allow(unused_imports)]
-pub(crate) use terrain::{TerrainDetailPatch, TerrainMaterialPresentation};
+pub(crate) use terrain::{
+    TerrainDetailPatch, TerrainMaterialPresentation, terrain_heightmap_image,
+};
 #[allow(unused_imports)]
 pub(crate) use vista::{VistaTerrain, VistaTreePresentation};
 #[allow(unused_imports)]

--- a/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/geometry/wood_mesh.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/geometry/wood_mesh.rs
@@ -62,6 +62,18 @@ pub(in crate::presentation) fn procedural_woody_branch_mesh(
         PrimitiveTopology::TriangleList,
         RenderAssetUsages::RENDER_WORLD,
     );
+    if visible.iter().any(|branch| branch.depth == 0) {
+        // The bark shader needs metric height above the root contact plane for
+        // its UV-free soil-deposition mask. Vertex colour is an interpolated
+        // geometry channel here, not pigment: local Y remains exact across a
+        // triangle and avoids creating a unique material for every tree.
+        let ground_y = -TREE_TRUNK_HEIGHT_METRES * 0.5;
+        let root_heights = positions
+            .iter()
+            .map(|position| [position[1] - ground_y, 1.0, 1.0, 1.0])
+            .collect::<Vec<_>>();
+        mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, root_heights);
+    }
     mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
     mesh.insert_attribute(Mesh::ATTRIBUTE_NORMAL, normals);
     mesh.insert_attribute(Mesh::ATTRIBUTE_UV_0, uvs);
@@ -980,6 +992,10 @@ mod tests {
             panic!("branch mesh has float UVs");
         };
         assert!(mesh.attribute(Mesh::ATTRIBUTE_TANGENT).is_none());
+        assert!(
+            mesh.attribute(Mesh::ATTRIBUTE_COLOR).is_none(),
+            "crown-only wood must not pay for the root deposition channel"
+        );
         let positions = mesh
             .attribute(Mesh::ATTRIBUTE_POSITION)
             .and_then(|attribute| attribute.as_float3())
@@ -998,6 +1014,28 @@ mod tests {
             uvs.iter().map(|uv| uv[1]).fold(0.0_f32, f32::max) > 0.5,
             "a two-metre-long axis must advance a full physical bark tile"
         );
+    }
+
+    #[test]
+    fn trunk_mesh_carries_metric_root_height_without_an_authored_dirt_uv() {
+        let branches = procedural_tree_skeleton(42, 0.0);
+        let mesh = procedural_tree_branch_mesh(&branches, 0);
+        let positions = mesh
+            .attribute(Mesh::ATTRIBUTE_POSITION)
+            .and_then(VertexAttributeValues::as_float3)
+            .expect("trunk mesh has float positions");
+        let Some(VertexAttributeValues::Float32x4(root_data)) =
+            mesh.attribute(Mesh::ATTRIBUTE_COLOR)
+        else {
+            panic!("trunk mesh has metric root data");
+        };
+        let ground_y = -TREE_TRUNK_HEIGHT_METRES * 0.5;
+
+        assert_eq!(positions.len(), root_data.len());
+        for (position, root) in positions.iter().zip(root_data) {
+            assert!((root[0] - (position[1] - ground_y)).abs() < 1.0e-5);
+            assert_eq!(root[1..], [1.0, 1.0, 1.0]);
+        }
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/materials.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/materials.rs
@@ -1,3 +1,4 @@
+use adventuresim_tactical_core::prelude::SceneTerrain;
 use bevy::{
     pbr::{ExtendedMaterial, Material, MaterialExtension},
     prelude::*,
@@ -13,7 +14,12 @@ use super::geometry::{
 };
 #[cfg(test)]
 use crate::presentation::generate_procedural_environment_assets;
-use crate::presentation::{LeafTextureSet, ProceduralEnvironmentAssets};
+use crate::presentation::procedural_assets::{
+    FOREST_SOIL_HEIGHT_RANGE_METRES, FOREST_SOIL_TILE_METRES,
+};
+use crate::presentation::{
+    LeafTextureSet, ProceduralEnvironmentAssets, color_vec4, terrain::TACTICAL_DIRT_SRGB,
+};
 
 const TREE_IMPOSTOR_SHADER: &str = "shaders/tactical_tree_impostor.wgsl";
 const TREE_LEAF_CARD_SHADER: &str = "shaders/tactical_tree_leaf_card.wgsl";
@@ -86,6 +92,32 @@ pub(crate) struct TacticalTreeBarkExtension {
     /// Direction toward dominant light and normalized directional strength.
     #[uniform(102)]
     pub(in crate::presentation) lighting: Vec4,
+    /// Linear bark pigment and perceptual roughness.
+    #[uniform(102)]
+    surface: Vec4,
+    /// Linear soil pigment and perceptual roughness. Soil remains a single
+    /// molded albedo; only the binary coverage mask varies spatially.
+    #[uniform(102)]
+    soil_surface: Vec4,
+    /// Solid soil height, maximum speck height, cell size, minimum radius.
+    #[uniform(102)]
+    deposition: Vec4,
+    /// Playable half extents and encoded minimum/maximum terrain heights.
+    #[uniform(102)]
+    terrain_surface: Vec4,
+    /// Soil tiles/metre, physical height range, normal strength, AO strength.
+    #[uniform(102)]
+    soil_response: Vec4,
+    /// Soil dielectric reflectance; remaining components are reserved.
+    #[uniform(102)]
+    soil_optics: Vec4,
+    /// Row-major playable terrain heightfield encoded into two channels.
+    #[texture(103)]
+    terrain_heightmap: Handle<Image>,
+    /// The same packed height/AO surface sampled by tactical terrain.
+    #[texture(104)]
+    #[sampler(105)]
+    soil_height_ao: Handle<Image>,
 }
 
 impl MaterialExtension for TacticalTreeBarkExtension {
@@ -101,9 +133,17 @@ impl MaterialExtension for TacticalTreeBarkExtension {
 pub(crate) type TacticalTreeBarkMaterial =
     ExtendedMaterial<StandardMaterial, TacticalTreeBarkExtension>;
 
-pub(crate) fn oak_bark_material(assets: &ProceduralEnvironmentAssets) -> TacticalTreeBarkMaterial {
+pub(crate) fn oak_bark_material(
+    assets: &ProceduralEnvironmentAssets,
+    terrain_heightmap: Handle<Image>,
+    terrain_height_range: Vec2,
+    terrain: &SceneTerrain,
+) -> TacticalTreeBarkMaterial {
     bark_material(
         assets,
+        terrain_heightmap,
+        terrain_height_range,
+        terrain,
         Color::srgb_u8(96, 68, 43),
         180.0 / 255.0,
         Vec4::new(2.0, 0.032, 1.30, 0.95),
@@ -112,11 +152,17 @@ pub(crate) fn oak_bark_material(assets: &ProceduralEnvironmentAssets) -> Tactica
 
 pub(in crate::presentation) fn beech_bark_material(
     assets: &ProceduralEnvironmentAssets,
+    terrain_heightmap: Handle<Image>,
+    terrain_height_range: Vec2,
+    terrain: &SceneTerrain,
 ) -> TacticalTreeBarkMaterial {
     // Beech shares the pipeline so streamed wood remains one material type,
     // but its smooth bark deliberately bypasses oak relief and cavity AO.
     bark_material(
         assets,
+        terrain_heightmap,
+        terrain_height_range,
+        terrain,
         Color::srgb_u8(145, 145, 135),
         0.9,
         Vec4::new(2.0, 0.0, 0.0, 0.0),
@@ -125,10 +171,18 @@ pub(in crate::presentation) fn beech_bark_material(
 
 fn bark_material(
     assets: &ProceduralEnvironmentAssets,
+    terrain_heightmap: Handle<Image>,
+    terrain_height_range: Vec2,
+    terrain: &SceneTerrain,
     base_color: Color,
     perceptual_roughness: f32,
     relief: Vec4,
 ) -> TacticalTreeBarkMaterial {
+    let soil_color = Color::srgb_u8(
+        TACTICAL_DIRT_SRGB[0],
+        TACTICAL_DIRT_SRGB[1],
+        TACTICAL_DIRT_SRGB[2],
+    );
     TacticalTreeBarkMaterial {
         base: StandardMaterial {
             base_color,
@@ -141,6 +195,27 @@ fn bark_material(
             relief,
             projection: Vec4::new(4.0, 0.92, 0.52, 12.0),
             lighting: Vec3::new(0.25, 0.92, 0.3).normalize().extend(1.0),
+            surface: color_vec4(base_color).xyz().extend(perceptual_roughness),
+            soil_surface: color_vec4(soil_color).xyz().extend(0.84),
+            // The 7 mm minimum radius yields a 14 mm minimum full speck
+            // diameter before edge antialiasing. A 45 mm cell leaves enough
+            // negative space for the separate deposits to read clearly.
+            deposition: Vec4::new(0.12, 0.46, 0.045, 0.007),
+            terrain_surface: Vec4::new(
+                terrain.width() * 0.5,
+                terrain.depth() * 0.5,
+                terrain_height_range.x,
+                terrain_height_range.y,
+            ),
+            soil_response: Vec4::new(
+                1.0 / FOREST_SOIL_TILE_METRES,
+                FOREST_SOIL_HEIGHT_RANGE_METRES,
+                1.0,
+                0.82,
+            ),
+            soil_optics: Vec4::new(0.35, 0.0, 0.0, 0.0),
+            terrain_heightmap,
+            soil_height_ao: assets.forest_soil.height_ao.clone(),
         },
     }
 }
@@ -365,7 +440,10 @@ mod tests {
         let assets = generate_procedural_environment_assets(
             &mut app.world_mut().resource_mut::<Assets<Image>>(),
         );
-        let bark = oak_bark_material(&assets);
+        let terrain = SceneTerrain::new(2, 2, 1.0, |point| point.x * 0.1 + point.y * 0.2);
+        let heightmap = Handle::<Image>::default();
+        let terrain_height_range = Vec2::new(-0.075, 0.705);
+        let bark = oak_bark_material(&assets, heightmap.clone(), terrain_height_range, &terrain);
 
         assert_eq!(bark.base.base_color, Color::srgb_u8(96, 68, 43));
         assert!(bark.base.base_color_texture.is_none());
@@ -377,10 +455,47 @@ mod tests {
         assert_eq!(bark.extension.relief, Vec4::new(2.0, 0.032, 1.30, 0.95));
         assert_eq!(bark.extension.projection, Vec4::new(4.0, 0.92, 0.52, 12.0));
         assert!(bark.extension.lighting.xyz().is_normalized());
+        assert_eq!(
+            bark.extension.surface,
+            color_vec4(Color::srgb_u8(96, 68, 43))
+                .xyz()
+                .extend(180.0 / 255.0)
+        );
+        assert_eq!(
+            bark.extension.soil_surface,
+            color_vec4(Color::srgb_u8(
+                TACTICAL_DIRT_SRGB[0],
+                TACTICAL_DIRT_SRGB[1],
+                TACTICAL_DIRT_SRGB[2],
+            ))
+            .xyz()
+            .extend(0.84)
+        );
+        assert_eq!(
+            bark.extension.deposition,
+            Vec4::new(0.12, 0.46, 0.045, 0.007)
+        );
+        assert!(bark.extension.deposition.w * 2.0 >= 0.01);
+        assert_eq!(bark.extension.terrain_heightmap, heightmap);
+        assert_eq!(
+            bark.extension.terrain_surface,
+            Vec4::new(1.0, 1.0, -0.075, 0.705)
+        );
+        assert_eq!(
+            bark.extension.soil_response,
+            Vec4::new(
+                1.0 / FOREST_SOIL_TILE_METRES,
+                FOREST_SOIL_HEIGHT_RANGE_METRES,
+                1.0,
+                0.82,
+            )
+        );
+        assert_eq!(bark.extension.soil_height_ao, assets.forest_soil.height_ao);
+        assert_eq!(bark.extension.soil_optics, Vec4::new(0.35, 0.0, 0.0, 0.0));
     }
 
     #[test]
-    fn bark_shader_blends_scalar_height_before_surface_gradient_normals() {
+    fn bark_shader_blends_shared_soil_response_at_the_sampled_terrain_contact() {
         let shader = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../assets/shaders/tactical_tree_bark.wgsl"
@@ -389,7 +504,7 @@ mod tests {
         assert!(shader.contains("let height_metres = (sample.r - 0.5)"));
         assert!(shader.contains("let height_dx = dpdx(height_metres)"));
         assert!(shader.contains("let height_dy = dpdy(height_metres)"));
-        assert!(shader.contains("pbr_input.N = composed_normal"));
+        assert!(shader.contains("pbr_input.N = normalize(mix(composed_normal, soil_normal"));
         assert!(shader.contains("fn parallax_branch_coordinates"));
         assert!(shader.contains("branch_texture_coordinates(in.uv)"));
         assert!(shader.contains("view.lod_view_world_position"));
@@ -399,7 +514,30 @@ mod tests {
         assert!(shader.contains("fn directional_horizon_visibility"));
         assert!(shader.contains("layer < 6"));
         assert!(shader.contains("horizon_step <= 3"));
-        assert!(shader.contains("pbr_input.material.perceptual_roughness = clamp"));
+        assert!(shader.contains("let bark_roughness = clamp"));
+        assert!(shader.contains("bark.soil_surface.w"));
+        assert!(shader.contains("vec3<f32>(bark.soil_optics.x)"));
+        assert!(shader.contains("fn root_soil_signed_distance"));
+        assert!(shader.contains("fn soil_speck_distance"));
+        assert!(shader.contains("let fine_specks = soil_speck_distance"));
+        assert!(shader.contains("let coarse_specks = soil_speck_distance"));
+        assert!(shader.contains("if root_height > bark.deposition.y + cell_size"));
+        assert!(shader.contains("let edge_width = max(fwidth(signed_distance)"));
+        assert!(shader.contains("mix(bark.surface.rgb, bark.soil_surface.rgb, soil_coverage)"));
+        assert!(shader.contains("let terrain_height = terrain_height_at(in.world_position.xz)"));
+        assert!(shader.contains("let terrain_clearance = in.world_position.y - terrain_height"));
+        assert!(shader.contains("var soil_response_coverage = 0.0"));
+        assert!(shader.contains("smoothstep(0.0381, 0.0508"));
+        assert!(shader.contains("soil_response_coverage = soil_coverage * contact_response"));
+        assert!(shader.contains("soil_sample = soil_surface_sample(in.world_position.xyz)"));
+        assert!(shader.contains("mix(composed_normal, soil_normal, soil_response_coverage)"));
+        assert!(shader.contains("bark.soil_surface.w,\n        soil_coverage"));
+        assert!(
+            shader.contains("mix(ambient_visibility, soil_visibility, soil_response_coverage)")
+        );
+        assert!(!shader.contains("mix(ambient_visibility, soil_visibility, soil_coverage)"));
+        assert!(shader.contains("#ifdef VERTEX_COLORS"));
+        assert_eq!(shader.matches("textureSample(soil_height_ao,").count(), 1);
         assert!(!shader.contains("normal_map"));
     }
 

--- a/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/presentation.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/presentation.rs
@@ -17,9 +17,10 @@ use super::{
     procedural_woody_plant_skeleton,
 };
 use crate::presentation::{
-    ActiveTacticalScene, ProceduralEnvironmentAssets, SceneEnvironment, obstacle_seed, splitmix64,
-    unit_hash,
+    ActiveTacticalScene, ActiveVistaSurface, ProceduralEnvironmentAssets, SceneEnvironment,
+    obstacle_seed, splitmix64, unit_hash,
 };
+use adventuresim_tactical_core::prelude::{SceneGround, SceneObstacle, SceneTerrain};
 use bevy::{
     camera::{primitives::Aabb, visibility::NoFrustumCulling},
     light::NotShadowCaster,
@@ -44,6 +45,9 @@ pub(in crate::presentation) struct TreePresentationCache {
     variants: std::collections::HashMap<u64, CachedTreePresentation>,
     oak_bark_material: Option<Handle<TacticalTreeBarkMaterial>>,
     beech_bark_material: Option<Handle<TacticalTreeBarkMaterial>>,
+    terrain_scene_digest: Option<String>,
+    terrain_heightmap: Option<Handle<Image>>,
+    terrain_height_range: Vec2,
 }
 
 impl TreePresentationCache {
@@ -765,9 +769,14 @@ pub(in crate::presentation) fn present_pending_trees(
     pending: Query<(Entity, &Transform), With<PendingTreePresentation>>,
     active: Res<ActiveTacticalScene>,
     environments: Query<&SceneEnvironment>,
+    terrains: Query<&SceneTerrain>,
+    grounds: Query<&SceneGround>,
+    obstacles: Query<(&SceneObstacle, &Transform)>,
+    vista: Res<ActiveVistaSurface>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut bark_materials: ResMut<Assets<TacticalTreeBarkMaterial>>,
     mut leaf_card_materials: ResMut<Assets<TacticalTreeLeafCardMaterial>>,
+    mut images: ResMut<Assets<Image>>,
     mut tree_cache: ResMut<TreePresentationCache>,
     mut residency: ResMut<TreeAssetResidencyDiagnostics>,
     procedural_assets: Res<ProceduralEnvironmentAssets>,
@@ -778,6 +787,30 @@ pub(in crate::presentation) fn present_pending_trees(
     else {
         return;
     };
+    let Some(terrain) = active.entity.and_then(|entity| terrains.get(entity).ok()) else {
+        return;
+    };
+    let ground = active.entity.and_then(|entity| grounds.get(entity).ok());
+    if tree_cache.terrain_scene_digest.as_deref() != Some(&environment.scene_digest) {
+        tree_cache.variants.clear();
+        tree_cache.oak_bark_material = None;
+        tree_cache.beech_bark_material = None;
+        let (heightmap, height_range) =
+            crate::presentation::terrain::terrain_contact_heightmap_image(
+                terrain,
+                ground,
+                environment,
+                &vista,
+                &obstacles,
+            );
+        tree_cache.terrain_heightmap = Some(images.add(heightmap));
+        tree_cache.terrain_height_range = height_range;
+        tree_cache.terrain_scene_digest = Some(environment.scene_digest.clone());
+    }
+    let terrain_heightmap = tree_cache
+        .terrain_heightmap
+        .clone()
+        .expect("active terrain creates a tree contact heightmap");
     let competition = canopy_competition(environment.canopy_bps);
     let site_key = oak_site_key(environment);
     for (entity, transform) in &pending {
@@ -829,14 +862,24 @@ pub(in crate::presentation) fn present_pending_trees(
             let bark_material = match species {
                 TreePresentationSpecies::EnglishOak => {
                     tree_cache.oak_bark_material.clone().unwrap_or_else(|| {
-                        let material = bark_materials.add(oak_bark_material(&procedural_assets));
+                        let material = bark_materials.add(oak_bark_material(
+                            &procedural_assets,
+                            terrain_heightmap.clone(),
+                            tree_cache.terrain_height_range,
+                            terrain,
+                        ));
                         tree_cache.oak_bark_material = Some(material.clone());
                         material
                     })
                 }
                 TreePresentationSpecies::CommonBeech => {
                     tree_cache.beech_bark_material.clone().unwrap_or_else(|| {
-                        let material = bark_materials.add(beech_bark_material(&procedural_assets));
+                        let material = bark_materials.add(beech_bark_material(
+                            &procedural_assets,
+                            terrain_heightmap.clone(),
+                            tree_cache.terrain_height_range,
+                            terrain,
+                        ));
                         tree_cache.beech_bark_material = Some(material.clone());
                         material
                     })

--- a/crates/adventuresim-tactical-client/src/presentation/terrain.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/terrain.rs
@@ -9,18 +9,19 @@ const DETAIL_PATCH_SPACING_METRES: f32 = 0.25;
 const DETAIL_PATCH_SNAP_METRES: f32 = 1.0;
 const DETAIL_PATCH_DEPTH_BIAS: f32 = 2.0;
 const DETAIL_PATCH_BASE_CUTOUT_RADIUS_METRES: f32 = 18.5;
+const DETAIL_RELIEF_MINIMUM_METRES: f32 = -0.075;
+const DETAIL_RELIEF_MAXIMUM_METRES: f32 = 0.105;
+pub(in crate::presentation) const TACTICAL_DIRT_SRGB: [u8; 3] = [101, 82, 49];
 
 pub(super) fn scene_ground_color(environment: &SceneEnvironment) -> Color {
     let mut rgb = if environment.water_bps >= 5_000 {
         [52.0, 83.0, 98.0]
     } else if environment.wetland_bps >= 4_000 {
         [70.0, 62.0, 43.0]
-    } else if environment.canopy_bps >= 5_000 {
-        [65.0, 52.0, 32.0]
     } else if environment.cultivation_bps >= 4_000 {
         [116.0, 91.0, 49.0]
     } else {
-        [101.0, 82.0, 49.0]
+        TACTICAL_DIRT_SRGB.map(f32::from)
     };
     let snow = f32::from(environment.weather.snow_cover_bps) / 10_000.0;
     let wet = f32::from(environment.weather.ground_moisture_bps) / 10_000.0;
@@ -29,6 +30,89 @@ pub(super) fn scene_ground_color(environment: &SceneEnvironment) -> Color {
         *channel = *channel * (1.0 - snow) + 220.0 * snow;
     }
     Color::srgb(rgb[0] / 255.0, rgb[1] / 255.0, rgb[2] / 255.0)
+}
+
+pub(crate) fn terrain_heightmap_image(terrain: &SceneTerrain) -> Image {
+    let width = terrain.grid_width() as u32;
+    let height = terrain.grid_depth() as u32;
+    let minimum = terrain.minimum_height();
+    let maximum = terrain.maximum_height();
+    encoded_terrain_heightmap_image(width, height, minimum, maximum, |x, z| {
+        let world = Vec2::new(
+            x as f32 * terrain.grid_scale() - terrain.width() * 0.5,
+            z as f32 * terrain.grid_scale() - terrain.depth() * 0.5,
+        );
+        terrain.height_at(world).unwrap_or(minimum)
+    })
+}
+
+/// Builds the heightfield used to seat tree materials against the close-range
+/// render mesh. Unlike the authoritative heightmap, this includes the same
+/// presentation-only clods, drainage, root mounds, and obstacle contact relief
+/// evaluated by [`terrain_detail_patch_mesh`]. Sampling it at the detail patch
+/// spacing keeps the shader's triangle reconstruction aligned with the visible
+/// ground rather than a coarser surface hidden underneath it.
+pub(crate) fn terrain_contact_heightmap_image(
+    terrain: &SceneTerrain,
+    ground: Option<&SceneGround>,
+    environment: &SceneEnvironment,
+    vista: &ActiveVistaSurface,
+    obstacles: &Query<(&SceneObstacle, &Transform)>,
+) -> (Image, Vec2) {
+    let width = (terrain.width() / DETAIL_PATCH_SPACING_METRES).round() as u32 + 1;
+    let height = (terrain.depth() / DETAIL_PATCH_SPACING_METRES).round() as u32 + 1;
+    let minimum = terrain.minimum_height() + DETAIL_RELIEF_MINIMUM_METRES;
+    let maximum = terrain.maximum_height() + DETAIL_RELIEF_MAXIMUM_METRES;
+    let tree_positions = detail_tree_positions(obstacles);
+    let rock_influences = detail_rock_influences(obstacles);
+    let image = encoded_terrain_heightmap_image(width, height, minimum, maximum, |x, z| {
+        let point = Vec2::new(
+            x as f32 / (width - 1) as f32 * terrain.width() - terrain.width() * 0.5,
+            z as f32 / (height - 1) as f32 * terrain.depth() - terrain.depth() * 0.5,
+        );
+        let base_height = terrain.height_at(point).unwrap_or(terrain.minimum_height());
+        base_height
+            + terrain_surface_relief(
+                stable_text_seed(&environment.scene_digest) ^ 0x7465_7272_6169_6e64,
+                point,
+                terrain,
+                ground,
+                environment,
+                vista,
+                &tree_positions,
+                &rock_influences,
+            )
+    });
+    (image, Vec2::new(minimum, maximum))
+}
+
+fn encoded_terrain_heightmap_image(
+    width: u32,
+    height: u32,
+    minimum: f32,
+    maximum: f32,
+    mut height_at: impl FnMut(u32, u32) -> f32,
+) -> Image {
+    let range = (maximum - minimum).max(0.001);
+    let mut pixels = Vec::with_capacity(width as usize * height as usize * 4);
+    for z in 0..height {
+        for x in 0..width {
+            let normalized = ((height_at(x, z) - minimum) / range).clamp(0.0, 1.0);
+            let encoded = (normalized * 65_535.0).round() as u16;
+            pixels.extend_from_slice(&[(encoded & 0xff) as u8, (encoded >> 8) as u8, 0, 255]);
+        }
+    }
+    Image::new(
+        Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        pixels,
+        TextureFormat::Rgba8Unorm,
+        RenderAssetUsages::RENDER_WORLD,
+    )
 }
 
 #[derive(Component)]
@@ -510,7 +594,7 @@ fn terrain_surface_relief(
         + roots
         + rock_contact
         + rock_strata)
-        .clamp(-0.075, 0.105)
+        .clamp(DETAIL_RELIEF_MINIMUM_METRES, DETAIL_RELIEF_MAXIMUM_METRES)
 }
 
 fn signed_ground_noise(seed: u64, point: Vec2) -> f32 {
@@ -1117,6 +1201,26 @@ mod tests {
     use bevy::asset::{AssetApp, AssetPlugin};
 
     #[test]
+    fn ordinary_dirt_uses_one_palette_color_regardless_of_canopy() {
+        let mut environment = legacy_scene_environment(&SceneId("dirt-palette".into()));
+        environment.weather.ground_moisture_bps = 0;
+        environment.weather.snow_cover_bps = 0;
+        environment.wetland_bps = 0;
+        environment.cultivation_bps = 0;
+        environment.water_bps = 0;
+        let expected = Color::srgb_u8(
+            TACTICAL_DIRT_SRGB[0],
+            TACTICAL_DIRT_SRGB[1],
+            TACTICAL_DIRT_SRGB[2],
+        );
+
+        environment.canopy_bps = 0;
+        assert_eq!(scene_ground_color(&environment), expected);
+        environment.canopy_bps = 10_000;
+        assert_eq!(scene_ground_color(&environment), expected);
+    }
+
+    #[test]
     fn ground_shader_keeps_solid_palette_albedo_and_uses_one_planar_height_ao_sample() {
         let shader = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -1136,9 +1240,10 @@ mod tests {
         assert!(shader.contains("let height_dx = dpdx(height_metres)"));
         assert!(shader.contains("pbr_input.diffuse_occlusion *= mix(1.0, soil_sample.g"));
         assert!(!shader.contains("select(color, terrain.grass_color.rgb, tall_grass > 0.5)"));
-        assert!(shader.contains("let shaded_substrate = select("));
-        assert!(shader.contains("let canopy_floor = ground_sample.a"));
-        assert!(shader.contains("canopy_floor >= 0.78"));
+        assert!(!shader.contains("shaded_substrate"));
+        assert!(!shader.contains("tall_grass > 0.5 && canopy_floor"));
+        assert!(!shader.contains("canopy_floor"));
+        assert!(!shader.contains("litter_color"));
         assert!(shader.contains("let sward_color = terrain.grass_color.rgb"));
         assert!(!shader.contains("sward_color = color *"));
         assert!(shader.contains("sward_dither < sward_amount"));

--- a/crates/adventuresim-tactical-client/src/presentation/weather.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/weather.rs
@@ -1,3 +1,4 @@
+use super::terrain::terrain_heightmap_image;
 use super::*;
 
 const WEATHER_SHADER: &str = "shaders/tactical_weather.wgsl";
@@ -103,7 +104,7 @@ pub(super) fn apply_active_scene_weather(
         return;
     }
 
-    let heightmap = images.add(weather_heightmap_image(terrain));
+    let heightmap = images.add(terrain_heightmap_image(terrain));
     let occlusion_map = images.add(empty_weather_occlusion_image());
     occlusion.image = Some(occlusion_map.clone());
     let falling_material = materials.add(weather_material(
@@ -443,37 +444,6 @@ fn rasterize_weather_branch(
     }
 }
 
-fn weather_heightmap_image(terrain: &SceneTerrain) -> Image {
-    let width = terrain.grid_width() as u32;
-    let height = terrain.grid_depth() as u32;
-    let minimum = terrain.minimum_height();
-    let range = (terrain.maximum_height() - minimum).max(0.001);
-    let mut pixels = Vec::with_capacity(width as usize * height as usize * 4);
-    for z in 0..height {
-        for x in 0..width {
-            let world = Vec2::new(
-                x as f32 * terrain.grid_scale() - terrain.width() * 0.5,
-                z as f32 * terrain.grid_scale() - terrain.depth() * 0.5,
-            );
-            let normalized =
-                ((terrain.height_at(world).unwrap_or(minimum) - minimum) / range).clamp(0.0, 1.0);
-            let encoded = (normalized * 65_535.0).round() as u16;
-            pixels.extend_from_slice(&[(encoded & 0xff) as u8, (encoded >> 8) as u8, 0, 255]);
-        }
-    }
-    Image::new(
-        Extent3d {
-            width,
-            height,
-            depth_or_array_layers: 1,
-        },
-        TextureDimension::D2,
-        pixels,
-        TextureFormat::Rgba8Unorm,
-        RenderAssetUsages::RENDER_WORLD,
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -490,7 +460,7 @@ mod tests {
     #[test]
     fn heightmap_encoding_preserves_terrain_range() {
         let terrain = SceneTerrain::from_heightmap(2, 2, 1.0, vec![-2.0, 0.0, 1.0, 4.0]).unwrap();
-        let image = weather_heightmap_image(&terrain);
+        let image = terrain_heightmap_image(&terrain);
         assert_eq!(image.texture_descriptor.size.width, 2);
         assert_eq!(image.texture_descriptor.size.height, 2);
         let pixels = image.data.as_deref().unwrap();

--- a/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
@@ -55,7 +55,7 @@ use crate::presentation::{
     TerrainMaterialPresentation, TreeAssetResidencyDiagnostics, TreeImpostorProvenance,
     TreeLeafRepresentation, TreeLeafTriangleCount, TreeLod, TreeLodCluster, TreeLodRenderOverride,
     TreeTrunkLod, VistaTerrain, VistaTreePresentation, WeatherParticle, oak_bark_material,
-    oak_leaf_material, oak_review_terminal_specimen,
+    oak_leaf_material, oak_review_terminal_specimen, terrain_heightmap_image,
 };
 
 const VIEW_WIDTH: u32 = 1280;
@@ -1345,6 +1345,7 @@ fn setup_scene(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut bark_materials: ResMut<Assets<TacticalTreeBarkMaterial>>,
     mut leaf_card_materials: ResMut<Assets<TacticalTreeLeafCardMaterial>>,
+    mut images: ResMut<Assets<Image>>,
     procedural_assets: Res<ProceduralEnvironmentAssets>,
 ) {
     let setup = setup.0.take().expect("scene setup runs exactly once");
@@ -1585,7 +1586,12 @@ fn setup_scene(
             local_focus,
             camera_direction,
         ) = oak_review_terminal_specimen(tree, canopy_bps);
-        let bark_material = bark_materials.add(oak_bark_material(&procedural_assets));
+        let bark_material = bark_materials.add(oak_bark_material(
+            &procedural_assets,
+            images.add(terrain_heightmap_image(&terrain)),
+            Vec2::new(terrain.minimum_height(), terrain.maximum_height()),
+            &terrain,
+        ));
         let leaf_material = leaf_card_materials.add(oak_leaf_material(&procedural_assets));
         let bud_material = materials.add(StandardMaterial {
             base_color: Color::srgb(0.36, 0.27, 0.1),


### PR DESCRIPTION
## Summary

- add a UV-free, near-binary dirt mask to procedural tree roots with centimetre-scale deposits
- sample the detailed tactical terrain heightfield so the mask follows the visible tree/ground intersection
- share the terrain dirt albedo and soil surface response with tree dirt while limiting normal/AO blending to the first two inches
- apply dirt roughness and dielectric reflectance across the full dirt mask
- restore ground-cover visibility by correcting litter batch bounds

## Why

Tree roots met the terrain with a visibly hard seam, while the original ground-cover presentation could be culled despite visible instances. The first contact implementation sampled only the authoritative coarse terrain, but the close-range ground adds presentation relief—including root mounds—so the visible surface could occlude most of the dirt band on one side.

## Impact

Tree dirt now follows uneven close-range terrain without requiring tree UVs. It retains the tactical scene's single molded dirt color and practically binary coverage, borrows terrain normal/AO only at the physical contact, and uses a consistent dry-soil specular response throughout the deposit.

## Validation

- `cargo test -p adventuresim-tactical-client presentation::obstacles::tree::materials::tests`
- `cargo test -p adventuresim-tactical-client heightmap_encoding_preserves_terrain_range`
- `cargo fmt --all -- --check`
- `git diff --check`
- validated the `sparse-woodland` `tree-root-detail` runtime capture
