### PR TITLE
Blend forest-floor litter and scatter

### DIFF
--- a/assets/shaders/tactical_terrain.wgsl
+++ b/assets/shaders/tactical_terrain.wgsl
@@ -24,6 +24,7 @@ struct TacticalTerrainMaterial {
     playable_bounds: vec4<f32>,
     detail_patch: vec4<f32>,
     soil_detail: vec4<f32>,
+    litter_detail: vec4<f32>,
 }
 
 @group(#{MATERIAL_BIND_GROUP}) @binding(100)
@@ -36,11 +37,20 @@ var ground_map_sampler: sampler;
 var soil_height_ao: texture_2d<f32>;
 @group(#{MATERIAL_BIND_GROUP}) @binding(104)
 var soil_height_ao_sampler: sampler;
+@group(#{MATERIAL_BIND_GROUP}) @binding(105)
+var litter_surface: texture_2d<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(106)
+var litter_surface_sampler: sampler;
+@group(#{MATERIAL_BIND_GROUP}) @binding(107)
+var litter_normal_map: texture_2d<f32>;
+@group(#{MATERIAL_BIND_GROUP}) @binding(108)
+var litter_normal_sampler: sampler;
 
 fn height_perturbed_normal(
     world_position: vec3<f32>,
     macro_normal: vec3<f32>,
     height_metres: f32,
+    normal_strength: f32,
 ) -> vec3<f32> {
     let position_dx = dpdx(world_position);
     let position_dy = dpdy(world_position);
@@ -57,7 +67,7 @@ fn height_perturbed_normal(
     let surface_gradient = (
         reciprocal_x * height_dx + reciprocal_y * height_dy
     ) / safe_determinant;
-    return normalize(macro_normal - surface_gradient * terrain.soil_detail.z);
+    return normalize(macro_normal - surface_gradient * normal_strength);
 }
 
 @fragment
@@ -101,8 +111,49 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     ) * 0.035;
     let soil_uv = position.xz * terrain.soil_detail.x + soil_warp;
     let soil_sample = textureSample(soil_height_ao, soil_height_ao_sampler, soil_uv).rg;
+    let litter_warp = vec2<f32>(
+        sin(position.z * 0.17 - position.x * 0.07),
+        sin(position.x * 0.13 + position.z * 0.09),
+    ) * 0.021;
+    let litter_uv = position.xz * terrain.litter_detail.x + litter_warp;
+    // R is also a true parallax height field. One bounded relief lookup shifts
+    // the shared normal/surface samples at grazing angles, while an overhead
+    // view remains exactly on the unshifted world-XZ projection.
+    let litter_base_sample = textureSample(
+        litter_surface,
+        litter_surface_sampler,
+        litter_uv,
+    );
+    let view_to_camera = normalize(view.lod_view_world_position.xyz - position);
+    let parallax_direction = view_to_camera.xz / max(abs(view_to_camera.y), 0.24);
+    let parallax_height_metres = (litter_base_sample.r - 0.48) * terrain.litter_detail.y;
+    let parallax_offset = clamp(
+        parallax_direction * parallax_height_metres * terrain.litter_detail.x,
+        vec2<f32>(-0.035),
+        vec2<f32>(0.035),
+    );
+    let litter_parallax_uv = litter_uv - parallax_offset;
+    // RGBA carries normalized height, broad/local AO, a stable muted-palette
+    // selector, and physical litter coverage. The separate RG normal map is
+    // generated from this exact height field, so color, relief, and parallax
+    // retain one leaf silhouette through their complete mip chains.
+    let litter_sample = textureSample(
+        litter_surface,
+        litter_surface_sampler,
+        litter_parallax_uv,
+    );
+    let litter_normal_xz = textureSample(
+        litter_normal_map,
+        litter_normal_sampler,
+        litter_parallax_uv,
+    ).rg * 2.0 - 1.0;
     let height_metres = (soil_sample.r - 0.5) * terrain.soil_detail.y;
-    let soil_normal = height_perturbed_normal(position, base_normal, height_metres);
+    let soil_normal = height_perturbed_normal(
+        position,
+        base_normal,
+        height_metres,
+        terrain.soil_detail.z,
+    );
     let soil_substrate = 1.0 - step(0.5, abs(substrate_kind - 0.0));
     let mud_substrate = 1.0 - step(0.5, abs(substrate_kind - 3.0));
     let road_substrate = 1.0 - step(0.5, abs(substrate_kind - 4.0));
@@ -113,9 +164,33 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     pbr_input.N = normalize(mix(base_normal, soil_normal, soil_response));
     pbr_input.diffuse_occlusion *= mix(1.0, soil_sample.g, soil_response * 0.82);
     let tall_grass = 1.0 - step(0.5, abs(cover_kind - 1.0));
+    let leaf_litter = 1.0 - step(0.5, abs(cover_kind - 2.0));
+    // Ground-map alpha is a signed canopy-floor distance: the lower half is
+    // the exterior approach and the upper half is depth inside leaf litter.
+    // Keep categorical authority while allowing a broad, organic material
+    // transition beyond the last litter cell.
+    let canopy_floor = smoothstep(0.14, 0.72, ground_sample.a);
+    let litter_region = max(leaf_litter * 0.88, canopy_floor)
+        * soil_substrate
+        * upward_response
+        * (1.0 - snow);
+    let litter_distance_fade = 1.0 - smoothstep(20.0, terrain.litter_detail.w, camera_distance);
+    let litter_normal_y = sqrt(max(0.0, 1.0 - dot(litter_normal_xz, litter_normal_xz)));
+    let litter_mapped_normal = normalize(
+        base_normal * litter_normal_y
+        + vec3<f32>(litter_normal_xz.x, 0.0, litter_normal_xz.y)
+    );
+    let litter_relief = litter_region * litter_sample.a * litter_distance_fade;
+    pbr_input.N = normalize(mix(
+        pbr_input.N,
+        litter_mapped_normal,
+        litter_relief * terrain.litter_detail.z,
+    ));
+    pbr_input.diffuse_occlusion *= mix(1.0, litter_sample.g, litter_relief * 0.88);
 
-    // Ordinary soil keeps one solid molded-material albedo regardless of
-    // grass, litter, or canopy cover. There is no sampled albedo detail.
+    // Ordinary soil keeps one solid molded-material albedo. Canopy floor adds
+    // a constrained procedural palette: dark shaded soil remains visible in
+    // the packed coverage gaps while overlapping litter supplies the mass.
     var color = terrain.base_color.rgb;
     if cultivation >= 0.4 { color = vec3<f32>(0.17, 0.11, 0.035); }
     if wetland >= 0.4 || substrate_kind == 3.0 { color = vec3<f32>(0.18, 0.16, 0.105); }
@@ -126,6 +201,21 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
         color = vec3<f32>(0.31, 0.30, 0.275);
     }
     if water >= 0.5 || substrate_kind == 5.0 { color = vec3<f32>(0.09, 0.18, 0.22); }
+
+    let shaded_soil = terrain.base_color.rgb * vec3<f32>(0.38, 0.40, 0.37);
+    // Match the dark/medium/pale bands of the physical dry-oak cards. Stronger
+    // separation from the soil and a narrow generated coverage rim keep these
+    // leaves recognizable instead of reducing the terrain layer to mottling.
+    let litter_dark = vec3<f32>(0.016, 0.010, 0.006);
+    let litter_mid = vec3<f32>(0.035, 0.021, 0.011);
+    let litter_pale = vec3<f32>(0.062, 0.036, 0.018);
+    let litter_color = mix(
+        mix(litter_dark, litter_mid, smoothstep(0.05, 0.58, litter_sample.b)),
+        litter_pale,
+        smoothstep(0.62, 0.96, litter_sample.b),
+    );
+    color = mix(color, shaded_soil, litter_region * 0.76);
+    color = mix(color, litter_color, litter_region * litter_sample.a * 0.92);
 
     // Use the same true camera distance that drives mesh visibility. Horizontal
     // distance alone left an overhead camera with culled blades but no
@@ -164,7 +254,9 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
     let dry_roughness = select(0.84, 0.9, terrain.detail_patch.x > 0.5);
     // A continuous film darkens porous ground and narrows its highlights.
     // Snow remains a rough dielectric unless the underlying surface is water.
-    let base_roughness = dry_roughness - wetness * 0.22 + snow_mask * 0.08 - water * 0.19;
+    let litter_roughness = litter_region * litter_sample.a * 0.055;
+    let base_roughness = dry_roughness + litter_roughness
+        - wetness * 0.22 + snow_mask * 0.08 - water * 0.19;
     pbr_input.material.perceptual_roughness = clamp(base_roughness, 0.55, 1.0);
     pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
 

--- a/assets/shaders/tactical_tree_leaf_card.wgsl
+++ b/assets/shaders/tactical_tree_leaf_card.wgsl
@@ -216,6 +216,10 @@ fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> Fragment
         albedo = textureSample(back_albedo, back_albedo_sampler, in.uv).rgb;
         tangent_normal = textureSample(back_normal, back_normal_sampler, in.uv).xyz * 2.0 - 1.0;
     }
+    // Ground litter opts into deterministic per-leaf pigments. Tree foliage
+    // leaves physical_parameters.z at zero, so its vertex color remains free
+    // for canopy visibility and coherent thinning metadata.
+    albedo = mix(albedo, in.color.rgb, leaf_card.physical_parameters.z);
     let arm = textureSample(leaf_arm, leaf_arm_sampler, in.uv).rgb;
     tangent_normal = normalize(vec3<f32>(
         tangent_normal.xy * leaf_card.surface_parameters.y,

--- a/crates/adventuresim-tactical-client/src/presentation/ground_scatter/litter.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/ground_scatter/litter.rs
@@ -19,13 +19,15 @@ use super::{
     TacticalFoliageMaterial, TacticalTreeLeafCardMaterial, foliage_transform,
 };
 
-const DRY_LEAF_PASSES_PER_SAMPLE: u64 = 3;
-const TWIG_PASSES_PER_SAMPLE: u64 = 2;
+const DRY_LEAF_PASSES_PER_SAMPLE: u64 = 12;
+const TWIG_PASSES_PER_SAMPLE: u64 = 4;
 const WOODLAND_PLANT_PASSES_PER_SAMPLE: u64 = 1;
 const WOODLAND_FLOOR_TRANSITION_METRES: f32 = 3.2;
-const LITTER_BATCH_CELL_METRES: f32 = 64.0;
+const LITTER_BATCH_CELL_METRES: f32 = 24.0;
 const LITTER_BATCH_HALF_DIAGONAL_METRES: f32 =
     LITTER_BATCH_CELL_METRES * core::f32::consts::FRAC_1_SQRT_2;
+const DRY_LEAVES_PER_PATCH: u64 = 84;
+const TWIGS_PER_PATCH: u64 = 8;
 
 pub(super) struct Assets {
     pub dry_leaf_meshes: Vec<Handle<Mesh>>,
@@ -84,7 +86,7 @@ pub(super) fn spawn(
         for pass in 0..DRY_LEAF_PASSES_PER_SAMPLE {
             let hash =
                 splitmix64(base_seed ^ index as u64 ^ pass.rotate_left(19) ^ 0x2b6f_5dd9_81aa_9135);
-            if unit_hash(hash) >= density * 0.92 {
+            if unit_hash(hash) >= density * 0.97 {
                 continue;
             }
             let Some(transform) =
@@ -174,7 +176,7 @@ pub(super) fn spawn(
                 NotShadowCaster,
                 Mesh3d(meshes.add(mesh)),
                 MeshMaterial3d(assets.dry_leaf_material.clone()),
-                batched_litter_visibility(35.0),
+                batched_litter_visibility(26.0),
                 transform,
             ));
         }
@@ -185,7 +187,7 @@ pub(super) fn spawn(
                 NotShadowCaster,
                 Mesh3d(meshes.add(mesh)),
                 MeshMaterial3d(assets.twig_material.clone()),
-                batched_litter_visibility(24.0),
+                batched_litter_visibility(20.0),
                 transform,
             ));
         }
@@ -338,8 +340,16 @@ pub(super) fn forest_floor_leaf_material(
     material.parameters.z = 0.0;
     material.surface_parameters.z = 0.0;
     material.surface_parameters.w = 0.035;
+    // The dry-leaf height map remains available to close inspection, but its
+    // embossed midrib must not make every geometry leaf readable from the
+    // acceptance distance when the terrain layer's relief has minified.
+    material.surface_parameters.y = 0.18;
     material.physical_parameters.x = 0.96;
     material.physical_parameters.y = 0.00035;
+    // Fallen-leaf meshes already carry deterministic dry pigments per leaf.
+    // Blend those pigments over the shared dry-oak texture; live canopy cards
+    // keep zero here and retain their species albedo unchanged.
+    material.physical_parameters.z = 0.38;
     material
 }
 
@@ -372,43 +382,57 @@ fn forest_floor_patch_transform(
 }
 pub(super) fn dry_leaf_patch_mesh(variant: u64) -> Mesh {
     let mut data = GroundLitterMeshData::default();
+    // Keep the vertex pigments in the same narrow value bands as the packed
+    // terrain litter. Variation remains legible up close without turning the
+    // physical leaves into isolated copper markers.
     let leaf_colors = [
-        Color::srgb_u8(190, 132, 61),
-        Color::srgb_u8(139, 82, 43),
-        Color::srgb_u8(202, 164, 81),
-        Color::srgb_u8(104, 72, 48),
-        Color::srgb_u8(157, 126, 74),
+        Color::srgb_u8(106, 90, 69),
+        Color::srgb_u8(99, 86, 68),
+        Color::srgb_u8(112, 95, 72),
+        Color::srgb_u8(95, 83, 67),
+        Color::srgb_u8(104, 91, 72),
     ];
-    let cluster_count = 4;
-    let clusters = (0..cluster_count)
+    const STRATIFIED_LEAVES: u64 = 56;
+    const STRATIFIED_COLUMNS: u64 = 8;
+    const CLUSTER_COUNT: u64 = 7;
+    let clusters = (0..CLUSTER_COUNT)
         .map(|cluster| {
             let hash = splitmix64(variant.rotate_left(17) ^ cluster as u64 ^ 0x5a9d_31c4);
             Vec2::new(unit_hash(hash) - 0.5, unit_hash(splitmix64(hash ^ 1)) - 0.5) * 0.68
         })
         .collect::<Vec<_>>();
-    for leaf in 0..24_u64 {
+    for leaf in 0..DRY_LEAVES_PER_PATCH {
         let hash = splitmix64(leaf ^ variant.rotate_left(29) ^ 0x5ec4_57d2_bf90_1c37);
-        let cluster_angle = unit_hash(splitmix64(hash ^ 0x43)) * core::f32::consts::TAU;
-        let centre = if leaf < 20 {
-            let cluster = clusters[leaf as usize % clusters.len()];
-            let radial = 0.04 + unit_hash(splitmix64(hash ^ 0x42)) * 0.14;
-            cluster + Vec2::new(cluster_angle.cos(), cluster_angle.sin()) * radial
+        let scatter_angle = unit_hash(splitmix64(hash ^ 0x43)) * core::f32::consts::TAU;
+        let centre = if leaf < STRATIFIED_LEAVES {
+            let column = leaf % STRATIFIED_COLUMNS;
+            let row = leaf / STRATIFIED_COLUMNS;
+            let jitter = Vec2::new(
+                unit_hash(splitmix64(hash ^ 0x9a31)) - 0.5,
+                unit_hash(splitmix64(hash ^ 0xb477)) - 0.5,
+            ) * 0.075;
+            Vec2::new(
+                (column as f32 + 0.5) / STRATIFIED_COLUMNS as f32 - 0.5,
+                (row as f32 + 0.5) / (STRATIFIED_LEAVES / STRATIFIED_COLUMNS) as f32 - 0.5,
+            ) * 0.90
+                + jitter
         } else {
-            Vec2::new(cluster_angle.cos(), cluster_angle.sin())
-                * (0.36 + unit_hash(splitmix64(hash ^ 0x42)) * 0.16)
+            let cluster = clusters[leaf as usize % clusters.len()];
+            let radial = 0.025 + unit_hash(splitmix64(hash ^ 0x42)) * 0.12;
+            cluster + Vec2::new(scatter_angle.cos(), scatter_angle.sin()) * radial
         };
         let angle = unit_hash(splitmix64(hash ^ 2)) * core::f32::consts::TAU;
         let long =
-            Vec2::new(angle.cos(), angle.sin()) * (0.065 + unit_hash(splitmix64(hash ^ 3)) * 0.045);
-        let side = Vec2::new(-long.y, long.x) * (0.34 + unit_hash(splitmix64(hash ^ 4)) * 0.16);
+            Vec2::new(angle.cos(), angle.sin()) * (0.045 + unit_hash(splitmix64(hash ^ 3)) * 0.040);
+        let side = Vec2::new(-long.y, long.x) * (0.45 + unit_hash(splitmix64(hash ^ 4)) * 0.18);
         data.append_cambered_leaf(
             centre,
             long,
             side,
-            if leaf < 20 {
-                [0.0, 0.0025, 0.005][(leaf as usize / 4) % 3]
+            if leaf % 5 == 0 {
+                0.004 + unit_hash(splitmix64(hash ^ 0x781d)) * 0.008
             } else {
-                0.0
+                unit_hash(splitmix64(hash ^ 0x781d)) * 0.0015
             },
             hash,
             leaf_colors[leaf as usize % leaf_colors.len()],
@@ -426,7 +450,7 @@ pub(super) fn twig_patch_mesh(variant: u64) -> Mesh {
         Color::srgb_u8(102, 62, 29),
         Color::srgb_u8(62, 40, 25),
     ];
-    for twig in 0..9_u64 {
+    for twig in 0..TWIGS_PER_PATCH {
         let hash = splitmix64(twig ^ variant.rotate_left(31) ^ 0xa773_9fe2_410c_862d);
         let centre = Vec2::new(unit_hash(hash) - 0.5, unit_hash(splitmix64(hash ^ 1)) - 0.5) * 1.02;
         let angle = unit_hash(splitmix64(hash ^ 2)) * core::f32::consts::TAU;
@@ -705,10 +729,18 @@ impl GroundLitterMeshData {
         // Fallen leaves should curl without becoming little tents. Build the
         // varied plate first, then seat its lowest vertex just below the local
         // patch ground plane so every instance visibly makes contact.
-        let long_slope = (unit_hash(splitmix64(seed ^ 0x11)) - 0.5) * 0.12;
-        let side_slope = (unit_hash(splitmix64(seed ^ 0x12)) - 0.5) * 0.08;
-        let camber = 0.003 + unit_hash(splitmix64(seed ^ 0x13)) * 0.008;
-        let curl = (unit_hash(splitmix64(seed ^ 0x14)) - 0.5) * 0.007;
+        let elevated = height >= 0.004;
+        let long_slope =
+            (unit_hash(splitmix64(seed ^ 0x11)) - 0.5) * if elevated { 0.12 } else { 0.035 };
+        let side_slope =
+            (unit_hash(splitmix64(seed ^ 0x12)) - 0.5) * if elevated { 0.08 } else { 0.025 };
+        let camber = if elevated {
+            0.004 + unit_hash(splitmix64(seed ^ 0x13)) * 0.007
+        } else {
+            0.0012 + unit_hash(splitmix64(seed ^ 0x13)) * 0.0022
+        };
+        let curl =
+            (unit_hash(splitmix64(seed ^ 0x14)) - 0.5) * if elevated { 0.007 } else { 0.002 };
         let burial = 0.0007 + height.min(0.006) * 0.15 + unit_hash(splitmix64(seed ^ 0x15)) * 0.001;
         let long3 = Vec3::new(long.x, long_slope * long.length(), long.y);
         let side3 = Vec3::new(side.x, side_slope * side.length(), side.y);
@@ -844,10 +876,13 @@ mod tests {
             .attribute(Mesh::ATTRIBUTE_NORMAL)
             .and_then(VertexAttributeValues::as_float3)
             .unwrap();
-        assert_eq!(leaf_positions.len(), 24 * 9);
-        assert_eq!(leaves.indices().unwrap().len() / 3, 24 * 8);
-        assert!((190..=300).contains(&twig_positions.len()));
-        assert!((360..=520).contains(&(twigs.indices().unwrap().len() / 3)));
+        assert_eq!(leaf_positions.len(), DRY_LEAVES_PER_PATCH as usize * 9);
+        assert_eq!(
+            leaves.indices().unwrap().len() / 3,
+            DRY_LEAVES_PER_PATCH as usize * 8
+        );
+        assert!((168..=288).contains(&twig_positions.len()));
+        assert!((320..=496).contains(&(twigs.indices().unwrap().len() / 3)));
         assert_eq!(
             leaves.attribute(Mesh::ATTRIBUTE_POSITION),
             repeated_leaves.attribute(Mesh::ATTRIBUTE_POSITION)
@@ -884,6 +919,7 @@ mod tests {
                 .any(|normal| Vec3::from_array(*normal).distance(Vec3::Y) > 0.03)
         );
         let mut contacting_leaves = 0;
+        let mut seated_leaves = 0;
         let leaf_spans = leaf_positions
             .chunks_exact(9)
             .map(|leaf| {
@@ -896,15 +932,20 @@ mod tests {
                     .map(|point| point[1])
                     .fold(f32::NEG_INFINITY, f32::max);
                 contacting_leaves += usize::from(minimum <= -0.0006);
-                assert!(maximum <= 0.025, "leaf lift must stay bounded: {maximum}");
+                seated_leaves += usize::from(minimum <= 0.004);
+                assert!(maximum <= 0.032, "leaf lift must stay bounded: {maximum}");
                 maximum - minimum
             })
             .collect::<Vec<_>>();
         assert!(
-            contacting_leaves >= 8,
+            contacting_leaves >= 4,
             "each loose pile needs seated base leaves"
         );
-        assert!(leaf_spans.iter().all(|span| *span > 0.003));
+        assert!(
+            seated_leaves >= DRY_LEAVES_PER_PATCH as usize * 3 / 4,
+            "most leaves must sit within four millimetres: {seated_leaves}"
+        );
+        assert!(leaf_spans.iter().all(|span| *span > 0.0008));
         assert!(
             leaf_spans
                 .windows(2)
@@ -983,8 +1024,11 @@ mod tests {
         assert_eq!(floor.surface_parameters.z, 0.0);
         assert!(floor.surface_parameters.w < oak.surface_parameters.w * 0.2);
         assert!(floor.physical_parameters.y < oak.physical_parameters.y);
+        assert!((0.3..0.5).contains(&floor.physical_parameters.z));
+        assert_eq!(oak.physical_parameters.z, 0.0);
         let shader = include_str!("../../../../../assets/shaders/tactical_tree_leaf_card.wgsl");
         assert!(shader.contains("pbr_input.material.base_color = vec4<f32>(\n        albedo,"));
+        assert!(shader.contains("albedo = mix(albedo, in.color.rgb"));
         assert!(!shader.contains("spatial_hue"));
     }
 
@@ -1013,7 +1057,7 @@ mod tests {
             let mut expected_vertices = 0;
             let mut expected_triangles = 0;
             let mut expected_boundaries = 0;
-            for twig in 0..9_u64 {
+            for twig in 0..TWIGS_PER_PATCH {
                 let hash = splitmix64(twig ^ variant.rotate_left(31) ^ 0xa773_9fe2_410c_862d);
                 let sides = 5 + (hash % 2) as usize;
                 expected_vertices += sides * 4 + 2;

--- a/crates/adventuresim-tactical-client/src/presentation/ground_scatter/loose_stone.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/ground_scatter/loose_stone.rs
@@ -7,8 +7,8 @@ use bevy::{
     mesh::{Indices, PrimitiveTopology},
     pbr::Material,
     prelude::{
-        Asset, Assets, Commands, Component, Mesh, Mesh3d, MeshMaterial3d, Name, Quat, Reflect,
-        StandardMaterial, Transform, Vec2, Vec3, Vec4,
+        Asset, Assets, Color, Commands, Component, Mesh, Mesh3d, MeshMaterial3d, Name, Quat,
+        Reflect, StandardMaterial, Transform, Vec2, Vec3, Vec4,
     },
     render::render_resource::{
         AsBindGroup, RenderPipelineDescriptor, SpecializedMeshPipelineError,
@@ -39,7 +39,7 @@ const HERO_PEBBLE_TRIANGLES: usize = HERO_PEBBLE_RADIAL_SEGMENTS * HERO_PEBBLE_R
 const BILLBOARD_VERTICES: usize = 4;
 const BILLBOARD_TRIANGLES: usize = 2;
 const MIN_PEBBLE_RADIUS_METRES: f32 = 0.03;
-const MAX_PEBBLE_RADIUS_METRES: f32 = 0.09;
+const MAX_PEBBLE_RADIUS_METRES: f32 = 0.08;
 
 #[derive(Asset, AsBindGroup, Reflect, Debug, Clone)]
 pub(crate) struct TacticalPebbleBillboardMaterial {
@@ -93,17 +93,19 @@ enum PebbleMeshLod {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PebbleDensity {
+    Woodland,
     Sparse,
     Dense,
 }
 
 impl PebbleDensity {
-    const ALL: [Self; 2] = [Self::Sparse, Self::Dense];
+    const ALL: [Self; 3] = [Self::Woodland, Self::Sparse, Self::Dense];
 
     const fn asset_offset(self) -> usize {
         match self {
-            Self::Sparse => 0,
-            Self::Dense => MESH_VARIANTS as usize,
+            Self::Woodland => 0,
+            Self::Sparse => MESH_VARIANTS as usize,
+            Self::Dense => MESH_VARIANTS as usize * 2,
         }
     }
 }
@@ -146,6 +148,11 @@ pub(super) fn spawn(
         perceptual_roughness: 1.0,
         ..Default::default()
     });
+    let woodland_stone_material = materials.add(StandardMaterial {
+        base_color: Color::srgb_u8(104, 91, 70),
+        perceptual_roughness: 1.0,
+        ..Default::default()
+    });
     let billboard_material = billboard_materials.add(TacticalPebbleBillboardMaterial {
         color: Vec4::from_array(
             rock_color(RockLithology::Granite)
@@ -157,7 +164,10 @@ pub(super) fn spawn(
     });
 
     for (index, sample) in ground.samples().iter().enumerate() {
-        if sample.cover != GroundCover::LooseStone {
+        if !matches!(
+            sample.cover,
+            GroundCover::LooseStone | GroundCover::LeafLitter
+        ) {
             continue;
         }
         let grid_x = index % ground.grid_width();
@@ -175,58 +185,90 @@ pub(super) fn spawn(
             continue;
         }
         let hash = splitmix64(base_seed ^ index as u64 ^ 0x7374_6f6e_655f_7363);
-        let coverage = scree_patch_coverage(base_seed, position, normal);
-        let density = if coverage >= 0.61 {
-            PebbleDensity::Dense
-        } else if coverage >= 0.34 {
-            PebbleDensity::Sparse
+        let woodland = sample.cover == GroundCover::LeafLitter;
+        let density = if woodland {
+            // Every woodland cell gets a sparse candidate patch. Individual
+            // survival still leaves irregular gaps, but keeping the patches
+            // continuous yields roughly one visible 3--8 cm stone per square
+            // metre instead of making rocks disappear from review frames.
+            PebbleDensity::Woodland
         } else {
-            continue;
+            let coverage = scree_patch_coverage(base_seed, position, normal);
+            if coverage >= 0.61 {
+                PebbleDensity::Dense
+            } else if coverage >= 0.34 {
+                PebbleDensity::Sparse
+            } else {
+                continue;
+            }
         };
         let variant = density.asset_offset() + (hash % MESH_VARIANTS) as usize;
         let yaw = Quat::from_rotation_y(
             unit_hash(splitmix64(hash ^ 0x55d8_093b)) * core::f32::consts::TAU,
         );
-        let transform = Transform::from_xyz(position.x, height + 0.006, position.y)
-            .with_rotation(Quat::from_rotation_arc(Vec3::Y, normal) * yaw);
+        let transform = Transform::from_xyz(
+            position.x,
+            height + if woodland { -0.006 } else { 0.006 },
+            position.y,
+        )
+        .with_rotation(Quat::from_rotation_arc(Vec3::Y, normal) * yaw)
+        .with_scale(Vec3::splat(if woodland { 0.58 } else { 1.0 }));
 
         commands.spawn((
-            Name::new("Tactical loose-stone hero pebble patch"),
+            Name::new(if woodland {
+                "Tactical woodland hero pebble patch"
+            } else {
+                "Tactical loose-stone hero pebble patch"
+            }),
             GroundScatterLayer::LooseStone,
             LooseStonePebblePatch {
                 physical_pebbles: pebble_counts[variant],
             },
             NotShadowCaster,
             Mesh3d(hero_meshes[variant].clone()),
-            MeshMaterial3d(stone_material.clone()),
+            MeshMaterial3d(if woodland {
+                woodland_stone_material.clone()
+            } else {
+                stone_material.clone()
+            }),
             pebble_lod_visibility(PebbleMeshLod::Hero),
             transform,
         ));
         commands.spawn((
-            Name::new("Tactical loose-stone near pebble patch"),
+            Name::new(if woodland {
+                "Tactical woodland near pebble patch"
+            } else {
+                "Tactical loose-stone near pebble patch"
+            }),
             GroundScatterLayer::LooseStone,
             LooseStonePebblePatch {
                 physical_pebbles: 0,
             },
             NotShadowCaster,
             Mesh3d(near_meshes[variant].clone()),
-            MeshMaterial3d(stone_material.clone()),
+            MeshMaterial3d(if woodland {
+                woodland_stone_material.clone()
+            } else {
+                stone_material.clone()
+            }),
             pebble_lod_visibility(PebbleMeshLod::Near),
             transform,
         ));
-        commands.spawn((
-            Name::new("Tactical loose-stone billboard pebble patch"),
-            GroundScatterLayer::LooseStone,
-            LooseStonePebblePatch {
-                physical_pebbles: 0,
-            },
-            NoFrustumCulling,
-            NotShadowCaster,
-            Mesh3d(billboard_meshes[variant].clone()),
-            MeshMaterial3d(billboard_material.clone()),
-            pebble_lod_visibility(PebbleMeshLod::Billboard),
-            transform,
-        ));
+        if !woodland {
+            commands.spawn((
+                Name::new("Tactical loose-stone billboard pebble patch"),
+                GroundScatterLayer::LooseStone,
+                LooseStonePebblePatch {
+                    physical_pebbles: 0,
+                },
+                NoFrustumCulling,
+                NotShadowCaster,
+                Mesh3d(billboard_meshes[variant].clone()),
+                MeshMaterial3d(billboard_material.clone()),
+                pebble_lod_visibility(PebbleMeshLod::Billboard),
+                transform,
+            ));
+        }
     }
 }
 
@@ -312,6 +354,7 @@ fn pebble_survives(
     .map(|cluster| (-(centre.distance_squared(cluster) / radius.powi(2)) * 1.4).exp())
     .fold(0.0_f32, f32::max);
     let chance = match density {
+        PebbleDensity::Woodland => 0.045 + influence * 0.16,
         PebbleDensity::Sparse => 0.035 + influence * 0.42,
         PebbleDensity::Dense => 0.09 + influence * 0.76,
     };
@@ -369,11 +412,20 @@ fn pebble_patch_mesh(
         ) {
             continue;
         }
-        let height = radius * (0.85 + unit_hash(splitmix64(hash ^ 0x4f08_d119)) * 0.45);
+        let height_scale = if density == PebbleDensity::Woodland {
+            0.52 + unit_hash(splitmix64(hash ^ 0x4f08_d119)) * 0.30
+        } else {
+            0.85 + unit_hash(splitmix64(hash ^ 0x4f08_d119)) * 0.45
+        };
+        let height = radius * height_scale;
         let yaw = unit_hash(splitmix64(hash ^ 0x5ca1_0f77)) * core::f32::consts::TAU;
         let direction = Vec3::new(yaw.cos(), 0.0, yaw.sin());
         let tangent = Vec3::new(-direction.z, 0.0, direction.x);
-        let lateral_scale = 0.72 + unit_hash(splitmix64(hash ^ 0xd71c_820e)) * 0.26;
+        let lateral_scale = if density == PebbleDensity::Woodland {
+            0.52 + unit_hash(splitmix64(hash ^ 0xd71c_820e)) * 0.34
+        } else {
+            0.72 + unit_hash(splitmix64(hash ^ 0xd71c_820e)) * 0.26
+        };
         let base = positions.len() as u32;
         positions.push((centre - Vec3::Y * radius * 0.18).to_array());
         normals.push(Vec3::NEG_Y.to_array());
@@ -382,10 +434,15 @@ fn pebble_patch_mesh(
         for &(height_fraction, radius_scale, normal_y) in ring_profiles {
             for segment in 0..radial_segments {
                 let angle = segment as f32 / radial_segments as f32 * core::f32::consts::TAU;
+                let facet_scale = if density == PebbleDensity::Woodland {
+                    0.82 + unit_hash(splitmix64(hash ^ segment as u64 ^ 0xa94f_3b21)) * 0.28
+                } else {
+                    1.0
+                };
                 let horizontal = direction * angle.cos() + tangent * angle.sin() * lateral_scale;
                 let vertex = centre
-                    + direction * angle.cos() * radius * radius_scale
-                    + tangent * angle.sin() * radius * radius_scale * lateral_scale
+                    + direction * angle.cos() * radius * radius_scale * facet_scale
+                    + tangent * angle.sin() * radius * radius_scale * lateral_scale * facet_scale
                     + Vec3::Y * height * height_fraction;
                 positions.push(vertex.to_array());
                 normals.push(
@@ -565,13 +622,17 @@ mod tests {
 
     #[test]
     fn scree_density_is_clustered_and_preserved_across_lods() {
+        let woodland = pebble_patch_mesh(19, PebbleMeshLod::Hero, 1.0, PebbleDensity::Woodland)
+            .count_vertices()
+            / HERO_PEBBLE_VERTICES;
         let sparse = pebble_patch_mesh(19, PebbleMeshLod::Hero, 1.0, PebbleDensity::Sparse)
             .count_vertices()
             / HERO_PEBBLE_VERTICES;
         let dense = pebble_patch_mesh(19, PebbleMeshLod::Hero, 1.0, PebbleDensity::Dense)
             .count_vertices()
             / HERO_PEBBLE_VERTICES;
-        assert!(sparse > 0);
+        assert!(woodland > 0);
+        assert!(sparse > woodland, "woodland {woodland}, sparse {sparse}");
         assert!(dense > sparse, "sparse {sparse}, dense {dense}");
 
         let normal = Vec3::new(0.25, 0.9, -0.15).normalize();
@@ -588,6 +649,30 @@ mod tests {
                 - samples.iter().copied().fold(f32::INFINITY, f32::min)
                 > 0.25,
             "world-space scree field needs broad occupied and exposed bands"
+        );
+    }
+
+    #[test]
+    fn woodland_pebbles_average_half_to_one_and_a_half_stones_per_square_metre() {
+        let half_extent = 1.0_f32;
+        let patch_area = (half_extent * 2.0).powi(2);
+        let stone_count = (0..MESH_VARIANTS)
+            .map(|variant| {
+                let seed = splitmix64(0x7065_6262_6c65_0000 ^ variant);
+                pebble_patch_mesh(
+                    seed,
+                    PebbleMeshLod::Hero,
+                    half_extent,
+                    PebbleDensity::Woodland,
+                )
+                .count_vertices()
+                    / HERO_PEBBLE_VERTICES
+            })
+            .sum::<usize>();
+        let stones_per_square_metre = stone_count as f32 / (MESH_VARIANTS as f32 * patch_area);
+        assert!(
+            (0.5..=1.5).contains(&stones_per_square_metre),
+            "woodland density was {stones_per_square_metre} stones/m2"
         );
     }
 

--- a/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/materials.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/materials.rs
@@ -52,7 +52,8 @@ pub(crate) struct TacticalTreeLeafCardMaterial {
     /// diffuse transmission for the species' leaf thickness.
     #[uniform(12)]
     pub(crate) surface_parameters: Vec4,
-    /// Perceptual roughness, physical thickness in metres, and reserved.
+    /// Perceptual roughness, physical thickness in metres, ground-litter
+    /// vertex-pigment strength, and reserved.
     #[uniform(12)]
     pub(crate) physical_parameters: Vec4,
 }

--- a/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/materials.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/obstacles/tree/materials.rs
@@ -24,6 +24,7 @@ use crate::presentation::{
 const TREE_IMPOSTOR_SHADER: &str = "shaders/tactical_tree_impostor.wgsl";
 const TREE_LEAF_CARD_SHADER: &str = "shaders/tactical_tree_leaf_card.wgsl";
 const TREE_BARK_SHADER: &str = "shaders/tactical_tree_bark.wgsl";
+const CANOPY_SHADED_SOIL_LINEAR_SCALE: Vec3 = Vec3::new(0.38, 0.40, 0.37);
 
 #[derive(Asset, AsBindGroup, Reflect, Debug, Clone)]
 pub(crate) struct TacticalTreeLeafCardMaterial {
@@ -179,11 +180,15 @@ fn bark_material(
     perceptual_roughness: f32,
     relief: Vec4,
 ) -> TacticalTreeBarkMaterial {
-    let soil_color = Color::srgb_u8(
+    let dirt_color = Color::srgb_u8(
         TACTICAL_DIRT_SRGB[0],
         TACTICAL_DIRT_SRGB[1],
         TACTICAL_DIRT_SRGB[2],
     );
+    // Match the soil deposited at the root contact to the shaded substrate
+    // beneath canopy litter. The terrain shader applies this same linear
+    // multiplier before layering individual litter pigments over the ground.
+    let shaded_soil_color = color_vec4(dirt_color).xyz() * CANOPY_SHADED_SOIL_LINEAR_SCALE;
     TacticalTreeBarkMaterial {
         base: StandardMaterial {
             base_color,
@@ -197,7 +202,7 @@ fn bark_material(
             projection: Vec4::new(4.0, 0.92, 0.52, 12.0),
             lighting: Vec3::new(0.25, 0.92, 0.3).normalize().extend(1.0),
             surface: color_vec4(base_color).xyz().extend(perceptual_roughness),
-            soil_surface: color_vec4(soil_color).xyz().extend(0.84),
+            soil_surface: shaded_soil_color.extend(0.84),
             // The 7 mm minimum radius yields a 14 mm minimum full speck
             // diameter before edge antialiasing. A 45 mm cell leaves enough
             // negative space for the separate deposits to read clearly.
@@ -464,13 +469,14 @@ mod tests {
         );
         assert_eq!(
             bark.extension.soil_surface,
-            color_vec4(Color::srgb_u8(
+            (color_vec4(Color::srgb_u8(
                 TACTICAL_DIRT_SRGB[0],
                 TACTICAL_DIRT_SRGB[1],
                 TACTICAL_DIRT_SRGB[2],
             ))
             .xyz()
-            .extend(0.84)
+                * CANOPY_SHADED_SOIL_LINEAR_SCALE)
+                .extend(0.84)
         );
         assert_eq!(
             bark.extension.deposition,

--- a/crates/adventuresim-tactical-client/src/presentation/procedural_assets/mod.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/procedural_assets/mod.rs
@@ -11,6 +11,8 @@ const FOREST_SOIL_AO_DIRECTIONS: [(i32, i32); 4] = [(1, 0), (0, 1), (-1, 0), (0,
 const FOREST_SOIL_AO_STEPS: [i32; 4] = [1, 4, 12, 32];
 pub(super) const FOREST_SOIL_TILE_METRES: f32 = 2.0;
 pub(super) const FOREST_SOIL_HEIGHT_RANGE_METRES: f32 = 0.028;
+pub(super) const FOREST_LITTER_TILE_METRES: f32 = 4.0;
+pub(super) const FOREST_LITTER_HEIGHT_RANGE_METRES: f32 = 0.016;
 
 #[derive(Clone, Debug)]
 pub(super) struct LeafTextureSet {
@@ -41,6 +43,8 @@ pub(super) struct BarkTextureSet {
 #[derive(Clone, Debug)]
 pub(super) struct GroundTextureSet {
     pub(super) height_ao: Handle<Image>,
+    pub(super) litter_surface: Handle<Image>,
+    pub(super) litter_normal: Handle<Image>,
 }
 
 #[derive(Resource, Clone, Debug)]
@@ -67,6 +71,7 @@ struct LeafRecipe {
     tooth_depth: f32,
     vein_pairs: u32,
     bend: f32,
+    width_scale: f32,
     blade: [u8; 3],
     vein: [u8; 3],
     back_blade: [u8; 3],
@@ -84,6 +89,7 @@ impl LeafRecipe {
         tooth_depth: 0.0,
         vein_pairs: 7,
         bend: 0.035,
+        width_scale: 0.43,
         blade: [76, 111, 48],
         vein: [139, 157, 76],
         back_blade: [91, 116, 65],
@@ -91,9 +97,10 @@ impl LeafRecipe {
     };
 
     const DRY_WHITE_OAK: Self = Self {
-        blade: [157, 105, 49],
-        vein: [190, 139, 69],
-        back_blade: [126, 82, 43],
+        width_scale: 0.68,
+        blade: [107, 90, 68],
+        vein: [109, 92, 70],
+        back_blade: [98, 85, 68],
         roughness: 232,
         ..Self::WHITE_OAK
     };
@@ -108,6 +115,7 @@ impl LeafRecipe {
         tooth_depth: 0.075,
         vein_pairs: 9,
         bend: -0.025,
+        width_scale: 0.43,
         blade: [66, 112, 48],
         vein: [129, 154, 75],
         back_blade: [82, 119, 61],
@@ -124,6 +132,7 @@ impl LeafRecipe {
         tooth_depth: 0.028,
         vein_pairs: 6,
         bend: 0.018,
+        width_scale: 0.43,
         blade: [61, 103, 42],
         vein: [117, 139, 66],
         back_blade: [77, 111, 56],
@@ -140,6 +149,7 @@ impl LeafRecipe {
         tooth_depth: 0.035,
         vein_pairs: 6,
         bend: -0.012,
+        width_scale: 0.43,
         blade: [72, 113, 44],
         vein: [132, 151, 68],
         back_blade: [84, 119, 58],
@@ -156,6 +166,7 @@ impl LeafRecipe {
         tooth_depth: 0.018,
         vein_pairs: 8,
         bend: 0.022,
+        width_scale: 0.43,
         blade: [67, 108, 46],
         vein: [126, 147, 72],
         back_blade: [81, 117, 59],
@@ -299,6 +310,70 @@ fn image_rg_mipped(data: Vec<u8>, size: u32, repeat: bool) -> Image {
     image
 }
 
+fn image_rgba_mipped(data: Vec<u8>, size: u32, repeat: bool) -> Image {
+    assert!(size.is_power_of_two());
+    assert_eq!(data.len(), (size * size * 4) as usize);
+    let base_level = data.clone();
+    let mut mip_data = data;
+    let mut previous = base_level.clone();
+    let mut previous_size = size;
+    while previous_size > 1 {
+        let next_size = previous_size / 2;
+        let mut next = Vec::with_capacity((next_size * next_size * 4) as usize);
+        for y in 0..next_size {
+            for x in 0..next_size {
+                for channel in 0..4 {
+                    let mut sum = 0_u32;
+                    for offset_y in 0..2 {
+                        for offset_x in 0..2 {
+                            let source_x = x * 2 + offset_x;
+                            let source_y = y * 2 + offset_y;
+                            let index =
+                                ((source_y * previous_size + source_x) * 4 + channel) as usize;
+                            sum += previous[index] as u32;
+                        }
+                    }
+                    next.push(((sum + 2) / 4) as u8);
+                }
+            }
+        }
+        mip_data.extend_from_slice(&next);
+        previous = next;
+        previous_size = next_size;
+    }
+
+    let mut image = Image::new(
+        Extent3d {
+            width: size,
+            height: size,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        base_level,
+        TextureFormat::Rgba8Unorm,
+        RenderAssetUsages::RENDER_WORLD,
+    );
+    image.data = Some(mip_data);
+    image.texture_descriptor.mip_level_count = size.ilog2() + 1;
+    use bevy::image::{ImageAddressMode, ImageSamplerDescriptor};
+    image.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+        address_mode_u: if repeat {
+            ImageAddressMode::Repeat
+        } else {
+            ImageAddressMode::ClampToEdge
+        },
+        address_mode_v: if repeat {
+            ImageAddressMode::Repeat
+        } else {
+            ImageAddressMode::ClampToEdge
+        },
+        address_mode_w: ImageAddressMode::Repeat,
+        anisotropy_clamp: 8,
+        ..ImageSamplerDescriptor::linear()
+    });
+    image
+}
+
 fn leaf_width(recipe: LeafRecipe, t: f32) -> f32 {
     let base = if t < recipe.widest_point {
         (t / recipe.widest_point)
@@ -335,7 +410,7 @@ fn leaf_sample(recipe: LeafRecipe, u: f32, v: f32) -> (bool, bool, f32) {
     if !(0.0..=1.0).contains(&t) {
         return (petiole, petiole, if petiole { 0.08 } else { 0.0 });
     }
-    let width = leaf_width(recipe, t) * 0.43;
+    let width = leaf_width(recipe, t) * recipe.width_scale;
     let inside = x.abs() <= width;
     let midrib = x.abs() < 0.012;
     let mut vein = midrib;
@@ -1003,6 +1078,165 @@ fn forest_soil_local_cavity(field: &[f32], x: i32, y: i32) -> f32 {
     (1.0 - cavity * 2.2).clamp(0.78, 1.0)
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct LitterLeafImprint {
+    coverage: f32,
+    dome: f32,
+    tone: f32,
+    vein: f32,
+}
+
+fn litter_leaf_field(point: Vec2, grid: i32, salt: u64) -> LitterLeafImprint {
+    let scaled = point * grid as f32;
+    let base_cell = scaled.floor().as_ivec2();
+    let mut field = LitterLeafImprint::default();
+    for offset_y in -1..=1 {
+        for offset_x in -1..=1 {
+            let cell = base_cell + IVec2::new(offset_x, offset_y);
+            let centre = cell.as_vec2()
+                + Vec2::new(
+                    0.10 + soil_random(cell.x, cell.y, grid, salt ^ 0x13a7) * 0.80,
+                    0.10 + soil_random(cell.x, cell.y, grid, salt ^ 0x91cb) * 0.80,
+                );
+            let angle = soil_random(cell.x, cell.y, grid, salt ^ 0xc72d) * core::f32::consts::TAU;
+            let long_axis = Vec2::new(angle.cos(), angle.sin());
+            let delta = scaled - centre;
+            let local = Vec2::new(delta.dot(long_axis), delta.perp_dot(long_axis));
+            let radius = 0.66 + soil_random(cell.x, cell.y, grid, salt ^ 0x27f1) * 0.30;
+            let aspect = 0.30 + soil_random(cell.x, cell.y, grid, salt ^ 0xe419) * 0.20;
+            let longitudinal = local.x / radius;
+            if longitudinal.abs() >= 0.98 {
+                continue;
+            }
+            // Match the physical scatter's procedural white-oak silhouette.
+            // Its cards and this aggregate representation now agree on waist,
+            // lobes, tip, and broad scale instead of merely sharing a palette.
+            let blade_t = (longitudinal + 1.0) * 0.5;
+            let blade_envelope = leaf_width(LeafRecipe::DRY_WHITE_OAK, blade_t);
+            let phase = soil_random(cell.x, cell.y, grid, salt ^ 0x41af) * core::f32::consts::TAU;
+            let edge_warp = 0.96 + 0.04 * (longitudinal * 7.0 + phase).sin();
+            let half_width = radius * aspect * blade_envelope * edge_warp;
+            let lateral = local.y.abs() / half_width.max(0.001);
+            // Retain only a narrow antialiased rim. The old broad ramp made
+            // aggregate leaves dissolve into mottling beside the crisp alpha
+            // silhouettes used by the physical scatter.
+            let coverage = 1.0 - smoothstep(0.92, 1.02, lateral);
+            if coverage <= field.coverage {
+                continue;
+            }
+            let midrib = 1.0 - smoothstep(0.025, 0.11, local.y.abs() / radius.max(0.001));
+            let vein_phase = (longitudinal * 6.5 + lateral * 0.72).fract().abs();
+            let side_veins = (1.0 - smoothstep(0.035, 0.11, (vein_phase - 0.5).abs()))
+                * smoothstep(0.12, 0.72, lateral);
+            let pigment = soil_random(cell.x, cell.y, grid, salt ^ 0xa531);
+            let pigment_tone = 0.18 + pigment * 0.64;
+            field = LitterLeafImprint {
+                coverage,
+                dome: (1.0 - lateral.powf(1.45)).max(0.0) * (0.72 + midrib * 0.18) * coverage,
+                tone: (pigment_tone
+                    + (longitudinal * 5.0 + phase).sin() * 0.06
+                    + midrib * 0.20
+                    + side_veins * 0.10)
+                    .clamp(0.0, 1.0),
+                vein: (midrib.max(side_veins) * coverage).clamp(0.0, 1.0),
+            };
+        }
+    }
+    field
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ForestLitterSample {
+    height: f32,
+    ao: f32,
+    tone: f32,
+    coverage: f32,
+}
+
+fn forest_litter_sample(u: f32, v: f32) -> ForestLitterSample {
+    let point = Vec2::new(u, v);
+    let warp = Vec2::new(
+        soil_value_noise(point, 7, 0x51a7),
+        soil_value_noise(point + Vec2::new(0.41, 0.23), 7, 0x8d31),
+    ) * 0.014;
+    let sample = point + warp;
+    let lower = litter_leaf_field(sample, 41, 0x1eaf_0001);
+    let middle = litter_leaf_field(sample, 47, 0x1eaf_0002);
+    // The upper stratum deliberately uses a coarser field. Its isolated
+    // 10--16 cm oak silhouettes remain recognizable over the two dense,
+    // composting strata instead of washing into a third layer of mottling.
+    let upper = litter_leaf_field(sample, 43, 0x1eaf_0003);
+    let coverage = 1.0 - (1.0 - lower.coverage) * (1.0 - middle.coverage) * (1.0 - upper.coverage);
+    let overlap =
+        (lower.coverage + middle.coverage + upper.coverage - coverage).clamp(0.0, 2.0) * 0.5;
+    let pile = (lower.dome * 0.18 + middle.dome * 0.28 + upper.dome * 0.42).clamp(0.0, 1.0);
+    let height = 0.48 + pile * 0.38 + overlap * 0.08;
+    let vein =
+        lower.vein * (1.0 - middle.coverage) + middle.vein * (1.0 - upper.coverage) + upper.vein;
+    let ao = (1.0 - coverage * 0.06 - overlap * 0.16 - vein * 0.025).clamp(0.70, 1.0);
+    let visible_tone = lower.tone * lower.coverage * (1.0 - middle.coverage)
+        + middle.tone * middle.coverage * (1.0 - upper.coverage)
+        + upper.tone * upper.coverage;
+    let compost_tone = soil_value_noise(sample, 79, 0xb875) * 0.5 + 0.5;
+    let tone = visible_tone
+        .lerp(compost_tone, (1.0 - coverage) * 0.75)
+        .clamp(0.0, 1.0);
+    ForestLitterSample {
+        height,
+        ao,
+        tone,
+        coverage,
+    }
+}
+
+fn generate_forest_litter_textures() -> (Image, Image) {
+    let size = FOREST_SOIL_TEXTURE_SIZE;
+    let samples = (0..size)
+        .flat_map(|y| {
+            (0..size).map(move |x| {
+                forest_litter_sample(
+                    (x as f32 + 0.5) / size as f32,
+                    (y as f32 + 0.5) / size as f32,
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    let mut data = Vec::with_capacity((size * size * 4) as usize);
+    for sample in &samples {
+        data.extend_from_slice(&[
+            (sample.height * 255.0).round().clamp(0.0, 255.0) as u8,
+            (sample.ao * 255.0).round().clamp(0.0, 255.0) as u8,
+            (sample.tone * 255.0).round().clamp(0.0, 255.0) as u8,
+            (sample.coverage * 255.0).round().clamp(0.0, 255.0) as u8,
+        ]);
+    }
+    let sample_at = |x: i32, y: i32| {
+        samples[y.rem_euclid(size as i32) as usize * size as usize
+            + x.rem_euclid(size as i32) as usize]
+    };
+    let texel_metres = FOREST_LITTER_TILE_METRES / size as f32;
+    let mut normal_data = Vec::with_capacity((size * size * 2) as usize);
+    for y in 0..size as i32 {
+        for x in 0..size as i32 {
+            let height_x = (sample_at(x + 1, y).height - sample_at(x - 1, y).height)
+                * FOREST_LITTER_HEIGHT_RANGE_METRES
+                / (2.0 * texel_metres);
+            let height_z = (sample_at(x, y + 1).height - sample_at(x, y - 1).height)
+                * FOREST_LITTER_HEIGHT_RANGE_METRES
+                / (2.0 * texel_metres);
+            let normal = Vec3::new(-height_x, 1.0, -height_z).normalize();
+            normal_data.extend_from_slice(&[
+                ((normal.x * 0.5 + 0.5) * 255.0).round().clamp(0.0, 255.0) as u8,
+                ((normal.z * 0.5 + 0.5) * 255.0).round().clamp(0.0, 255.0) as u8,
+            ]);
+        }
+    }
+    (
+        image_rgba_mipped(data, size, true),
+        image_rg_mipped(normal_data, size, true),
+    )
+}
+
 fn generate_forest_soil_texture(images: &mut Assets<Image>) -> GroundTextureSet {
     let size = FOREST_SOIL_TEXTURE_SIZE;
     let heights = (0..size)
@@ -1037,8 +1271,11 @@ fn generate_forest_soil_texture(images: &mut Assets<Image>) -> GroundTextureSet 
             height_ao.extend_from_slice(&[encoded_height, ao]);
         }
     }
+    let (litter_surface, litter_normal) = generate_forest_litter_textures();
     GroundTextureSet {
         height_ao: images.add(image_rg_mipped(height_ao, size, true)),
+        litter_surface: images.add(litter_surface),
+        litter_normal: images.add(litter_normal),
     }
 }
 
@@ -1157,10 +1394,10 @@ mod tests {
     }
 
     #[test]
-    fn forest_soil_is_one_packed_1024_texture_with_a_complete_mip_chain() {
+    fn forest_ground_uses_packed_surface_and_normal_textures_with_complete_mip_chains() {
         let mut images = Assets::<Image>::default();
         let textures = generate_forest_soil_texture(&mut images);
-        assert_eq!(images.len(), 1);
+        assert_eq!(images.len(), 3);
         let image = images.get(&textures.height_ao).unwrap();
         assert_eq!((image.width(), image.height()), (1024, 1024));
         assert_eq!(image.texture_descriptor.format, TextureFormat::Rg8Unorm);
@@ -1173,6 +1410,29 @@ mod tests {
             (mip_texels * 2) as usize
         );
         assert_eq!(FOREST_SOIL_AO_SIZE, FOREST_SOIL_TEXTURE_SIZE / 2);
+
+        let litter = images.get(&textures.litter_surface).unwrap();
+        assert_eq!((litter.width(), litter.height()), (1024, 1024));
+        assert_eq!(litter.texture_descriptor.format, TextureFormat::Rgba8Unorm);
+        assert_eq!(litter.texture_descriptor.mip_level_count, 11);
+        assert_eq!(
+            litter.data.as_ref().unwrap().len(),
+            (mip_texels * 4) as usize
+        );
+        let litter_normal = images.get(&textures.litter_normal).unwrap();
+        assert_eq!(
+            (litter_normal.width(), litter_normal.height()),
+            (1024, 1024)
+        );
+        assert_eq!(
+            litter_normal.texture_descriptor.format,
+            TextureFormat::Rg8Unorm
+        );
+        assert_eq!(litter_normal.texture_descriptor.mip_level_count, 11);
+        assert_eq!(
+            litter_normal.data.as_ref().unwrap().len(),
+            (mip_texels * 2) as usize
+        );
     }
 
     #[test]
@@ -1209,6 +1469,39 @@ mod tests {
             * FOREST_SOIL_AO_DIRECTIONS.len() as u32
             * FOREST_SOIL_AO_STEPS.len() as u32;
         assert_eq!(horizon_samples, 4_194_304);
+    }
+
+    #[test]
+    fn forest_litter_is_periodic_dense_and_retains_soil_gaps() {
+        let mut covered = 0_usize;
+        let mut exposed = 0_usize;
+        let mut minimum_ao = 1.0_f32;
+        let mut maximum_repeat_error = 0.0_f32;
+        for y in 0..128 {
+            for x in 0..128 {
+                let u = (x as f32 + 0.5) / 128.0;
+                let v = (y as f32 + 0.5) / 128.0;
+                let sample = forest_litter_sample(u, v);
+                let repeated = forest_litter_sample(u + 1.0, v - 1.0);
+                maximum_repeat_error = maximum_repeat_error
+                    .max((sample.coverage - repeated.coverage).abs())
+                    .max((sample.height - repeated.height).abs());
+                assert!((0.47..=0.94).contains(&sample.height));
+                minimum_ao = minimum_ao.min(sample.ao);
+                covered += usize::from(sample.coverage >= 0.5);
+                exposed += usize::from(sample.coverage <= 0.1);
+            }
+        }
+        let samples = 128 * 128;
+        assert!(
+            maximum_repeat_error < 0.01,
+            "maximum periodic repeat error: {maximum_repeat_error}"
+        );
+        assert!(covered * 100 / samples >= 68, "covered texels: {covered}");
+        assert!(exposed * 100 / samples >= 3, "exposed texels: {exposed}");
+        assert!(minimum_ao <= 0.82, "minimum litter AO: {minimum_ao}");
+        assert_eq!(FOREST_LITTER_TILE_METRES, 4.0);
+        assert!((0.014..=0.020).contains(&FOREST_LITTER_HEIGHT_RANGE_METRES));
     }
 
     #[test]

--- a/crates/adventuresim-tactical-client/src/presentation/terrain.rs
+++ b/crates/adventuresim-tactical-client/src/presentation/terrain.rs
@@ -1,4 +1,7 @@
-use super::procedural_assets::{FOREST_SOIL_HEIGHT_RANGE_METRES, FOREST_SOIL_TILE_METRES};
+use super::procedural_assets::{
+    FOREST_LITTER_HEIGHT_RANGE_METRES, FOREST_LITTER_TILE_METRES, FOREST_SOIL_HEIGHT_RANGE_METRES,
+    FOREST_SOIL_TILE_METRES,
+};
 use super::*;
 
 const TERMINAL_SWARD_FADE_START_METRES: f32 = 124.0;
@@ -157,12 +160,20 @@ pub(in crate::presentation) struct TacticalTerrainExtension {
     detail_patch: Vec4,
     #[uniform(100)]
     soil_detail: Vec4,
+    #[uniform(100)]
+    litter_detail: Vec4,
     #[texture(101)]
     #[sampler(102)]
     ground_map: Handle<Image>,
     #[texture(103)]
     #[sampler(104)]
     soil_height_ao: Handle<Image>,
+    #[texture(105)]
+    #[sampler(106)]
+    litter_surface: Handle<Image>,
+    #[texture(107)]
+    #[sampler(108)]
+    litter_normal: Handle<Image>,
 }
 
 impl MaterialExtension for TacticalTerrainExtension {
@@ -914,11 +925,22 @@ pub(in crate::presentation) fn terrain_material(
                 1.0,
                 24.0,
             ),
+            // Dense leaf litter is an aggregate terrain material first. Its
+            // packed height/AO/tone/coverage map supplies the continuous
+            // forest-floor mass beneath sparse silhouette-breaking meshes.
+            litter_detail: Vec4::new(
+                1.0 / FOREST_LITTER_TILE_METRES,
+                FOREST_LITTER_HEIGHT_RANGE_METRES,
+                0.72,
+                32.0,
+            ),
             ground_map: images.add(ground_map_image(
                 ground,
                 stable_text_seed(&environment.scene_digest),
             )),
             soil_height_ao: procedural_assets.forest_soil.height_ao.clone(),
+            litter_surface: procedural_assets.forest_soil.litter_surface.clone(),
+            litter_normal: procedural_assets.forest_soil.litter_normal.clone(),
         },
     }
 }
@@ -1221,17 +1243,31 @@ mod tests {
     }
 
     #[test]
-    fn ground_shader_keeps_solid_palette_albedo_and_uses_one_planar_height_ao_sample() {
+    fn ground_shader_layers_parallax_litter_and_normal_over_one_planar_soil_sample() {
         let shader = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../../assets/shaders/tactical_terrain.wgsl"
         ));
         assert!(shader.contains("var ground_map: texture_2d<f32>"));
         assert!(shader.contains("var soil_height_ao: texture_2d<f32>"));
+        assert!(shader.contains("var litter_surface: texture_2d<f32>"));
+        assert!(shader.contains("var litter_normal_map: texture_2d<f32>"));
         assert_eq!(
             shader.matches("textureSample(soil_height_ao,").count(),
             1,
             "forest soil should add exactly one packed texture fetch"
+        );
+        assert_eq!(
+            shader
+                .matches("textureSample(\n        litter_surface,")
+                .count(),
+            2
+        );
+        assert_eq!(
+            shader
+                .matches("textureSample(\n        litter_normal_map,")
+                .count(),
+            1
         );
         assert!(shader.contains("pbr_input.material.base_color = vec4<f32>(color, 1.0)"));
         assert!(shader.contains("distance(position, view.lod_view_world_position.xyz)"));
@@ -1242,8 +1278,11 @@ mod tests {
         assert!(!shader.contains("select(color, terrain.grass_color.rgb, tall_grass > 0.5)"));
         assert!(!shader.contains("shaded_substrate"));
         assert!(!shader.contains("tall_grass > 0.5 && canopy_floor"));
-        assert!(!shader.contains("canopy_floor"));
-        assert!(!shader.contains("litter_color"));
+        assert!(shader.contains("let canopy_floor = smoothstep(0.14, 0.72"));
+        assert!(shader.contains("let litter_color = mix("));
+        assert!(shader.contains("litter_region * litter_sample.a"));
+        assert!(shader.contains("let parallax_offset = clamp("));
+        assert!(shader.contains("let litter_mapped_normal = normalize("));
         assert!(shader.contains("let sward_color = terrain.grass_color.rgb"));
         assert!(!shader.contains("sward_color = color *"));
         assert!(shader.contains("sward_dither < sward_amount"));

--- a/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
@@ -1124,6 +1124,19 @@ mod capture_lighting_tests {
     }
 
     #[test]
+    fn root_detail_suppresses_only_occluding_floor_vegetation() {
+        let views = selected_capture_views("environment-review", &[]).unwrap();
+        let root = views
+            .iter()
+            .find(|view| view.slug == "tree-root-detail")
+            .unwrap();
+        assert!(root.suppress_grass);
+        assert!(root.suppress_understory);
+        assert!(!root.suppress_leaves);
+        assert!(!root.hide_obstacles);
+    }
+
+    #[test]
     fn environment_profile_has_deterministic_grazing_debris_target() {
         let views = selected_capture_views("environment-review", &[]).unwrap();
         assert_eq!(views.len(), 12);
@@ -2629,7 +2642,11 @@ fn capture_views(
         let specimen_representation = view.specimen_leaf;
         let specimen_view = specimen_representation.is_some();
         let specimen_pipeline_warmup = view.warmup;
-        let (suppress_leaves, suppress_grass) = (view.suppress_leaves, view.suppress_grass);
+        let (suppress_leaves, suppress_grass, suppress_understory) = (
+            view.suppress_leaves,
+            view.suppress_grass,
+            view.suppress_understory,
+        );
         let production_leaves = scene_visibility.p4().iter().collect::<Vec<_>>();
         for entity in production_leaves {
             commands.entity(entity).insert(if suppress_leaves {
@@ -2712,10 +2729,14 @@ fn capture_views(
             let hide_for_view = if view.understory_species.is_some() {
                 !isolated_understory_visible
             } else {
-                (layer == GroundScatterLayer::Grass && suppress_grass) || view.hide_obstacles
+                (layer == GroundScatterLayer::Grass && suppress_grass)
+                    || (layer == GroundScatterLayer::Understory && suppress_understory)
+                    || view.hide_obstacles
             };
-            if layer == GroundScatterLayer::Grass
-                || view.hide_obstacles
+            if matches!(
+                layer,
+                GroundScatterLayer::Grass | GroundScatterLayer::Understory
+            ) || view.hide_obstacles
                 || view.understory_species.is_some()
             {
                 commands.entity(entity).insert(if hide_for_view {

--- a/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_scene_viewer.rs
@@ -3994,11 +3994,11 @@ fn reviewable_debris_capture_target(
                 .map(|(position, _)| (target.focus.xz() - position.xz()).normalize_or_zero())
                 .filter(|direction| direction.length_squared() > 0.5)
                 .unwrap_or(Vec2::new(fallback.sin(), fallback.cos()));
-            let camera_xz = target.focus.xz() + camera_horizontal * 0.36;
+            let camera_xz = target.focus.xz() + camera_horizontal * 1.15;
             let camera_ground = terrain.height_at(camera_xz)?;
             target.camera = Vec3::new(
                 camera_xz.x,
-                (target.focus.y + 0.72).max(camera_ground + 0.5),
+                (target.focus.y + 1.35).max(camera_ground + 1.0),
                 camera_xz.y,
             );
             let score = obstacle_clearance.min(8.0) * 4.0 + edge_clearance.min(8.0) + normal.y;
@@ -4022,7 +4022,7 @@ fn debris_detail_camera(
 ) -> (Vec3, Vec3, Vec3) {
     let azimuth = azimuth_degrees.to_radians();
     (
-        camera.unwrap_or(target + Vec3::new(azimuth.sin() * 0.36, 0.72, azimuth.cos() * 0.36)),
+        camera.unwrap_or(target + Vec3::new(azimuth.sin() * 1.15, 1.35, azimuth.cos() * 1.15)),
         target,
         Vec3::Y,
     )

--- a/crates/adventuresim-tactical-client/src/tactical_scene_viewer/view_specs.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_scene_viewer/view_specs.rs
@@ -75,6 +75,7 @@ pub(super) struct CaptureViewSpec {
     pub understory_species: Option<&'static str>,
     pub suppress_leaves: bool,
     pub suppress_grass: bool,
+    pub suppress_understory: bool,
     pub vista_visible: bool,
     pub hide_obstacles: bool,
     pub show_tree_backdrop: bool,
@@ -108,6 +109,7 @@ impl CaptureViewSpec {
             understory_species: None,
             suppress_leaves: false,
             suppress_grass: false,
+            suppress_understory: false,
             vista_visible: false,
             hide_obstacles: false,
             show_tree_backdrop: false,
@@ -156,6 +158,10 @@ impl CaptureViewSpec {
     }
     pub const fn suppress_grass(mut self) -> Self {
         self.suppress_grass = true;
+        self
+    }
+    pub const fn suppress_understory(mut self) -> Self {
+        self.suppress_understory = true;
         self
     }
     pub const fn vista(mut self) -> Self {
@@ -501,6 +507,8 @@ pub(super) const ENVIRONMENT_REVIEW_VIEWS: [CaptureViewSpec; 12] = [
         38.0,
         350
     )
+    .suppress_grass()
+    .suppress_understory()
     .detail(DetailRequirement::TreeFocus),
     v!(
         "tree-branch-junction",

--- a/crates/adventuresim-tactical-client/src/tactical_scene_viewer/view_specs.rs
+++ b/crates/adventuresim-tactical-client/src/tactical_scene_viewer/view_specs.rs
@@ -538,12 +538,13 @@ pub(super) const ENVIRONMENT_REVIEW_VIEWS: [CaptureViewSpec; 12] = [
     .detail(DetailRequirement::GrassPresent),
     v!(
         "forest-floor-debris-detail",
-        "Fallen oak leaves and twig geometry close-up",
+        "Unobstructed forest-floor leaf-bed, twig, and pebble review",
         CapturePose::Debris,
-        39.6,
+        44.0,
         500
     )
     .debris()
+    .suppress_grass()
     .detail(DetailRequirement::DebrisPair),
     v!(
         "horizon",

--- a/wiki/shared/terrain.md
+++ b/wiki/shared/terrain.md
@@ -240,74 +240,91 @@ occlusion responses; a small solid-color palette and softened upward normals
 keep the dense field readable without making individual cards look heavily lit.
 A procedural terrain material selects hard-bounded forest floor, dry ground,
 mud, cultivation, stone, water, and snow albedo regions. Both playable and vista
-ground omit sampled albedo. Near walkable soil adds one shared 1024-square RG8
-height/AO sample with a complete mip chain; world-XZ mapping and screen-space
-height derivatives perturb the geometric normal without storing a normal map.
-The two-metre tile represents sub-two-centimetre compacted earth, hollows,
-clods, and fine aggregate, then fades from 12 to 24 metres and is suppressed on
-steep, stone, gravel, water, and snow-covered surfaces. A camera-local 40-metre
-detail patch refines the underlying geometric normal response to a 25-centimetre
-grid without changing the authoritative two-metre collider. Its world-space,
-centimetre-scale relief is deterministic and fades to the source surface over
-the outer 4.5 metres. The residual height is signed and bounded to roughly seven
-centimetres down and ten centimetres up: broad soil undulation and sparse clods
-break up flat ground; local terrain gradients orient narrow drainage rills
-downhill and soil-creep ridges across slopes; concavity gathers a shallow
-sediment layer. Water stays flat. Road samples infer the local road axis and
-edges from authoritative ground semantics, then form a raised crown and paired
-compacted wheel ruts. Nearby replicated tree positions add a shallow mound,
-basin, and several long curved radial root ridges, tying the ground silhouette
-to the generated roots instead of applying unrelated noise. Stone and gravel
-suppress soil clods in favor of broad contour-following bedrock ledges and
-sparse intersecting fractures. Nearby replicated boulders carve a shallow visual
-socket, build a contact apron, and deposit a widening downhill debris tail, so
-the rock mass meets the landform instead of resting on a flat plane. These
-obstacle-aware residuals remain presentation-only and do not alter the
-authoritative terrain height or conservative colliders. These process layers are
-geometry, never baked albedo or normal detail. A camera-centred shader cutout
-removes the coarse base only beneath the safely covered patch interior, allowing
-signed channels to remain visible instead of being depth-occluded. The outer
-1.5-metre overlap retains the base terrain and a small fixed-function depth bias
-resolves the almost fully morphed, coplanar perimeter without a second texture
-or non-WebGPU shader stage. The patch snaps in one-metre increments and retains
-the nearest vista height samples, so its quality radius follows the camera
-across the playable boundary. Its PBR response modestly expands the lateral
-components of the actual refined geometry normals and lowers dry roughness
-within the patch; this preserves solid albedo while keeping centimetre-scale
-facets legible under the bright environment-light floor. This is bounded
-CPU-generated triangle refinement that runs on WebGPU's ordinary vertex/fragment
-pipeline, not unavailable hardware tessellation or native-only mesh shaders.
-Tree-canopy ground is presented as a deterministic ecological sequence rather
-than a binary grass cutout. A high-resolution signed distance field derived from
-authoritative leaf-litter cover selects discrete dark-loam, litter, shaded-soil,
-and open-soil colors, and grades grass density and height across a 4.8-metre
-exterior band. Sparse fallen leaves, twigs, and multi-segment shade-plant
-rosettes extend into the outer 3.2 metres while the deep core stays mostly bare.
-These remain solid molded-material regions and procedural meshes rather than
-being baked into the soil texture. Tree sampling follows canopy coverage; rock
-sampling uses an independent deterministic roll scaled by hilly coverage, so the
-two features do not suppress one another. Weather affects ground wetness/snow
-tint, bounded rain or snow particles, wind drift, sunlight transmission, and
-distance fog. Clear weather retains a subtle kilometre-scale contrast haze
-beyond tactical gameplay range. At the playable boundary, the first vista ring
-reuses exact edge heights and eases the solid substrate pigment over several
-regional samples while preserving its independent geometric-sward coverage.
-Coarse vista samples preserve local peaks and render as seam-sharing rings of
-independently culled 32-by-32-cell mesh chunks out to 50 km. Chunking changes
-only CPU/ECS submission and culling granularity, not regional sampling or
-visible tessellation, and avoids tens of thousands of startup-time entities;
-coarser rings leave the playable and finer-ring interiors open rather than
-overdrawing them. The 50-metre and 250-metre regional rings also
-deterministically scatter bounded samples of the production whole-tree impostor
-over canopy-bearing cells; the outer ring relies on aggregate canopy colour.
-Those presentation-only trees share one cached atlas family, have no gameplay
-collider, and are seated on the same morphed vista surface as the terrain. Tree
-stand sampling scales with physical cell area instead of capping the first
-250-metre ring to three silhouettes. Exposed terrain likewise continues rocks
-beyond the playable rectangle: a shared procedural mesh hands off to a
-twelve-face silhouette mesh, then to the vista terrain's aggregate rock palette
-before either representation becomes subpixel. None of this vista scatter gains
-collision or server authority.
+ground omit sampled photographic albedo. Near walkable soil adds one shared
+1024-square RG8 height/AO sample with a complete mip chain; world-XZ mapping and
+screen-space height derivatives perturb the geometric normal without storing a
+normal map. The two-metre tile represents sub-two-centimetre compacted earth,
+hollows, clods, and fine aggregate, then fades from 12 to 24 metres and is
+suppressed on steep, stone, gravel, water, and snow-covered surfaces. A
+camera-local 40-metre detail patch refines the underlying geometric normal
+response to a 25-centimetre grid without changing the authoritative two-metre
+collider. Its world-space, centimetre-scale relief is deterministic and fades to
+the source surface over the outer 4.5 metres. The residual height is signed and
+bounded to roughly seven centimetres down and ten centimetres up: broad soil
+undulation and sparse clods break up flat ground; local terrain gradients orient
+narrow drainage rills downhill and soil-creep ridges across slopes; concavity
+gathers a shallow sediment layer. Water stays flat. Road samples infer the local
+road axis and edges from authoritative ground semantics, then form a raised
+crown and paired compacted wheel ruts. Nearby replicated tree positions add a
+shallow mound, basin, and several long curved radial root ridges, tying the
+ground silhouette to the generated roots instead of applying unrelated noise.
+Stone and gravel suppress soil clods in favor of broad contour-following bedrock
+ledges and sparse intersecting fractures. Nearby replicated boulders carve a
+shallow visual socket, build a contact apron, and deposit a widening downhill
+debris tail, so the rock mass meets the landform instead of resting on a flat
+plane. These obstacle-aware residuals remain presentation-only and do not alter
+the authoritative terrain height or conservative colliders. These process layers
+are geometry, never baked albedo or normal detail. A camera-centred shader
+cutout removes the coarse base only beneath the safely covered patch interior,
+allowing signed channels to remain visible instead of being depth-occluded. The
+outer 1.5-metre overlap retains the base terrain and a small fixed-function
+depth bias resolves the almost fully morphed, coplanar perimeter without a
+second texture or non-WebGPU shader stage. The patch snaps in one-metre
+increments and retains the nearest vista height samples, so its quality radius
+follows the camera across the playable boundary. Its PBR response modestly
+expands the lateral components of the actual refined geometry normals and lowers
+dry roughness within the patch; this preserves solid albedo while keeping
+centimetre-scale facets legible under the bright environment-light floor. This
+is bounded CPU-generated triangle refinement that runs on WebGPU's ordinary
+vertex/fragment pipeline, not unavailable hardware tessellation or native-only
+mesh shaders. Tree-canopy ground is presented as a deterministic ecological
+sequence rather than a binary grass cutout. A high-resolution signed distance
+field derived from authoritative leaf-litter cover blends dark loam, shaded
+soil, and open soil and grades grass density and height across a 4.8-metre
+exterior band. The canopy floor adds shared, fully mipped 1024-square aggregate
+litter surface and normal maps. Their four-metre world-space tile uses the same
+dry-oak blade envelope as the scattered leaves and packs sub-two-centimetre
+relief, ambient occlusion, muted palette selection, and overlapping leaf
+coverage while retaining small soil gaps. A coarser upper stratum preserves
+individual 10--16-centimetre silhouettes over two denser composting strata. A
+bounded grazing-angle parallax
+offset and explicit normal response give that relief depth without adding a
+shell layer. The aggregate supplies the continuous litter mass; it does not
+carry authored photographic color. Procedural fallen-leaf and twig meshes are
+distributed in smaller batches with several independent placement passes and a
+compressed dry-brown pigment range to break the surface silhouette without
+reproducing every leaf as geometry. Each leaf variant mixes 56
+jittered-stratified leaves with 28 loose clustered leaves; four-fifths remain
+seated within four millimetres while the remainder may curl above the bed.
+Multi-segment shade-plant rosettes extend into the outer 3.2 metres. Sparse
+brown-gray woodland pebble patches remain continuous across leaf-litter cells
+and average roughly one visible 3--8-centimetre stone per square metre without
+enabling the dense loose-stone billboard field. These stones use flattened,
+irregular outlines and buried bases instead of smooth exposed spheres. No shell
+layers are used. Tree sampling follows
+canopy coverage; open-ground rock sampling uses an independent deterministic
+roll scaled by hilly coverage, so the two features do not suppress one another.
+Weather affects ground wetness/snow tint, bounded rain or snow particles, wind
+drift, sunlight transmission, and distance fog. Clear weather retains a subtle
+kilometre-scale contrast haze beyond tactical gameplay range. At the playable
+boundary, the first vista ring reuses exact edge heights and eases the solid
+substrate pigment over several regional samples while preserving its independent
+geometric-sward coverage. Coarse vista samples preserve local peaks and render
+as seam-sharing rings of independently culled 32-by-32-cell mesh chunks out to
+50 km. Chunking changes only CPU/ECS submission and culling granularity, not
+regional sampling or visible tessellation, and avoids tens of thousands of
+startup-time entities; coarser rings leave the playable and finer-ring interiors
+open rather than overdrawing them. The 50-metre and 250-metre regional rings
+also deterministically scatter bounded samples of the production whole-tree
+impostor over canopy-bearing cells; the outer ring relies on aggregate canopy
+colour. Those presentation-only trees share one cached atlas family, have no
+gameplay collider, and are seated on the same morphed vista surface as the
+terrain. Tree stand sampling scales with physical cell area instead of capping
+the first 250-metre ring to three silhouettes. Exposed terrain likewise
+continues rocks beyond the playable rectangle: a shared procedural mesh hands
+off to a twelve-face silhouette mesh, then to the vista terrain's aggregate rock
+palette before either representation becomes subpixel. None of this vista
+scatter gains collision or server authority.
 
 Near-tree PBR leaf cards participate in the horizon-aware directional shadow
 map, producing both cast shadows and leaf-on-leaf self shadow. Their vertex data


### PR DESCRIPTION
## Summary

- replace the sparse, patchy canopy floor with a dense hybrid of aggregate terrain litter and bounded geometric scatter
- generate matching litter surface and normal maps, with explicit normal response and bounded grazing-angle parallax
- distribute 84 leaves per patch using stratified and clustered placement, with most leaves seated close to the terrain
- add restrained leaf color variation, twigs, and embedded brown-gray woodland stones
- add an unobstructed forest-floor capture view and document the presentation approach

## Why

The previous forest floor exposed a strong visual seam between soft terrain mottling and sparse, crisp geometric leaves. Scatter formed obvious islands, veins revealed which leaves were geometry, and small rocks were effectively absent.

This revision calibrates both representations into the same value, silhouette, and edge ranges so the transition passes a squint test while preserving selective geometric depth.

## Implementation

- shared dry-oak morphology between generated terrain litter and scatter leaves
- fully mipped aggregate surface and explicit normal textures
- bounded parallax without shell layers
- 56 stratified and 28 loosely clustered leaves per patch across twelve placement passes
- approximately 80% seated leaves and 20% raised depth accents
- reduced scatter vein contrast and a coarser terrain top stratum with readable 10–16 cm silhouettes
- flattened, faceted, partially buried woodland stones at tested canopy-floor density

## Validation

- independent visual reviewer: PASS
- 140 ground-scatter test executions passed across four binaries
- forest-litter texture tests passed across four binaries
- `cargo check -p adventuresim-tactical-client`
- production forest-floor capture validation
- wiki formatting and mdBook build
- `git diff --check`
